### PR TITLE
feat: add cookie consent banner

### DIFF
--- a/app/datenschutzerklaerung/page.tsx
+++ b/app/datenschutzerklaerung/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Datenschutzerklaerung = () => {
+  return (
+    <div>
+      {/* This page is intentionally left blank for now. */}
+    </div>
+  );
+};
+
+export default Datenschutzerklaerung;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Toaster } from "@/components/ui/toaster"
 import { PostHogProvider } from "./providers"
+import CookieConsent from "@/components/cookie-consent"
 // Vercel Analytics: visitor/page view tracking. To remove, delete the import and usage below.
 import { Analytics } from "@vercel/analytics/react"
 // Vercel SpeedInsights: performance metrics collection. To remove, delete the import and usage below.
@@ -33,6 +34,7 @@ export default function RootLayout({
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
           <PostHogProvider>
             {children}
+            <CookieConsent />
             <Toaster />
             {/* Vercel Analytics: visitor/page view tracking. Remove to disable. */}
             <Analytics />

--- a/components/cookie-consent.tsx
+++ b/components/cookie-consent.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
+
+const CookieConsent = () => {
+  const [showConsent, setShowConsent] = useState(false);
+
+  useEffect(() => {
+    const consent = localStorage.getItem('cookie-consent');
+    if (!consent) {
+      setShowConsent(true);
+    }
+  }, []);
+
+  const handleConsent = (consentType: 'denied' | 'necessary' | 'all') => {
+    localStorage.setItem('cookie-consent', consentType);
+    setShowConsent(false);
+  };
+
+  if (!showConsent) {
+    return null;
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 bg-gray-800 text-white p-4 rounded-lg shadow-lg max-w-sm z-50">
+      <p className="text-sm">
+        We use cookies to improve your experience. By using our site, you agree to our use of cookies.
+        <Link href="/datenschutzerklaerung" className="text-blue-400 hover:underline ml-1">
+          Datenschutzerklärung
+        </Link>
+      </p>
+      <div className="flex justify-end mt-4">
+        <button
+          onClick={() => handleConsent('denied')}
+          className="bg-gray-700 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded mr-2"
+        >
+          Deny
+        </button>
+        <button
+          onClick={() => handleConsent('necessary')}
+          className="bg-gray-700 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded mr-2"
+        >
+          Accept only necessary
+        </button>
+        <button
+          onClick={() => handleConsent('all')}
+          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+        >
+          Accept all cookies
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CookieConsent;


### PR DESCRIPTION
This commit introduces a cookie consent banner to the application.

- A new page `datenschutzerklaerung` has been created.
- A cookie consent component has been added to the main layout.
- The component provides three options: Deny, Accept only necessary, and Accept all cookies.
- Your choice is stored in local storage to prevent the banner from reappearing.