### PR TITLE
Feat/update search bar

### DIFF
--- a/components/command-menu.tsx
+++ b/components/command-menu.tsx
@@ -113,9 +113,9 @@ export function CommandMenu() {
         description: 'Could not open subscription management. Please try again later.',
         variant: 'destructive',
       });
+      setOpen(false); // Close the menu only on error
     } finally {
       setIsLoadingSubscription(false);
-      setOpen(false);
     }
   };
 

--- a/components/command-menu.tsx
+++ b/components/command-menu.tsx
@@ -95,6 +95,10 @@ export function CommandMenu() {
         }),
       });
 
+      if (!response.ok) {
+        throw new Error(`Failed to create customer portal session: ${response.status} ${response.statusText}`);
+      }
+
       const { url } = await response.json();
       
       if (url) {

--- a/components/command-menu.tsx
+++ b/components/command-menu.tsx
@@ -165,13 +165,6 @@ export function CommandMenu() {
             Rechnung erstellen
           </CommandItem>
           <CommandItem
-            onSelect={handleManageSubscription}
-            disabled={isLoadingSubscription}
-          >
-            <CreditCard className="mr-2 h-4 w-4" />
-            {isLoadingSubscription ? 'Lade...' : 'Abonnement verwalten'}
-          </CommandItem>
-          <CommandItem
             disabled={isLoadingWohnungContext} // Added disabled state
             onSelect={async () => {
               setIsLoadingWohnungContext(true)
@@ -253,6 +246,13 @@ export function CommandMenu() {
           >
             <CheckSquare className="mr-2 h-4 w-4" />
             Aufgabe hinzufügen
+          </CommandItem>
+          <CommandItem
+            onSelect={handleManageSubscription}
+            disabled={isLoadingSubscription}
+          >
+            <CreditCard className="mr-2 h-4 w-4" />
+            {isLoadingSubscription ? 'Lade...' : 'Abonnement verwalten'}
           </CommandItem>
         </CommandGroup>
       </CommandList>

--- a/components/command-menu.tsx
+++ b/components/command-menu.tsx
@@ -24,7 +24,7 @@ import {
 const navigationItems = [
   {
     title: "Dashboard",
-    href: "/",
+    href: "/home",
     icon: BarChart3,
   },
   {

--- a/components/command-menu.tsx
+++ b/components/command-menu.tsx
@@ -10,7 +10,7 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command"
-import { BarChart3, Building2, Home, Users, Wallet, FileSpreadsheet, CheckSquare } from "lucide-react"
+import { BarChart3, Building2, Home, Users, Wallet, FileSpreadsheet, CheckSquare, LayoutDashboard } from "lucide-react"
 import { useCommandMenu } from "@/hooks/use-command-menu"
 import { useModalStore } from "@/hooks/use-modal-store"
 import { toast } from "@/hooks/use-toast" // Added
@@ -25,7 +25,7 @@ const navigationItems = [
   {
     title: "Startseite",
     href: "/",
-    icon: Home,
+    icon: LayoutDashboard,
   },
   {
     title: "Dashboard",
@@ -45,7 +45,7 @@ const navigationItems = [
   {
     title: "Wohnungen",
     href: "/wohnungen",
-    icon: Building2,
+    icon: Home,
   },
   {
     title: "Finanzen",

--- a/components/command-menu.tsx
+++ b/components/command-menu.tsx
@@ -23,6 +23,11 @@ import {
 // Stelle sicher, dass der Mieter-Link im Command-Menü korrekt ist
 const navigationItems = [
   {
+    title: "Startseite",
+    href: "/",
+    icon: Home,
+  },
+  {
     title: "Dashboard",
     href: "/home",
     icon: BarChart3,
@@ -40,7 +45,7 @@ const navigationItems = [
   {
     title: "Wohnungen",
     href: "/wohnungen",
-    icon: Home,
+    icon: Building2,
   },
   {
     title: "Finanzen",

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -26,7 +26,7 @@ Command.displayName = CommandPrimitive.displayName
 const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent className="overflow-hidden p-0 shadow-lg" hideCloseButton>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -6,7 +6,7 @@ import { Command as CommandPrimitive } from "cmdk"
 import { Search } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -27,6 +27,7 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg" hideCloseButton>
+        <DialogTitle className="sr-only">Befehlsmenü</DialogTitle>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -33,12 +33,13 @@ interface DialogContentProps
   extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
   isDirty?: boolean
   onAttemptClose?: () => void // Changed: no event argument needed
+  hideCloseButton?: boolean
 }
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   DialogContentProps
->(({ className, children, isDirty, onAttemptClose, ...props }, ref) => {
+>(({ className, children, isDirty, onAttemptClose, hideCloseButton, ...props }, ref) => {
 
   const handleInteraction = (
     event: Parameters<NonNullable<React.ComponentProps<typeof DialogPrimitive.Content>['onInteractOutside']>>[0]
@@ -77,13 +78,15 @@ const DialogContent = React.forwardRef<
         {...props}
       >
         {children}
-        <DialogPrimitive.Close
-          onClick={handleCloseButtonClick}
-          className="absolute right-4 top-4 rounded-full p-3 opacity-70 ring-offset-background transition-all hover:opacity-100 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
-        >
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
+        {!hideCloseButton && (
+          <DialogPrimitive.Close
+            onClick={handleCloseButtonClick}
+            className="absolute right-4 top-4 rounded-full p-3 opacity-70 ring-offset-background transition-all hover:opacity-100 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
+          >
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
       </DialogPrimitive.Content>
     </DialogPortal>
   )


### PR DESCRIPTION
## Description

Extends the command menu with subscription management and fixes dialog accessibility.

## Summary of Changes

- New "Abonnement verwalten" action: creates a Stripe customer-portal session and redirects, with loading state and error toast
- Navigation split into "Startseite" (/) and "Dashboard" (/home) with proper icons; German input placeholder
- `CommandDialog` hides its close button and gets a screen-reader title ("Befehlsmenü") via a new `hideCloseButton` prop on the dialog content