### PR TITLE
I've updated the behavior of the 'Abo auswählen' button on the subscr…

### DIFF
--- a/app/subscription-locked/page.tsx
+++ b/app/subscription-locked/page.tsx
@@ -1,8 +1,16 @@
+"use client";
 import React from 'react';
-import { Lock, Download, Package } from 'lucide-react'; // Added Download and Package
+import { useRouter } from 'next/navigation'; // Imported useRouter
+import { Lock, Download, Package } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 const SubscriptionLockedPage = () => {
+  const router = useRouter(); // Instantiated router
+
+  const handleSelectSubscription = () => {
+    router.push('/landing#pricing'); // Redirect to pricing section on landing page
+  };
+
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-slate-900 dark:bg-slate-950 backdrop-blur-md p-4 text-slate-100">
       <div className="bg-card text-card-foreground p-8 rounded-lg shadow-xl text-center max-w-md w-full">
@@ -12,22 +20,26 @@ const SubscriptionLockedPage = () => {
         <h1 className="text-3xl font-bold mb-4">
           Zugriff gesperrt
         </h1>
-        <p className="text-muted-foreground mb-8">
+        <p className="text-muted-foreground mb-8"> {/* Reverted mb-6 to mb-8 as error message is removed */}
           Ihr aktuelles Abonnement erlaubt keinen Zugriff auf diese Seite. Bitte aktualisieren Sie Ihr Abonnement oder laden Sie Ihre Daten herunter.
         </p>
+        {/* Removed error display section */}
         <div className="flex flex-col sm:flex-row justify-center gap-4">
           <Button
             variant="default"
             size="lg"
             className="w-full sm:w-auto"
+            onClick={handleSelectSubscription} // Updated onClick handler
+            // Removed disabled attribute
           >
             <Package /> {/* Icon added */}
-            Abo auswählen
+            Abo auswählen {/* Reverted button text */}
           </Button>
           <Button
             variant="secondary"
             size="lg"
             className="w-full sm:w-auto"
+            // Removed disabled attribute from this button as well for consistency
           >
             <Download /> {/* Icon added */}
             Daten herunterladen


### PR DESCRIPTION
…iption locked page.

It now redirects you to the pricing section of the landing page (`/landing#pricing`).

This change leverages the existing plan selection and Stripe checkout functionality on the landing page, providing a more robust and user-friendly experience than directly initiating a checkout for a predefined plan from the lockscreen.

I also removed unused state management (loading, error) from the `SubscriptionLockedPage` as the redirection simplifies its role.