### PR TITLE
I have removed Vercel Analytics and Speed Insights.

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,10 +5,6 @@ import "./globals.css"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Toaster } from "@/components/ui/toaster"
 import { PostHogProvider } from "./providers"
-// Vercel Analytics: visitor/page view tracking. To remove, delete the import and usage below.
-import { Analytics } from "@vercel/analytics/react"
-// Vercel SpeedInsights: performance metrics collection. To remove, delete the import and usage below.
-import { SpeedInsights } from "@vercel/speed-insights/next"
 import { CookieConsentBanner } from "@/components/cookie-consent-banner"
 
 const inter = Inter({ subsets: ["latin"] })
@@ -36,10 +32,6 @@ export default function RootLayout({
             {children}
             <Toaster />
             <CookieConsentBanner />
-            {/* Vercel Analytics: visitor/page view tracking. Remove to disable. */}
-            <Analytics />
-            {/* Vercel SpeedInsights: performance metrics collection. Remove to disable. */}
-            <SpeedInsights />
           </PostHogProvider>
         </ThemeProvider>
       </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,8 +41,6 @@
         "@stripe/stripe-js": "^7.3.1",
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "latest",
-        "@vercel/analytics": "^1.5.0",
-        "@vercel/speed-insights": "^1.2.0",
         "autoprefixer": "^10.4.20",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -5146,79 +5144,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@vercel/analytics": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
-      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
-      "license": "MPL-2.0",
-      "peerDependencies": {
-        "@remix-run/react": "^2",
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/react": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vercel/speed-insights": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.2.0.tgz",
-      "integrity": "sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
-      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,6 @@
     "@stripe/stripe-js": "^7.3.1",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "latest",
-    "@vercel/analytics": "^1.5.0",
-    "@vercel/speed-insights": "^1.2.0",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Description

Removes Vercel Analytics and Speed Insights from the app.

## Summary of Changes

- `<Analytics />` and `<SpeedInsights />` components and their imports dropped from the root layout (PostHog remains the analytics provider)
- `@vercel/analytics` and `@vercel/speed-insights` dependencies removed