### PR TITLE
Fix: Consistent dimming for DashboardSidebar with SettingsModal

### DIFF
--- a/components/dashboard-sidebar.tsx
+++ b/components/dashboard-sidebar.tsx
@@ -84,7 +84,7 @@ export function DashboardSidebar() {
       />
       <aside
         className={cn(
-          "fixed inset-y-0 left-0 z-[51] flex w-72 flex-col transition-transform md:sticky md:translate-x-0",
+          "fixed inset-y-0 left-0 z-[49] flex w-72 flex-col transition-transform md:sticky md:translate-x-0",
           isOpen ? "translate-x-0" : "-translate-x-full",
         )}
       >

--- a/components/settings-modal.tsx
+++ b/components/settings-modal.tsx
@@ -278,7 +278,6 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogOverlay />
       <DialogContent className="w-[700px] h-[75vh] max-w-full max-h-full overflow-hidden mt-2 ml-2">
           <DialogTitle className="sr-only">Einstellungen</DialogTitle>
         <div className="flex h-full overflow-hidden">


### PR DESCRIPTION
The DashboardSidebar was dimming to a darker color than the main page content when the SettingsModal was open. This was due to two issues:

1. A redundant DialogOverlay component was used in SettingsModal, causing a "double overlay" effect on elements that might have been caught between or under multiple overlay layers.
2. The DashboardSidebar had a z-index of 51, placing it above the modal's overlay (z-index 50), preventing it from being dimmed as intended.

This commit addresses these issues by:
- Removing the redundant DialogOverlay from components/settings-modal.tsx.
- Adjusting the DashboardSidebar's z-index from z-[51] to z-[49] in components/dashboard-sidebar.tsx, allowing it to be correctly positioned under the modal's primary overlay.

With these changes, both the DashboardSidebar and the main page content should now dim to the same level when the SettingsModal is active.