### PR TITLE
Feature/landing page mobile optimization

### DIFF
--- a/components/cookie-consent-banner.tsx
+++ b/components/cookie-consent-banner.tsx
@@ -48,16 +48,14 @@ export function CookieConsentBanner() {
         <div className="flex flex-col sm:flex-row gap-3 w-full">
           <Button 
             variant="outline" 
-            size="sm"
-            className="flex-1"
+            className="flex-1 py-2 px-4 h-auto sm:h-9 text-sm font-medium"
             onClick={() => handleAccept('necessary')}
           >
             Nur notwendige
           </Button>
           <Button 
             variant="default" 
-            size="sm"
-            className="flex-1"
+            className="flex-1 py-2 px-4 h-auto sm:h-9 text-sm font-medium"
             onClick={() => handleAccept('all')}
           >
             Alle akzeptieren

--- a/components/cookie-consent-banner.tsx
+++ b/components/cookie-consent-banner.tsx
@@ -48,14 +48,16 @@ export function CookieConsentBanner() {
         <div className="flex flex-col sm:flex-row gap-3 w-full">
           <Button 
             variant="outline" 
-            className="flex-1 py-2 px-4 h-auto sm:h-9"
+            size="default"
+            className="flex-1 h-auto sm:h-9"
             onClick={() => handleAccept('necessary')}
           >
             Nur notwendige
           </Button>
           <Button 
             variant="default" 
-            className="flex-1 py-2 px-4 h-auto sm:h-9"
+            size="default"
+            className="flex-1 h-auto sm:h-9"
             onClick={() => handleAccept('all')}
           >
             Alle akzeptieren

--- a/components/cookie-consent-banner.tsx
+++ b/components/cookie-consent-banner.tsx
@@ -30,7 +30,7 @@ export function CookieConsentBanner() {
 
   return (
     <div 
-      className="fixed bottom-4 right-4 max-w-md p-6 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 z-50"
+      className="fixed bottom-4 left-1/2 -translate-x-1/2 sm:left-auto sm:right-4 sm:translate-x-0 w-[calc(100%-2rem)] sm:w-auto sm:max-w-md p-6 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 z-50"
       role="dialog"
       aria-modal="true"
       aria-labelledby="cookie-consent-title"

--- a/components/cookie-consent-banner.tsx
+++ b/components/cookie-consent-banner.tsx
@@ -48,14 +48,14 @@ export function CookieConsentBanner() {
         <div className="flex flex-col sm:flex-row gap-3 w-full">
           <Button 
             variant="outline" 
-            className="flex-1 py-2 px-4 h-auto sm:h-9 text-sm font-medium"
+            className="flex-1 py-2 px-4 h-auto sm:h-9"
             onClick={() => handleAccept('necessary')}
           >
             Nur notwendige
           </Button>
           <Button 
             variant="default" 
-            className="flex-1 py-2 px-4 h-auto sm:h-9 text-sm font-medium"
+            className="flex-1 py-2 px-4 h-auto sm:h-9"
             onClick={() => handleAccept('all')}
           >
             Alle akzeptieren

--- a/components/cookie-consent-banner.tsx
+++ b/components/cookie-consent-banner.tsx
@@ -48,16 +48,16 @@ export function CookieConsentBanner() {
         <div className="flex flex-col sm:flex-row gap-3 w-full">
           <Button 
             variant="outline" 
-            size="default"
-            className="flex-1 h-auto sm:h-9"
+            size="sm"
+            className="flex-1 h-auto sm:h-9 px-4 py-2"
             onClick={() => handleAccept('necessary')}
           >
             Nur notwendige
           </Button>
           <Button 
             variant="default" 
-            size="default"
-            className="flex-1 h-auto sm:h-9"
+            size="sm"
+            className="flex-1 h-auto sm:h-9 px-4 py-2"
             onClick={() => handleAccept('all')}
           >
             Alle akzeptieren

--- a/components/cookie-consent-banner.tsx
+++ b/components/cookie-consent-banner.tsx
@@ -30,7 +30,7 @@ export function CookieConsentBanner() {
 
   return (
     <div 
-      className="fixed bottom-4 left-1/2 -translate-x-1/2 sm:left-auto sm:right-4 sm:translate-x-0 w-[calc(100%-2rem)] sm:w-auto sm:max-w-md p-6 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 z-50"
+      className="fixed bottom-0 left-0 right-0 sm:bottom-4 sm:left-auto sm:right-4 sm:w-auto sm:max-w-md w-[calc(100%-2rem)] mx-auto sm:mx-0 mb-4 sm:mb-0 p-6 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 z-50"
       role="dialog"
       aria-modal="true"
       aria-labelledby="cookie-consent-title"

--- a/components/cookie-consent-banner.tsx
+++ b/components/cookie-consent-banner.tsx
@@ -30,7 +30,7 @@ export function CookieConsentBanner() {
 
   return (
     <div 
-      className="fixed bottom-0 left-0 right-0 sm:bottom-4 sm:left-auto sm:right-4 sm:w-auto sm:max-w-md w-[calc(100%-2rem)] mx-auto sm:mx-0 mb-4 sm:mb-0 p-6 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 z-50"
+      className="fixed inset-x-4 bottom-4 sm:inset-x-auto sm:right-4 sm:max-w-md p-6 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 z-50"
       role="dialog"
       aria-modal="true"
       aria-labelledby="cookie-consent-title"


### PR DESCRIPTION
## Description

Makes the cookie consent banner usable on small screens.

## Summary of Changes

- Banner stretches full-width on mobile (`inset-x-4`) and returns to a right-aligned card on `sm:` breakpoints
- Buttons grow to fit their labels on mobile (`h-auto`, padding) and keep the compact size on desktop