### PR TITLE
Refactor: Improve type safety in error handling

### DIFF
--- a/app/api/wohnungen/route.ts
+++ b/app/api/wohnungen/route.ts
@@ -36,8 +36,13 @@ export async function POST(request: Request) {
           console.error(`API: Invalid limitWohnungen configuration: ${planDetails.limitWohnungen}`);
           return NextResponse.json({ error: "Ungültige Konfiguration für Wohnungslimit in Ihrem Plan." }, { status: 500 });
         }
-      } catch (planError: any) {
-        console.error("API: Error fetching plan details for limit enforcement:", planError);
+      } catch (planError: unknown) {
+        if (planError instanceof Error) {
+          console.error("API: Error fetching plan details for limit enforcement:", planError.message);
+          console.error("Stack trace:", planError.stack);
+        } else {
+          console.error("API: Error fetching plan details for limit enforcement (unknown type):", planError);
+        }
         // It's important to inform the user if plan details fetching fails
         return NextResponse.json({ error: "Fehler beim Abrufen der Plandetails für Ihr Abonnement." }, { status: 500 });
       }


### PR DESCRIPTION
I've updated the error handling in `app/api/wohnungen/route.ts` to use `unknown` instead of `any` for the error object in the catch block when fetching plan details.

This change enhances type safety by requiring an explicit type check. The code now checks if the caught error is an instance of `Error`. If it is, it logs the error message and stack trace for better debugging. Otherwise, it logs the unknown error object.