### PR TITLE
Feature/Dashboard overhaul: bento layout, modular charts, tenant payments, and recent transactions

### DIFF
--- a/app/(dashboard)/finanzen/page.tsx
+++ b/app/(dashboard)/finanzen/page.tsx
@@ -16,7 +16,7 @@ async function getSummaryData(year: number) {
   
   let allTransactions: any[] = [];
   let page = 0;
-  const pageSize = 1000; // Process 1000 records at a time
+  const pageSize = 5000; // Increased batch size for better performance
   let hasMore = true;
   
   try {

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Building2, Home, Users, Wallet, FileSpreadsheet, CheckSquare } from "lucide-react"
 import { DashboardCharts } from "@/components/dashboard-charts"
-import { TenantDataTable } from "@/components/tenant-data-table"
+import { TenantPaymentBento } from "@/components/tenant-payment-bento"
 import { getDashboardSummary } from "@/lib/data-fetching"
 
 export default async function Dashboard() {
@@ -94,7 +94,7 @@ export default async function Dashboard() {
 
       <DashboardCharts />
 
-      <TenantDataTable />
+      <TenantPaymentBento />
     </div>
   )
 }

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -21,7 +21,7 @@ export default async function Dashboard() {
       </div>
       <div className="grid gap-4 grid-cols-3 auto-rows-[minmax(140px,auto)] grid-flow-dense">
         <Link href="/haeuser" className="col-span-1 row-span-1">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Häuser</CardTitle>
               <Building2 className="h-4 w-4 text-muted-foreground" />
@@ -33,7 +33,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/wohnungen" className="col-span-1 row-span-1">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Wohnungen</CardTitle>
               <Home className="h-4 w-4 text-muted-foreground" />
@@ -52,7 +52,7 @@ export default async function Dashboard() {
           <OccupancyChart />
         </div>
         <Link href="/mieter" className="col-span-1 row-span-1">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Mieter</CardTitle>
               <Users className="h-4 w-4 text-muted-foreground" />
@@ -68,7 +68,7 @@ export default async function Dashboard() {
           <RevenueExpensesChart />
         </div>
         <Link href="/todos" className="col-span-1 row-span-1">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
               <CheckSquare className="h-4 w-4 text-muted-foreground" />
@@ -83,7 +83,7 @@ export default async function Dashboard() {
           <MaintenanceDonutChart />
         </div>
         <Link href="/finanzen" className="col-span-1 row-span-1">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
               <Wallet className="h-4 w-4 text-muted-foreground" />
@@ -95,7 +95,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/betriebskosten" className="col-span-1 row-span-1">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
               <FileSpreadsheet className="h-4 w-4 text-muted-foreground" />

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -54,30 +54,6 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
-        <Link href="/finanzen">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer lg:col-span-2">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
-              <Wallet className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.monatlicheEinnahmen)}</div>
-              <p className="text-xs text-muted-foreground">Monatliche Mieteinnahmen</p>
-            </CardContent>
-          </Card>
-        </Link>
-        <Link href="/betriebskosten">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
-              <FileSpreadsheet className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.jaehrlicheAusgaben)}</div>
-              <p className="text-xs text-muted-foreground">Jährliche Ausgaben</p>
-            </CardContent>
-          </Card>
-        </Link>
         <Link href="/todos">
           <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -96,7 +72,31 @@ export default async function Dashboard() {
         <div className="lg:col-span-8">
           <DashboardCharts />
         </div>
-        <div className="lg:col-span-4">
+        <div className="lg:col-span-4 flex flex-col gap-4">
+          <Link href="/finanzen">
+            <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
+                <Wallet className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.monatlicheEinnahmen)}</div>
+                <p className="text-xs text-muted-foreground">Monatliche Mieteinnahmen</p>
+              </CardContent>
+            </Card>
+          </Link>
+          <Link href="/betriebskosten">
+            <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
+                <FileSpreadsheet className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.jaehrlicheAusgaben)}</div>
+                <p className="text-xs text-muted-foreground">Jährliche Ausgaben</p>
+              </CardContent>
+            </Card>
+          </Link>
           <TenantPaymentBento />
         </div>
       </div>

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -20,7 +20,7 @@ export default async function Dashboard() {
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
       </div>
       <div className="grid gap-4 grid-cols-6 auto-rows-[140px] h-[calc(100vh-200px)]">
-        {/* Row 1: Three summary cards (2/3 width) + Tenant Payment List (1/3 width) */}
+        {/* Row 1: Three summary cards using maximum 2/3 width (4 columns) + Tenant Payment List (1/3 width - 2 columns) */}
         <Link href="/haeuser" className="col-span-1 row-span-1">
           <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -58,7 +58,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <div className="col-span-1 row-span-1">
-          {/* Empty space for better layout */}
+          {/* Extra space to maximize summary cards width within 2/3 of page */}
         </div>
         {/* Tenant Payment List (1/3 width - 2 columns) */}
         <div className="col-span-2 row-span-4">

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -64,7 +64,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
 
-        <div className="col-span-2 row-span-3">
+        <div className="col-span-2 row-span-4">
           <RevenueExpensesChart />
         </div>
         <Link href="/todos" className="col-span-1 row-span-1">

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -20,7 +20,7 @@ export default async function Dashboard() {
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
       </div>
       <div className="grid gap-4 grid-cols-6 auto-rows-[140px] h-[calc(100vh-200px)]">
-        {/* Row 1: Three summary cards using maximum 2/3 width (4 columns) + Tenant Payment List (1/3 width - 2 columns) */}
+        {/* Row 1: Three wider summary cards (2/3 width - 4 columns total) + Tenant Payment List (1/3 width - 2 columns) */}
         <Link href="/haeuser" className="col-span-1 row-span-1">
           <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -33,7 +33,7 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
-        <Link href="/wohnungen" className="col-span-1 row-span-1">
+        <Link href="/wohnungen" className="col-span-2 row-span-1">
           <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Wohnungen</CardTitle>
@@ -57,9 +57,6 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
-        <div className="col-span-1 row-span-1">
-          {/* Extra space to maximize summary cards width within 2/3 of page */}
-        </div>
         {/* Tenant Payment List (1/3 width - 2 columns) */}
         <div className="col-span-2 row-span-4">
           <TenantPaymentBento />

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -67,50 +67,56 @@ export default async function Dashboard() {
           <OccupancyChart />
         </div>
 
-        {/* Row 5: Revenue Chart + Other cards */}
-        <div className="col-span-3 row-span-3">
+        {/* Row 5: Revenue Chart (4 cols, 3 rows) + Empty space for proper alignment */}
+        <div className="col-span-4 row-span-3">
           <RevenueExpensesChart />
         </div>
-        <Link href="/todos" className="col-span-1 row-span-1">
-          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
-              <CheckSquare className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{summary.offeneAufgabenCount}</div>
-              <p className="text-xs text-muted-foreground">Offene Aufgaben</p>
-            </CardContent>
-          </Card>
-        </Link>
-
-        {/* Row 6: Finance cards */}
-        <Link href="/finanzen" className="col-span-1 row-span-1">
-          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
-              <Wallet className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.monatlicheEinnahmen)}</div>
-              <p className="text-xs text-muted-foreground">Monatliche Mieteinnahmen</p>
-            </CardContent>
-          </Card>
-        </Link>
-
-        {/* Row 7: Betriebskosten card */}
-        <Link href="/betriebskosten" className="col-span-1 row-span-1">
-          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
-              <FileSpreadsheet className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.jaehrlicheAusgaben)}</div>
-              <p className="text-xs text-muted-foreground">Jährliche Ausgaben</p>
-            </CardContent>
-          </Card>
-        </Link>
+        <div className="col-span-1 row-span-3">
+          {/* Container for vertically stacked summary cards */}
+          <div className="h-full flex flex-col gap-4">
+            <Link href="/todos" className="flex-1">
+              <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
+                  <CheckSquare className="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">{summary.offeneAufgabenCount}</div>
+                  <p className="text-xs text-muted-foreground">Offene Aufgaben</p>
+                </CardContent>
+              </Card>
+            </Link>
+            
+            <Link href="/finanzen" className="flex-1">
+              <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
+                  <Wallet className="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.monatlicheEinnahmen)}</div>
+                  <p className="text-xs text-muted-foreground">Monatliche Mieteinnahmen</p>
+                </CardContent>
+              </Card>
+            </Link>
+            
+            <Link href="/betriebskosten" className="flex-1">
+              <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
+                  <FileSpreadsheet className="h-4 w-4 text-muted-foreground" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.jaehrlicheAusgaben)}</div>
+                  <p className="text-xs text-muted-foreground">Jährliche Ausgaben</p>
+                </CardContent>
+              </Card>
+            </Link>
+          </div>
+        </div>
+        <div className="col-span-1 row-span-3">
+          {/* Empty space to maintain grid alignment */}
+        </div>
 
         {/* Row 8: Instandhaltung Chart - Full width row */}
         <div className="col-span-6 row-span-1">

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -83,14 +83,14 @@ export default async function Dashboard() {
           <div className="h-full flex flex-col gap-4">
             <Link href="/todos" className="flex-1">
               <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 flex-shrink-0">
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
                     <CheckSquare className="h-4 w-4 text-muted-foreground" />
                   </div>
                 </CardHeader>
-                <CardContent className="flex-1 flex flex-col justify-center pt-0">
-                  <div className="flex items-baseline gap-2">
+                <CardContent className="flex-1 flex flex-col justify-between pt-0 pb-6">
+                  <div className="flex items-center gap-2 mt-1">
                     <div className="text-2xl font-bold leading-none">{summary.offeneAufgabenCount}</div>
                     {summary.offeneAufgabenCount > 0 && (
                       <div className="px-2 py-1 bg-muted text-muted-foreground text-xs font-medium rounded-full">
@@ -98,47 +98,47 @@ export default async function Dashboard() {
                       </div>
                     )}
                   </div>
-                  <p className="text-xs text-muted-foreground mt-2">Offene Aufgaben</p>
+                  <p className="text-xs text-muted-foreground">Offene Aufgaben</p>
                 </CardContent>
               </Card>
             </Link>
             
             <Link href="/finanzen" className="flex-1">
               <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 flex-shrink-0">
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
                     <Wallet className="h-4 w-4 text-muted-foreground" />
                   </div>
                 </CardHeader>
-                <CardContent className="flex-1 flex flex-col justify-center pt-0">
-                  <div className="flex items-baseline gap-2 flex-wrap">
+                <CardContent className="flex-1 flex flex-col justify-between pt-0 pb-6">
+                  <div className="flex items-center gap-2 mt-1">
                     <div className="text-2xl font-bold leading-none">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.monatlicheEinnahmen)}</div>
                     <div className="px-2 py-1 bg-muted text-muted-foreground text-xs font-medium rounded-full">
                       /Monat
                     </div>
                   </div>
-                  <p className="text-xs text-muted-foreground mt-2">Monatliche Mieteinnahmen</p>
+                  <p className="text-xs text-muted-foreground">Monatliche Mieteinnahmen</p>
                 </CardContent>
               </Card>
             </Link>
             
             <Link href="/betriebskosten" className="flex-1">
               <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 flex-shrink-0">
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
                     <FileSpreadsheet className="h-4 w-4 text-muted-foreground" />
                   </div>
                 </CardHeader>
-                <CardContent className="flex-1 flex flex-col justify-center pt-0">
-                  <div className="flex items-baseline gap-2 flex-wrap">
+                <CardContent className="flex-1 flex flex-col justify-between pt-0 pb-6">
+                  <div className="flex items-center gap-2 mt-1">
                     <div className="text-2xl font-bold leading-none">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.jaehrlicheAusgaben)}</div>
                     <div className="px-2 py-1 bg-muted text-muted-foreground text-xs font-medium rounded-full">
                       /Jahr
                     </div>
                   </div>
-                  <p className="text-xs text-muted-foreground mt-2">Jährliche Ausgaben</p>
+                  <p className="text-xs text-muted-foreground">Jährliche Ausgaben</p>
                 </CardContent>
               </Card>
             </Link>

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -9,6 +9,7 @@ import { getDashboardSummary } from "@/lib/data-fetching"
 import { RevenueExpensesChart } from "@/components/charts/revenue-expenses-chart"
 import { OccupancyChart } from "@/components/charts/occupancy-chart"
 import { MaintenanceDonutChart } from "@/components/charts/maintenance-donut-chart"
+import { LastTransactionsContainer } from "@/components/last-transactions-container"
 
 export default async function Dashboard() {
   // Fetch real data from database
@@ -115,8 +116,11 @@ export default async function Dashboard() {
           </div>
         </div>
 
-        {/* Row 8: Instandhaltung Chart - Full width with increased height */}
-        <div className="col-span-6 row-span-3">
+        {/* Row 8: Last Transactions (left 50%) + Instandhaltung Chart (right 50%) */}
+        <div className="col-span-3 row-span-3">
+          <LastTransactionsContainer />
+        </div>
+        <div className="col-span-3 row-span-3">
           <MaintenanceDonutChart />
         </div>
       </div>

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -44,7 +44,7 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
-        <div className="col-span-1 row-span-6">
+        <div className="col-span-1 row-span-2">
           <TenantPaymentBento />
         </div>
 

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -20,7 +20,7 @@ export default async function Dashboard() {
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
       </div>
       <div className="grid gap-4 grid-cols-6 auto-rows-[140px] h-[calc(100vh-200px)]">
-        {/* Row 1: Three narrow summary cards + tenant payment list */}
+        {/* Row 1: Three narrow summary cards + Tenant Payment List starts here */}
         <Link href="/haeuser" className="col-span-1 row-span-1">
           <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -57,16 +57,14 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
-        <div className="col-span-3 row-span-1">
-          {/* Empty space for better layout */}
+        {/* Tenant Payment List now starts from row 1 and spans 4 rows */}
+        <div className="col-span-3 row-span-4">
+          <TenantPaymentBento />
         </div>
 
-        {/* Row 2: Belegung Chart (expanded height) + Tenant Payment List */}
+        {/* Row 2: Belegung Chart (expanded height) */}
         <div className="col-span-3 row-span-3">
           <OccupancyChart />
-        </div>
-        <div className="col-span-3 row-span-3">
-          <TenantPaymentBento />
         </div>
 
         {/* Row 5: Revenue Chart (expanded height) + Other cards */}

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -115,8 +115,8 @@ export default async function Dashboard() {
           </div>
         </div>
 
-        {/* Row 8: Instandhaltung Chart - Full width row */}
-        <div className="col-span-6 row-span-1">
+        {/* Row 8: Instandhaltung Chart - Full width with increased height */}
+        <div className="col-span-6 row-span-3">
           <MaintenanceDonutChart />
         </div>
       </div>

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -23,38 +23,44 @@ export default async function Dashboard() {
       <div className="grid gap-4 grid-cols-6 auto-rows-[140px] h-[calc(100vh-200px)]">
         {/* Row 1: Three wider summary cards (2/3 width - 4 columns total) + Tenant Payment List (1/3 width - 2 columns) */}
         <Link href="/haeuser" className="col-span-1 row-span-1">
-          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Häuser</CardTitle>
-              <Building2 className="h-4 w-4 text-muted-foreground" />
+              <div className="p-2 bg-muted rounded-lg">
+                <Building2 className="h-4 w-4 text-muted-foreground" />
+              </div>
             </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{summary.haeuserCount}</div>
-              <p className="text-xs text-muted-foreground">Verwaltete Immobilien</p>
+            <CardContent className="flex-1 flex flex-col justify-center pt-0">
+              <div className="text-2xl font-bold leading-none">{summary.haeuserCount}</div>
+              <p className="text-xs text-muted-foreground mt-2">Verwaltete Immobilien</p>
             </CardContent>
           </Card>
         </Link>
         <Link href="/wohnungen" className="col-span-2 row-span-1">
-          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Wohnungen</CardTitle>
-              <Home className="h-4 w-4 text-muted-foreground" />
+              <div className="p-2 bg-muted rounded-lg">
+                <Home className="h-4 w-4 text-muted-foreground" />
+              </div>
             </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{summary.wohnungenCount}</div>
-              <p className="text-xs text-muted-foreground">Verwaltete Einheiten</p>
+            <CardContent className="flex-1 flex flex-col justify-center pt-0">
+              <div className="text-2xl font-bold leading-none">{summary.wohnungenCount}</div>
+              <p className="text-xs text-muted-foreground mt-2">Verwaltete Einheiten</p>
             </CardContent>
           </Card>
         </Link>
         <Link href="/mieter" className="col-span-1 row-span-1">
-          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Mieter</CardTitle>
-              <Users className="h-4 w-4 text-muted-foreground" />
+              <div className="p-2 bg-muted rounded-lg">
+                <Users className="h-4 w-4 text-muted-foreground" />
+              </div>
             </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{summary.mieterCount}</div>
-              <p className="text-xs text-muted-foreground">Aktive Mietverhältnisse</p>
+            <CardContent className="flex-1 flex flex-col justify-center pt-0">
+              <div className="text-2xl font-bold leading-none">{summary.mieterCount}</div>
+              <p className="text-xs text-muted-foreground mt-2">Aktive Mietverhältnisse</p>
             </CardContent>
           </Card>
         </Link>
@@ -76,40 +82,63 @@ export default async function Dashboard() {
           {/* Container for vertically stacked summary cards - 1/3 of page width */}
           <div className="h-full flex flex-col gap-4">
             <Link href="/todos" className="flex-1">
-              <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card">
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
-                  <CheckSquare className="h-4 w-4 text-muted-foreground" />
+                  <div className="p-2 bg-muted rounded-lg">
+                    <CheckSquare className="h-4 w-4 text-muted-foreground" />
+                  </div>
                 </CardHeader>
-                <CardContent>
-                  <div className="text-2xl font-bold">{summary.offeneAufgabenCount}</div>
-                  <p className="text-xs text-muted-foreground">Offene Aufgaben</p>
+                <CardContent className="flex-1 flex flex-col justify-center pt-0">
+                  <div className="flex items-baseline gap-2">
+                    <div className="text-2xl font-bold leading-none">{summary.offeneAufgabenCount}</div>
+                    {summary.offeneAufgabenCount > 0 && (
+                      <div className="px-2 py-1 bg-muted text-muted-foreground text-xs font-medium rounded-full">
+                        Offen
+                      </div>
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-2">Offene Aufgaben</p>
                 </CardContent>
               </Card>
             </Link>
             
             <Link href="/finanzen" className="flex-1">
-              <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card">
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
-                  <Wallet className="h-4 w-4 text-muted-foreground" />
+                  <div className="p-2 bg-muted rounded-lg">
+                    <Wallet className="h-4 w-4 text-muted-foreground" />
+                  </div>
                 </CardHeader>
-                <CardContent>
-                  <div className="text-2xl font-bold">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.monatlicheEinnahmen)}</div>
-                  <p className="text-xs text-muted-foreground">Monatliche Mieteinnahmen</p>
+                <CardContent className="flex-1 flex flex-col justify-center pt-0">
+                  <div className="flex items-baseline gap-2 flex-wrap">
+                    <div className="text-2xl font-bold leading-none">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.monatlicheEinnahmen)}</div>
+                    <div className="px-2 py-1 bg-muted text-muted-foreground text-xs font-medium rounded-full">
+                      /Monat
+                    </div>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-2">Monatliche Mieteinnahmen</p>
                 </CardContent>
               </Card>
             </Link>
             
             <Link href="/betriebskosten" className="flex-1">
-              <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card">
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
-                  <FileSpreadsheet className="h-4 w-4 text-muted-foreground" />
+                  <div className="p-2 bg-muted rounded-lg">
+                    <FileSpreadsheet className="h-4 w-4 text-muted-foreground" />
+                  </div>
                 </CardHeader>
-                <CardContent>
-                  <div className="text-2xl font-bold">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.jaehrlicheAusgaben)}</div>
-                  <p className="text-xs text-muted-foreground">Jährliche Ausgaben</p>
+                <CardContent className="flex-1 flex flex-col justify-center pt-0">
+                  <div className="flex items-baseline gap-2 flex-wrap">
+                    <div className="text-2xl font-bold leading-none">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.jaehrlicheAusgaben)}</div>
+                    <div className="px-2 py-1 bg-muted text-muted-foreground text-xs font-medium rounded-full">
+                      /Jahr
+                    </div>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-2">Jährliche Ausgaben</p>
                 </CardContent>
               </Card>
             </Link>

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -19,9 +19,10 @@ export default async function Dashboard() {
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
       </div>
-      <div className="grid gap-4 grid-cols-3 auto-rows-[minmax(140px,auto)] grid-flow-dense">
+      <div className="grid gap-4 grid-cols-3 auto-rows-[140px] h-[calc(100vh-200px)]">
+        {/* Row 1: Small cards + Tenant Payment (spans 2 rows) */}
         <Link href="/haeuser" className="col-span-1 row-span-1">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
+          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Häuser</CardTitle>
               <Building2 className="h-4 w-4 text-muted-foreground" />
@@ -33,7 +34,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/wohnungen" className="col-span-1 row-span-1">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
+          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Wohnungen</CardTitle>
               <Home className="h-4 w-4 text-muted-foreground" />
@@ -48,11 +49,9 @@ export default async function Dashboard() {
           <TenantPaymentBento />
         </div>
 
-        <div className="col-span-2 row-span-2">
-          <OccupancyChart />
-        </div>
+        {/* Row 2: Mieter card + Occupancy Chart */}
         <Link href="/mieter" className="col-span-1 row-span-1">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
+          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Mieter</CardTitle>
               <Users className="h-4 w-4 text-muted-foreground" />
@@ -63,12 +62,16 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
+        <div className="col-span-1 row-span-1">
+          <OccupancyChart />
+        </div>
 
-        <div className="col-span-2 row-span-4">
+        {/* Row 3: Revenue Chart (spans 2 cols, 2 rows) + Todos */}
+        <div className="col-span-2 row-span-2">
           <RevenueExpensesChart />
         </div>
         <Link href="/todos" className="col-span-1 row-span-1">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
+          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
               <CheckSquare className="h-4 w-4 text-muted-foreground" />
@@ -79,11 +82,13 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
-        <div className="col-span-1 row-span-2">
+
+        {/* Row 4: Maintenance Chart + Finance cards */}
+        <div className="col-span-1 row-span-1">
           <MaintenanceDonutChart />
         </div>
         <Link href="/finanzen" className="col-span-1 row-span-1">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
+          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
               <Wallet className="h-4 w-4 text-muted-foreground" />
@@ -95,7 +100,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/betriebskosten" className="col-span-1 row-span-1">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
+          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
               <FileSpreadsheet className="h-4 w-4 text-muted-foreground" />

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -67,12 +67,12 @@ export default async function Dashboard() {
           <OccupancyChart />
         </div>
 
-        {/* Row 5: Revenue Chart (3 cols, 3 rows) + Wider vertically stacked summary cards (3 cols, 3 rows) */}
-        <div className="col-span-3 row-span-3">
+        {/* Row 5: Revenue Chart (4 cols, 3 rows) + Vertically stacked summary cards (2 cols, 3 rows) */}
+        <div className="col-span-4 row-span-3">
           <RevenueExpensesChart />
         </div>
-        <div className="col-span-3 row-span-3">
-          {/* Container for wider vertically stacked summary cards - reaching to right side */}
+        <div className="col-span-2 row-span-3">
+          {/* Container for vertically stacked summary cards - 1/3 of page width */}
           <div className="h-full flex flex-col gap-4">
             <Link href="/todos" className="flex-1">
               <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -19,9 +19,9 @@ export default async function Dashboard() {
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
       </div>
-      <div className="grid gap-4 grid-cols-3 auto-rows-[200px] grid-flow-dense">
+      <div className="grid gap-4 grid-cols-3 auto-rows-[minmax(140px,auto)] grid-flow-dense">
         <Link href="/haeuser" className="col-span-1 row-span-1">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer h-full">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Häuser</CardTitle>
               <Building2 className="h-4 w-4 text-muted-foreground" />
@@ -33,7 +33,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/wohnungen" className="col-span-1 row-span-1">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer h-full">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Wohnungen</CardTitle>
               <Home className="h-4 w-4 text-muted-foreground" />
@@ -52,7 +52,7 @@ export default async function Dashboard() {
           <OccupancyChart />
         </div>
         <Link href="/mieter" className="col-span-1 row-span-1">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer h-full">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Mieter</CardTitle>
               <Users className="h-4 w-4 text-muted-foreground" />
@@ -68,7 +68,7 @@ export default async function Dashboard() {
           <RevenueExpensesChart />
         </div>
         <Link href="/todos" className="col-span-1 row-span-1">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer h-full">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
               <CheckSquare className="h-4 w-4 text-muted-foreground" />
@@ -83,7 +83,7 @@ export default async function Dashboard() {
           <MaintenanceDonutChart />
         </div>
         <Link href="/finanzen" className="col-span-1 row-span-1">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer h-full">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
               <Wallet className="h-4 w-4 text-muted-foreground" />
@@ -95,7 +95,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/betriebskosten" className="col-span-1 row-span-1">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer h-full">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
               <FileSpreadsheet className="h-4 w-4 text-muted-foreground" />

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -23,7 +23,7 @@ export default async function Dashboard() {
       <div className="grid gap-4 grid-cols-6 auto-rows-[140px] h-[calc(100vh-200px)]">
         {/* Row 1: Three wider summary cards (2/3 width - 4 columns total) + Tenant Payment List (1/3 width - 2 columns) */}
         <Link href="/haeuser" className="col-span-1 row-span-1">
-          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
+          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Häuser</CardTitle>
               <Building2 className="h-4 w-4 text-muted-foreground" />
@@ -35,7 +35,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/wohnungen" className="col-span-2 row-span-1">
-          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
+          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Wohnungen</CardTitle>
               <Home className="h-4 w-4 text-muted-foreground" />
@@ -47,7 +47,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/mieter" className="col-span-1 row-span-1">
-          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
+          <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Mieter</CardTitle>
               <Users className="h-4 w-4 text-muted-foreground" />
@@ -76,7 +76,7 @@ export default async function Dashboard() {
           {/* Container for vertically stacked summary cards - 1/3 of page width */}
           <div className="h-full flex flex-col gap-4">
             <Link href="/todos" className="flex-1">
-              <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
+              <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                   <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
                   <CheckSquare className="h-4 w-4 text-muted-foreground" />
@@ -89,7 +89,7 @@ export default async function Dashboard() {
             </Link>
             
             <Link href="/finanzen" className="flex-1">
-              <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
+              <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                   <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
                   <Wallet className="h-4 w-4 text-muted-foreground" />
@@ -102,7 +102,7 @@ export default async function Dashboard() {
             </Link>
             
             <Link href="/betriebskosten" className="flex-1">
-              <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
+              <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                   <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
                   <FileSpreadsheet className="h-4 w-4 text-muted-foreground" />

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -20,7 +20,7 @@ export default async function Dashboard() {
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
       </div>
       <div className="grid gap-4 grid-cols-6 auto-rows-[140px] h-[calc(100vh-200px)]">
-        {/* Row 1: Three narrow summary cards + Tenant Payment List starts here */}
+        {/* Row 1: Three summary cards (2/3 width) + Tenant Payment List (1/3 width) */}
         <Link href="/haeuser" className="col-span-1 row-span-1">
           <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -57,18 +57,21 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
-        {/* Tenant Payment List now starts from row 1 and spans 4 rows */}
-        <div className="col-span-3 row-span-4">
+        <div className="col-span-1 row-span-1">
+          {/* Empty space for better layout */}
+        </div>
+        {/* Tenant Payment List (1/3 width - 2 columns) */}
+        <div className="col-span-2 row-span-4">
           <TenantPaymentBento />
         </div>
 
-        {/* Row 2: Belegung Chart (expanded height) */}
-        <div className="col-span-3 row-span-3">
+        {/* Row 2: Belegung Chart (2/3 width - 4 columns) */}
+        <div className="col-span-4 row-span-3">
           <OccupancyChart />
         </div>
 
-        {/* Row 5: Revenue Chart (expanded height) + Other cards */}
-        <div className="col-span-4 row-span-3">
+        {/* Row 5: Revenue Chart + Other cards */}
+        <div className="col-span-3 row-span-3">
           <RevenueExpensesChart />
         </div>
         <Link href="/todos" className="col-span-1 row-span-1">
@@ -83,9 +86,6 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
-        <div className="col-span-1 row-span-2">
-          <MaintenanceDonutChart />
-        </div>
 
         {/* Row 6: Finance cards */}
         <Link href="/finanzen" className="col-span-1 row-span-1">
@@ -114,6 +114,11 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
+
+        {/* Row 8: Instandhaltung Chart - Full width row */}
+        <div className="col-span-6 row-span-1">
+          <MaintenanceDonutChart />
+        </div>
       </div>
     </div>
   )

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -17,7 +17,7 @@ export default async function Dashboard() {
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
       </div>
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      <div className="grid gap-4 auto-rows-[120px] md:grid-cols-2 lg:grid-cols-4 grid-flow-dense">
         <Link href="/haeuser">
           <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -55,7 +55,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/finanzen">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer lg:col-span-2">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
               <Wallet className="h-4 w-4 text-muted-foreground" />
@@ -92,9 +92,14 @@ export default async function Dashboard() {
         </Link>
       </div>
 
-      <DashboardCharts />
-
-      <TenantPaymentBento />
+      <div className="grid gap-4 lg:grid-cols-12">
+        <div className="lg:col-span-8">
+          <DashboardCharts />
+        </div>
+        <div className="lg:col-span-4">
+          <TenantPaymentBento />
+        </div>
+      </div>
     </div>
   )
 }

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -19,7 +19,7 @@ export default async function Dashboard() {
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
       </div>
-      <div className="grid gap-4 grid-cols-3 auto-rows-[150px] grid-flow-dense">
+      <div className="grid gap-4 grid-cols-3 auto-rows-[200px] grid-flow-dense">
         <Link href="/haeuser" className="col-span-1 row-span-1">
           <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer h-full">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -44,11 +44,11 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
-        <div className="col-span-1 row-span-4 lg:row-span-5">
+        <div className="col-span-1 row-span-6">
           <TenantPaymentBento />
         </div>
 
-        <div className="col-span-2 row-span-1">
+        <div className="col-span-2 row-span-2">
           <OccupancyChart />
         </div>
         <Link href="/mieter" className="col-span-1 row-span-1">
@@ -64,7 +64,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
 
-        <div className="col-span-2 row-span-2">
+        <div className="col-span-2 row-span-3">
           <RevenueExpensesChart />
         </div>
         <Link href="/todos" className="col-span-1 row-span-1">
@@ -79,7 +79,7 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
-        <div className="col-span-1 row-span-1">
+        <div className="col-span-1 row-span-2">
           <MaintenanceDonutChart />
         </div>
         <Link href="/finanzen" className="col-span-1 row-span-1">

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -4,9 +4,11 @@ export const dynamic = 'force-dynamic';
 import Link from "next/link"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Building2, Home, Users, Wallet, FileSpreadsheet, CheckSquare } from "lucide-react"
-import { DashboardCharts } from "@/components/dashboard-charts"
 import { TenantPaymentBento } from "@/components/tenant-payment-bento"
 import { getDashboardSummary } from "@/lib/data-fetching"
+import { RevenueExpensesChart } from "@/components/charts/revenue-expenses-chart"
+import { OccupancyChart } from "@/components/charts/occupancy-chart"
+import { MaintenanceDonutChart } from "@/components/charts/maintenance-donut-chart"
 
 export default async function Dashboard() {
   // Fetch real data from database
@@ -17,9 +19,9 @@ export default async function Dashboard() {
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
       </div>
-      <div className="grid gap-4 auto-rows-[120px] md:grid-cols-2 lg:grid-cols-4 grid-flow-dense">
-        <Link href="/haeuser">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
+      <div className="grid gap-4 grid-cols-3 auto-rows-[150px] grid-flow-dense">
+        <Link href="/haeuser" className="col-span-1 row-span-1">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer h-full">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Häuser</CardTitle>
               <Building2 className="h-4 w-4 text-muted-foreground" />
@@ -30,8 +32,8 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
-        <Link href="/wohnungen">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
+        <Link href="/wohnungen" className="col-span-1 row-span-1">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer h-full">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Wohnungen</CardTitle>
               <Home className="h-4 w-4 text-muted-foreground" />
@@ -42,8 +44,15 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
-        <Link href="/mieter">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
+        <div className="col-span-1 row-span-4 lg:row-span-5">
+          <TenantPaymentBento />
+        </div>
+
+        <div className="col-span-2 row-span-1">
+          <OccupancyChart />
+        </div>
+        <Link href="/mieter" className="col-span-1 row-span-1">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer h-full">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Mieter</CardTitle>
               <Users className="h-4 w-4 text-muted-foreground" />
@@ -54,8 +63,12 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
-        <Link href="/todos">
-          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
+
+        <div className="col-span-2 row-span-2">
+          <RevenueExpensesChart />
+        </div>
+        <Link href="/todos" className="col-span-1 row-span-1">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer h-full">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
               <CheckSquare className="h-4 w-4 text-muted-foreground" />
@@ -66,39 +79,33 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
-      </div>
-
-      <div className="grid gap-4 lg:grid-cols-12">
-        <div className="lg:col-span-8">
-          <DashboardCharts />
+        <div className="col-span-1 row-span-1">
+          <MaintenanceDonutChart />
         </div>
-        <div className="lg:col-span-4 flex flex-col gap-4">
-          <Link href="/finanzen">
-            <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
-              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
-                <Wallet className="h-4 w-4 text-muted-foreground" />
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.monatlicheEinnahmen)}</div>
-                <p className="text-xs text-muted-foreground">Monatliche Mieteinnahmen</p>
-              </CardContent>
-            </Card>
-          </Link>
-          <Link href="/betriebskosten">
-            <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer">
-              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
-                <FileSpreadsheet className="h-4 w-4 text-muted-foreground" />
-              </CardHeader>
-              <CardContent>
-                <div className="text-2xl font-bold">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.jaehrlicheAusgaben)}</div>
-                <p className="text-xs text-muted-foreground">Jährliche Ausgaben</p>
-              </CardContent>
-            </Card>
-          </Link>
-          <TenantPaymentBento />
-        </div>
+        <Link href="/finanzen" className="col-span-1 row-span-1">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer h-full">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
+              <Wallet className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.monatlicheEinnahmen)}</div>
+              <p className="text-xs text-muted-foreground">Monatliche Mieteinnahmen</p>
+            </CardContent>
+          </Card>
+        </Link>
+        <Link href="/betriebskosten" className="col-span-1 row-span-1">
+          <Card className="overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer h-full">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
+              <FileSpreadsheet className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.jaehrlicheAusgaben)}</div>
+              <p className="text-xs text-muted-foreground">Jährliche Ausgaben</p>
+            </CardContent>
+          </Card>
+        </Link>
       </div>
     </div>
   )

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -19,8 +19,8 @@ export default async function Dashboard() {
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
       </div>
-      <div className="grid gap-4 grid-cols-3 auto-rows-[140px] h-[calc(100vh-200px)]">
-        {/* Row 1: Small cards + Tenant Payment (spans 2 rows) */}
+      <div className="grid gap-4 grid-cols-6 auto-rows-[140px] h-[calc(100vh-200px)]">
+        {/* Row 1: Three narrow summary cards + tenant payment list */}
         <Link href="/haeuser" className="col-span-1 row-span-1">
           <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -45,11 +45,6 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
-        <div className="col-span-1 row-span-2">
-          <TenantPaymentBento />
-        </div>
-
-        {/* Row 2: Mieter card + Occupancy Chart */}
         <Link href="/mieter" className="col-span-1 row-span-1">
           <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -62,12 +57,20 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
-        <div className="col-span-1 row-span-1">
-          <OccupancyChart />
+        <div className="col-span-3 row-span-1">
+          {/* Empty space for better layout */}
         </div>
 
-        {/* Row 3: Revenue Chart (spans 2 cols, 2 rows) + Todos */}
-        <div className="col-span-2 row-span-2">
+        {/* Row 2: Belegung Chart (expanded height) + Tenant Payment List */}
+        <div className="col-span-3 row-span-3">
+          <OccupancyChart />
+        </div>
+        <div className="col-span-3 row-span-3">
+          <TenantPaymentBento />
+        </div>
+
+        {/* Row 5: Revenue Chart (expanded height) + Other cards */}
+        <div className="col-span-4 row-span-3">
           <RevenueExpensesChart />
         </div>
         <Link href="/todos" className="col-span-1 row-span-1">
@@ -82,11 +85,11 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
-
-        {/* Row 4: Maintenance Chart + Finance cards */}
-        <div className="col-span-1 row-span-1">
+        <div className="col-span-1 row-span-2">
           <MaintenanceDonutChart />
         </div>
+
+        {/* Row 6: Finance cards */}
         <Link href="/finanzen" className="col-span-1 row-span-1">
           <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -99,6 +102,8 @@ export default async function Dashboard() {
             </CardContent>
           </Card>
         </Link>
+
+        {/* Row 7: Betriebskosten card */}
         <Link href="/betriebskosten" className="col-span-1 row-span-1">
           <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -67,12 +67,12 @@ export default async function Dashboard() {
           <OccupancyChart />
         </div>
 
-        {/* Row 5: Revenue Chart (4 cols, 3 rows) + Empty space for proper alignment */}
-        <div className="col-span-4 row-span-3">
+        {/* Row 5: Revenue Chart (3 cols, 3 rows) + Wider vertically stacked summary cards (3 cols, 3 rows) */}
+        <div className="col-span-3 row-span-3">
           <RevenueExpensesChart />
         </div>
-        <div className="col-span-1 row-span-3">
-          {/* Container for vertically stacked summary cards */}
+        <div className="col-span-3 row-span-3">
+          {/* Container for wider vertically stacked summary cards - reaching to right side */}
           <div className="h-full flex flex-col gap-4">
             <Link href="/todos" className="flex-1">
               <Card className="h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer border border-black/80">
@@ -113,9 +113,6 @@ export default async function Dashboard() {
               </Card>
             </Link>
           </div>
-        </div>
-        <div className="col-span-1 row-span-3">
-          {/* Empty space to maintain grid alignment */}
         </div>
 
         {/* Row 8: Instandhaltung Chart - Full width row */}

--- a/app/api/finanzen/balance/route.ts
+++ b/app/api/finanzen/balance/route.ts
@@ -2,15 +2,15 @@ export const runtime = 'edge';
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 
-// Helper function to fetch all records with pagination
+// Helper function to fetch all records with pagination - no limits
 async function fetchAllRecords(query: any) {
-  const pageSize = 1000; // Process 1000 records at a time
+  const pageSize = 5000; // Increased batch size for better performance
   let page = 0;
   let allRecords: any[] = [];
   let hasMore = true;
 
   while (hasMore) {
-    const { data, error, count } = await query
+    const { data, error } = await query
       .range(page * pageSize, (page + 1) * pageSize - 1);
     
     if (error) {

--- a/app/api/finanzen/export/route.ts
+++ b/app/api/finanzen/export/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: Request) {
     const selectedType = searchParams.get('selectedType');
 
     const supabase = await createClient();
-    const BATCH_SIZE = 1000; // Process 1000 records at a time
+    const BATCH_SIZE = 5000; // Increased batch size for better performance
     let allData: any[] = [];
     let offset = 0;
     let hasMore = true;
@@ -114,8 +114,8 @@ export async function GET(request: Request) {
         offset += BATCH_SIZE;
       }
 
-      // Safety check to prevent infinite loops
-      if (offset >= 25000) { // Max 25,000 rows
+      // Safety check to prevent infinite loops - removed arbitrary limit
+      if (offset >= 100000) { // Increased safety limit to 100,000 rows
         hasMore = false;
       }
     }

--- a/app/globals.css
+++ b/app/globals.css
@@ -79,3 +79,9 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  .summary-card {
+    @apply border-2 border-border;
+  }
+}

--- a/components/charts/maintenance-donut-chart.tsx
+++ b/components/charts/maintenance-donut-chart.tsx
@@ -19,8 +19,8 @@ export function MaintenanceDonutChart() {
         <CardTitle>Instandhaltung</CardTitle>
         <CardDescription>Verteilung nach Kategorie</CardDescription>
       </CardHeader>
-      <CardContent className="flex items-center justify-center h-[180px]">
-        <ResponsiveContainer width="100%" height={160}>
+      <CardContent className="h-full p-0 overflow-hidden">
+        <ResponsiveContainer width="100%" height="100%">
           <PieChart>
             <Pie
               data={placeholderData}
@@ -28,8 +28,8 @@ export function MaintenanceDonutChart() {
               nameKey="name"
               cx="50%"
               cy="50%"
-              innerRadius={36}
-              outerRadius={60}
+              innerRadius="50%"
+              outerRadius="80%"
               fill="#8884d8"
               paddingAngle={2}
             >

--- a/components/charts/maintenance-donut-chart.tsx
+++ b/components/charts/maintenance-donut-chart.tsx
@@ -1,0 +1,47 @@
+"use client";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { PieChart, Pie, Cell, Legend, Tooltip, ResponsiveContainer } from "recharts";
+
+const COLORS = ["#34d399", "#f59e42", "#818cf8", "#f87171"];
+
+const placeholderData = [
+  { name: "Instandhaltung", value: 0 },
+  { name: "Reparatur", value: 0 },
+  { name: "Steuern", value: 0 },
+  { name: "Rücklage", value: 0 },
+];
+
+export function MaintenanceDonutChart() {
+  // TODO: Replace with dynamic data from Finanzen if needed
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle>Instandhaltung</CardTitle>
+        <CardDescription>Verteilung nach Kategorie</CardDescription>
+      </CardHeader>
+      <CardContent className="flex items-center justify-center h-[180px]">
+        <ResponsiveContainer width="100%" height={160}>
+          <PieChart>
+            <Pie
+              data={placeholderData}
+              dataKey="value"
+              nameKey="name"
+              cx="50%"
+              cy="50%"
+              innerRadius={36}
+              outerRadius={60}
+              fill="#8884d8"
+              paddingAngle={2}
+            >
+              {placeholderData.map((entry, idx) => (
+                <Cell key={`cell-${idx}`} fill={COLORS[idx % COLORS.length]} />
+              ))}
+            </Pie>
+            <Legend />
+            <Tooltip />
+          </PieChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/charts/maintenance-donut-chart.tsx
+++ b/components/charts/maintenance-donut-chart.tsx
@@ -14,12 +14,12 @@ const placeholderData = [
 export function MaintenanceDonutChart() {
   // TODO: Replace with dynamic data from Finanzen if needed
   return (
-    <Card className="h-full">
-      <CardHeader>
-        <CardTitle>Instandhaltung</CardTitle>
-        <CardDescription>Verteilung nach Kategorie</CardDescription>
+    <Card className="h-full flex flex-col">
+      <CardHeader className="flex-shrink-0 pb-2">
+        <CardTitle className="text-sm">Instandhaltung</CardTitle>
+        <CardDescription className="text-xs">Verteilung nach Kategorie</CardDescription>
       </CardHeader>
-      <CardContent className="h-full p-0 overflow-hidden">
+      <CardContent className="flex-1 p-2 min-h-0">
         <ResponsiveContainer width="100%" height="100%">
           <PieChart>
             <Pie
@@ -28,8 +28,8 @@ export function MaintenanceDonutChart() {
               nameKey="name"
               cx="50%"
               cy="50%"
-              innerRadius="50%"
-              outerRadius="80%"
+              innerRadius="40%"
+              outerRadius="70%"
               fill="#8884d8"
               paddingAngle={2}
             >
@@ -37,7 +37,7 @@ export function MaintenanceDonutChart() {
                 <Cell key={`cell-${idx}`} fill={COLORS[idx % COLORS.length]} />
               ))}
             </Pie>
-            <Legend />
+            <Legend wrapperStyle={{ fontSize: 10 }} />
             <Tooltip />
           </PieChart>
         </ResponsiveContainer>

--- a/components/charts/maintenance-donut-chart.tsx
+++ b/components/charts/maintenance-donut-chart.tsx
@@ -1,46 +1,165 @@
 "use client";
+import { useEffect, useState } from "react";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { PieChart, Pie, Cell, Legend, Tooltip, ResponsiveContainer } from "recharts";
+import { createClient } from "@/utils/supabase/client";
 
 const COLORS = ["#34d399", "#f59e42", "#818cf8", "#f87171"];
 
-const placeholderData = [
+type MaintenanceData = {
+  name: string;
+  value: number;
+};
+
+const initialData: MaintenanceData[] = [
   { name: "Instandhaltung", value: 0 },
   { name: "Reparatur", value: 0 },
   { name: "Steuern", value: 0 },
-  { name: "Rücklage", value: 0 },
+  { name: "Sonstige", value: 0 },
 ];
 
 export function MaintenanceDonutChart() {
-  // TODO: Replace with dynamic data from Finanzen if needed
+  const [maintenanceData, setMaintenanceData] = useState<MaintenanceData[]>(initialData);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchMaintenanceData = async () => {
+      const supabase = createClient();
+      
+      try {
+        // Fetch ALL finance data without limits - expenses only
+        let allFinanzenData: any[] = [];
+        let page = 0;
+        const pageSize = 5000;
+        let hasMore = true;
+
+        while (hasMore) {
+          const { data, error } = await supabase
+            .from("Finanzen")
+            .select("*")
+            .eq("ist_einnahmen", false) // Only expenses
+            .order("datum", { ascending: false })
+            .range(page * pageSize, (page + 1) * pageSize - 1);
+
+          if (error) {
+            console.error("Error fetching maintenance data:", error);
+            setLoading(false);
+            return;
+          }
+
+          if (data && data.length > 0) {
+            allFinanzenData = [...allFinanzenData, ...data];
+            page++;
+            if (data.length < pageSize) {
+              hasMore = false;
+            }
+          } else {
+            hasMore = false;
+          }
+        }
+
+        // Categorize expenses based on keywords in the name
+        const categories = {
+          instandhaltung: 0,
+          reparatur: 0,
+          steuern: 0,
+          sonstige: 0,
+        };
+
+        allFinanzenData.forEach((item) => {
+          const name = item.name?.toLowerCase() || "";
+          const betrag = Number(item.betrag) || 0;
+
+          if (name.includes("instandhaltung") || name.includes("wartung") || name.includes("pflege")) {
+            categories.instandhaltung += betrag;
+          } else if (name.includes("reparatur") || name.includes("reparieren") || name.includes("defekt")) {
+            categories.reparatur += betrag;
+          } else if (name.includes("steuer") || name.includes("abgabe") || name.includes("gebühr")) {
+            categories.steuern += betrag;
+          } else {
+            categories.sonstige += betrag;
+          }
+        });
+
+        // Format data for the chart
+        const formattedData: MaintenanceData[] = [
+          { name: "Instandhaltung", value: categories.instandhaltung },
+          { name: "Reparatur", value: categories.reparatur },
+          { name: "Steuern", value: categories.steuern },
+          { name: "Sonstige", value: categories.sonstige },
+        ];
+
+        // Only show categories with values > 0
+        const filteredData = formattedData.filter(item => item.value > 0);
+        
+        setMaintenanceData(filteredData.length > 0 ? filteredData : [
+          { name: "Keine Daten", value: 1 }
+        ]);
+      } catch (error) {
+        console.error("Error processing maintenance data:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchMaintenanceData();
+  }, []);
+
+  // Custom tooltip to format currency
+  const CustomTooltip = ({ active, payload }: any) => {
+    if (active && payload && payload.length) {
+      const data = payload[0];
+      return (
+        <div className="bg-white p-2 border rounded shadow-lg">
+          <p className="text-sm font-medium">{data.name}</p>
+          <p className="text-sm text-blue-600">
+            {new Intl.NumberFormat('de-DE', { 
+              style: 'currency', 
+              currency: 'EUR' 
+            }).format(data.value)}
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
+
   return (
     <Card className="h-full flex flex-col">
       <CardHeader className="flex-shrink-0 pb-2">
-        <CardTitle className="text-sm">Instandhaltung</CardTitle>
-        <CardDescription className="text-xs">Verteilung nach Kategorie</CardDescription>
+        <CardTitle className="text-sm">Ausgaben nach Kategorie</CardTitle>
+        <CardDescription className="text-xs">
+          {loading ? "Lade Daten..." : "Verteilung der Ausgaben"}
+        </CardDescription>
       </CardHeader>
       <CardContent className="flex-1 p-2 min-h-0">
-        <ResponsiveContainer width="100%" height="100%">
-          <PieChart>
-            <Pie
-              data={placeholderData}
-              dataKey="value"
-              nameKey="name"
-              cx="50%"
-              cy="50%"
-              innerRadius="40%"
-              outerRadius="70%"
-              fill="#8884d8"
-              paddingAngle={2}
-            >
-              {placeholderData.map((entry, idx) => (
-                <Cell key={`cell-${idx}`} fill={COLORS[idx % COLORS.length]} />
-              ))}
-            </Pie>
-            <Legend wrapperStyle={{ fontSize: 10 }} />
-            <Tooltip />
-          </PieChart>
-        </ResponsiveContainer>
+        {loading ? (
+          <div className="flex justify-center items-center h-full">
+            <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary" />
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie
+                data={maintenanceData}
+                dataKey="value"
+                nameKey="name"
+                cx="50%"
+                cy="50%"
+                innerRadius="40%"
+                outerRadius="70%"
+                fill="#8884d8"
+                paddingAngle={2}
+              >
+                {maintenanceData.map((entry, idx) => (
+                  <Cell key={`cell-${idx}`} fill={COLORS[idx % COLORS.length]} />
+                ))}
+              </Pie>
+              <Legend wrapperStyle={{ fontSize: 10 }} />
+              <Tooltip content={<CustomTooltip />} />
+            </PieChart>
+          </ResponsiveContainer>
+        )}
       </CardContent>
     </Card>
   );

--- a/components/charts/maintenance-donut-chart.tsx
+++ b/components/charts/maintenance-donut-chart.tsx
@@ -127,10 +127,8 @@ export function MaintenanceDonutChart() {
   return (
     <Card className="h-full flex flex-col">
       <CardHeader className="flex-shrink-0 pb-2">
-        <CardTitle className="text-sm">Ausgaben nach Kategorie</CardTitle>
-        <CardDescription className="text-xs">
-          {loading ? "Lade Daten..." : "Verteilung der Ausgaben"}
-        </CardDescription>
+        <CardTitle className="text-lg">Ausgaben nach Kategorie</CardTitle>
+        <CardDescription>Verteilung der Betriebskosten</CardDescription>
       </CardHeader>
       <CardContent className="flex-1 p-2 min-h-0">
         {loading ? (

--- a/components/charts/occupancy-chart.tsx
+++ b/components/charts/occupancy-chart.tsx
@@ -1,0 +1,101 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { Line, LineChart, ResponsiveContainer, XAxis, YAxis, CartesianGrid, Legend } from "recharts";
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { createClient } from "@/utils/supabase/client";
+
+const initialOccupancyData = Array.from({ length: 12 }, (_, i) => ({
+  month: ["Jan", "Feb", "Mär", "Apr", "Mai", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dez"][i],
+  vermietet: 0,
+  frei: 0,
+}));
+
+export function OccupancyChart() {
+  const [occupancyData, setOccupancyData] = useState(initialOccupancyData);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const supabase = createClient();
+
+      const { data: wohnungen, error: wohnungenError } = await supabase
+        .from("Wohnungen")
+        .select("*");
+      const { data: mieter, error: mieterError } = await supabase
+        .from("Mieter")
+        .select("*");
+
+      if (wohnungenError || mieterError) return;
+
+      const now = new Date();
+      type OccupancyData = { month: string; vermietet: number; frei: number; };
+      const occupancy: Record<string, OccupancyData> = {};
+
+      for (let i = 11; i >= 0; i--) {
+        const date = new Date(now);
+        date.setMonth(date.getMonth() - i);
+        const month = new Intl.DateTimeFormat('de-DE', { month: 'short' }).format(date);
+        const monthKey = `${date.getFullYear()}-${date.getMonth() + 1}`;
+        const vermietetCount = mieter.filter(m => {
+          const einzug = m.einzug ? new Date(m.einzug) : null;
+          const auszug = m.auszug ? new Date(m.auszug) : null;
+          return einzug && einzug <= date && (!auszug || auszug >= date);
+        }).length;
+        occupancy[monthKey] = {
+          month,
+          vermietet: vermietetCount,
+          frei: wohnungen.length - vermietetCount,
+        };
+      }
+
+      const lastMonths = Array.from({ length: 12 }, (_, i) => {
+        const date = new Date();
+        date.setMonth(date.getMonth() - (11 - i));
+        return `${date.getFullYear()}-${date.getMonth() + 1}`;
+      });
+
+      const formattedOccupancyData = lastMonths.map(monthKey =>
+        occupancy[monthKey] || {
+          month: new Intl.DateTimeFormat('de-DE', { month: 'short' }).format(
+            new Date(parseInt(monthKey.split('-')[0]), parseInt(monthKey.split('-')[1]) - 1, 1)
+          ),
+          vermietet: 0,
+          frei: 0,
+        }
+      );
+
+      setOccupancyData(formattedOccupancyData);
+    };
+
+    fetchData();
+  }, []);
+
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle>Belegung</CardTitle>
+        <CardDescription>Monatliche Übersicht über vermietete und freie Wohnungen</CardDescription>
+      </CardHeader>
+      <CardContent className="chart-container h-[180px]">
+        <ChartContainer
+          config={{
+            vermietet: { label: "Vermietet", color: "hsl(var(--chart-1))" },
+            frei: { label: "Frei", color: "hsl(var(--chart-3))" },
+          }}
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={occupancyData}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="month" />
+              <YAxis />
+              <ChartTooltip content={<ChartTooltipContent />} />
+              <Legend />
+              <Line type="monotone" dataKey="vermietet" stroke="var(--color-vermietet)" strokeWidth={2} />
+              <Line type="monotone" dataKey="frei" stroke="var(--color-frei)" strokeWidth={2} />
+            </LineChart>
+          </ResponsiveContainer>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/charts/occupancy-chart.tsx
+++ b/components/charts/occupancy-chart.tsx
@@ -14,6 +14,19 @@ const initialOccupancyData = Array.from({ length: 12 }, (_, i) => ({
 export function OccupancyChart() {
   const [occupancyData, setOccupancyData] = useState(initialOccupancyData);
 
+  // Dynamic tick count for Y axis
+  const [tickCount, setTickCount] = useState(5);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const ro = new ResizeObserver(([entry]) => {
+      const h = entry.contentRect.height;
+      setTickCount(Math.max(3, Math.floor(h / 50)));
+    });
+    if (containerRef.current) ro.observe(containerRef.current);
+    return () => ro.disconnect();
+  }, []);
+
   useEffect(() => {
     const fetchData = async () => {
       const supabase = createClient();
@@ -76,7 +89,7 @@ export function OccupancyChart() {
         <CardTitle>Belegung</CardTitle>
         <CardDescription>Monatliche Übersicht über vermietete und freie Wohnungen</CardDescription>
       </CardHeader>
-      <CardContent className="h-full p-0">
+      <CardContent className="h-full p-0 min-h-[240px]" ref={containerRef}>
         <ChartContainer
           className="w-full h-full overflow-hidden aspect-auto"
           config={{
@@ -91,7 +104,7 @@ export function OccupancyChart() {
             >
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="month" tick={{ fontSize: 10 }} />
-              <YAxis tick={{ fontSize: 10 }} width={30} />
+              <YAxis tick={{ fontSize: 10 }} width={30} tickCount={tickCount} />
               <ChartTooltip content={<ChartTooltipContent />} />
               <Legend wrapperStyle={{ fontSize: 10 }} />
               <Line type="monotone" dataKey="vermietet" stroke="var(--color-vermietet)" strokeWidth={2} />

--- a/components/charts/occupancy-chart.tsx
+++ b/components/charts/occupancy-chart.tsx
@@ -76,8 +76,9 @@ export function OccupancyChart() {
         <CardTitle>Belegung</CardTitle>
         <CardDescription>Monatliche Übersicht über vermietete und freie Wohnungen</CardDescription>
       </CardHeader>
-      <CardContent className="chart-container h-[180px]">
+      <CardContent className="h-full p-0">
         <ChartContainer
+          className="w-full h-full"
           config={{
             vermietet: { label: "Vermietet", color: "hsl(var(--chart-1))" },
             frei: { label: "Frei", color: "hsl(var(--chart-3))" },

--- a/components/charts/occupancy-chart.tsx
+++ b/components/charts/occupancy-chart.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { Line, LineChart, ResponsiveContainer, XAxis, YAxis, CartesianGrid, Legend } from "recharts";
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";

--- a/components/charts/occupancy-chart.tsx
+++ b/components/charts/occupancy-chart.tsx
@@ -84,14 +84,14 @@ export function OccupancyChart() {
   }, []);
 
   return (
-    <Card className="h-full">
-      <CardHeader>
-        <CardTitle>Belegung</CardTitle>
-        <CardDescription>Monatliche Übersicht über vermietete und freie Wohnungen</CardDescription>
+    <Card className="h-full flex flex-col">
+      <CardHeader className="flex-shrink-0 pb-2">
+        <CardTitle className="text-sm">Belegung</CardTitle>
+        <CardDescription className="text-xs">Monatliche Übersicht über vermietete und freie Wohnungen</CardDescription>
       </CardHeader>
-      <CardContent className="h-[240px] p-0 overflow-hidden" ref={containerRef}>
+      <CardContent className="flex-1 p-2 min-h-0" ref={containerRef}>
         <ChartContainer
-          className="w-full h-full overflow-hidden aspect-auto"
+          className="w-full h-full"
           config={{
             vermietet: { label: "Vermietet", color: "hsl(var(--chart-1))" },
             frei: { label: "Frei", color: "hsl(var(--chart-3))" },
@@ -100,13 +100,13 @@ export function OccupancyChart() {
           <ResponsiveContainer width="100%" height="100%">
             <LineChart
               data={occupancyData}
-              margin={{ top: 8, right: 8, left: 8, bottom: 8 }}
+              margin={{ top: 5, right: 5, left: 5, bottom: 5 }}
             >
               <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="month" tick={{ fontSize: 10 }} />
-              <YAxis tick={{ fontSize: 10 }} width={30} tickCount={tickCount} />
+              <XAxis dataKey="month" tick={{ fontSize: 9 }} />
+              <YAxis tick={{ fontSize: 9 }} width={25} tickCount={tickCount} />
               <ChartTooltip content={<ChartTooltipContent />} />
-              <Legend wrapperStyle={{ fontSize: 10 }} />
+              <Legend wrapperStyle={{ fontSize: 9 }} />
               <Line type="monotone" dataKey="vermietet" stroke="var(--color-vermietet)" strokeWidth={2} />
               <Line type="monotone" dataKey="frei" stroke="var(--chart-3)" strokeWidth={2} />
             </LineChart>

--- a/components/charts/occupancy-chart.tsx
+++ b/components/charts/occupancy-chart.tsx
@@ -86,8 +86,8 @@ export function OccupancyChart() {
   return (
     <Card className="h-full flex flex-col">
       <CardHeader className="flex-shrink-0 pb-2">
-        <CardTitle className="text-sm">Belegung</CardTitle>
-        <CardDescription className="text-xs">Monatliche Übersicht über vermietete und freie Wohnungen</CardDescription>
+        <CardTitle className="text-lg">Belegung</CardTitle>
+        <CardDescription>Wohnungsbelegung nach Monat</CardDescription>
       </CardHeader>
       <CardContent className="flex-1 p-2 min-h-0" ref={containerRef}>
         <ChartContainer

--- a/components/charts/occupancy-chart.tsx
+++ b/components/charts/occupancy-chart.tsx
@@ -78,7 +78,7 @@ export function OccupancyChart() {
       </CardHeader>
       <CardContent className="h-full p-0">
         <ChartContainer
-          className="w-full h-full"
+          className="w-full h-full overflow-hidden"
           config={{
             vermietet: { label: "Vermietet", color: "hsl(var(--chart-1))" },
             frei: { label: "Frei", color: "hsl(var(--chart-3))" },

--- a/components/charts/occupancy-chart.tsx
+++ b/components/charts/occupancy-chart.tsx
@@ -85,14 +85,17 @@ export function OccupancyChart() {
           }}
         >
           <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={occupancyData}>
+            <LineChart
+              data={occupancyData}
+              margin={{ top: 8, right: 8, left: 8, bottom: 8 }}
+            >
               <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="month" />
-              <YAxis />
+              <XAxis dataKey="month" tick={{ fontSize: 10 }} />
+              <YAxis tick={{ fontSize: 10 }} width={30} />
               <ChartTooltip content={<ChartTooltipContent />} />
-              <Legend />
+              <Legend wrapperStyle={{ fontSize: 10 }} />
               <Line type="monotone" dataKey="vermietet" stroke="var(--color-vermietet)" strokeWidth={2} />
-              <Line type="monotone" dataKey="frei" stroke="var(--color-frei)" strokeWidth={2} />
+              <Line type="monotone" dataKey="frei" stroke="var(--chart-3)" strokeWidth={2} />
             </LineChart>
           </ResponsiveContainer>
         </ChartContainer>

--- a/components/charts/occupancy-chart.tsx
+++ b/components/charts/occupancy-chart.tsx
@@ -89,7 +89,7 @@ export function OccupancyChart() {
         <CardTitle>Belegung</CardTitle>
         <CardDescription>Monatliche Übersicht über vermietete und freie Wohnungen</CardDescription>
       </CardHeader>
-      <CardContent className="h-full p-0" ref={containerRef}>
+      <CardContent className="h-[240px] p-0 overflow-hidden" ref={containerRef}>
         <ChartContainer
           className="w-full h-full overflow-hidden aspect-auto"
           config={{

--- a/components/charts/occupancy-chart.tsx
+++ b/components/charts/occupancy-chart.tsx
@@ -89,7 +89,7 @@ export function OccupancyChart() {
         <CardTitle>Belegung</CardTitle>
         <CardDescription>Monatliche Übersicht über vermietete und freie Wohnungen</CardDescription>
       </CardHeader>
-      <CardContent className="h-full p-0 min-h-[240px]" ref={containerRef}>
+      <CardContent className="h-full p-0" ref={containerRef}>
         <ChartContainer
           className="w-full h-full overflow-hidden aspect-auto"
           config={{

--- a/components/charts/occupancy-chart.tsx
+++ b/components/charts/occupancy-chart.tsx
@@ -78,7 +78,7 @@ export function OccupancyChart() {
       </CardHeader>
       <CardContent className="h-full p-0">
         <ChartContainer
-          className="w-full h-full overflow-hidden"
+          className="w-full h-full overflow-hidden aspect-auto"
           config={{
             vermietet: { label: "Vermietet", color: "hsl(var(--chart-1))" },
             frei: { label: "Frei", color: "hsl(var(--chart-3))" },

--- a/components/charts/revenue-expenses-chart.tsx
+++ b/components/charts/revenue-expenses-chart.tsx
@@ -1,0 +1,94 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis, CartesianGrid, Legend } from "recharts";
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+import { createClient } from "@/utils/supabase/client";
+
+const initialRevenueData = Array.from({ length: 12 }, (_, i) => ({
+  month: ["Jan", "Feb", "Mär", "Apr", "Mai", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dez"][i],
+  einnahmen: 0,
+  ausgaben: 0,
+}));
+
+export function RevenueExpensesChart() {
+  const [revenueData, setRevenueData] = useState(initialRevenueData);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const supabase = createClient();
+      const { data: finanzenData, error } = await supabase
+        .from("Finanzen")
+        .select("*")
+        .order("datum", { ascending: true });
+
+      if (error) return;
+
+      // Finanzdaten nach Monaten gruppieren
+      type MonthlyData = { month: string; einnahmen: number; ausgaben: number; };
+      const monthlyFinances = finanzenData.reduce<Record<string, MonthlyData>>((acc, item) => {
+        if (!item.datum) return acc;
+        const date = new Date(item.datum);
+        const month = new Intl.DateTimeFormat('de-DE', { month: 'short' }).format(date);
+        const monthKey = `${date.getFullYear()}-${date.getMonth() + 1}`;
+        if (!acc[monthKey]) {
+          acc[monthKey] = { month, einnahmen: 0, ausgaben: 0 };
+        }
+        if (item.ist_einnahmen) {
+          acc[monthKey].einnahmen += Number(item.betrag);
+        } else {
+          acc[monthKey].ausgaben += Number(item.betrag);
+        }
+        return acc;
+      }, {});
+
+      const lastMonths = Array.from({ length: 12 }, (_, i) => {
+        const date = new Date();
+        date.setMonth(date.getMonth() - (11 - i));
+        return `${date.getFullYear()}-${date.getMonth() + 1}`;
+      });
+
+      const formattedRevenueData = lastMonths.map(monthKey =>
+        monthlyFinances[monthKey] || {
+          month: new Intl.DateTimeFormat('de-DE', { month: 'short' }).format(
+            new Date(parseInt(monthKey.split('-')[0]), parseInt(monthKey.split('-')[1]) - 1, 1)
+          ),
+          einnahmen: 0,
+          ausgaben: 0,
+        }
+      );
+
+      setRevenueData(formattedRevenueData);
+    };
+    fetchData();
+  }, []);
+
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle>Einnahmen & Ausgaben</CardTitle>
+        <CardDescription>Monatliche Übersicht über Mieteinnahmen und Betriebskosten</CardDescription>
+      </CardHeader>
+      <CardContent className="chart-container h-[280px]">
+        <ChartContainer
+          config={{
+            einnahmen: { label: "Einnahmen", color: "hsl(var(--chart-1))" },
+            ausgaben: { label: "Ausgaben", color: "hsl(var(--chart-2))" },
+          }}
+        >
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={revenueData}>
+              <CartesianGrid strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="month" />
+              <YAxis />
+              <ChartTooltip content={<ChartTooltipContent />} />
+              <Legend />
+              <Bar dataKey="einnahmen" fill="var(--color-einnahmen)" radius={4} />
+              <Bar dataKey="ausgaben" fill="var(--color-ausgaben)" radius={4} />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/charts/revenue-expenses-chart.tsx
+++ b/components/charts/revenue-expenses-chart.tsx
@@ -78,12 +78,15 @@ export function RevenueExpensesChart() {
           }}
         >
           <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={revenueData}>
+            <BarChart
+              data={revenueData}
+              margin={{ top: 8, right: 8, left: 8, bottom: 8 }}
+            >
               <CartesianGrid strokeDasharray="3 3" vertical={false} />
-              <XAxis dataKey="month" />
-              <YAxis />
+              <XAxis dataKey="month" tick={{ fontSize: 10 }} />
+              <YAxis tick={{ fontSize: 10 }} width={30} />
               <ChartTooltip content={<ChartTooltipContent />} />
-              <Legend />
+              <Legend wrapperStyle={{ fontSize: 10 }} />
               <Bar dataKey="einnahmen" fill="var(--color-einnahmen)" radius={4} />
               <Bar dataKey="ausgaben" fill="var(--color-ausgaben)" radius={4} />
             </BarChart>

--- a/components/charts/revenue-expenses-chart.tsx
+++ b/components/charts/revenue-expenses-chart.tsx
@@ -14,6 +14,19 @@ const initialRevenueData = Array.from({ length: 12 }, (_, i) => ({
 export function RevenueExpensesChart() {
   const [revenueData, setRevenueData] = useState(initialRevenueData);
 
+  // Dynamic tick count for Y axis
+  const [tickCount, setTickCount] = useState(5);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const ro = new ResizeObserver(([entry]) => {
+      const h = entry.contentRect.height;
+      setTickCount(Math.max(3, Math.floor(h / 50)));
+    });
+    if (containerRef.current) ro.observe(containerRef.current);
+    return () => ro.disconnect();
+  }, []);
+
   useEffect(() => {
     const fetchData = async () => {
       const supabase = createClient();
@@ -69,7 +82,7 @@ export function RevenueExpensesChart() {
         <CardTitle>Einnahmen & Ausgaben</CardTitle>
         <CardDescription>Monatliche Übersicht über Mieteinnahmen und Betriebskosten</CardDescription>
       </CardHeader>
-      <CardContent className="h-full p-0">
+      <CardContent className="h-full p-0 min-h-[240px]" ref={containerRef}>
         <ChartContainer
           className="w-full h-full overflow-hidden aspect-auto"
           config={{
@@ -84,7 +97,7 @@ export function RevenueExpensesChart() {
             >
               <CartesianGrid strokeDasharray="3 3" vertical={false} />
               <XAxis dataKey="month" tick={{ fontSize: 10 }} />
-              <YAxis tick={{ fontSize: 10 }} width={30} />
+              <YAxis tick={{ fontSize: 10 }} width={30} tickCount={tickCount} />
               <ChartTooltip content={<ChartTooltipContent />} />
               <Legend wrapperStyle={{ fontSize: 10 }} />
               <Bar dataKey="einnahmen" fill="var(--color-einnahmen)" radius={4} />

--- a/components/charts/revenue-expenses-chart.tsx
+++ b/components/charts/revenue-expenses-chart.tsx
@@ -82,7 +82,7 @@ export function RevenueExpensesChart() {
         <CardTitle>Einnahmen & Ausgaben</CardTitle>
         <CardDescription>Monatliche Übersicht über Mieteinnahmen und Betriebskosten</CardDescription>
       </CardHeader>
-      <CardContent className="h-full p-0" ref={containerRef}>
+      <CardContent className="h-[300px] p-0 overflow-hidden" ref={containerRef}>
         <ChartContainer
           className="w-full h-full overflow-hidden aspect-auto"
           config={{

--- a/components/charts/revenue-expenses-chart.tsx
+++ b/components/charts/revenue-expenses-chart.tsx
@@ -82,7 +82,7 @@ export function RevenueExpensesChart() {
         <CardTitle>Einnahmen & Ausgaben</CardTitle>
         <CardDescription>Monatliche Übersicht über Mieteinnahmen und Betriebskosten</CardDescription>
       </CardHeader>
-      <CardContent className="h-full p-0 min-h-[240px]" ref={containerRef}>
+      <CardContent className="h-full p-0" ref={containerRef}>
         <ChartContainer
           className="w-full h-full overflow-hidden aspect-auto"
           config={{

--- a/components/charts/revenue-expenses-chart.tsx
+++ b/components/charts/revenue-expenses-chart.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { Bar, BarChart, ResponsiveContainer, XAxis, YAxis, CartesianGrid, Legend } from "recharts";
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";

--- a/components/charts/revenue-expenses-chart.tsx
+++ b/components/charts/revenue-expenses-chart.tsx
@@ -30,12 +30,37 @@ export function RevenueExpensesChart() {
   useEffect(() => {
     const fetchData = async () => {
       const supabase = createClient();
-      const { data: finanzenData, error } = await supabase
-        .from("Finanzen")
-        .select("*")
-        .order("datum", { ascending: true });
+      
+      // Fetch ALL finance data without any limits
+      let allFinanzenData: any[] = [];
+      let page = 0;
+      const pageSize = 1000;
+      let hasMore = true;
 
-      if (error) return;
+      while (hasMore) {
+        const { data, error } = await supabase
+          .from("Finanzen")
+          .select("*")
+          .order("datum", { ascending: true })
+          .range(page * pageSize, (page + 1) * pageSize - 1);
+
+        if (error) {
+          console.error("Error fetching finance data:", error);
+          return;
+        }
+
+        if (data && data.length > 0) {
+          allFinanzenData = [...allFinanzenData, ...data];
+          page++;
+          if (data.length < pageSize) {
+            hasMore = false;
+          }
+        } else {
+          hasMore = false;
+        }
+      }
+
+      const finanzenData = allFinanzenData;
 
       // Finanzdaten nach Monaten gruppieren
       type MonthlyData = { month: string; einnahmen: number; ausgaben: number; };

--- a/components/charts/revenue-expenses-chart.tsx
+++ b/components/charts/revenue-expenses-chart.tsx
@@ -69,8 +69,9 @@ export function RevenueExpensesChart() {
         <CardTitle>Einnahmen & Ausgaben</CardTitle>
         <CardDescription>Monatliche Übersicht über Mieteinnahmen und Betriebskosten</CardDescription>
       </CardHeader>
-      <CardContent className="chart-container h-[280px]">
+      <CardContent className="h-full p-0">
         <ChartContainer
+          className="w-full h-full"
           config={{
             einnahmen: { label: "Einnahmen", color: "hsl(var(--chart-1))" },
             ausgaben: { label: "Ausgaben", color: "hsl(var(--chart-2))" },

--- a/components/charts/revenue-expenses-chart.tsx
+++ b/components/charts/revenue-expenses-chart.tsx
@@ -71,7 +71,7 @@ export function RevenueExpensesChart() {
       </CardHeader>
       <CardContent className="h-full p-0">
         <ChartContainer
-          className="w-full h-full overflow-hidden"
+          className="w-full h-full overflow-hidden aspect-auto"
           config={{
             einnahmen: { label: "Einnahmen", color: "hsl(var(--chart-1))" },
             ausgaben: { label: "Ausgaben", color: "hsl(var(--chart-2))" },

--- a/components/charts/revenue-expenses-chart.tsx
+++ b/components/charts/revenue-expenses-chart.tsx
@@ -103,9 +103,9 @@ export function RevenueExpensesChart() {
 
   return (
     <Card className="h-full flex flex-col">
-      <CardHeader className="flex-shrink-0 pb-3">
-        <CardTitle>Einnahmen & Ausgaben</CardTitle>
-        <CardDescription>Monatliche Übersicht über Mieteinnahmen und Betriebskosten</CardDescription>
+      <CardHeader className="flex-shrink-0 pb-2">
+        <CardTitle className="text-lg">Einnahmen & Ausgaben</CardTitle>
+        <CardDescription>Monatliche Übersicht der Finanzen</CardDescription>
       </CardHeader>
       <CardContent className="flex-1 p-3 min-h-0" ref={containerRef}>
         <ChartContainer

--- a/components/charts/revenue-expenses-chart.tsx
+++ b/components/charts/revenue-expenses-chart.tsx
@@ -71,7 +71,7 @@ export function RevenueExpensesChart() {
       </CardHeader>
       <CardContent className="h-full p-0">
         <ChartContainer
-          className="w-full h-full"
+          className="w-full h-full overflow-hidden"
           config={{
             einnahmen: { label: "Einnahmen", color: "hsl(var(--chart-1))" },
             ausgaben: { label: "Ausgaben", color: "hsl(var(--chart-2))" },

--- a/components/charts/revenue-expenses-chart.tsx
+++ b/components/charts/revenue-expenses-chart.tsx
@@ -77,14 +77,14 @@ export function RevenueExpensesChart() {
   }, []);
 
   return (
-    <Card className="h-full">
-      <CardHeader>
+    <Card className="h-full flex flex-col">
+      <CardHeader className="flex-shrink-0 pb-3">
         <CardTitle>Einnahmen & Ausgaben</CardTitle>
         <CardDescription>Monatliche Übersicht über Mieteinnahmen und Betriebskosten</CardDescription>
       </CardHeader>
-      <CardContent className="h-[300px] p-0 overflow-hidden" ref={containerRef}>
+      <CardContent className="flex-1 p-3 min-h-0" ref={containerRef}>
         <ChartContainer
-          className="w-full h-full overflow-hidden aspect-auto"
+          className="w-full h-full"
           config={{
             einnahmen: { label: "Einnahmen", color: "hsl(var(--chart-1))" },
             ausgaben: { label: "Ausgaben", color: "hsl(var(--chart-2))" },
@@ -93,13 +93,13 @@ export function RevenueExpensesChart() {
           <ResponsiveContainer width="100%" height="100%">
             <BarChart
               data={revenueData}
-              margin={{ top: 8, right: 8, left: 8, bottom: 8 }}
+              margin={{ top: 10, right: 10, left: 10, bottom: 10 }}
             >
               <CartesianGrid strokeDasharray="3 3" vertical={false} />
-              <XAxis dataKey="month" tick={{ fontSize: 10 }} />
-              <YAxis tick={{ fontSize: 10 }} width={30} tickCount={tickCount} />
+              <XAxis dataKey="month" tick={{ fontSize: 11 }} />
+              <YAxis tick={{ fontSize: 11 }} width={40} tickCount={tickCount} />
               <ChartTooltip content={<ChartTooltipContent />} />
-              <Legend wrapperStyle={{ fontSize: 10 }} />
+              <Legend wrapperStyle={{ fontSize: 11 }} />
               <Bar dataKey="einnahmen" fill="var(--color-einnahmen)" radius={4} />
               <Bar dataKey="ausgaben" fill="var(--color-ausgaben)" radius={4} />
             </BarChart>

--- a/components/dashboard-charts.tsx
+++ b/components/dashboard-charts.tsx
@@ -1,7 +1,6 @@
 "use client"
 import { useEffect, useState } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Bar, BarChart, Line, LineChart, ResponsiveContainer, XAxis, YAxis, CartesianGrid, Legend } from "recharts"
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart"
 import { createClient } from "@/utils/supabase/client"
@@ -166,120 +165,112 @@ export function DashboardCharts() {
   }, [])
   
   return (
-    <Tabs defaultValue="einnahmen" className="w-full">
-      <TabsList className="grid w-full grid-cols-3">
-        <TabsTrigger value="einnahmen">Einnahmen & Ausgaben</TabsTrigger>
-        <TabsTrigger value="belegung">Belegung</TabsTrigger>
-        <TabsTrigger value="instandhaltung">Instandhaltung</TabsTrigger>
-      </TabsList>
-      <TabsContent value="einnahmen">
-        <Card>
-          <CardHeader>
-            <CardTitle>Einnahmen & Ausgaben</CardTitle>
-            <CardDescription>Monatliche Übersicht über Mieteinnahmen und Betriebskosten</CardDescription>
-          </CardHeader>
-          <CardContent className="chart-container">
-            <div className="h-full min-h-[400px] w-full">
-              <ChartContainer
-                config={{
-                  einnahmen: {
-                    label: "Einnahmen",
-                    color: "hsl(var(--chart-1))",
-                  },
-                  ausgaben: {
-                    label: "Ausgaben",
-                    color: "hsl(var(--chart-2))",
-                  },
-                }}
-              >
-                <ResponsiveContainer width="100%" height="100%">
-                  <BarChart data={revenueData}>
-                    <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                    <XAxis dataKey="month" />
-                    <YAxis />
-                    <ChartTooltip content={<ChartTooltipContent />} />
-                    <Legend />
-                    <Bar dataKey="einnahmen" fill="var(--color-einnahmen)" radius={4} />
-                    <Bar dataKey="ausgaben" fill="var(--color-ausgaben)" radius={4} />
-                  </BarChart>
-                </ResponsiveContainer>
-              </ChartContainer>
-            </div>
-          </CardContent>
-        </Card>
-      </TabsContent>
-      <TabsContent value="belegung">
-        <Card>
-          <CardHeader>
-            <CardTitle>Belegung</CardTitle>
-            <CardDescription>Monatliche Übersicht über vermietete und freie Wohnungen</CardDescription>
-          </CardHeader>
-          <CardContent className="chart-container">
-            <div className="h-full min-h-[400px] w-full">
-              <ChartContainer
-                config={{
-                  vermietet: {
-                    label: "Vermietet",
-                    color: "hsl(var(--chart-1))",
-                  },
-                  frei: {
-                    label: "Frei",
-                    color: "hsl(var(--chart-3))",
-                  },
-                }}
-              >
-                <ResponsiveContainer width="100%" height="100%">
-                  <LineChart data={occupancyData}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="month" />
-                    <YAxis />
-                    <ChartTooltip content={<ChartTooltipContent />} />
-                    <Legend />
-                    <Line type="monotone" dataKey="vermietet" stroke="var(--color-vermietet)" strokeWidth={2} />
-                    <Line type="monotone" dataKey="frei" stroke="var(--color-frei)" strokeWidth={2} />
-                  </LineChart>
-                </ResponsiveContainer>
-              </ChartContainer>
-            </div>
-          </CardContent>
-        </Card>
-      </TabsContent>
-      <TabsContent value="instandhaltung">
-        <Card>
-          <CardHeader>
-            <CardTitle>Instandhaltung</CardTitle>
-            <CardDescription>Monatliche Übersicht über Reparaturen und Renovierungen</CardDescription>
-          </CardHeader>
-          <CardContent className="chart-container">
-            <div className="h-full min-h-[400px] w-full">
-              <ChartContainer
-                config={{
-                  einnahmen: {
-                    label: "Einnahmen",
-                    color: "hsl(var(--chart-1))",
-                  },
-                  ausgaben: {
-                    label: "Ausgaben",
-                    color: "hsl(var(--chart-2))",
-                  },
-                }}
-              >
-                <ResponsiveContainer width="100%" height="100%">
-                  <BarChart data={revenueData}>
-                    <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                    <XAxis dataKey="month" />
-                    <YAxis />
-                    <ChartTooltip content={<ChartTooltipContent />} />
-                    <Legend />
-                    <Bar dataKey="einnahmen" fill="var(--color-einnahmen)" radius={4} />
-                    <Bar dataKey="ausgaben" fill="var(--color-ausgaben)" radius={4} />
-                  </BarChart>
-                </ResponsiveContainer>
-              </ChartContainer>
-            </div>
-          </CardContent>
-        </Card>
-      </TabsContent>
-    </Tabs>
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {/* Einnahmen & Ausgaben */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Einnahmen & Ausgaben</CardTitle>
+          <CardDescription>Monatliche Übersicht über Mieteinnahmen und Betriebskosten</CardDescription>
+        </CardHeader>
+        <CardContent className="chart-container">
+          <div className="h-full min-h-[400px] w-full">
+            <ChartContainer
+              config={{
+                einnahmen: {
+                  label: "Einnahmen",
+                  color: "hsl(var(--chart-1))",
+                },
+                ausgaben: {
+                  label: "Ausgaben",
+                  color: "hsl(var(--chart-2))",
+                },
+              }}
+            >
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={revenueData}>
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                  <XAxis dataKey="month" />
+                  <YAxis />
+                  <ChartTooltip content={<ChartTooltipContent />} />
+                  <Legend />
+                  <Bar dataKey="einnahmen" fill="var(--color-einnahmen)" radius={4} />
+                  <Bar dataKey="ausgaben" fill="var(--color-ausgaben)" radius={4} />
+                </BarChart>
+              </ResponsiveContainer>
+            </ChartContainer>
+          </div>
+        </CardContent>
+      </Card>
+      {/* Belegung */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Belegung</CardTitle>
+          <CardDescription>Monatliche Übersicht über vermietete und freie Wohnungen</CardDescription>
+        </CardHeader>
+        <CardContent className="chart-container">
+          <div className="h-full min-h-[400px] w-full">
+            <ChartContainer
+              config={{
+                vermietet: {
+                  label: "Vermietet",
+                  color: "hsl(var(--chart-1))",
+                },
+                frei: {
+                  label: "Frei",
+                  color: "hsl(var(--chart-3))",
+                },
+              }}
+            >
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={occupancyData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="month" />
+                  <YAxis />
+                  <ChartTooltip content={<ChartTooltipContent />} />
+                  <Legend />
+                  <Line type="monotone" dataKey="vermietet" stroke="var(--color-vermietet)" strokeWidth={2} />
+                  <Line type="monotone" dataKey="frei" stroke="var(--color-frei)" strokeWidth={2} />
+                </LineChart>
+              </ResponsiveContainer>
+            </ChartContainer>
+          </div>
+        </CardContent>
+      </Card>
+      {/* Instandhaltung */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Instandhaltung</CardTitle>
+          <CardDescription>Monatliche Übersicht über Reparaturen und Renovierungen</CardDescription>
+        </CardHeader>
+        <CardContent className="chart-container">
+          <div className="h-full min-h-[400px] w-full">
+            <ChartContainer
+              config={{
+                einnahmen: {
+                  label: "Einnahmen",
+                  color: "hsl(var(--chart-1))",
+                },
+                ausgaben: {
+                  label: "Ausgaben",
+                  color: "hsl(var(--chart-2))",
+                },
+              }}
+            >
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={revenueData}>
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                  <XAxis dataKey="month" />
+                  <YAxis />
+                  <ChartTooltip content={<ChartTooltipContent />} />
+                  <Legend />
+                  <Bar dataKey="einnahmen" fill="var(--color-einnahmen)" radius={4} />
+                  <Bar dataKey="ausgaben" fill="var(--color-ausgaben)" radius={4} />
+                </BarChart>
+              </ResponsiveContainer>
+            </ChartContainer>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
   )
 }

--- a/components/dashboard-charts.tsx
+++ b/components/dashboard-charts.tsx
@@ -21,7 +21,6 @@ const initialOccupancyData = Array.from({ length: 12 }, (_, i) => ({
 export function DashboardCharts() {
   const [revenueData, setRevenueData] = useState(initialRevenueData)
   const [occupancyData, setOccupancyData] = useState(initialOccupancyData)
-  const [chartHeight, setChartHeight] = useState(250)
   
   useEffect(() => {
     const fetchData = async () => {
@@ -142,26 +141,6 @@ export function DashboardCharts() {
     }
     
     fetchData()
-    
-    // Event Listener für Anpassung der Chart-Höhe an Container
-    const updateDimensions = () => {
-      const chartContainer = document.querySelector('.chart-container')
-      if (chartContainer) {
-        const containerHeight = chartContainer.getBoundingClientRect().height
-        setChartHeight(containerHeight || 250) // Fallback auf 250px
-      }
-    }
-    
-    // Initial ausführen
-    updateDimensions()
-    
-    // Event Listener für Größenänderungen
-    window.addEventListener('resize', updateDimensions)
-    
-    // Cleanup
-    return () => {
-      window.removeEventListener('resize', updateDimensions)
-    }
   }, [])
   
   return (

--- a/components/last-transactions-container.tsx
+++ b/components/last-transactions-container.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { createClient } from "@/utils/supabase/client";
+import { ArrowUpRight, ArrowDownRight, Eye } from "lucide-react";
+import Link from "next/link";
+
+type Transaction = {
+  id: string;
+  name: string;
+  datum: string;
+  betrag: number;
+  ist_einnahmen: boolean;
+  wohnung_name?: string;
+};
+
+export function LastTransactionsContainer() {
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchLastTransactions = async () => {
+      const supabase = createClient();
+      
+      try {
+        // Fetch the last 8 transactions with apartment names
+        const { data, error } = await supabase
+          .from("Finanzen")
+          .select(`
+            id,
+            name,
+            datum,
+            betrag,
+            ist_einnahmen,
+            Wohnungen!left(name)
+          `)
+          .order("datum", { ascending: false })
+          .limit(8);
+
+        if (error) {
+          console.error("Error fetching last transactions:", error);
+          return;
+        }
+
+        // Format the data
+        const formattedTransactions: Transaction[] = (data || []).map((item: any) => ({
+          id: item.id,
+          name: item.name,
+          datum: item.datum,
+          betrag: Number(item.betrag),
+          ist_einnahmen: item.ist_einnahmen,
+          wohnung_name: item.Wohnungen?.name || null,
+        }));
+
+        setTransactions(formattedTransactions);
+      } catch (error) {
+        console.error("Error processing transactions:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchLastTransactions();
+  }, []);
+
+  const formatDate = (dateString: string) => {
+    if (!dateString) return "-";
+    const date = new Date(dateString);
+    return date.toLocaleDateString('de-DE', {
+      day: '2-digit',
+      month: '2-digit',
+      year: '2-digit'
+    });
+  };
+
+  const formatCurrency = (amount: number) => {
+    return new Intl.NumberFormat('de-DE', {
+      style: 'currency',
+      currency: 'EUR',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(Math.abs(amount));
+  };
+
+  return (
+    <Card className="h-full flex flex-col">
+      <CardHeader className="flex-shrink-0 pb-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="text-lg">Letzte Transaktionen</CardTitle>
+            <p className="text-sm text-muted-foreground mt-1">
+              {loading ? "Lade Daten..." : `${transactions.length} neueste Einträge`}
+            </p>
+          </div>
+          <Link href="/finanzen">
+            <Button variant="outline" size="sm" className="flex items-center gap-2">
+              <Eye className="h-4 w-4" />
+              Alle anzeigen
+            </Button>
+          </Link>
+        </div>
+      </CardHeader>
+      <CardContent className="flex-1 p-3 min-h-0 overflow-hidden">
+        {loading ? (
+          <div className="flex justify-center items-center h-full">
+            <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary" />
+          </div>
+        ) : (
+          <div className="space-y-2 overflow-y-auto h-full pr-2">
+            {transactions.length > 0 ? (
+              transactions.map((transaction) => (
+                <div
+                  key={transaction.id}
+                  className="flex items-center justify-between p-3 rounded-lg border bg-white hover:bg-gray-50 transition-colors"
+                >
+                  <div className="flex items-center gap-3 flex-1 min-w-0">
+                    <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${
+                      transaction.ist_einnahmen 
+                        ? 'bg-green-100 text-green-600' 
+                        : 'bg-red-100 text-red-600'
+                    }`}>
+                      {transaction.ist_einnahmen ? (
+                        <ArrowUpRight className="h-4 w-4" />
+                      ) : (
+                        <ArrowDownRight className="h-4 w-4" />
+                      )}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium truncate">
+                        {transaction.name}
+                      </p>
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <span>{formatDate(transaction.datum)}</span>
+                        {transaction.wohnung_name && (
+                          <>
+                            <span>•</span>
+                            <span className="truncate">{transaction.wohnung_name}</span>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex-shrink-0 text-right">
+                    <p className={`text-sm font-semibold ${
+                      transaction.ist_einnahmen ? 'text-green-600' : 'text-red-600'
+                    }`}>
+                      {transaction.ist_einnahmen ? '+' : '-'}{formatCurrency(transaction.betrag)}
+                    </p>
+                  </div>
+                </div>
+              ))
+            ) : (
+              <div className="flex flex-col items-center justify-center h-full text-center">
+                <div className="w-12 h-12 rounded-full bg-gray-100 flex items-center justify-center mb-3">
+                  <ArrowUpRight className="h-6 w-6 text-gray-400" />
+                </div>
+                <p className="text-sm text-muted-foreground">Keine Transaktionen gefunden</p>
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/stat-card.tsx
+++ b/components/stat-card.tsx
@@ -33,7 +33,7 @@ export function StatCard({
   }
 
   return (
-    <Card className={`relative overflow-hidden rounded-xl shadow-md transition-opacity duration-200 flex-1 ${className}`}>
+    <Card className={`relative overflow-hidden rounded-xl shadow-md transition-opacity duration-200 flex-1 summary-card ${className}`}>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-sm font-medium">{title}</CardTitle>
         {icon}

--- a/components/summary-card.tsx
+++ b/components/summary-card.tsx
@@ -21,7 +21,7 @@ export function SummaryCard({
   className = "",
 }: SummaryCardProps) {
   return (
-    <Card className={`relative overflow-hidden rounded-xl shadow-md transition-opacity duration-200 border-2 border-border ${isLoading ? 'opacity-75' : 'opacity-100'} ${className}`}>
+    <Card className={`relative overflow-hidden rounded-xl shadow-md transition-opacity duration-200 summary-card ${isLoading ? 'opacity-75' : 'opacity-100'} ${className}`}>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-sm font-medium">{title}</CardTitle>
         {icon}

--- a/components/summary-card.tsx
+++ b/components/summary-card.tsx
@@ -21,7 +21,7 @@ export function SummaryCard({
   className = "",
 }: SummaryCardProps) {
   return (
-    <Card className={`relative overflow-hidden rounded-xl shadow-md transition-opacity duration-200 ${isLoading ? 'opacity-75' : 'opacity-100'} ${className}`}>
+    <Card className={`relative overflow-hidden rounded-xl shadow-md transition-opacity duration-200 border-2 border-border ${isLoading ? 'opacity-75' : 'opacity-100'} ${className}`}>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-sm font-medium">{title}</CardTitle>
         {icon}

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -201,12 +201,6 @@ export function TenantPaymentBento() {
         <CardDescription>Bezahlt vs. offen</CardDescription>
       </CardHeader>
       <CardContent className="flex-1 overflow-y-auto pr-2">
-    <Card className="h-full flex flex-col">
-      <CardHeader>
-        <CardTitle>Mietzahlungen</CardTitle>
-        <CardDescription>Bezahlt vs. offen</CardDescription>
-      </CardHeader>
-      <CardContent className="flex-1 overflow-y-auto pr-2">
         {loading ? (
           <div className="flex justify-center items-center py-8">
             <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary"></div>
@@ -249,6 +243,10 @@ export function TenantPaymentBento() {
             )}
           </div>
         )}
+      </CardContent>
+    </Card>
+  )
+}
       </CardContent>
     </Card>
   )

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -129,7 +129,6 @@ export function TenantPaymentBento() {
       }
 
       // Refresh data
-      // re-fetch logic
       setLoading(true)
       const supabase2 = createClient()
 
@@ -244,10 +243,6 @@ export function TenantPaymentBento() {
             )}
           </div>
         )}
-      </CardContent>
-    </Card>
-  );
-}
       </CardContent>
     </Card>
   );

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { createClient } from "@/utils/supabase/client"
-import { Home } from "lucide-react"
+import { Home, User } from "lucide-react"
 
 type TenantBentoItem = {
   id: string
@@ -214,7 +214,10 @@ export function TenantPaymentBento() {
                   className="w-full flex flex-col justify-between p-4 rounded-lg shadow-md bg-white border"
                 >
                   <div>
-                    <div className="font-semibold">{tenant.tenant}</div>
+                    <div className="flex items-center gap-1 font-semibold">
+                      <User className="h-3.5 w-3.5" />
+                      <span>{tenant.tenant}</span>
+                    </div>
                     <div className="flex items-center gap-1 text-sm text-muted-foreground">
                       <Home className="h-3.5 w-3.5" />
                       <span>{tenant.apartment}</span>

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -203,7 +203,7 @@ export function TenantPaymentBento() {
       <CardContent className="flex-1 overflow-y-auto pr-2">
         {loading ? (
           <div className="flex justify-center items-center py-8">
-            <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary"></div>
+            <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary" />
           </div>
         ) : (
           <div className="flex flex-col gap-4">
@@ -221,19 +221,20 @@ export function TenantPaymentBento() {
                     <button
                       type="button"
                       className={
-                        "px-3 py-1 rounded-full text-xs font-medium border transition-colors duration-150 " +
-                        (tenant.paid
-                          ? "bg-green-50 text-green-700 border-green-200 hover:bg-green-100"
-                          : "bg-red-50 text-red-700 border-red-200 hover:bg-red-100")
+                        `px-3 py-1 rounded-full text-xs font-medium border transition-colors duration-150 ${
+                          tenant.paid
+                            ? 'bg-green-50 text-green-700 border-green-200 hover:bg-green-100'
+                            : 'bg-red-50 text-red-700 border-red-200 hover:bg-red-100'
+                        }`
                       }
                       disabled={updatingStatus === tenant.id}
                       onClick={() => toggleRentPayment(tenant)}
                     >
                       {updatingStatus === tenant.id
-                        ? "Aktualisiere..."
+                        ? 'Aktualisiere...'
                         : tenant.paid
-                        ? "Miete bezahlt"
-                        : "Miete unbezahlt"}
+                        ? 'Miete bezahlt'
+                        : 'Miete unbezahlt'}
                     </button>
                   </div>
                 </div>
@@ -245,7 +246,7 @@ export function TenantPaymentBento() {
         )}
       </CardContent>
     </Card>
-  )
+  );
 }
       </CardContent>
     </Card>

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -250,5 +250,5 @@ export function TenantPaymentBento() {
 }
       </CardContent>
     </Card>
-  )
+  );
 }

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -67,7 +67,7 @@ export function TenantPaymentBento() {
       const formatted: TenantBentoItem[] = (mieterData || [])
         .filter(mieter => mieter.Wohnungen)
         .map(mieter => {
-          const wohnung = mieter.Wohnungen as { id: string; name: string }
+          const wohnung = mieter.Wohnungen as unknown as { id: string; name: string }
           return {
             id: mieter.id,
             tenant: mieter.name,

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -211,11 +211,15 @@ export function TenantPaymentBento() {
               data.map((tenant) => (
                 <div
                   key={tenant.id}
-                  className="w-full flex items-center justify-between p-4 rounded-lg shadow-md bg-white border"
+                  className={`w-full flex items-center justify-between p-4 rounded-lg shadow-md bg-white border transition-colors duration-200 ${
+                    tenant.paid
+                      ? 'border-green-200 hover:bg-green-50/50'
+                      : 'border-red-200 hover:bg-red-50/50'
+                  }`}
                 >
                   {/* Left side: Tenant name and apartment */}
                   <div className="flex flex-col gap-1">
-                    <div className="flex items-center gap-1 font-semibold">
+                    <div className="flex items-center gap-1 font-semibold text-foreground">
                       <User className="h-3.5 w-3.5" />
                       <span>{tenant.tenant}</span>
                     </div>
@@ -227,7 +231,9 @@ export function TenantPaymentBento() {
                   
                   {/* Right side: Price and payment button */}
                   <div className="flex flex-col items-end gap-2">
-                    <div className={`flex items-center gap-1 font-medium ${tenant.paid ? 'text-green-600' : 'text-red-600'}`}>
+                    <div className={`flex items-center gap-1 font-medium ${
+                      tenant.paid ? 'text-green-600' : 'text-red-600'
+                    }`}>
                       <Tag className="h-3 w-3" />
                       <span>{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(tenant.mieteRaw)}</span>
                     </div>

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -196,8 +196,8 @@ export function TenantPaymentBento() {
 
   return (
     <Card className="h-full flex flex-col">
-      <CardHeader>
-        <CardTitle>Mietzahlungen</CardTitle>
+      <CardHeader className="flex-shrink-0 pb-2">
+        <CardTitle className="text-lg">Mietzahlungen</CardTitle>
         <CardDescription>Bezahlt vs. offen</CardDescription>
       </CardHeader>
       <CardContent className="flex-1 overflow-y-auto pr-2">

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -195,12 +195,12 @@ export function TenantPaymentBento() {
   }
 
   return (
-    <Card>
+    <Card className="h-full flex flex-col">
       <CardHeader>
         <CardTitle>Mietzahlungen</CardTitle>
         <CardDescription>Bezahlt vs. offen</CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent className="flex-1 overflow-y-auto pr-2">
         {loading ? (
           <div className="flex justify-center items-center py-8">
             <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary"></div>

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { createClient } from "@/utils/supabase/client"
-import { Home, User } from "lucide-react"
+import { Home, User, Tag } from "lucide-react"
 
 type TenantBentoItem = {
   id: string
@@ -220,7 +220,11 @@ export function TenantPaymentBento() {
                     </div>
                     <div className="flex items-center gap-1 text-sm text-muted-foreground">
                       <Home className="h-3.5 w-3.5" />
-                      <span>{tenant.apartment}</span>
+                      <span className="mr-2">{tenant.apartment}</span>
+                      <span className={`flex items-center gap-1 ${tenant.paid ? 'text-green-600' : 'text-red-600'}`}>
+                        <Tag className="h-3 w-3" />
+                        <span>{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(tenant.mieteRaw)}</span>
+                      </span>
                     </div>
                   </div>
                   <div className="mt-4">

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -201,6 +201,12 @@ export function TenantPaymentBento() {
         <CardDescription>Bezahlt vs. offen</CardDescription>
       </CardHeader>
       <CardContent className="flex-1 overflow-y-auto pr-2">
+    <Card className="h-full flex flex-col">
+      <CardHeader>
+        <CardTitle>Mietzahlungen</CardTitle>
+        <CardDescription>Bezahlt vs. offen</CardDescription>
+      </CardHeader>
+      <CardContent className="flex-1 overflow-y-auto pr-2">
         {loading ? (
           <div className="flex justify-center items-center py-8">
             <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary"></div>

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -195,7 +195,7 @@ export function TenantPaymentBento() {
   }
 
   return (
-    <Card className="h-full flex flex-col">
+    <Card className="h-full flex flex-col overflow-hidden rounded-xl shadow-md">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Mietzahlungen</CardTitle>
         <CardDescription>Bezahlt vs. offen</CardDescription>

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -211,23 +211,26 @@ export function TenantPaymentBento() {
               data.map((tenant) => (
                 <div
                   key={tenant.id}
-                  className="w-full flex flex-col justify-between p-4 rounded-lg shadow-md bg-white border"
+                  className="w-full flex items-center justify-between p-4 rounded-lg shadow-md bg-white border"
                 >
-                  <div>
+                  {/* Left side: Tenant name and apartment */}
+                  <div className="flex flex-col gap-1">
                     <div className="flex items-center gap-1 font-semibold">
                       <User className="h-3.5 w-3.5" />
                       <span>{tenant.tenant}</span>
                     </div>
                     <div className="flex items-center gap-1 text-sm text-muted-foreground">
                       <Home className="h-3.5 w-3.5" />
-                      <span className="mr-2">{tenant.apartment}</span>
-                      <span className={`flex items-center gap-1 ${tenant.paid ? 'text-green-600' : 'text-red-600'}`}>
-                        <Tag className="h-3 w-3" />
-                        <span>{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(tenant.mieteRaw)}</span>
-                      </span>
+                      <span>{tenant.apartment}</span>
                     </div>
                   </div>
-                  <div className="mt-4">
+                  
+                  {/* Right side: Price and payment button */}
+                  <div className="flex flex-col items-end gap-2">
+                    <div className={`flex items-center gap-1 font-medium ${tenant.paid ? 'text-green-600' : 'text-red-600'}`}>
+                      <Tag className="h-3 w-3" />
+                      <span>{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(tenant.mieteRaw)}</span>
+                    </div>
                     <button
                       type="button"
                       className={

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { createClient } from "@/utils/supabase/client"
+
+type TenantBentoItem = {
+  id: string
+  tenant: string
+  apartment: string
+  paid: boolean
+}
+
+export function TenantPaymentBento() {
+  const [data, setData] = useState<TenantBentoItem[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true)
+      const supabase = createClient()
+
+      // Fetch active tenants and their apartments
+      const { data: mieterData, error: mieterError } = await supabase
+        .from("Mieter")
+        .select(`
+          id,
+          name,
+          einzug,
+          auszug,
+          Wohnungen:wohnung_id (
+            id,
+            name
+          )
+        `)
+        .or(`auszug.is.null,auszug.gt.${new Date().toISOString()}`)
+
+      if (mieterError) {
+        setLoading(false)
+        return
+      }
+
+      // Fetch payment info for current month
+      const currentDate = new Date()
+      const currentMonth = currentDate.getMonth() + 1
+      const currentYear = currentDate.getFullYear()
+      const startOfMonth = new Date(currentYear, currentMonth - 1, 1).toISOString().split('T')[0]
+      const endOfMonth = new Date(currentYear, currentMonth, 0).toISOString().split('T')[0]
+
+      const { data: finanzData } = await supabase
+        .from("Finanzen")
+        .select('wohnung_id')
+        .eq('ist_einnahmen', true)
+        .gte('datum', startOfMonth)
+        .lte('datum', endOfMonth)
+        .ilike('name', '%Mietzahlung%')
+
+      // Build paid lookup set
+      const paidWohnungen = new Set<string>()
+      finanzData?.forEach(finanz => {
+        if (finanz.wohnung_id) {
+          paidWohnungen.add(finanz.wohnung_id)
+        }
+      })
+
+      // Format data for bento grid
+      const formatted: TenantBentoItem[] = (mieterData || [])
+        .filter(mieter => mieter.Wohnungen)
+        .map(mieter => {
+          const wohnung = mieter.Wohnungen as { id: string; name: string }
+          return {
+            id: mieter.id,
+            tenant: mieter.name,
+            apartment: wohnung.name,
+            paid: paidWohnungen.has(wohnung.id),
+          }
+        })
+
+      setData(formatted)
+      setLoading(false)
+    }
+
+    fetchData()
+  }, [])
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Mietzahlungen</CardTitle>
+        <CardDescription>Bezahlt vs. offen</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="flex justify-center items-center py-8">
+            <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary"></div>
+          </div>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 auto-rows-[minmax(120px,1fr)]">
+            {data.length > 0 ? (
+              data.map((tenant) => (
+                <div
+                  key={tenant.id}
+                  className="flex flex-col justify-between p-4 rounded-lg shadow-md bg-white border"
+                >
+                  <div>
+                    <div className="font-semibold">{tenant.tenant}</div>
+                    <div className="text-sm text-muted-foreground">{tenant.apartment}</div>
+                  </div>
+                  <div className="mt-4">
+                    {tenant.paid ? (
+                      <span className="inline-block px-3 py-1 rounded-full text-xs font-medium bg-green-50 text-green-700">
+                        Bezahlt
+                      </span>
+                    ) : (
+                      <span className="inline-block px-3 py-1 rounded-full text-xs font-medium bg-red-50 text-red-700">
+                        Offen
+                      </span>
+                    )}
+                  </div>
+                </div>
+              ))
+            ) : (
+              <div className="col-span-full text-center text-muted-foreground py-6">Keine aktiven Mieter gefunden.</div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { createClient } from "@/utils/supabase/client"
+import { Home } from "lucide-react"
 
 type TenantBentoItem = {
   id: string
@@ -214,7 +215,10 @@ export function TenantPaymentBento() {
                 >
                   <div>
                     <div className="font-semibold">{tenant.tenant}</div>
-                    <div className="text-sm text-muted-foreground">{tenant.apartment}</div>
+                    <div className="flex items-center gap-1 text-sm text-muted-foreground">
+                      <Home className="h-3.5 w-3.5" />
+                      <span>{tenant.apartment}</span>
+                    </div>
                   </div>
                   <div className="mt-4">
                     <button

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -206,12 +206,12 @@ export function TenantPaymentBento() {
             <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary"></div>
           </div>
         ) : (
-          <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 auto-rows-[minmax(120px,1fr)]">
+          <div className="flex flex-col gap-4">
             {data.length > 0 ? (
               data.map((tenant) => (
                 <div
                   key={tenant.id}
-                  className="flex flex-col justify-between p-4 rounded-lg shadow-md bg-white border"
+                  className="w-full flex flex-col justify-between p-4 rounded-lg shadow-md bg-white border"
                 >
                   <div>
                     <div className="font-semibold">{tenant.tenant}</div>
@@ -239,7 +239,7 @@ export function TenantPaymentBento() {
                 </div>
               ))
             ) : (
-              <div className="col-span-full text-center text-muted-foreground py-6">Keine aktiven Mieter gefunden.</div>
+              <div className="text-center text-muted-foreground py-6">Keine aktiven Mieter gefunden.</div>
             )}
           </div>
         )}


### PR DESCRIPTION
## Description

Builds out the bento dashboard: new chart widgets and a tenant payment tracker, plus faster finance data loading.

## Summary of Changes

- Home grid finalized: stat cards row, occupancy line chart (12-month vermietet/frei with resize-aware tick counts), revenue-vs-expenses bar chart, maintenance donut (keyword-categorized expenses) and the tenant payment bento with paid/unpaid toggle that writes/deletes the monthly Mietzahlung record
- Summary cards get a bordered `.summary-card` utility; stacked finance/cost cards show /Monat and /Jahr chips
- Finance summary, balance and export routes fetch in 5,000-row batches (export ceiling raised to 100k rows)