### PR TITLE
feat: Sort Stripe plans by position metadata

### DIFF
--- a/app/api/stripe/plans/route.ts
+++ b/app/api/stripe/plans/route.ts
@@ -13,6 +13,7 @@ interface Plan {
   limit_wohnungen?: number;
   // priceId is the same as id, kept for consistency if frontend expects it explicitly
   priceId: string;
+  position?: number;
 }
 
 export async function GET() {
@@ -53,6 +54,15 @@ export async function GET() {
           limitWohnungen = undefined;
       }
 
+      let position: number | undefined = undefined;
+      if (price.metadata.position) {
+        position = parseInt(price.metadata.position, 10);
+      } else if (product.metadata.position) {
+        position = parseInt(product.metadata.position, 10);
+      }
+      if (isNaN(position!)) {
+        position = undefined;
+      }
 
       return {
         id: price.id,
@@ -64,7 +74,15 @@ export async function GET() {
         interval_count: price.recurring?.interval_count || null,
         features: featuresArray,
         limit_wohnungen: limitWohnungen,
+        position: position,
       };
+    });
+
+    plans.sort((a, b) => {
+      if (a.position === undefined && b.position === undefined) return 0;
+      if (a.position === undefined) return 1; // a comes after b
+      if (b.position === undefined) return -1; // b comes after a
+      return a.position - b.position;
     });
 
     return NextResponse.json(plans);

--- a/app/modern/components/pricing.tsx
+++ b/app/modern/components/pricing.tsx
@@ -22,6 +22,7 @@ interface Plan {
   features: string[];
   limit_wohnungen?: number; // From API, but not directly displayed in this basic card
   priceId: string; // Stripe Price ID (same as id)
+  position?: number;
 }
 
 // Helper function to format price


### PR DESCRIPTION
This commit introduces the ability to sort Stripe subscription plans based on a 'position' metadata tag.

The changes include:

- Updated the backend API route (`app/api/stripe/plans/route.ts`) to:
  - Include an optional `position` field in the `Plan` interface.
  - Extract the `position` metadata from Stripe Price or Product objects.
  - Sort the plans based on this `position` (ascending) before returning them. Plans without a position or with an invalid one are sorted to the end.

- Updated the frontend `Pricing` component (`app/modern/components/pricing.tsx`) to:
  - Include the optional `position` field in its `Plan` interface to align with the API response.

The frontend component already renders plans in the order they are received, so no further frontend logic changes were needed for sorting. You will need to manually verify after deployment to ensure plans are displayed in the intended order based on their Stripe metadata.