### PR TITLE
feat: implement DSGVO and cookie consent

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Toaster } from "@/components/ui/toaster"
 import { PostHogProvider } from "./providers"
+import CookieBanner from "@/components/cookie-banner"
 // Vercel Analytics: visitor/page view tracking. To remove, delete the import and usage below.
 import { Analytics } from "@vercel/analytics/react"
 // Vercel SpeedInsights: performance metrics collection. To remove, delete the import and usage below.
@@ -34,6 +35,7 @@ export default function RootLayout({
           <PostHogProvider>
             {children}
             <Toaster />
+            <CookieBanner />
             {/* Vercel Analytics: visitor/page view tracking. Remove to disable. */}
             <Analytics />
             {/* Vercel SpeedInsights: performance metrics collection. Remove to disable. */}

--- a/app/modern/components/footer.tsx
+++ b/app/modern/components/footer.tsx
@@ -14,6 +14,7 @@ const footerLinks = {
 // Special links that require custom routing or display text
 const specialLinks: Record<string, { href: string; text: string }> = {
   "Hilfezentrum": { href: "/modern/documentation", text: "Dokumentation" },
+  "Datenschutz": { href: "/privacy", text: "Datenschutz" },
 }
 
 const socialLinks = [

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,93 @@
+import { Fragment } from 'react';
+
+const PrivacyPolicy = () => {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <h1 className="text-3xl font-extrabold text-gray-900">Datenschutzerklärung</h1>
+        <div className="mt-6 prose prose-indigo prose-lg text-gray-500 mx-auto">
+          <p>
+            Verantwortlicher im Sinne der Datenschutzgesetze, insbesondere der EU-Datenschutzgrundverordnung (DSGVO), ist:
+          </p>
+          <p>
+            <strong>[Ihr Name/Unternehmen]</strong>
+            <br />
+            [Ihre Adresse]
+            <br />
+            [Ihre E-Mail-Adresse]
+            <br />
+            [Ihre Telefonnummer]
+          </p>
+
+          <h2 className="text-2xl font-bold text-gray-900 mt-8">Ihre Betroffenenrechte</h2>
+          <p>
+            Unter den angegebenen Kontaktdaten unseres Datenschutzbeauftragten können Sie jederzeit folgende Rechte ausüben:
+          </p>
+          <ul>
+            <li>Auskunft über Ihre bei uns gespeicherten Daten und deren Verarbeitung (Art. 15 DSGVO),</li>
+            <li>Berichtigung unrichtiger personenbezogener Daten (Art. 16 DSGVO),</li>
+            <li>Löschung Ihrer bei uns gespeicherten Daten (Art. 17 DSGVO),</li>
+            <li>Einschränkung der Datenverarbeitung, sofern wir Ihre Daten aufgrund gesetzlicher Pflichten noch nicht löschen dürfen (Art. 18 DSGVO),</li>
+            <li>Widerspruch gegen die Verarbeitung Ihrer Daten bei uns (Art. 21 DSGVO) und</li>
+            <li>Datenübertragbarkeit, sofern Sie in die Datenverarbeitung eingewilligt haben oder einen Vertrag mit uns abgeschlossen haben (Art. 20 DSGVO).</li>
+          </ul>
+          <p>
+            Sofern Sie uns eine Einwilligung erteilt haben, können Sie diese jederzeit mit Wirkung für die Zukunft widerrufen.
+          </p>
+
+          <h2 className="text-2xl font-bold text-gray-900 mt-8">Erfassung allgemeiner Informationen beim Besuch unserer Website</h2>
+          <h3 className="text-xl font-bold text-gray-900 mt-4">Art und Zweck der Verarbeitung:</h3>
+          <p>
+            Wenn Sie auf unsere Website zugreifen, d.h., wenn Sie sich nicht registrieren oder anderweitig Informationen übermitteln, werden automatisch Informationen allgemeiner Natur erfasst. Diese Informationen (Server-Logfiles) beinhalten etwa die Art des Webbrowsers, das verwendete Betriebssystem, den Domainnamen Ihres Internet-Service-Providers, Ihre IP-Adresse und ähnliches.
+          </p>
+          <h3 className="text-xl font-bold text-gray-900 mt-4">Rechtsgrundlage:</h3>
+          <p>
+            Die Verarbeitung erfolgt gemäß Art. 6 Abs. 1 lit. f DSGVO auf Basis unseres berechtigten Interesses an der Verbesserung der Stabilität und Funktionalität unserer Website.
+          </p>
+
+          <h2 className="text-2xl font-bold text-gray-900 mt-8">Cookies</h2>
+          <p>
+            Unsere Webseite verwendet Cookies. Das sind kleine Textdateien, die auf Ihrem Endgerät gespeichert werden. Einige Cookies werden nach Ende der Browser-Sitzung wieder gelöscht (Sitzungs-Cookies). Andere Cookies verbleiben auf Ihrem Endgerät und ermöglichen es, Ihren Browser beim nächsten Besuch wiederzuerkennen (persistente Cookies). Sie können Ihren Browser so einstellen, dass Sie über das Setzen von Cookies informiert werden und einzeln über deren Annahme entscheiden oder die Annahme für bestimmte Fälle oder generell ausschließen.
+          </p>
+
+          <h2 className="text-2xl font-bold text-gray-900 mt-8">Registrierung auf unserer Website</h2>
+          <h3 className="text-xl font-bold text-gray-900 mt-4">Art und Zweck der Verarbeitung:</h3>
+          <p>
+            Bei der Registrierung für die Nutzung unserer personalisierten Leistungen werden einige personenbezogene Daten erhoben, wie Name, Anschrift, Kontakt- und Kommunikationsdaten (z.B. Telefonnummer und E-Mail-Adresse). Sind Sie bei uns registriert, können Sie auf Inhalte und Leistungen zugreifen, die wir nur registrierten Nutzern anbieten.
+          </p>
+          <h3 className="text-xl font-bold text-gray-900 mt-4">Rechtsgrundlage:</h3>
+          <p>
+            Die Verarbeitung der bei der Registrierung eingegebenen Daten erfolgt auf Grundlage einer Einwilligung des Nutzers (Art. 6 Abs. 1 lit. a DSGVO).
+          </p>
+
+          <h2 className="text-2xl font-bold text-gray-900 mt-8">Verwendung von Supabase</h2>
+          <p>
+            Wir nutzen Supabase als Backend-Dienst. Supabase stellt eine Datenbank, Authentifizierung, und APIs zur Verfügung. Die Daten werden in der EU gehostet.
+          </p>
+
+          <h2 className="text-2xl font-bold text-gray-900 mt-8">Verwendung von Cloudflare</h2>
+          <p>
+            Wir setzen Cloudflare als Content Delivery Network (CDN) ein. Cloudflare hilft uns, die Ladezeiten unserer Website zu optimieren und die Sicherheit zu erhöhen. Dabei wird Ihre IP-Adresse an Cloudflare übertragen.
+          </p>
+
+          <h2 className="text-2xl font-bold text-gray-900 mt-8">Verwendung von Stripe</h2>
+          <p>
+            Für die Abwicklung von Zahlungen nutzen wir den Dienstleister Stripe. Wenn Sie eine Zahlung über Stripe durchführen, werden Ihre Zahlungsdaten (z.B. Kreditkartennummer) direkt an Stripe übermittelt.
+          </p>
+
+          <h2 className="text-2xl font-bold text-gray-900 mt-8">Verwendung von PostHog</h2>
+          <p>
+            Wir verwenden PostHog zur Analyse des Nutzerverhaltens, um unser Angebot zu verbessern. PostHog wird nur dann aktiviert, wenn Sie Ihre Einwilligung dazu geben.
+          </p>
+
+          <h2 className="text-2xl font-bold text-gray-900 mt-8">Änderung unserer Datenschutzbestimmungen</h2>
+          <p>
+            Wir behalten uns vor, diese Datenschutzerklärung anzupassen, damit sie stets den aktuellen rechtlichen Anforderungen entspricht oder um Änderungen unserer Leistungen in der Datenschutzerklärung umzusetzen, z.B. bei der Einführung neuer Services. Für Ihren erneuten Besuch gilt dann die neue Datenschutzerklärung.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PrivacyPolicy;

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -2,16 +2,21 @@
 import posthog from 'posthog-js'
 import { PostHogProvider as PHProvider } from 'posthog-js/react'
 import { useEffect } from 'react'
+import { useCookieConsent } from '@/hooks/use-cookie-consent'
 
 import React from 'react'
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  const { consent } = useCookieConsent();
+
   useEffect(() => {
-    posthog.init('phc_jfMUSdIAQg9y9uJNtHpT4vf8kdv0ZvT6aHfq7R4Kyx3', {
-      api_host: 'https://eu.i.posthog.com',
-      defaults: '2025-05-24',
-    })
-  }, [])
+    if (consent) {
+      posthog.init('phc_jfMUSdIAQg9y9uJNtHpT4vf8kdv0ZvT6aHfq7R4Kyx3', {
+        api_host: 'https://eu.i.posthog.com',
+        defaults: '2025-05-24',
+      });
+    }
+  }, [consent]);
 
   return (
     <PHProvider client={posthog}>

--- a/components/cookie-banner.tsx
+++ b/components/cookie-banner.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+
+const CookieBanner = () => {
+  const [showBanner, setShowBanner] = useState(false);
+
+  useEffect(() => {
+    const consent = localStorage.getItem('cookie-consent');
+    if (!consent) {
+      setShowBanner(true);
+    }
+  }, []);
+
+  const acceptCookies = () => {
+    localStorage.setItem('cookie-consent', 'true');
+    setShowBanner(false);
+  };
+
+  const declineCookies = () => {
+    localStorage.setItem('cookie-consent', 'false');
+    setShowBanner(false);
+  };
+
+  if (!showBanner) {
+    return null;
+  }
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-gray-800 text-white p-4 z-50">
+      <div className="container mx-auto flex justify-between items-center">
+        <p>
+          Wir verwenden Cookies, um Ihr Erlebnis zu verbessern. Bitte lesen Sie unsere{' '}
+          <Link href="/privacy" className="underline">
+            Datenschutzerklärung
+          </Link>
+          .
+        </p>
+        <div>
+          <button
+            onClick={acceptCookies}
+            className="bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded mr-2"
+          >
+            Akzeptieren
+          </button>
+          <button
+            onClick={declineCookies}
+            className="bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-4 rounded"
+          >
+            Ablehnen
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CookieBanner;

--- a/hooks/use-cookie-consent.tsx
+++ b/hooks/use-cookie-consent.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export const useCookieConsent = () => {
+  const [consent, setConsent] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const storedConsent = localStorage.getItem('cookie-consent');
+    if (storedConsent) {
+      setConsent(storedConsent === 'true');
+    }
+  }, []);
+
+  const accept = () => {
+    localStorage.setItem('cookie-consent', 'true');
+    setConsent(true);
+  };
+
+  const decline = () => {
+    localStorage.setItem('cookie-consent', 'false');
+    setConsent(false);
+  };
+
+  return { consent, accept, decline };
+};


### PR DESCRIPTION
## Description

Gates PostHog analytics behind an explicit cookie consent and adds a privacy page.

## Summary of Changes

- PostHog only initializes when the user has accepted cookies (new `use-cookie-consent` hook reading localStorage)
- New simple `CookieBanner` (accept/decline persisted as a boolean)
- New `/privacy` page (93 lines) covering data subject rights, server logs, cookies, registration and the used providers; footer link added