### PR TITLE
feat: add cookie consent banner

### DIFF
--- a/app/datenschutzerklaerung/page.tsx
+++ b/app/datenschutzerklaerung/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Datenschutzerklaerung = () => {
+  return (
+    <div>
+      <h1>Datenschutzerklärung</h1>
+    </div>
+  );
+};
+
+export default Datenschutzerklaerung;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Toaster } from "@/components/ui/toaster"
 import { PostHogProvider } from "./providers"
+import CookieConsent from "@/components/cookie-consent"
 // Vercel Analytics: visitor/page view tracking. To remove, delete the import and usage below.
 import { Analytics } from "@vercel/analytics/react"
 // Vercel SpeedInsights: performance metrics collection. To remove, delete the import and usage below.
@@ -34,6 +35,7 @@ export default function RootLayout({
           <PostHogProvider>
             {children}
             <Toaster />
+            <CookieConsent />
             {/* Vercel Analytics: visitor/page view tracking. Remove to disable. */}
             <Analytics />
             {/* Vercel SpeedInsights: performance metrics collection. Remove to disable. */}

--- a/components/__tests__/cookie-consent.test.tsx
+++ b/components/__tests__/cookie-consent.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CookieConsent from '../cookie-consent';
+
+describe('CookieConsent', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should render when no consent is given', () => {
+    render(<CookieConsent />);
+    expect(screen.getByText(/we use cookies/i)).toBeInTheDocument();
+  });
+
+  it('should not render when consent is already given', () => {
+    localStorage.setItem('cookie-consent', 'all');
+    render(<CookieConsent />);
+    expect(screen.queryByText(/we use cookies/i)).not.toBeInTheDocument();
+  });
+
+  it('should set consent to "denied" when "Deny" is clicked', () => {
+    render(<CookieConsent />);
+    fireEvent.click(screen.getByText('Deny'));
+    expect(localStorage.getItem('cookie-consent')).toBe('denied');
+    expect(screen.queryByText(/we use cookies/i)).not.toBeInTheDocument();
+  });
+
+  it('should set consent to "necessary" when "Accept only necessary" is clicked', () => {
+    render(<CookieConsent />);
+    fireEvent.click(screen.getByText('Accept only necessary'));
+    expect(localStorage.getItem('cookie-consent')).toBe('necessary');
+    expect(screen.queryByText(/we use cookies/i)).not.toBeInTheDocument();
+  });
+
+  it('should set consent to "all" when "Accept all cookies" is clicked', () => {
+    render(<CookieConsent />);
+    fireEvent.click(screen.getByText('Accept all cookies'));
+    expect(localStorage.getItem('cookie-consent')).toBe('all');
+    expect(screen.queryByText(/we use cookies/i)).not.toBeInTheDocument();
+  });
+});

--- a/components/cookie-consent.tsx
+++ b/components/cookie-consent.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
+
+const CookieConsent = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const consent = localStorage.getItem('cookie-consent');
+    if (!consent) {
+      setVisible(true);
+    }
+  }, []);
+
+  const handleDeny = () => {
+    localStorage.setItem('cookie-consent', 'denied');
+    setVisible(false);
+  };
+
+  const handleAcceptNecessary = () => {
+    localStorage.setItem('cookie-consent', 'necessary');
+    setVisible(false);
+  };
+
+  const handleAcceptAll = () => {
+    localStorage.setItem('cookie-consent', 'all');
+    setVisible(false);
+  };
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 bg-gray-800 text-white p-4 rounded-lg shadow-lg">
+      <p className="mb-2">
+        We use cookies to improve your experience. By using our site, you agree to our{' '}
+        <Link href="/datenschutzerklaerung" className="underline">
+          Privacy Policy
+        </Link>
+        .
+      </p>
+      <div className="flex justify-end gap-2">
+        <button onClick={handleDeny} className="px-4 py-2 rounded bg-gray-700 hover:bg-gray-600">
+          Deny
+        </button>
+        <button onClick={handleAcceptNecessary} className="px-4 py-2 rounded bg-gray-700 hover:bg-gray-600">
+          Accept only necessary
+        </button>
+        <button onClick={handleAcceptAll} className="px-4 py-2 rounded bg-blue-600 hover:bg-blue-500">
+          Accept all cookies
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CookieConsent;


### PR DESCRIPTION
This commit introduces a cookie consent banner that is displayed at the bottom right of the screen. It provides options to deny, accept necessary, or accept all cookies. The banner also includes a link to a new, empty `datenschutzerklärung` page.

- Creates a new `datenschutzerklärung` page.
- Implements a `CookieConsent` component with the required UI and logic.
- Integrates the component into the main layout.
- Adds tests for the `CookieConsent` component.