### PR TITLE
Fix: Remove debug console.log statements

### DIFF
--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -461,24 +461,6 @@ export function AbrechnungModal({
       // Draw "Betriebskosten gesamt" sums manually below the table, aligned with columns
       let sumsDrawnSuccessfully = false;
 
-      // --- BEGIN DEBUG LOGS ---
-      if (lastTable) {
-        console.log("Debug PDF: lastTable object:", JSON.parse(JSON.stringify(lastTable))); // Full table object
-        console.log("Debug PDF: lastTable.columns:", lastTable.columns);
-        console.log("Debug PDF: lastTable.columns type:", typeof lastTable.columns);
-        if (Array.isArray(lastTable.columns)) {
-          console.log("Debug PDF: lastTable.columns.length:", lastTable.columns.length);
-          lastTable.columns.forEach((col: any, index: number) => {
-            console.log(`Debug PDF: Column ${index}: x=${col?.x} (type: ${typeof col?.x}), width=${col?.width} (type: ${typeof col?.width})`);
-          });
-        }
-        console.log("Debug PDF: lastTable.settings:", lastTable.settings);
-        console.log("Debug PDF: lastTable.settings.margin:", lastTable.settings?.margin);
-      } else {
-        console.log("Debug PDF: lastTable is null or undefined.");
-      }
-      // --- END DEBUG LOGS ---
-
       if (lastTable && Array.isArray(lastTable.columns) && lastTable.settings?.margin) {
         const col0 = lastTable.columns[0];
         const col1 = lastTable.columns[1];


### PR DESCRIPTION
Removed a block of console.log statements from components/abrechnung-modal.tsx that were used for debugging PDF generation.