### PR TITLE
feat: replace IV and house icon with mascot image

### DIFF
--- a/app/modern/components/finance-showcase.tsx
+++ b/app/modern/components/finance-showcase.tsx
@@ -37,7 +37,7 @@ const financeTabsData: FinanceTab[] = [
     id: 'dashboard',
     title: 'Dashboard-Karten',
     description: 'Vier zentrale Kennzahlen-Karten mit intelligenter Berechnung: Durchschnittswerte nur aus vergangenen Monaten, Cashflow-Analyse und präzise Jahresprognosen',
-    image: '/product-images/finance-page.png',
+    image: '/mascot/normal.png',
     imageAlt: 'Finance Dashboard Screenshot showing summary cards and key metrics',
     features: [
       'Ø Monatliche Einnahmen (nur bereits vergangene Monate)',
@@ -50,7 +50,7 @@ const financeTabsData: FinanceTab[] = [
     id: 'charts',
     title: 'Interaktive Diagramme',
     description: 'Vier verschiedene Diagrammtypen mit Jahresfilter: Einnahmen nach Wohnung, monatliche Trends, Einnahmen-Ausgaben-Vergleich und Ausgabenkategorien',
-    image: '/product-images/finance-page.png',
+    image: '/mascot/normal.png',
     imageAlt: 'Finance Charts showing income and expense trends with interactive analytics',
     features: [
       'Pie-Chart: Einnahmenverteilung nach Wohnungen',
@@ -63,7 +63,7 @@ const financeTabsData: FinanceTab[] = [
     id: 'transactions',
     title: 'Transaktionsverwaltung',
     description: 'Vollständige CRUD-Transaktionsverwaltung mit mehrstufigen Filtern, Volltext-Suche, Rechtsklick-Kontextmenü und Echtzeit-Saldo-Berechnung',
-    image: '/product-images/finance-page.png',
+    image: '/mascot/normal.png',
     imageAlt: 'Transaction management table with filtering and search capabilities',
     features: [
       'Mehrstufige Filter: Wohnung, Jahr, Transaktionstyp kombinierbar',
@@ -76,7 +76,7 @@ const financeTabsData: FinanceTab[] = [
     id: 'reporting',
     title: 'Exportfunktionalität',
     description: 'Professionelle CSV-Export-Funktionen für Steuerberater, vollständiges Transaktionsformular mit Wohnungszuordnung und intelligente Validierung',
-    image: '/product-images/finance-page.png',
+    image: '/mascot/normal.png',
     imageAlt: 'Financial reporting interface with export options',
     features: [
       'CSV-Export mit deutschen Trennzeichen für Excel-Kompatibilität',

--- a/components/dashboard-sidebar.tsx
+++ b/components/dashboard-sidebar.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useEffect } from "react"
 import Link from "next/link"
+import Image from "next/image"
 import { usePathname } from "next/navigation"
-import { BarChart3, Building2, Home, Users, Wallet, FileSpreadsheet, CheckSquare, Menu, X, CreditCard } from "lucide-react"
+import { BarChart3, Building2, Users, Wallet, FileSpreadsheet, CheckSquare, Menu, X, CreditCard } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -12,6 +13,9 @@ import { UserSettings } from "@/components/user-settings"
 import { createClient } from "@/utils/supabase/client"
 
 // Stelle sicher, dass der Mieter-Link korrekt ist
+const MascotIcon = ({ className }: { className: string }) => (
+  <Image src="/mascot/normal.png" alt="Mascot" width={16} height={16} className={className} />
+);
 const sidebarNavItems = [
   {
     title: "Dashboard",
@@ -26,7 +30,7 @@ const sidebarNavItems = [
   {
     title: "Wohnungen",
     href: "/wohnungen",
-    icon: Home,
+    icon: MascotIcon,
   },
   {
     title: "Mieter",


### PR DESCRIPTION
## Description

Uses the mascot image in the finance showcase and as the Wohnungen sidebar icon.

## Summary of Changes

- All four finance-showcase tabs point to `/mascot/normal.png` instead of the finance screenshot
- Sidebar: small `MascotIcon` component replaces the Home icon for the Wohnungen nav item