### PR TITLE
fix: Prevent data loss in modal on tab switch & Refactor tenanct inovices ("Rechnungen")

### DIFF
--- a/components/betriebskosten-edit-modal.tsx
+++ b/components/betriebskosten-edit-modal.tsx
@@ -287,7 +287,7 @@ export function BetriebskostenEditModal({
       currentCostItems.forEach(costItem => {
         if (costItem.berechnungsart === 'nach Rechnung') {
           newRechnungenState[costItem.id] = currentTenants.map(tenant => {
-            const dbRechnungForTenant = dbRechnungen?.find(dbR => dbR.mieter_id === tenant.id && dbR.name.includes(costItem.art)); // Simple check if name includes costItem.art
+            const dbRechnungForTenant = dbRechnungen?.find(dbR => dbR.mieter_id === tenant.id && dbR.name === costItem.art); // Changed to exact match for name
             const existingEntryInState = (prevRechnungen[costItem.id] || []).find(r => r.mieterId === tenant.id);
             
             // Prioritize DB data if available for the specific cost item and tenant
@@ -448,7 +448,7 @@ export function BetriebskostenEditModal({
                   nebenkosten_id: nebenkosten_id,
                   mieter_id: rechnungEinzel.mieterId,
                   betrag: parsedAmount,
-                  name: `Rechnung für ${item.art || 'Unbenannte Kostenart'} - Mieter ${mieterName} - ${jahr}`,
+                  name: item.art, // Changed name assignment to item.art
                 });
               }
             });


### PR DESCRIPTION
## Fix Modal Data Loss 
This commit addresses a critical issue in `BetriebskostenEditModal.tsx` where unsaved input from you was being lost if you switched browser tabs and then returned.

The root cause was traced to the main form initialization `useEffect` re-running when the `nebenkostenToEdit` prop received a new object reference from its parent component (often due to the parent re-fetching data on window focus). This effect would then reset the form state using the (potentially stale) data from the prop, overwriting any local changes.

The fix involves:
- Introducing `useRef` hooks within the modal to track:
    - `initialLoadDoneForCurrentInstance`: A boolean flag indicating if the form has been initialized since the modal was opened for the current instance.
    - `currentlyLoadedNebenkostenId`: The ID of the `Nebenkosten` record currently loaded in the form.
- Modifying the logic within the main initialization `useEffect` (which depends on `isOpen`, `nebenkostenToEdit`, and `haeuser`):
    - A full reset of the form state now only occurs if: - The modal is being opened (`initialLoadDoneForCurrentInstance` is false). - Or, a different `Nebenkosten` record (with a different ID) is being loaded into the already open modal.
    - If the `nebenkostenToEdit` prop changes reference but its ID remains the same as `currentlyLoadedNebenkostenId`, and the initial load for the current modal instance is done, the form state (including your unsaved changes) is preserved.
- The `useEffect` that resets the form when `isOpen` becomes false also resets these tracking refs.

This change makes the modal more resilient to parent component re-renders and should prevent the loss of unsaved data during tab switches.


## Refactor tenanct inovices ("Rechnungen")
This commit refactors how individual tenant invoices ("Rechnungen")
are handled for "nach Rechnung" cost items in the Betriebskosten modal,
addressing your feedback for more robust data mapping.

Key changes:

1.  **Saving `Rechnungen.name`**:
    - In `BetriebskostenEditModal.tsx`, the `handleSubmit` function
      now sets the `name` property of each `RechnungData` object
      (for "nach Rechnung" items) directly to the `costItem.art`
      (e.g., "Heizung", "Wasserzähler"). This replaces the previous
      descriptive, longer name.

2.  **Loading `Rechnungen`**:
    - The `syncRechnungenState` function in the modal has been updated
      to use this new `name` convention for mapping.
    - When pre-populating tenant invoice amounts during editing, it now
      finds the corresponding database `Rechnung` by matching:
      `dbRechnung.mieter_id === tenant.id && dbRechnung.name === costItem.art`.
      This ensures accurate association of invoices with specific tenants
      and specific cost types, especially if a Nebenkosten entry has
      multiple "nach Rechnung" cost items.

This approach provides a more direct and less fragile link between
the `costItem` in the UI and its corresponding `Rechnungen` data in
the database. You should be aware that existing `Rechnungen` records
with the old naming convention will not be loaded by this new logic
unless their names are updated in the database or they are re-saved.