### PR TITLE
Fix: Handle undefined stripe_price_id in user-actions

### DIFF
--- a/app/user-actions.ts
+++ b/app/user-actions.ts
@@ -19,8 +19,8 @@ export async function getUserSubscriptionContext(): Promise<{
       };
     }
     return {
-      stripe_price_id: userProfile.stripe_price_id,
-      stripe_subscription_status: userProfile.stripe_subscription_status,
+      stripe_price_id: userProfile.stripe_price_id ?? null,
+      stripe_subscription_status: userProfile.stripe_subscription_status ?? null,
     };
   } catch (error) {
     console.error("Error in getUserSubscriptionContext:", error);
@@ -61,7 +61,7 @@ export async function getUserApartmentCount(): Promise<{
   error?: string;
 }> {
   try {
-    const supabase = createClient();
+    const supabase = await createClient();
     const {
       data: { user },
       error: authError,


### PR DESCRIPTION
The build was failing due to a type error in `app/user-actions.ts`. The `stripe_price_id` property of the `userProfile` object could be `string | null | undefined`, but it was being assigned to a variable that expected `string | null`.

This commit fixes the error by using the nullish coalescing operator (`??`) to default `stripe_price_id` to `null` if it is `undefined`.

Additionally, a similar change was made for `stripe_subscription_status` for consistency and to prevent potential future issues.

Finally, `await` was added to the `createClient()` call in the `getUserApartmentCount` function, as it appears to be an async function.