### PR TITLE
refactor: enforce number type for betrag field in financial data

### DIFF
--- a/app/(dashboard)/finanzen/client-wrapper.tsx
+++ b/app/(dashboard)/finanzen/client-wrapper.tsx
@@ -8,6 +8,7 @@ import { FinanceVisualization } from "@/components/finance-visualization";
 import { FinanceTransactions } from "@/components/finance-transactions";
 import { SummaryCardSkeleton } from "@/components/summary-card-skeleton";
 import { SummaryCard } from "@/components/summary-card";
+import { PAGINATION } from "@/constants";
 import { useModalStore } from "@/hooks/use-modal-store";
 import { useDebounce } from "@/hooks/use-debounce";
 
@@ -88,7 +89,7 @@ export default function FinanzenClientWrapper({ finances: initialFinances, wohnu
     try {
       const params = new URLSearchParams({
         page: targetPage.toString(),
-        pageSize: '25',
+        pageSize: PAGINATION.DEFAULT_PAGE_SIZE.toString(),
         searchQuery: debouncedSearchQuery,
         selectedApartment: filters.selectedApartment,
         selectedYear: filters.selectedYear,

--- a/app/(dashboard)/finanzen/client-wrapper.tsx
+++ b/app/(dashboard)/finanzen/client-wrapper.tsx
@@ -279,7 +279,12 @@ export default function FinanzenClientWrapper({ finances: initialFinances, wohnu
         )}
       </div>
 
-      <FinanceVisualization finances={finData} summaryData={summaryData} key={summaryData?.year} />
+      <FinanceVisualization 
+        finances={finData} 
+        summaryData={summaryData} 
+        availableYears={availableYears}
+        key={summaryData?.year} 
+      />
       <FinanceTransactions
         finances={finData}
         wohnungen={wohnungen}

--- a/app/(dashboard)/finanzen/page.tsx
+++ b/app/(dashboard)/finanzen/page.tsx
@@ -51,7 +51,7 @@ export default async function FinanzenPage() {
     .from('Finanzen')
     .select('*, Wohnungen(name)')
     .order('datum', { ascending: false })
-    .range(0, PAGINATION.INITIAL_ITEMS - 1);
+    .range(0, PAGINATION.DEFAULT_PAGE_SIZE - 1);
   const finances = finanzenData ?? [];
 
   // Summary-Daten für das aktuelle Jahr laden

--- a/app/(dashboard)/finanzen/page.tsx
+++ b/app/(dashboard)/finanzen/page.tsx
@@ -4,6 +4,8 @@ export const dynamic = 'force-dynamic';
 import FinanzenClientWrapper from "./client-wrapper";
 import { createClient } from "@/utils/supabase/server";
 
+import { calculateFinancialSummary } from "@/utils/financeCalculations";
+
 async function getSummaryData(year: number) {
   const supabase = await createClient();
   
@@ -24,69 +26,16 @@ async function getSummaryData(year: number) {
     return null;
   }
 
-  // Calculate summary statistics
-  const currentDate = new Date();
-  const currentYear = currentDate.getFullYear();
-  const currentMonth = currentDate.getMonth(); // 0-based
-  
-  // Group data by month
-  const monthlyData: Record<number, { income: number; expenses: number }> = {};
-  
-  (data || []).forEach(item => {
-    if (!item.datum) return;
-    
-    const itemDate = new Date(item.datum);
-    const month = itemDate.getMonth();
-    
-    if (!monthlyData[month]) {
-      monthlyData[month] = { income: 0, expenses: 0 };
-    }
-    
-    const amount = Number(item.betrag);
-    if (item.ist_einnahmen) {
-      monthlyData[month].income += amount;
-    } else {
-      monthlyData[month].expenses += amount;
-    }
-  });
+  // Map the data to match the Finanzen type expected by calculateFinancialSummary
+  const transactions = (data || []).map(item => ({
+    id: item.id,
+    betrag: item.betrag,
+    ist_einnahmen: item.ist_einnahmen,
+    datum: item.datum
+  }));
 
-  // Calculate totals and averages
-  const monthsPassed = year === currentYear ? currentMonth + 1 : 12;
-  
-  let totalIncome = 0;
-  let totalExpenses = 0;
-  let incomeForPassedMonths = 0;
-  let expensesForPassedMonths = 0;
-
-  Object.entries(monthlyData).forEach(([monthKey, data]) => {
-    const monthIndex = Number(monthKey);
-    totalIncome += data.income;
-    totalExpenses += data.expenses;
-    
-    // Only count months that have passed for average calculation
-    if (year < currentYear || (year === currentYear && monthIndex <= currentMonth)) {
-      incomeForPassedMonths += data.income;
-      expensesForPassedMonths += data.expenses;
-    }
-  });
-
-  const averageMonthlyIncome = monthsPassed > 0 ? incomeForPassedMonths / monthsPassed : 0;
-  const averageMonthlyExpenses = monthsPassed > 0 ? expensesForPassedMonths / monthsPassed : 0;
-  const averageMonthlyCashflow = averageMonthlyIncome - averageMonthlyExpenses;
-  const yearlyProjection = averageMonthlyCashflow * 12;
-
-  return {
-    year,
-    totalIncome,
-    totalExpenses,
-    totalCashflow: totalIncome - totalExpenses,
-    averageMonthlyIncome,
-    averageMonthlyExpenses,
-    averageMonthlyCashflow,
-    yearlyProjection,
-    monthsPassed,
-    monthlyData
-  };
+  // Use the shared utility function to calculate the summary
+  return calculateFinancialSummary(transactions, year, new Date());
 }
 
 export default async function FinanzenPage() {

--- a/app/(dashboard)/finanzen/page.tsx
+++ b/app/(dashboard)/finanzen/page.tsx
@@ -5,6 +5,7 @@ import FinanzenClientWrapper from "./client-wrapper";
 import { createClient } from "@/utils/supabase/server";
 
 import { calculateFinancialSummary } from "@/utils/financeCalculations";
+import { PAGINATION } from "@/constants";
 
 async function getSummaryData(year: number) {
   const supabase = await createClient();
@@ -45,12 +46,12 @@ export default async function FinanzenPage() {
   const { data: wohnungenData } = await supabase.from('Wohnungen').select('id,name');
   const wohnungen = wohnungenData ?? [];
   
-  // Initial Finanzen laden (nur erste 25 für die Transaktionsliste)
+  // Initial Finanzen laden (nur die erste Seite für die Transaktionsliste)
   const { data: finanzenData } = await supabase
     .from('Finanzen')
     .select('*, Wohnungen(name)')
     .order('datum', { ascending: false })
-    .range(0, 24);
+    .range(0, PAGINATION.INITIAL_ITEMS - 1);
   const finances = finanzenData ?? [];
 
   // Summary-Daten für das aktuelle Jahr laden

--- a/app/api/finanzen/route.ts
+++ b/app/api/finanzen/route.ts
@@ -1,12 +1,13 @@
 export const runtime = 'edge';
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
+import { PAGINATION } from "@/constants";
 
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
     const page = parseInt(searchParams.get('page') ?? '1', 10);
-    const pageSize = parseInt(searchParams.get('pageSize') ?? '25', 10);
+    const pageSize = parseInt(searchParams.get('pageSize') ?? PAGINATION.DEFAULT_PAGE_SIZE.toString(), 10);
     const searchQuery = searchParams.get('searchQuery') || '';
     const selectedApartment = searchParams.get('selectedApartment') || '';
     const selectedYear = searchParams.get('selectedYear') || '';

--- a/app/api/finanzen/route.ts
+++ b/app/api/finanzen/route.ts
@@ -58,8 +58,8 @@ export async function GET(request: Request) {
         query = query.order('name', { ascending });
         break;
       case 'wohnung':
-        // For apartment sorting, we need to join and sort by apartment name
-        query = query.order('wohnung_id', { ascending });
+        // Sort by the apartment name from the related table, not by its ID
+        query = query.order('name', { foreignTable: 'Wohnungen', ascending });
         break;
       case 'betrag':
         query = query.order('betrag', { ascending });

--- a/components/finance-edit-modal.tsx
+++ b/components/finance-edit-modal.tsx
@@ -29,7 +29,7 @@ import { createClient } from "@/utils/supabase/client"; // For fetching Wohnunge
 import { useModalStore } from "@/hooks/use-modal-store"; // Import the modal store
 
 // Interfaces (can be moved to a types file if not already covered by store types)
-interface Finanz { // This should align with `financeInitialData` type from store
+interface Finanz {
   id: string;
   wohnung_id?: string | null;
   name: string;
@@ -37,6 +37,9 @@ interface Finanz { // This should align with `financeInitialData` type from stor
   betrag: number;
   ist_einnahmen: boolean;
   notiz?: string | null;
+  Wohnungen?: {
+    name: string;
+  };
 }
 
 interface Wohnung { // This should align with `financeModalWohnungen` items type from store

--- a/components/finance-visualization.tsx
+++ b/components/finance-visualization.tsx
@@ -111,6 +111,7 @@ interface ChartData {
 interface FinanceVisualizationProps {
   finances: Finanz[]
   summaryData?: SummaryData | null
+  availableYears: number[]
 }
 
 // Farben für Pie Chart
@@ -155,38 +156,12 @@ const EmptyChartState = ({ title, description }: { title: string; description: s
   </Card>
 )
 
-export function FinanceVisualization({ finances, summaryData }: FinanceVisualizationProps) {
+export function FinanceVisualization({ finances, summaryData, availableYears }: FinanceVisualizationProps) {
   const [selectedYear, setSelectedYear] = useState(() => new Date().getFullYear().toString())
   const [selectedChart, setSelectedChart] = useState("apartment-income")
   const [chartData, setChartData] = useState<ChartData | null>(null)
-  const [availableYears, setAvailableYears] = useState<number[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-
-  // Load available years on component mount
-  useEffect(() => {
-    const setFallbackYears = () => {
-      const currentYear = new Date().getFullYear();
-      setAvailableYears([currentYear, currentYear - 1, currentYear - 2, currentYear - 3]);
-    };
-
-    const loadAvailableYears = async () => {
-      try {
-        const response = await fetch('/api/finanzen/years')
-        if (response.ok) {
-          const years = await response.json()
-          setAvailableYears(years)
-        } else {
-          setFallbackYears();
-        }
-      } catch (err) {
-        console.error('Error loading available years:', err)
-        setFallbackYears();
-      }
-    }
-
-    loadAvailableYears()
-  }, [])
 
   // Load chart data for selected year
   useEffect(() => {
@@ -257,14 +232,11 @@ export function FinanceVisualization({ finances, summaryData }: FinanceVisualiza
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              {availableYears.length > 0 
-                ? availableYears.map(y => <SelectItem key={y} value={y.toString()}>{y}</SelectItem>)
-                : (() => {
-                    const currentYear = new Date().getFullYear();
-                    return [currentYear, currentYear - 1, currentYear - 2, currentYear - 3]
-                      .map(y => <SelectItem key={y} value={y.toString()}>{y}</SelectItem>);
-                  })()
-              }
+              {availableYears.map((year: number) => (
+                <SelectItem key={year} value={year.toString()}>
+                  {year}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
 

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,5 +1,5 @@
 // Application-wide constants
 export const PAGINATION = {
+  // Default number of items to display per page and for initial data loading
   DEFAULT_PAGE_SIZE: 25,
-  INITIAL_ITEMS: 25, // Used for initial data loading in page.tsx
 };

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,0 +1,5 @@
+// Application-wide constants
+export const PAGINATION = {
+  DEFAULT_PAGE_SIZE: 25,
+  INITIAL_ITEMS: 25, // Used for initial data loading in page.tsx
+};

--- a/types/finanzen.ts
+++ b/types/finanzen.ts
@@ -1,6 +1,6 @@
 export interface Finanzen {
   id: string;
-  betrag: string | number;
+  betrag: number;
   ist_einnahmen: boolean;
   datum: string;
   name?: string;


### PR DESCRIPTION
## Description

Centralizes finance constants and the summary calculation, and passes available years down instead of refetching them.

## Summary of Changes

- New `constants/index.ts` with `PAGINATION.DEFAULT_PAGE_SIZE` used by the page, the API route and the client wrapper
- Summary calculation extracted to `calculateFinancialSummary` in `utils/financeCalculations` (~60 lines of inline logic removed from the page)
- `FinanceVisualization` receives `availableYears` as a prop and no longer fetches `/api/finanzen/years` itself
- Apartment sorting on the finance API now orders by the related `Wohnungen.name` (foreignTable) instead of the raw id; `Finanzen.betrag` typed as number