### PR TITLE
feat: Implement infinite scroll for finance transactions

### DIFF
--- a/app/(dashboard)/finanzen/client-wrapper.tsx
+++ b/app/(dashboard)/finanzen/client-wrapper.tsx
@@ -1,22 +1,12 @@
 "use client";
 
-import { useState, useRef, useCallback, useEffect } from "react"; // useEffect might be removable if not used elsewhere
+import { useState, useRef, useCallback, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { PlusCircle, ArrowUpCircle, ArrowDownCircle, BarChart3, Wallet } from "lucide-react";
 import { FinanceVisualization } from "@/components/finance-visualization";
 import { FinanceTransactions } from "@/components/finance-transactions";
-// Dialog, Input, Label, Select, DatePicker, toast, format are removed as they were for the local modal
-// If other parts of the component use them, they should be kept. For now, assuming they are modal-specific.
-// import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
-// import { Input } from "@/components/ui/input";
-// import { Label } from "@/components/ui/label";
-// import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
-// import { toast } from "@/components/ui/use-toast";
-// import { DatePicker } from "@/components/ui/date-picker";
-// import { format } from "date-fns";
-
-import { useModalStore } from "@/hooks/use-modal-store"; // Added
+import { useModalStore } from "@/hooks/use-modal-store";
 
 interface Finanz {
   id: string;
@@ -36,49 +26,53 @@ interface FinanzenClientWrapperProps {
   wohnungen: Wohnung[];
 }
 
-export default function FinanzenClientWrapper({ finances, wohnungen }: FinanzenClientWrapperProps) {
-  // Local state for dialog (dialogOpen, editingId, formData) is removed
-  // const [dialogOpen, setDialogOpen] = useState(false);
-  // const [editingId, setEditingId] = useState<string | null>(null);
-  // const [formData, setFormData] = useState({ 
-  //   wohnung_id: "", 
-  //   name: "", 
-  //   datum: "", 
-  //   betrag: "", 
-  //   ist_einnahmen: false, 
-  //   notiz: "" 
-  // });
-  const [finData, setFinData] = useState<Finanz[]>(finances); // Keep for display
-  const reloadRef = useRef<(() => void) | null>(null); // Keep for FinanceTransactions reload
+export default function FinanzenClientWrapper({ finances: initialFinances, wohnungen }: FinanzenClientWrapperProps) {
+  const [finData, setFinData] = useState<Finanz[]>(initialFinances);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  // Add handler for new entries
+  const reloadRef = useRef<(() => void) | null>(null);
+
+  const loadMoreTransactions = useCallback(async () => {
+    if (isLoading || !hasMore) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/finanzen?page=${page + 1}&pageSize=25`);
+      if (!response.ok) {
+        throw new Error('Failed to fetch transactions');
+      }
+      const newTransactions = await response.json();
+      setFinData(prev => [...prev, ...newTransactions]);
+      setPage(prev => prev + 1);
+      setHasMore(newTransactions.length > 0);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [page, hasMore, isLoading]);
+
   const handleAddFinance = useCallback((newFinance: Finanz) => {
     setFinData(prev => {
-      // Check if the entry already exists to prevent duplicates
       const exists = prev.some(item => item.id === newFinance.id);
       if (exists) {
-        // If it exists, update the existing entry
-        return prev.map(item => 
+        return prev.map(item =>
           item.id === newFinance.id ? { ...item, ...newFinance } : item
         );
       }
-      // If it's a new entry, add it to the beginning of the list
       return [newFinance, ...prev];
     });
   }, []);
-  
-  // Handle successful form submission
+
   const handleSuccess = useCallback((data: any) => {
-    // The server returns the created/updated finance entry
     if (data) {
       handleAddFinance(data);
     }
   }, [handleAddFinance]);
 
-  // useEffect for 'open-add-finance-modal' event is removed.
-  // This will be handled by CommandMenu triggering useModalStore.
-
-  // Werte berechnen (keep)
   const currentYear = new Date().getFullYear();
   const financesForCurrentYear = finData.filter(f => f.datum && new Date(f.datum).getFullYear() === currentYear);
 
@@ -99,14 +93,13 @@ export default function FinanzenClientWrapper({ finances, wohnungen }: FinanzenC
   const totalIncome = monthlyEntries.reduce((sum, item) => sum + item.income, 0);
   const totalExpenses = monthlyEntries.reduce((sum, item) => sum + item.expenses, 0);
 
-  // Improved average calculation - only consider months that have passed
   const now = new Date();
-  const currentMonthIndex = now.getMonth(); // 0-based (0 = January)
+  const currentMonthIndex = now.getMonth();
   const monthsPassed = currentMonthIndex + 1;
 
   const totalsForPassedMonths = Object.entries(monthlyData).reduce(
     (acc, [monthKey, data]) => {
-      const monthIndex = Number(monthKey); // monthKey is already 0-based from getMonth()
+      const monthIndex = Number(monthKey);
       if (monthIndex <= currentMonthIndex) {
         acc.income += data.income;
         acc.expenses += data.expenses;
@@ -122,8 +115,6 @@ export default function FinanzenClientWrapper({ finances, wohnungen }: FinanzenC
   const averageMonthlyCashflow = averageMonthlyIncome - averageMonthlyExpenses;
   const yearlyProjection = averageMonthlyCashflow * 12;
 
-  // handleOpenChange, handleChange, handleDateChange, and original handleSubmit are removed.
-  // The old handleEdit is also removed. A new one will be added in the next step for the global modal.
   const handleEdit = useCallback((finance: Finanz) => {
     useModalStore.getState().openFinanceModal(finance, wohnungen, handleSuccess);
   }, [wohnungen, handleSuccess]);
@@ -131,16 +122,23 @@ export default function FinanzenClientWrapper({ finances, wohnungen }: FinanzenC
   const handleAddTransaction = () => {
     useModalStore.getState().openFinanceModal(undefined, wohnungen, handleSuccess);
   };
-  
-  // Function to refresh finance data, can be called by FinanceTransactions or after modal operations
+
   const refreshFinances = async () => {
-    // This logic was part of the old handleSubmit, adapt if still needed for table refresh
-    // For now, router.refresh() in the modal should handle revalidation.
-    // If specific client-side state update is needed without full page reload, this can be expanded.
-    const dataRes = await fetch('/api/finanzen'); // Or call a server action that just fetches
-    if (dataRes.ok) {
-      const newData = await dataRes.json();
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/finanzen?page=1&pageSize=25');
+      if (!response.ok) {
+        throw new Error('Failed to refresh transactions');
+      }
+      const newData = await response.json();
       setFinData(newData);
+      setPage(1);
+      setHasMore(newData.length > 0);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -152,17 +150,13 @@ export default function FinanzenClientWrapper({ finances, wohnungen }: FinanzenC
           <h1 className="text-3xl font-bold tracking-tight">Finanzen</h1>
           <p className="text-muted-foreground">Verwalten Sie Ihre Einnahmen und Ausgaben</p>
         </div>
-        {/* Button to add a new transaction - now uses the global modal store */}
         <Button onClick={handleAddTransaction} className="sm:w-auto">
           <PlusCircle className="mr-2 h-4 w-4" />
           Transaktion hinzufügen
         </Button>
-        {/* The local Dialog for add/edit is removed */}
       </div>
 
-      {/* Summary Cards (keep) */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        {/* Cards remain the same */}
         <Card className="overflow-hidden rounded-xl border-none shadow-md">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Ø Monatliche Einnahmen</CardTitle>
@@ -206,12 +200,16 @@ export default function FinanzenClientWrapper({ finances, wohnungen }: FinanzenC
       </div>
 
       <FinanceVisualization finances={finData} />
-      <FinanceTransactions 
-        finances={finData} 
-        onEdit={handleEdit} 
+      <FinanceTransactions
+        finances={finData}
+        onEdit={handleEdit}
         onAdd={handleAddFinance}
-        loadFinances={refreshFinances} 
+        loadFinances={loadMoreTransactions}
         reloadRef={reloadRef}
+        hasMore={hasMore}
+        isLoading={isLoading}
+        error={error}
+        fullReload={refreshFinances}
       />
     </div>
   );

--- a/app/(dashboard)/finanzen/page.tsx
+++ b/app/(dashboard)/finanzen/page.tsx
@@ -10,7 +10,7 @@ export default async function FinanzenPage() {
   const { data: wohnungenData } = await supabase.from('Wohnungen').select('id,name');
   const wohnungen = wohnungenData ?? [];
   // Finanzen laden
-  const { data: finanzenData } = await supabase.from('Finanzen').select('*, Wohnungen(name)');
+  const { data: finanzenData } = await supabase.from('Finanzen').select('*, Wohnungen(name)').order('datum', { ascending: false }).range(0, 24);
   const finances = finanzenData ?? [];
 
   return <FinanzenClientWrapper finances={finances} wohnungen={wohnungen} />;

--- a/app/api/finanzen/route.ts
+++ b/app/api/finanzen/route.ts
@@ -2,13 +2,21 @@ export const runtime = 'edge';
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
+    const { searchParams } = new URL(request.url);
+    const page = parseInt(searchParams.get('page') ?? '1', 10);
+    const pageSize = parseInt(searchParams.get('pageSize') ?? '25', 10);
+
+    const from = (page - 1) * pageSize;
+    const to = from + pageSize - 1;
+
     const supabase = await createClient();
     const { data, error } = await supabase
       .from('Finanzen')
       .select('*, Wohnungen(name)')
-      .order('datum', { ascending: false });
+      .order('datum', { ascending: false })
+      .range(from, to);
       
     if (error) {
       console.error('GET /api/finanzen error:', error);

--- a/components/finance-transactions.tsx
+++ b/components/finance-transactions.tsx
@@ -1,10 +1,10 @@
 "use client"
 
-import { useState, useEffect, useRef, useMemo } from "react"
+import { useState, useEffect, useRef, useMemo, useCallback } from "react"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
-import { Search, Download, Edit, Trash, ChevronsUpDown, ArrowUp, ArrowDown } from "lucide-react"
+import { Search, Download, Edit, Trash, ChevronsUpDown, ArrowUp, ArrowDown, Loader2 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
@@ -12,7 +12,6 @@ import { FinanceContextMenu } from "@/components/finance-context-menu"
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog"
 import { toast } from "@/hooks/use-toast"
 
-// Interface for finance transactions
 interface Finanz {
   id: string
   wohnung_id?: string
@@ -24,7 +23,6 @@ interface Finanz {
   Wohnungen?: { name: string }
 }
 
-// Define sortable fields for finance table
 type FinanceSortKey = "name" | "wohnung" | "datum" | "betrag" | "typ"
 type SortDirection = "asc" | "desc"
 
@@ -33,10 +31,13 @@ interface FinanceTransactionsProps {
   reloadRef?: any
   onEdit?: (finance: Finanz) => void
   onAdd?: (finance: Finanz) => void
-  loadFinances?: () => Promise<void>
+  loadFinances?: () => void
+  hasMore: boolean
+  isLoading: boolean
+  error: string | null
+  fullReload?: () => Promise<void>
 }
 
-// Helper function to format date in DD.MM.YYYY format
 const formatDate = (dateString: string | undefined): string => {
   if (!dateString) return '-'
   const date = new Date(dateString)
@@ -47,24 +48,43 @@ const formatDate = (dateString: string | undefined): string => {
   })
 }
 
-export function FinanceTransactions({ finances, reloadRef, onEdit, onAdd, loadFinances }: FinanceTransactionsProps) {
+export function FinanceTransactions({
+  finances,
+  reloadRef,
+  onEdit,
+  onAdd,
+  loadFinances,
+  hasMore,
+  isLoading,
+  error,
+  fullReload,
+}: FinanceTransactionsProps) {
   const [searchQuery, setSearchQuery] = useState("")
   const [selectedApartment, setSelectedApartment] = useState("Alle Wohnungen")
   const [selectedYear, setSelectedYear] = useState("Alle Jahre")
   const [selectedType, setSelectedType] = useState("Alle Transaktionen")
-  const [filteredData, setFilteredData] = useState<Finanz[]>([])
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [financeToDelete, setFinanceToDelete] = useState<Finanz | null>(null)
   const [isDeleting, setIsDeleting] = useState(false)
   const [sortKey, setSortKey] = useState<FinanceSortKey>("datum")
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc")
 
-  // Get unique apartment list from finances data
+  const observer = useRef<IntersectionObserver | null>(null)
+  const lastTransactionElementRef = useCallback((node: HTMLTableRowElement) => {
+    if (isLoading) return
+    if (observer.current) observer.current.disconnect()
+    observer.current = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting && hasMore) {
+        loadFinances && loadFinances()
+      }
+    })
+    if (node) observer.current.observe(node)
+  }, [isLoading, hasMore, loadFinances])
+
   const apartments = ["Alle Wohnungen", ...new Set(finances
     .filter(f => f.Wohnungen?.name)
     .map(f => f.Wohnungen?.name || ""))]
 
-  // Get unique years from finances data
   const years = ["Alle Jahre", ...new Set(finances
     .filter(f => f.datum)
     .map(f => f.datum!.split("-")[0])
@@ -73,12 +93,10 @@ export function FinanceTransactions({ finances, reloadRef, onEdit, onAdd, loadFi
   const sortedAndFilteredData = useMemo(() => {
     let result = [...finances]
 
-    // Filter by wohnung
     if (selectedApartment !== "Alle Wohnungen") {
       result = result.filter(f => f.Wohnungen?.name === selectedApartment)
     }
 
-    // Filter by year
     if (selectedYear !== "Alle Jahre") {
       result = result.filter(f => {
         if (!f.datum) return false
@@ -86,16 +104,14 @@ export function FinanceTransactions({ finances, reloadRef, onEdit, onAdd, loadFi
       })
     }
 
-    // Filter by transaction type
     if (selectedType !== "Alle Transaktionen") {
       const isEinnahme = selectedType === "Einnahme"
       result = result.filter(f => f.ist_einnahmen === isEinnahme)
     }
 
-    // Filter by search query
     if (searchQuery) {
       const query = searchQuery.toLowerCase()
-      result = result.filter(f => 
+      result = result.filter(f =>
         f.name.toLowerCase().includes(query) ||
         (f.Wohnungen?.name || "").toLowerCase().includes(query) ||
         (f.datum || "").includes(query) ||
@@ -103,51 +119,27 @@ export function FinanceTransactions({ finances, reloadRef, onEdit, onAdd, loadFi
       )
     }
 
-    // Apply sorting
     if (sortKey) {
       result.sort((a, b) => {
         let valA, valB
-
         switch (sortKey) {
-          case 'name':
-            valA = a.name || ''
-            valB = b.name || ''
-            break
-          case 'wohnung':
-            valA = a.Wohnungen?.name || ''
-            valB = b.Wohnungen?.name || ''
-            break
-          case 'datum':
-            valA = a.datum ? new Date(a.datum).getTime() : 0
-            valB = b.datum ? new Date(b.datum).getTime() : 0
-            break
-          case 'betrag':
-            valA = a.betrag || 0
-            valB = b.betrag || 0
-            break
-          case 'typ':
-            valA = a.ist_einnahmen ? 1 : 0
-            valB = b.ist_einnahmen ? 1 : 0
-            break
-          default:
-            valA = ''
-            valB = ''
+          case 'name': valA = a.name || ''; valB = b.name || ''; break
+          case 'wohnung': valA = a.Wohnungen?.name || ''; valB = b.Wohnungen?.name || ''; break
+          case 'datum': valA = a.datum ? new Date(a.datum).getTime() : 0; valB = b.datum ? new Date(b.datum).getTime() : 0; break
+          case 'betrag': valA = a.betrag || 0; valB = b.betrag || 0; break
+          case 'typ': valA = a.ist_einnahmen ? 1 : 0; valB = b.ist_einnahmen ? 1 : 0; break
+          default: valA = ''; valB = ''
         }
-
-        // Handle numeric comparisons
         if (typeof valA === 'number' && typeof valB === 'number') {
           if (valA < valB) return sortDirection === "asc" ? -1 : 1
           if (valA > valB) return sortDirection === "asc" ? 1 : -1
           return 0
         }
-
-        // Handle string comparisons
         const strA = String(valA)
         const strB = String(valB)
         return sortDirection === "asc" ? strA.localeCompare(strB) : strB.localeCompare(strA)
       })
     }
-
     return result
   }, [finances, searchQuery, selectedApartment, selectedYear, selectedType, sortKey, sortDirection])
 
@@ -164,43 +156,26 @@ export function FinanceTransactions({ finances, reloadRef, onEdit, onAdd, loadFi
     if (sortKey !== key) {
       return <ChevronsUpDown className="h-4 w-4 text-muted-foreground" />
     }
-    return sortDirection === "asc" ? (
-      <ArrowUp className="h-4 w-4" />
-    ) : (
-      <ArrowDown className="h-4 w-4" />
-    )
+    return sortDirection === "asc" ? <ArrowUp className="h-4 w-4" /> : <ArrowDown className="h-4 w-4" />
   }
 
   const TableHeaderCell = ({ sortKey, children, className }: { sortKey: FinanceSortKey, children: React.ReactNode, className?: string }) => (
     <TableHead className={className}>
-      <div
-        onClick={() => handleSort(sortKey)}
-        className="flex items-center gap-2 cursor-pointer rounded-md p-2 transition-colors hover:bg-muted/50 -ml-2"
-      >
+      <div onClick={() => handleSort(sortKey)} className="flex items-center gap-2 cursor-pointer rounded-md p-2 transition-colors hover:bg-muted/50 -ml-2">
         {children}
         {renderSortIcon(sortKey)}
       </div>
     </TableHead>
   )
 
-
-  // Calculate totals for filtered data
   const totalBalance = sortedAndFilteredData.reduce((total, transaction) => {
     const amount = Number(transaction.betrag)
     return transaction.ist_einnahmen ? total + amount : total - amount
   }, 0)
 
-  // Add CSV export function
   const handleExportCsv = () => {
-    const header = ['Bezeichnung','Wohnung','Datum','Betrag','Typ','Notiz'];
-    const rows = sortedAndFilteredData.map(f => [
-      f.name,
-      f.Wohnungen?.name||'',
-      f.datum||'',
-      f.betrag.toString(),
-      f.ist_einnahmen ? 'Einnahme' : 'Ausgabe',
-      f.notiz||''
-    ]);
+    const header = ['Bezeichnung', 'Wohnung', 'Datum', 'Betrag', 'Typ', 'Notiz'];
+    const rows = sortedAndFilteredData.map(f => [f.name, f.Wohnungen?.name || '', f.datum || '', f.betrag.toString(), f.ist_einnahmen ? 'Einnahme' : 'Ausgabe', f.notiz || '']);
     const csv = [header, ...rows].map(r => r.join(';')).join('\n');
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
@@ -212,7 +187,6 @@ export function FinanceTransactions({ finances, reloadRef, onEdit, onAdd, loadFi
     document.body.removeChild(a);
   };
 
-  // Delete finance
   const handleDeleteConfirm = async () => {
     if (!financeToDelete) return
     setIsDeleting(true)
@@ -220,8 +194,7 @@ export function FinanceTransactions({ finances, reloadRef, onEdit, onAdd, loadFi
       const res = await fetch(`/api/finanzen?id=${financeToDelete.id}`, { method: 'DELETE' })
       if (res.ok) {
         toast({ title: 'Gelöscht', description: 'Transaktion wurde entfernt.' })
-        loadFinances && loadFinances()
-        reloadRef?.current && reloadRef.current()
+        fullReload && fullReload()
       } else {
         const err = await res.json()
         toast({ title: 'Fehler', description: err.error || 'Löschen fehlgeschlagen', variant: 'destructive' })
@@ -247,67 +220,34 @@ export function FinanceTransactions({ finances, reloadRef, onEdit, onAdd, loadFi
             <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 w-full">
                 <Select value={selectedApartment} onValueChange={setSelectedApartment}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Wohnung auswählen" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {apartments.map((apartment) => (
-                      <SelectItem key={apartment} value={apartment}>
-                        {apartment}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
+                  <SelectTrigger><SelectValue placeholder="Wohnung auswählen" /></SelectTrigger>
+                  <SelectContent>{apartments.map((apartment) => <SelectItem key={apartment} value={apartment}>{apartment}</SelectItem>)}</SelectContent>
                 </Select>
-
                 <Select value={selectedYear} onValueChange={setSelectedYear}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Jahr auswählen" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {years.map((year) => (
-                      <SelectItem key={year} value={year}>
-                        {year}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
+                  <SelectTrigger><SelectValue placeholder="Jahr auswählen" /></SelectTrigger>
+                  <SelectContent>{years.map((year) => <SelectItem key={year} value={year}>{year}</SelectItem>)}</SelectContent>
                 </Select>
-
                 <Select value={selectedType} onValueChange={setSelectedType}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Transaktionstyp auswählen" />
-                  </SelectTrigger>
+                  <SelectTrigger><SelectValue placeholder="Transaktionstyp auswählen" /></SelectTrigger>
                   <SelectContent>
                     <SelectItem value="Alle Transaktionen">Alle Transaktionen</SelectItem>
                     <SelectItem value="Einnahme">Einnahme</SelectItem>
                     <SelectItem value="Ausgabe">Ausgabe</SelectItem>
                   </SelectContent>
                 </Select>
-
                 <div className="relative col-span-1 sm:col-span-2">
                   <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-                  <Input
-                    type="search"
-                    placeholder="Transaktion suchen..."
-                    className="pl-8"
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
-                  />
+                  <Input type="search" placeholder="Transaktion suchen..." className="pl-8" value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)} />
                 </div>
               </div>
-
               <div className="flex items-center gap-2 mt-4 md:mt-0">
-                <Button variant="outline" size="sm" onClick={handleExportCsv}>
-                  <Download className="mr-2 h-4 w-4" />
-                  Als CSV exportieren
-                </Button>
+                <Button variant="outline" size="sm" onClick={handleExportCsv}><Download className="mr-2 h-4 w-4" />Als CSV exportieren</Button>
               </div>
             </div>
-
             <div className="text-right">
               <div className="text-sm text-muted-foreground">Saldo</div>
               <div className="text-xl font-bold">{totalBalance.toFixed(2).replace(".", ",")} €</div>
             </div>
-
             <div className="rounded-md border">
               <Table>
                 <TableHeader>
@@ -320,80 +260,51 @@ export function FinanceTransactions({ finances, reloadRef, onEdit, onAdd, loadFi
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {sortedAndFilteredData.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={5} className="h-24 text-center">
-                        Keine Transaktionen gefunden.
-                      </TableCell>
-                    </TableRow>
+                  {sortedAndFilteredData.length === 0 && !isLoading ? (
+                    <TableRow><TableCell colSpan={5} className="h-24 text-center">Keine Transaktionen gefunden.</TableCell></TableRow>
                   ) : (
-                    sortedAndFilteredData.map((finance) => (
-                      <FinanceContextMenu
-                        key={finance.id}
-                        finance={finance}
-                        onEdit={() => onEdit && onEdit(finance)}
-                        onStatusToggle={async () => {
-                          try {
-                            const response = await fetch(`/api/finanzen/${finance.id}`, {
-                              method: "PATCH",
-                              headers: {
-                                "Content-Type": "application/json",
-                              },
-                              body: JSON.stringify({ 
-                                ist_einnahmen: !finance.ist_einnahmen 
-                              }),
-                            })
-                            
-                            if (!response.ok) {
-                              throw new Error("Fehler beim Umschalten des Status")
+                    sortedAndFilteredData.map((finance, index) => {
+                      const isLastElement = sortedAndFilteredData.length === index + 1;
+                      return (
+                        <FinanceContextMenu
+                          key={finance.id}
+                          finance={finance}
+                          onEdit={() => onEdit && onEdit(finance)}
+                          onStatusToggle={async () => {
+                            try {
+                              const response = await fetch(`/api/finanzen/${finance.id}`, {
+                                method: "PATCH", headers: { "Content-Type": "application/json" },
+                                body: JSON.stringify({ ist_einnahmen: !finance.ist_einnahmen }),
+                              })
+                              if (!response.ok) throw new Error("Fehler beim Umschalten des Status")
+                              toast({ title: "Status geändert", description: `Die Transaktion wurde als ${!finance.ist_einnahmen ? "Einnahme" : "Ausgabe"} markiert.` })
+                              fullReload && fullReload()
+                            } catch (error) {
+                              console.error("Fehler beim Umschalten des Status:", error)
+                              toast({ title: "Fehler", description: "Der Status konnte nicht geändert werden.", variant: "destructive" })
                             }
-                            
-                            toast({
-                              title: "Status geändert",
-                              description: `Die Transaktion wurde als ${!finance.ist_einnahmen ? "Einnahme" : "Ausgabe"} markiert.`,
-                            })
-                            
-                            // Aktualisieren der Daten
-                            loadFinances && loadFinances()
-                            reloadRef?.current && reloadRef.current()
-                          } catch (error) {
-                            console.error("Fehler beim Umschalten des Status:", error)
-                            toast({
-                              title: "Fehler",
-                              description: "Der Status konnte nicht geändert werden.",
-                              variant: "destructive",
-                            })
-                          }
-                        }}
-                        onRefresh={() => {
-                          loadFinances && loadFinances()
-                          reloadRef?.current && reloadRef.current()
-                        }}
-                      >
-                        <TableRow className="hover:bg-muted/50 cursor-pointer" onClick={() => onEdit && onEdit(finance)}>
-                          <TableCell>{finance.name}</TableCell>
-                          <TableCell>{finance.Wohnungen?.name || '-'}</TableCell>
-                          <TableCell>{formatDate(finance.datum)}</TableCell>
-                          <TableCell>
-                            <span className={finance.ist_einnahmen ? "text-green-600" : "text-red-600"}>
-                              {finance.betrag.toFixed(2).replace(".", ",")} €
-                            </span>
-                          </TableCell>
-                          <TableCell>
-                            <Badge
-                              variant="outline"
-                              className={
-                                finance.ist_einnahmen
-                                  ? "bg-green-50 text-green-700"
-                                  : "bg-red-50 text-red-700"
-                              }
-                            >
-                              {finance.ist_einnahmen ? "Einnahme" : "Ausgabe"}
-                            </Badge>
-                          </TableCell>
-                        </TableRow>
-                      </FinanceContextMenu>
-                    ))
+                          }}
+                          onRefresh={() => fullReload && fullReload()}
+                        >
+                          <TableRow ref={isLastElement ? lastTransactionElementRef : null} className="hover:bg-muted/50 cursor-pointer" onClick={() => onEdit && onEdit(finance)}>
+                            <TableCell>{finance.name}</TableCell>
+                            <TableCell>{finance.Wohnungen?.name || '-'}</TableCell>
+                            <TableCell>{formatDate(finance.datum)}</TableCell>
+                            <TableCell><span className={finance.ist_einnahmen ? "text-green-600" : "text-red-600"}>{finance.betrag.toFixed(2).replace(".", ",")} €</span></TableCell>
+                            <TableCell><Badge variant="outline" className={finance.ist_einnahmen ? "bg-green-50 text-green-700" : "bg-red-50 text-red-700"}>{finance.ist_einnahmen ? "Einnahme" : "Ausgabe"}</Badge></TableCell>
+                          </TableRow>
+                        </FinanceContextMenu>
+                      )
+                    })
+                  )}
+                  {isLoading && (
+                    <TableRow><TableCell colSpan={5} className="text-center"><Loader2 className="h-6 w-6 animate-spin mx-auto" /></TableCell></TableRow>
+                  )}
+                  {!isLoading && !hasMore && (
+                    <TableRow><TableCell colSpan={5} className="text-center text-muted-foreground">No more transactions</TableCell></TableRow>
+                  )}
+                  {error && (
+                    <TableRow><TableCell colSpan={5} className="text-center text-red-500">{error}<Button onClick={loadFinances} variant="link">Retry</Button></TableCell></TableRow>
                   )}
                 </TableBody>
               </Table>
@@ -402,7 +313,6 @@ export function FinanceTransactions({ finances, reloadRef, onEdit, onAdd, loadFi
         </CardContent>
       </Card>
 
-      {/* Delete Confirmation */}
       <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
         <AlertDialogContent>
           <AlertDialogHeader>


### PR DESCRIPTION
This feature implements infinite scroll functionality for the finance transactions table.

- The API now supports pagination with `page` and `pageSize` parameters.
- The finance page initially loads 25 transactions.
- As you scroll down, more transactions are fetched automatically.
- A loading indicator is shown while fetching more transactions.
- A message is displayed when there are no more transactions to load.
- Error handling with a retry option is included.

fix #418 