### PR TITLE
Fix/global search

### DIFF
--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -143,7 +143,7 @@ export async function GET(request: Request) {
                 id, name, email, telefonnummer, einzug, auszug,
                 Wohnungen!left(name, Haeuser!left(name))
               `)
-              .or(`name.ilike.${searchPattern},email.ilike.${searchPattern},telefonnummer.ilike.${searchPattern}`)
+              .or(`name.ILIKE.${searchPattern},email.ILIKE.${searchPattern},telefonnummer.ILIKE.${searchPattern}`)
               .order('name')
               .limit(limit);
 
@@ -190,7 +190,7 @@ export async function GET(request: Request) {
                 id, name, strasse, ort,
                 Wohnungen!left(id, miete, Mieter!left(id, auszug))
               `)
-              .or(`name.ilike.${searchPattern},strasse.ilike.${searchPattern},ort.ilike.${searchPattern}`)
+              .or(`name.ILIKE.${searchPattern},strasse.ILIKE.${searchPattern},ort.ILIKE.${searchPattern}`)
               .order('name')
               .limit(limit);
 
@@ -297,9 +297,9 @@ export async function GET(request: Request) {
         
       if (isNumericQuery) {
         const amount = parseFloat(query);
-        financeQueryBuilder = financeQueryBuilder.or(`name.ilike.${searchPattern},notiz.ilike.${searchPattern},betrag.eq.${amount}`);
+        financeQueryBuilder = financeQueryBuilder.or(`name.ILIKE.${searchPattern},notiz.ILIKE.${searchPattern},betrag.eq.${amount}`);
       } else {
-        financeQueryBuilder = financeQueryBuilder.or(`name.ilike.${searchPattern},notiz.ilike.${searchPattern}`);
+        financeQueryBuilder = financeQueryBuilder.or(`name.ILIKE.${searchPattern},notiz.ILIKE.${searchPattern}`);
       }
       
       searchPromises.push(
@@ -354,7 +354,7 @@ export async function GET(request: Request) {
             const { data, error } = await supabase
               .from('Aufgaben')
               .select('id, name, beschreibung, ist_erledigt, erstellungsdatum')
-              .or(`name.ilike.${searchPattern},beschreibung.ilike.${searchPattern}`)
+              .or(`name.ILIKE.${searchPattern},beschreibung.ILIKE.${searchPattern}`)
               .order('ist_erledigt', { ascending: true }) // Incomplete tasks first
               .order('erstellungsdatum', { ascending: false })
               .limit(limit);

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -32,7 +32,7 @@ export async function GET(request: Request) {
 
     const { data, error } = await supabase
       .from('Mieter')
-      .select('id, name, email')
+      .select('id, name, email, telefonnummer, einzug, auszug')
       .ilike('name', `%${query}%`);
 
     console.log("Supabase query data:", data);
@@ -43,6 +43,11 @@ export async function GET(request: Request) {
         id: tenant.id,
         name: tenant.name,
         email: tenant.email || undefined,
+        phone: tenant.telefonnummer || undefined,
+        apartment: undefined,
+        status: tenant.auszug ? 'moved_out' : 'active',
+        move_in_date: tenant.einzug || undefined,
+        move_out_date: tenant.auszug || undefined
       }));
     }
     

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -29,7 +29,7 @@ function getSearchPatterns(query: string): { pattern: string; exact: string } {
   }
 
   const sanitized = sanitizeQuery(query);
-  const pattern = `%${sanitized}%`;
+  const pattern = `%${sanitized.toLowerCase()}%`;
   const exact = sanitized;
 
   searchPatternCache.set(cacheKey, {

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -2,124 +2,23 @@ export const runtime = 'edge';
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 import type {
-  TenantSearchResult,
-  HouseSearchResult,
-  ApartmentSearchResult,
-  FinanceSearchResult,
-  TaskSearchResult,
   SearchResponse
 } from "@/types/search";
-
-// Cache for storing compiled search patterns
-const searchPatternCache = new Map<string, { pattern: string; exact: string; timestamp: number }>();
-const PATTERN_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
-
-// Helper function to sanitize search query
-function sanitizeQuery(query: string): string {
-  return query.trim().replace(/[%_]/g, '\\$&');
-}
-
-// Helper function to create search patterns with caching
-function getSearchPatterns(query: string): { pattern: string; exact: string } {
-  const cacheKey = query.toLowerCase();
-  const cached = searchPatternCache.get(cacheKey);
-  
-  if (cached && Date.now() - cached.timestamp < PATTERN_CACHE_TTL) {
-    return { pattern: cached.pattern, exact: cached.exact };
-  }
-  
-  const sanitized = sanitizeQuery(query);
-  const pattern = `%${sanitized}%`;
-  const exact = sanitized;
-  
-  searchPatternCache.set(cacheKey, {
-    pattern,
-    exact,
-    timestamp: Date.now()
-  });
-  
-  return { pattern, exact };
-}
-
-// Helper function to clean up expired cache entries
-function cleanupPatternCache(): void {
-  const now = Date.now();
-  for (const [key, value] of searchPatternCache.entries()) {
-    if (now - value.timestamp > PATTERN_CACHE_TTL) {
-      searchPatternCache.delete(key);
-    }
-  }
-}
-
-// Helper function to sort results by relevance
-function sortByRelevance<T extends { name?: string; title?: string }>(
-  results: T[], 
-  query: string
-): T[] {
-  const queryLower = query.toLowerCase();
-  
-  return results.sort((a, b) => {
-    const aName = (a.name || (a as any).title || '').toLowerCase();
-    const bName = (b.name || (b as any).title || '').toLowerCase();
-    
-    // Exact matches first
-    const aExact = aName === queryLower;
-    const bExact = bName === queryLower;
-    if (aExact && !bExact) return -1;
-    if (!aExact && bExact) return 1;
-    
-    // Starts with query second
-    const aStarts = aName.startsWith(queryLower);
-    const bStarts = bName.startsWith(queryLower);
-    if (aStarts && !bStarts) return -1;
-    if (!aStarts && bStarts) return 1;
-    
-    // Alphabetical order for the rest
-    return aName.localeCompare(bName);
-  });
-}
 
 export async function GET(request: Request) {
   const startTime = Date.now();
   
   try {
-    // Clean up expired cache entries periodically
-    if (Math.random() < 0.1) { // 10% chance to clean up
-      cleanupPatternCache();
-    }
-
-    // Add request timeout
-    const timeoutPromise = new Promise((_, reject) => {
-      setTimeout(() => reject(new Error('Request timeout')), 15000); // 15 second timeout
-    });
-    
     const { searchParams } = new URL(request.url);
     const query = searchParams.get('q');
-    const limit = parseInt(searchParams.get('limit') || '5', 10);
-    const categories = searchParams.get('categories')?.split(',') || ['tenants', 'houses', 'apartments', 'finances', 'tasks'];
     
-    // Validate query parameter
     if (!query || query.trim().length === 0) {
       return NextResponse.json({ 
         error: 'Search query is required' 
       }, { status: 400 });
     }
     
-    if (query.length > 100) {
-      return NextResponse.json({ 
-        error: 'Search query too long' 
-      }, { status: 400 });
-    }
-    
-    // Validate limit
-    if (limit < 1 || limit > 20) {
-      return NextResponse.json({ 
-        error: 'Limit must be between 1 and 20' 
-      }, { status: 400 });
-    }
-    
     const supabase = await createClient();
-    const { pattern: searchPattern, exact: exactPattern } = getSearchPatterns(query);
     
     const results: SearchResponse['results'] = {
       tenants: [],
@@ -129,286 +28,22 @@ export async function GET(request: Request) {
       tasks: []
     };
     
-    // Use Promise.allSettled for parallel execution with error isolation
-    const searchPromises = [];
-    
-    // Search tenants (Mieter) - Optimized query with proper JOINs
-    if (categories.includes('tenants')) {
-      searchPromises.push(
-        (async () => {
-          try {
-            const { data, error } = await supabase
-              .from('Mieter')
-              .select(`
-                id, name, email, telefonnummer, einzug, auszug,
-                Wohnungen!left(name, Haeuser!left(name))
-              `)
-              .or(`name.ILIKE.${searchPattern},email.ILIKE.${searchPattern},telefonnummer.ILIKE.${searchPattern}`)
-              .order('name')
-              .limit(limit);
+    console.log("Searching for tenants with query:", query);
 
-            if (error) {
-              console.error('Tenant search error:', error);
-              return { type: 'tenants', data: [] };
-            }
-            
-            if (!data) return { type: 'tenants', data: [] };
-            
-            const sortedTenants = sortByRelevance(data, query);
-            
-            const tenantResults = sortedTenants.map((tenant: any) => ({
-              id: tenant.id,
-              name: tenant.name,
-              email: tenant.email || undefined,
-              phone: tenant.telefonnummer || undefined,
-              apartment: tenant.Wohnungen && typeof tenant.Wohnungen === 'object' && !Array.isArray(tenant.Wohnungen) ? {
-                name: tenant.Wohnungen.name,
-                house_name: tenant.Wohnungen.Haeuser && typeof tenant.Wohnungen.Haeuser === 'object' && !Array.isArray(tenant.Wohnungen.Haeuser) ? tenant.Wohnungen.Haeuser.name : ''
-              } : undefined,
-              status: tenant.auszug ? 'moved_out' : 'active',
-              move_in_date: tenant.einzug || undefined,
-              move_out_date: tenant.auszug || undefined
-            }));
-            
-            return { type: 'tenants', data: tenantResults };
-          } catch (error) {
-            console.error('Error searching tenants:', error);
-            return { type: 'tenants', data: [] };
-          }
-        })()
-      );
-    }
-    
-    // Search houses (Haeuser) - Optimized with aggregated apartment data
-    if (categories.includes('houses')) {
-      searchPromises.push(
-        (async () => {
-          try {
-            const { data, error } = await supabase
-              .from('Haeuser')
-              .select(`
-                id, name, strasse, ort,
-                Wohnungen!left(id, miete, Mieter!left(id, auszug))
-              `)
-              .or(`name.ILIKE.${searchPattern},strasse.ILIKE.${searchPattern},ort.ILIKE.${searchPattern}`)
-              .order('name')
-              .limit(limit);
+    const { data, error } = await supabase
+      .from('Mieter')
+      .select('id, name, email')
+      .ilike('name', `%${query}%`);
 
-            if (error) {
-              console.error('House search error:', error);
-              return { type: 'houses', data: [] };
-            }
-            
-            if (!data) return { type: 'houses', data: [] };
-            
-            const sortedHouses = sortByRelevance(data, query);
-            
-            const houseResults = sortedHouses.map((house: any) => {
-              const apartments = Array.isArray(house.Wohnungen) ? house.Wohnungen : (house.Wohnungen ? [house.Wohnungen] : []);
-              const totalRent = apartments.reduce((sum: number, apt: any) => sum + (apt.miete || 0), 0);
-              const freeApartments = apartments.filter((apt: any) => 
-                !apt.Mieter || (Array.isArray(apt.Mieter) && apt.Mieter.length === 0) || 
-                (Array.isArray(apt.Mieter) && apt.Mieter.some((m: any) => m.auszug))
-              ).length;
-              
-              return {
-                id: house.id,
-                name: house.name,
-                address: [house.strasse, house.ort].filter(Boolean).join(', '),
-                apartment_count: apartments.length,
-                total_rent: totalRent,
-                free_apartments: freeApartments
-              };
-            });
-            
-            return { type: 'houses', data: houseResults };
-          } catch (error) {
-            console.error('Error searching houses:', error);
-            return { type: 'houses', data: [] };
-          }
-        })()
-      );
-    }
-    
-    // Search apartments (Wohnungen) - Optimized with single query
-    if (categories.includes('apartments')) {
-      searchPromises.push(
-        (async () => {
-          try {
-            const { data, error } = await supabase
-              .from('Wohnungen')
-              .select(`
-                id, name, groesse, miete,
-                Haeuser!left(name),
-                Mieter!left(name, einzug, auszug)
-              `)
-              .ilike('name', searchPattern)
-              .order('name')
-              .limit(limit);
+    console.log("Supabase query data:", data);
+    console.log("Supabase query error:", error);
 
-            if (error) {
-              console.error('Apartment search error:', error);
-              return { type: 'apartments', data: [] };
-            }
-            
-            if (!data) return { type: 'apartments', data: [] };
-            
-            const sortedApartments = sortByRelevance(data, query);
-            
-            const apartmentResults = sortedApartments.map((apartment: any) => {
-              const mieterArray = Array.isArray(apartment.Mieter) ? apartment.Mieter : (apartment.Mieter ? [apartment.Mieter] : []);
-              const currentTenant = mieterArray.find((m: any) => !m.auszug);
-              
-              return {
-                id: apartment.id,
-                name: apartment.name,
-                house_name: apartment.Haeuser && typeof apartment.Haeuser === 'object' && !Array.isArray(apartment.Haeuser) ? apartment.Haeuser.name : '',
-                size: apartment.groesse,
-                rent: apartment.miete,
-                status: currentTenant ? 'rented' : 'free',
-                current_tenant: currentTenant ? {
-                  name: currentTenant.name,
-                  move_in_date: currentTenant.einzug || ''
-                } : undefined
-              };
-            });
-            
-            return { type: 'apartments', data: apartmentResults };
-          } catch (error) {
-            console.error('Error searching apartments:', error);
-            return { type: 'apartments', data: [] };
-          }
-        })()
-      );
-    }
-    
-    // Search finances (Finanzen) - Optimized with conditional numeric search
-    if (categories.includes('finances')) {
-      const isNumericQuery = !isNaN(parseFloat(query));
-      
-      let financeQueryBuilder = supabase
-        .from('Finanzen')
-        .select(`
-          id, name, betrag, datum, ist_einnahmen, notiz,
-          Wohnungen!left(name, Haeuser!left(name))
-        `)
-        .order('datum', { ascending: false })
-        .limit(limit);
-        
-      if (isNumericQuery) {
-        const amount = parseFloat(query);
-        financeQueryBuilder = financeQueryBuilder.or(`name.ILIKE.${searchPattern},notiz.ILIKE.${searchPattern},betrag.eq.${amount}`);
-      } else {
-        financeQueryBuilder = financeQueryBuilder.or(`name.ILIKE.${searchPattern},notiz.ILIKE.${searchPattern}`);
-      }
-      
-      searchPromises.push(
-        (async () => {
-          try {
-            const { data, error } = await financeQueryBuilder;
-
-            if (error) {
-              console.error('Finance search error:', error);
-              return { type: 'finances', data: [] };
-            }
-            
-            if (!data) return { type: 'finances', data: [] };
-            
-            // Custom sorting for finances: relevance first, then by date
-            const sortedFinances = data.sort((a, b) => {
-              const aExact = a.name.toLowerCase() === query.toLowerCase();
-              const bExact = b.name.toLowerCase() === query.toLowerCase();
-              if (aExact && !bExact) return -1;
-              if (!aExact && bExact) return 1;
-              // Then by date (most recent first)
-              return new Date(b.datum).getTime() - new Date(a.datum).getTime();
-            });
-            
-            const financeResults = sortedFinances.map((finance: any) => ({
-              id: finance.id,
-              name: finance.name,
-              amount: finance.betrag,
-              date: finance.datum,
-              type: finance.ist_einnahmen ? 'income' : 'expense',
-              apartment: finance.Wohnungen && typeof finance.Wohnungen === 'object' && !Array.isArray(finance.Wohnungen) ? {
-                name: finance.Wohnungen.name,
-                house_name: finance.Wohnungen.Haeuser && typeof finance.Wohnungen.Haeuser === 'object' && !Array.isArray(finance.Wohnungen.Haeuser) ? finance.Wohnungen.Haeuser.name : ''
-              } : undefined,
-              notes: finance.notiz || undefined
-            }));
-            
-            return { type: 'finances', data: financeResults };
-          } catch (error) {
-            console.error('Error searching finances:', error);
-            return { type: 'finances', data: [] };
-          }
-        })()
-      );
-    }
-    
-    // Search tasks (Aufgaben) - Optimized with completion status ordering
-    if (categories.includes('tasks')) {
-      searchPromises.push(
-        (async () => {
-          try {
-            const { data, error } = await supabase
-              .from('Aufgaben')
-              .select('id, name, beschreibung, ist_erledigt, erstellungsdatum')
-              .or(`name.ILIKE.${searchPattern},beschreibung.ILIKE.${searchPattern}`)
-              .order('ist_erledigt', { ascending: true }) // Incomplete tasks first
-              .order('erstellungsdatum', { ascending: false })
-              .limit(limit);
-
-            if (error) {
-              console.error('Task search error:', error);
-              return { type: 'tasks', data: [] };
-            }
-            
-            if (!data) return { type: 'tasks', data: [] };
-            
-            const sortedTasks = sortByRelevance(data, query);
-            
-            const taskResults = sortedTasks.map((task: any) => ({
-              id: task.id,
-              name: task.name,
-              description: task.beschreibung,
-              completed: task.ist_erledigt,
-              created_date: task.erstellungsdatum
-            }));
-            
-            return { type: 'tasks', data: taskResults };
-          } catch (error) {
-            console.error('Error searching tasks:', error);
-            return { type: 'tasks', data: [] };
-          }
-        })()
-      );
-    }
-    
-    // Execute all searches in parallel with timeout
-    const searchResults = await Promise.race([
-      Promise.allSettled(searchPromises),
-      timeoutPromise
-    ]) as PromiseSettledResult<any>[];
-    
-    // Process results with graceful degradation
-    let successfulSearches = 0;
-    let failedSearches = 0;
-    
-    searchResults.forEach(result => {
-      if (result.status === 'fulfilled' && result.value) {
-        const { type, data } = result.value;
-        (results as any)[type] = data;
-        successfulSearches++;
-      } else {
-        failedSearches++;
-        console.warn('Search failed for category:', result.status === 'rejected' ? result.reason : 'Unknown error');
-      }
-    });
-
-    // Log performance metrics
-    if (process.env.NODE_ENV === 'development') {
-      console.log(`Search completed: ${successfulSearches} successful, ${failedSearches} failed`);
+    if (data) {
+      results.tenants = data.map((tenant: any) => ({
+        id: tenant.id,
+        name: tenant.name,
+        email: tenant.email || undefined,
+      }));
     }
     
     const totalCount = Object.values(results).reduce((sum, arr) => sum + arr.length, 0);
@@ -420,60 +55,20 @@ export async function GET(request: Request) {
       executionTime
     };
 
-    // Add warning header if some searches failed but we have partial results
-    const headers = new Headers({
-      'Content-Type': 'application/json',
-      'Cache-Control': 'public, max-age=60', // Cache for 1 minute
-    });
-    
-    if (failedSearches > 0 && successfulSearches > 0) {
-      headers.set('X-Partial-Results', 'true');
-      headers.set('X-Failed-Categories', failedSearches.toString());
-    }
-    
-    // Add compression hint for larger responses
-    if (totalCount > 10) {
-      headers.set('Content-Encoding', 'gzip');
-    }
-
-    // Return partial results even if some categories failed
     return new NextResponse(JSON.stringify(response), { 
-      status: totalCount > 0 || successfulSearches > 0 ? 200 : 206, // 206 for partial content
-      headers
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      }
     });
     
   } catch (error) {
     console.error('Search API error:', error);
     
-    // Provide more specific error messages
-    let errorMessage = 'Serverfehler bei der Suche.';
-    let statusCode = 500;
-    
-    if (error instanceof Error) {
-      if (error.message.includes('timeout')) {
-        errorMessage = 'Die Suche dauert zu lange. Bitte versuchen Sie es mit einem anderen Suchbegriff.';
-        statusCode = 408; // Request Timeout
-      } else if (error.message.includes('database') || error.message.includes('connection')) {
-        errorMessage = 'Datenbankverbindung nicht verfügbar. Bitte versuchen Sie es später erneut.';
-        statusCode = 503; // Service Unavailable
-      } else if (error.message.includes('memory') || error.message.includes('resource')) {
-        errorMessage = 'Server überlastet. Bitte versuchen Sie es in wenigen Sekunden erneut.';
-        statusCode = 503; // Service Unavailable
-      }
-    }
-    
-    const responseHeaders: Record<string, string> = {};
-    if (statusCode === 503) {
-      responseHeaders['Retry-After'] = '30'; // Suggest retry after 30 seconds for service unavailable
-    }
-
     return NextResponse.json({ 
-      error: errorMessage,
-      timestamp: new Date().toISOString(),
-      requestId: Math.random().toString(36).substring(7) // Simple request ID for debugging
+      error: 'Serverfehler bei der Suche.',
     }, { 
-      status: statusCode,
-      headers: responseHeaders
+      status: 500,
     });
   }
 }

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -2,125 +2,33 @@ export const runtime = 'edge';
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 import type {
-  TenantSearchResult,
-  HouseSearchResult,
-  ApartmentSearchResult,
-  FinanceSearchResult,
-  TaskSearchResult,
   SearchResponse
 } from "@/types/search";
-
-// Cache for storing compiled search patterns
-const searchPatternCache = new Map<string, { pattern: string; exact: string; timestamp: number }>();
-const PATTERN_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
-
-// Helper function to sanitize search query
-function sanitizeQuery(query: string): string {
-  return query.trim().replace(/[%_]/g, '\\$&');
-}
-
-// Helper function to create search patterns with caching
-function getSearchPatterns(query: string): { pattern: string; exact: string } {
-  const cacheKey = query.toLowerCase();
-  const cached = searchPatternCache.get(cacheKey);
-
-  if (cached && Date.now() - cached.timestamp < PATTERN_CACHE_TTL) {
-    return { pattern: cached.pattern, exact: cached.exact };
-  }
-
-  const sanitized = sanitizeQuery(query);
-  const pattern = `%${sanitized.toLowerCase()}%`;
-  const exact = sanitized;
-
-  searchPatternCache.set(cacheKey, {
-    pattern,
-    exact,
-    timestamp: Date.now()
-  });
-
-  return { pattern, exact };
-}
-
-// Helper function to clean up expired cache entries
-function cleanupPatternCache(): void {
-  const now = Date.now();
-  for (const [key, value] of searchPatternCache.entries()) {
-    if (now - value.timestamp > PATTERN_CACHE_TTL) {
-      searchPatternCache.delete(key);
-    }
-  }
-}
-
-// Helper function to sort results by relevance
-function sortByRelevance<T extends { name?: string; title?: string }>(
-  results: T[],
-  query: string
-): T[] {
-  const queryLower = query.toLowerCase();
-
-  return results.sort((a, b) => {
-    const aName = (a.name || (a as any).title || '').toLowerCase();
-    const bName = (b.name || (b as any).title || '').toLowerCase();
-
-    // Exact matches first
-    const aExact = aName === queryLower;
-    const bExact = bName === queryLower;
-    if (aExact && !bExact) return -1;
-    if (!aExact && bExact) return 1;
-
-    // Starts with query second
-    const aStarts = aName.startsWith(queryLower);
-    const bStarts = bName.startsWith(queryLower);
-    if (aStarts && !bStarts) return -1;
-    if (!aStarts && bStarts) return 1;
-
-    // Alphabetical order for the rest
-    return aName.localeCompare(bName);
-  });
-}
 
 export async function GET(request: Request) {
   const startTime = Date.now();
   
   try {
-    // Clean up expired cache entries periodically
-    if (Math.random() < 0.1) { // 10% chance to clean up
-      cleanupPatternCache();
-    }
-
-    // Add request timeout
-    const timeoutPromise = new Promise((_, reject) => {
-      setTimeout(() => reject(new Error('Request timeout')), 15000); // 15 second timeout
-    });
-
     const { searchParams } = new URL(request.url);
     const query = searchParams.get('q');
-    const limit = parseInt(searchParams.get('limit') || '5', 10);
-    const categories = searchParams.get('categories')?.split(',') || ['tenants', 'houses', 'apartments', 'finances', 'tasks'];
     
-    // Validate query parameter
     if (!query || query.trim().length === 0) {
       return NextResponse.json({ 
         error: 'Search query is required' 
       }, { status: 400 });
     }
     
-    if (query.length > 100) {
-      return NextResponse.json({
-        error: 'Search query too long'
-      }, { status: 400 });
-    }
-
-    // Validate limit
-    if (limit < 1 || limit > 20) {
-      return NextResponse.json({
-        error: 'Limit must be between 1 and 20'
-      }, { status: 400 });
-    }
-
     const supabase = await createClient();
-    const { pattern: searchPattern, exact: exactPattern } = getSearchPatterns(query);
-    
+
+    const { data, error } = await supabase.rpc('search_all', {
+      search_term: query
+    });
+
+    if (error) {
+      console.error('Search RPC error:', error);
+      throw new Error('Search failed');
+    }
+
     const results: SearchResponse['results'] = {
       tenants: [],
       houses: [],
@@ -128,287 +36,65 @@ export async function GET(request: Request) {
       finances: [],
       tasks: []
     };
-    
-    // Use Promise.allSettled for parallel execution with error isolation
-    const searchPromises = [];
 
-    // Search tenants (Mieter) - Optimized query with proper JOINs
-    if (categories.includes('tenants')) {
-      searchPromises.push(
-        (async () => {
-          try {
-            const { data, error } = await supabase
-              .from('Mieter')
-              .select(`
-                id, name, email, telefonnummer, einzug, auszug,
-                Wohnungen!left(name, Haeuser!left(name))
-              `)
-              .or(`name.ilike.${searchPattern},email.ilike.${searchPattern},telefonnummer.ilike.${searchPattern}`)
-              .order('name')
-              .limit(limit);
-
-            if (error) {
-              console.error('Tenant search error:', error);
-              return { type: 'tenants', data: [] };
-            }
-
-            if (!data) return { type: 'tenants', data: [] };
-
-            const sortedTenants = sortByRelevance(data, query);
-
-            const tenantResults = sortedTenants.map((tenant: any) => ({
-              id: tenant.id,
-              name: tenant.name,
-              email: tenant.email || undefined,
-              phone: tenant.telefonnummer || undefined,
-              apartment: tenant.Wohnungen && typeof tenant.Wohnungen === 'object' && !Array.isArray(tenant.Wohnungen) ? {
-                name: tenant.Wohnungen.name,
-                house_name: tenant.Wohnungen.Haeuser && typeof tenant.Wohnungen.Haeuser === 'object' && !Array.isArray(tenant.Wohnungen.Haeuser) ? tenant.Wohnungen.Haeuser.name : ''
-              } : undefined,
-              status: tenant.auszug ? 'moved_out' : 'active',
-              move_in_date: tenant.einzug || undefined,
-              move_out_date: tenant.auszug || undefined
-            }));
-
-            return { type: 'tenants', data: tenantResults };
-          } catch (error) {
-            console.error('Error searching tenants:', error);
-            return { type: 'tenants', data: [] };
-          }
-        })()
-      );
-    }
-
-    // Search houses (Haeuser) - Optimized with aggregated apartment data
-    if (categories.includes('houses')) {
-      searchPromises.push(
-        (async () => {
-          try {
-            const { data, error } = await supabase
-              .from('Haeuser')
-              .select(`
-                id, name, strasse, ort,
-                Wohnungen!left(id, miete, Mieter!left(id, auszug))
-              `)
-              .or(`name.ilike.${searchPattern},strasse.ilike.${searchPattern},ort.ilike.${searchPattern}`)
-              .order('name')
-              .limit(limit);
-
-            if (error) {
-              console.error('House search error:', error);
-              return { type: 'houses', data: [] };
-            }
-
-            if (!data) return { type: 'houses', data: [] };
-
-            const sortedHouses = sortByRelevance(data, query);
-
-            const houseResults = sortedHouses.map((house: any) => {
-              const apartments = Array.isArray(house.Wohnungen) ? house.Wohnungen : (house.Wohnungen ? [house.Wohnungen] : []);
-              const totalRent = apartments.reduce((sum: number, apt: any) => sum + (apt.miete || 0), 0);
-              const freeApartments = apartments.filter((apt: any) =>
-                !apt.Mieter || (Array.isArray(apt.Mieter) && apt.Mieter.length === 0) ||
-                (Array.isArray(apt.Mieter) && apt.Mieter.some((m: any) => m.auszug))
-              ).length;
-
-              return {
-                id: house.id,
-                name: house.name,
-                address: [house.strasse, house.ort].filter(Boolean).join(', '),
-                apartment_count: apartments.length,
-                total_rent: totalRent,
-                free_apartments: freeApartments
-              };
+    if (data) {
+      data.forEach((item: any) => {
+        switch (item.entity_type) {
+          case 'tenant':
+            results.tenants.push({
+              id: item.id,
+              name: item.name,
+              email: item.email,
+              phone: item.phone,
+              status: item.status,
+              move_in_date: item.move_in_date,
+              move_out_date: item.move_out_date,
+              apartment: item.apartment,
             });
-
-            return { type: 'houses', data: houseResults };
-          } catch (error) {
-            console.error('Error searching houses:', error);
-            return { type: 'houses', data: [] };
-          }
-        })()
-      );
-    }
-
-    // Search apartments (Wohnungen) - Optimized with single query
-    if (categories.includes('apartments')) {
-      searchPromises.push(
-        (async () => {
-          try {
-            const { data, error } = await supabase
-              .from('Wohnungen')
-              .select(`
-                id, name, groesse, miete,
-                Haeuser!left(name),
-                Mieter!left(name, einzug, auszug)
-              `)
-              .ilike('name', searchPattern)
-              .order('name')
-              .limit(limit);
-
-            if (error) {
-              console.error('Apartment search error:', error);
-              return { type: 'apartments', data: [] };
-            }
-
-            if (!data) return { type: 'apartments', data: [] };
-
-            const sortedApartments = sortByRelevance(data, query);
-
-            const apartmentResults = sortedApartments.map((apartment: any) => {
-              const mieterArray = Array.isArray(apartment.Mieter) ? apartment.Mieter : (apartment.Mieter ? [apartment.Mieter] : []);
-              const currentTenant = mieterArray.find((m: any) => !m.auszug);
-
-              return {
-                id: apartment.id,
-                name: apartment.name,
-                house_name: apartment.Haeuser && typeof apartment.Haeuser === 'object' && !Array.isArray(apartment.Haeuser) ? apartment.Haeuser.name : '',
-                size: apartment.groesse,
-                rent: apartment.miete,
-                status: currentTenant ? 'rented' : 'free',
-                current_tenant: currentTenant ? {
-                  name: currentTenant.name,
-                  move_in_date: currentTenant.einzug || ''
-                } : undefined
-              };
+            break;
+          case 'house':
+            results.houses.push({
+              id: item.id,
+              name: item.name,
+              address: item.address,
+              apartment_count: item.apartment_count,
+              total_rent: item.total_rent,
+              free_apartments: item.free_apartments,
             });
-
-            return { type: 'apartments', data: apartmentResults };
-          } catch (error) {
-            console.error('Error searching apartments:', error);
-            return { type: 'apartments', data: [] };
-          }
-        })()
-      );
-    }
-
-    // Search finances (Finanzen) - Optimized with conditional numeric search
-    if (categories.includes('finances')) {
-      const isNumericQuery = !isNaN(parseFloat(query));
-
-      let financeQueryBuilder = supabase
-        .from('Finanzen')
-        .select(`
-          id, name, betrag, datum, ist_einnahmen, notiz,
-          Wohnungen!left(name, Haeuser!left(name))
-        `)
-        .order('datum', { ascending: false })
-        .limit(limit);
-
-      if (isNumericQuery) {
-        const amount = parseFloat(query);
-        financeQueryBuilder = financeQueryBuilder.or(`name.ilike.${searchPattern},notiz.ilike.${searchPattern},betrag.eq.${amount}`);
-      } else {
-        financeQueryBuilder = financeQueryBuilder.or(`name.ilike.${searchPattern},notiz.ilike.${searchPattern}`);
-      }
-
-      searchPromises.push(
-        (async () => {
-          try {
-            const { data, error } = await financeQueryBuilder;
-
-            if (error) {
-              console.error('Finance search error:', error);
-              return { type: 'finances', data: [] };
-            }
-
-            if (!data) return { type: 'finances', data: [] };
-
-            // Custom sorting for finances: relevance first, then by date
-            const sortedFinances = data.sort((a, b) => {
-              const aExact = a.name.toLowerCase() === query.toLowerCase();
-              const bExact = b.name.toLowerCase() === query.toLowerCase();
-              if (aExact && !bExact) return -1;
-              if (!aExact && bExact) return 1;
-              // Then by date (most recent first)
-              return new Date(b.datum).getTime() - new Date(a.datum).getTime();
+            break;
+          case 'apartment':
+            results.apartments.push({
+              id: item.id,
+              name: item.name,
+              house_name: item.house_name,
+              size: item.size,
+              rent: item.rent,
+              status: item.status,
+              current_tenant: item.current_tenant,
             });
-
-            const financeResults = sortedFinances.map((finance: any) => ({
-              id: finance.id,
-              name: finance.name,
-              amount: finance.betrag,
-              date: finance.datum,
-              type: finance.ist_einnahmen ? 'income' : 'expense',
-              apartment: finance.Wohnungen && typeof finance.Wohnungen === 'object' && !Array.isArray(finance.Wohnungen) ? {
-                name: finance.Wohnungen.name,
-                house_name: finance.Wohnungen.Haeuser && typeof finance.Wohnungen.Haeuser === 'object' && !Array.isArray(finance.Wohnungen.Haeuser) ? finance.Wohnungen.Haeuser.name : ''
-              } : undefined,
-              notes: finance.notiz || undefined
-            }));
-
-            return { type: 'finances', data: financeResults };
-          } catch (error) {
-            console.error('Error searching finances:', error);
-            return { type: 'finances', data: [] };
-          }
-        })()
-      );
-    }
-
-    // Search tasks (Aufgaben) - Optimized with completion status ordering
-    if (categories.includes('tasks')) {
-      searchPromises.push(
-        (async () => {
-          try {
-            const { data, error } = await supabase
-              .from('Aufgaben')
-              .select('id, name, beschreibung, ist_erledigt, erstellungsdatum')
-              .or(`name.ilike.${searchPattern},beschreibung.ilike.${searchPattern}`)
-              .order('ist_erledigt', { ascending: true }) // Incomplete tasks first
-              .order('erstellungsdatum', { ascending: false })
-              .limit(limit);
-
-            if (error) {
-              console.error('Task search error:', error);
-              return { type: 'tasks', data: [] };
-            }
-
-            if (!data) return { type: 'tasks', data: [] };
-
-            const sortedTasks = sortByRelevance(data, query);
-
-            const taskResults = sortedTasks.map((task: any) => ({
-              id: task.id,
-              name: task.name,
-              description: task.beschreibung,
-              completed: task.ist_erledigt,
-              created_date: task.erstellungsdatum
-            }));
-
-            return { type: 'tasks', data: taskResults };
-          } catch (error) {
-            console.error('Error searching tasks:', error);
-            return { type: 'tasks', data: [] };
-          }
-        })()
-      );
-    }
-
-    // Execute all searches in parallel with timeout
-    const searchResults = await Promise.race([
-      Promise.allSettled(searchPromises),
-      timeoutPromise
-    ]) as PromiseSettledResult<any>[];
-
-    // Process results with graceful degradation
-    let successfulSearches = 0;
-    let failedSearches = 0;
-
-    searchResults.forEach(result => {
-      if (result.status === 'fulfilled' && result.value) {
-        const { type, data } = result.value;
-        (results as any)[type] = data;
-        successfulSearches++;
-      } else {
-        failedSearches++;
-        console.warn('Search failed for category:', result.status === 'rejected' ? result.reason : 'Unknown error');
-      }
-    });
-
-    // Log performance metrics
-    if (process.env.NODE_ENV === 'development') {
-      console.log(`Search completed: ${successfulSearches} successful, ${failedSearches} failed`);
+            break;
+          case 'finance':
+            results.finances.push({
+              id: item.id,
+              name: item.name,
+              amount: item.amount,
+              date: item.date,
+              type: item.type,
+              apartment: item.apartment,
+              notes: item.notes,
+            });
+            break;
+          case 'task':
+            results.tasks.push({
+              id: item.id,
+              name: item.name,
+              description: item.description,
+              completed: item.completed,
+              created_date: item.created_date,
+            });
+            break;
+        }
+      });
     }
     
     const totalCount = Object.values(results).reduce((sum, arr) => sum + arr.length, 0);
@@ -420,60 +106,20 @@ export async function GET(request: Request) {
       executionTime
     };
 
-    // Add warning header if some searches failed but we have partial results
-    const headers = new Headers({
-      'Content-Type': 'application/json',
-      'Cache-Control': 'public, max-age=60', // Cache for 1 minute
-    });
-
-    if (failedSearches > 0 && successfulSearches > 0) {
-      headers.set('X-Partial-Results', 'true');
-      headers.set('X-Failed-Categories', failedSearches.toString());
-    }
-
-    // Add compression hint for larger responses
-    if (totalCount > 10) {
-      headers.set('Content-Encoding', 'gzip');
-    }
-
-    // Return partial results even if some categories failed
     return new NextResponse(JSON.stringify(response), { 
-      status: totalCount > 0 || successfulSearches > 0 ? 200 : 206, // 206 for partial content
-      headers
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+      }
     });
     
   } catch (error) {
     console.error('Search API error:', error);
     
-    // Provide more specific error messages
-    let errorMessage = 'Serverfehler bei der Suche.';
-    let statusCode = 500;
-
-    if (error instanceof Error) {
-      if (error.message.includes('timeout')) {
-        errorMessage = 'Die Suche dauert zu lange. Bitte versuchen Sie es mit einem anderen Suchbegriff.';
-        statusCode = 408; // Request Timeout
-      } else if (error.message.includes('database') || error.message.includes('connection')) {
-        errorMessage = 'Datenbankverbindung nicht verfügbar. Bitte versuchen Sie es später erneut.';
-        statusCode = 503; // Service Unavailable
-      } else if (error.message.includes('memory') || error.message.includes('resource')) {
-        errorMessage = 'Server überlastet. Bitte versuchen Sie es in wenigen Sekunden erneut.';
-        statusCode = 503; // Service Unavailable
-      }
-    }
-
-    const responseHeaders: Record<string, string> = {};
-    if (statusCode === 503) {
-      responseHeaders['Retry-After'] = '30'; // Suggest retry after 30 seconds for service unavailable
-    }
-
     return NextResponse.json({ 
-      error: errorMessage,
-      timestamp: new Date().toISOString(),
-      requestId: Math.random().toString(36).substring(7) // Simple request ID for debugging
+      error: 'Serverfehler bei der Suche.',
     }, { 
-      status: statusCode,
-      headers: responseHeaders
+      status: 500,
     });
   }
 }

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -2,23 +2,124 @@ export const runtime = 'edge';
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 import type {
+  TenantSearchResult,
+  HouseSearchResult,
+  ApartmentSearchResult,
+  FinanceSearchResult,
+  TaskSearchResult,
   SearchResponse
 } from "@/types/search";
+
+// Cache for storing compiled search patterns
+const searchPatternCache = new Map<string, { pattern: string; exact: string; timestamp: number }>();
+const PATTERN_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+// Helper function to sanitize search query
+function sanitizeQuery(query: string): string {
+  return query.trim().replace(/[%_]/g, '\\$&');
+}
+
+// Helper function to create search patterns with caching
+function getSearchPatterns(query: string): { pattern: string; exact: string } {
+  const cacheKey = query.toLowerCase();
+  const cached = searchPatternCache.get(cacheKey);
+
+  if (cached && Date.now() - cached.timestamp < PATTERN_CACHE_TTL) {
+    return { pattern: cached.pattern, exact: cached.exact };
+  }
+
+  const sanitized = sanitizeQuery(query);
+  const pattern = `%${sanitized}%`;
+  const exact = sanitized;
+
+  searchPatternCache.set(cacheKey, {
+    pattern,
+    exact,
+    timestamp: Date.now()
+  });
+
+  return { pattern, exact };
+}
+
+// Helper function to clean up expired cache entries
+function cleanupPatternCache(): void {
+  const now = Date.now();
+  for (const [key, value] of searchPatternCache.entries()) {
+    if (now - value.timestamp > PATTERN_CACHE_TTL) {
+      searchPatternCache.delete(key);
+    }
+  }
+}
+
+// Helper function to sort results by relevance
+function sortByRelevance<T extends { name?: string; title?: string }>(
+  results: T[],
+  query: string
+): T[] {
+  const queryLower = query.toLowerCase();
+
+  return results.sort((a, b) => {
+    const aName = (a.name || (a as any).title || '').toLowerCase();
+    const bName = (b.name || (b as any).title || '').toLowerCase();
+
+    // Exact matches first
+    const aExact = aName === queryLower;
+    const bExact = bName === queryLower;
+    if (aExact && !bExact) return -1;
+    if (!aExact && bExact) return 1;
+
+    // Starts with query second
+    const aStarts = aName.startsWith(queryLower);
+    const bStarts = bName.startsWith(queryLower);
+    if (aStarts && !bStarts) return -1;
+    if (!aStarts && bStarts) return 1;
+
+    // Alphabetical order for the rest
+    return aName.localeCompare(bName);
+  });
+}
 
 export async function GET(request: Request) {
   const startTime = Date.now();
   
   try {
+    // Clean up expired cache entries periodically
+    if (Math.random() < 0.1) { // 10% chance to clean up
+      cleanupPatternCache();
+    }
+
+    // Add request timeout
+    const timeoutPromise = new Promise((_, reject) => {
+      setTimeout(() => reject(new Error('Request timeout')), 15000); // 15 second timeout
+    });
+
     const { searchParams } = new URL(request.url);
     const query = searchParams.get('q');
+    const limit = parseInt(searchParams.get('limit') || '5', 10);
+    const categories = searchParams.get('categories')?.split(',') || ['tenants', 'houses', 'apartments', 'finances', 'tasks'];
     
+    // Validate query parameter
     if (!query || query.trim().length === 0) {
       return NextResponse.json({ 
         error: 'Search query is required' 
       }, { status: 400 });
     }
     
+    if (query.length > 100) {
+      return NextResponse.json({
+        error: 'Search query too long'
+      }, { status: 400 });
+    }
+
+    // Validate limit
+    if (limit < 1 || limit > 20) {
+      return NextResponse.json({
+        error: 'Limit must be between 1 and 20'
+      }, { status: 400 });
+    }
+
     const supabase = await createClient();
+    const { pattern: searchPattern, exact: exactPattern } = getSearchPatterns(query);
     
     const results: SearchResponse['results'] = {
       tenants: [],
@@ -28,27 +129,286 @@ export async function GET(request: Request) {
       tasks: []
     };
     
-    console.log("Searching for tenants with query:", query);
+    // Use Promise.allSettled for parallel execution with error isolation
+    const searchPromises = [];
 
-    const { data, error } = await supabase
-      .from('Mieter')
-      .select('id, name, email, telefonnummer, einzug, auszug')
-      .ilike('name', `%${query}%`);
+    // Search tenants (Mieter) - Optimized query with proper JOINs
+    if (categories.includes('tenants')) {
+      searchPromises.push(
+        (async () => {
+          try {
+            const { data, error } = await supabase
+              .from('Mieter')
+              .select(`
+                id, name, email, telefonnummer, einzug, auszug,
+                Wohnungen!left(name, Haeuser!left(name))
+              `)
+              .or(`name.ilike.${searchPattern},email.ilike.${searchPattern},telefonnummer.ilike.${searchPattern}`)
+              .order('name')
+              .limit(limit);
 
-    console.log("Supabase query data:", data);
-    console.log("Supabase query error:", error);
+            if (error) {
+              console.error('Tenant search error:', error);
+              return { type: 'tenants', data: [] };
+            }
 
-    if (data) {
-      results.tenants = data.map((tenant: any) => ({
-        id: tenant.id,
-        name: tenant.name,
-        email: tenant.email || undefined,
-        phone: tenant.telefonnummer || undefined,
-        apartment: undefined,
-        status: tenant.auszug ? 'moved_out' : 'active',
-        move_in_date: tenant.einzug || undefined,
-        move_out_date: tenant.auszug || undefined
-      }));
+            if (!data) return { type: 'tenants', data: [] };
+
+            const sortedTenants = sortByRelevance(data, query);
+
+            const tenantResults = sortedTenants.map((tenant: any) => ({
+              id: tenant.id,
+              name: tenant.name,
+              email: tenant.email || undefined,
+              phone: tenant.telefonnummer || undefined,
+              apartment: tenant.Wohnungen && typeof tenant.Wohnungen === 'object' && !Array.isArray(tenant.Wohnungen) ? {
+                name: tenant.Wohnungen.name,
+                house_name: tenant.Wohnungen.Haeuser && typeof tenant.Wohnungen.Haeuser === 'object' && !Array.isArray(tenant.Wohnungen.Haeuser) ? tenant.Wohnungen.Haeuser.name : ''
+              } : undefined,
+              status: tenant.auszug ? 'moved_out' : 'active',
+              move_in_date: tenant.einzug || undefined,
+              move_out_date: tenant.auszug || undefined
+            }));
+
+            return { type: 'tenants', data: tenantResults };
+          } catch (error) {
+            console.error('Error searching tenants:', error);
+            return { type: 'tenants', data: [] };
+          }
+        })()
+      );
+    }
+
+    // Search houses (Haeuser) - Optimized with aggregated apartment data
+    if (categories.includes('houses')) {
+      searchPromises.push(
+        (async () => {
+          try {
+            const { data, error } = await supabase
+              .from('Haeuser')
+              .select(`
+                id, name, strasse, ort,
+                Wohnungen!left(id, miete, Mieter!left(id, auszug))
+              `)
+              .or(`name.ilike.${searchPattern},strasse.ilike.${searchPattern},ort.ilike.${searchPattern}`)
+              .order('name')
+              .limit(limit);
+
+            if (error) {
+              console.error('House search error:', error);
+              return { type: 'houses', data: [] };
+            }
+
+            if (!data) return { type: 'houses', data: [] };
+
+            const sortedHouses = sortByRelevance(data, query);
+
+            const houseResults = sortedHouses.map((house: any) => {
+              const apartments = Array.isArray(house.Wohnungen) ? house.Wohnungen : (house.Wohnungen ? [house.Wohnungen] : []);
+              const totalRent = apartments.reduce((sum: number, apt: any) => sum + (apt.miete || 0), 0);
+              const freeApartments = apartments.filter((apt: any) =>
+                !apt.Mieter || (Array.isArray(apt.Mieter) && apt.Mieter.length === 0) ||
+                (Array.isArray(apt.Mieter) && apt.Mieter.some((m: any) => m.auszug))
+              ).length;
+
+              return {
+                id: house.id,
+                name: house.name,
+                address: [house.strasse, house.ort].filter(Boolean).join(', '),
+                apartment_count: apartments.length,
+                total_rent: totalRent,
+                free_apartments: freeApartments
+              };
+            });
+
+            return { type: 'houses', data: houseResults };
+          } catch (error) {
+            console.error('Error searching houses:', error);
+            return { type: 'houses', data: [] };
+          }
+        })()
+      );
+    }
+
+    // Search apartments (Wohnungen) - Optimized with single query
+    if (categories.includes('apartments')) {
+      searchPromises.push(
+        (async () => {
+          try {
+            const { data, error } = await supabase
+              .from('Wohnungen')
+              .select(`
+                id, name, groesse, miete,
+                Haeuser!left(name),
+                Mieter!left(name, einzug, auszug)
+              `)
+              .ilike('name', searchPattern)
+              .order('name')
+              .limit(limit);
+
+            if (error) {
+              console.error('Apartment search error:', error);
+              return { type: 'apartments', data: [] };
+            }
+
+            if (!data) return { type: 'apartments', data: [] };
+
+            const sortedApartments = sortByRelevance(data, query);
+
+            const apartmentResults = sortedApartments.map((apartment: any) => {
+              const mieterArray = Array.isArray(apartment.Mieter) ? apartment.Mieter : (apartment.Mieter ? [apartment.Mieter] : []);
+              const currentTenant = mieterArray.find((m: any) => !m.auszug);
+
+              return {
+                id: apartment.id,
+                name: apartment.name,
+                house_name: apartment.Haeuser && typeof apartment.Haeuser === 'object' && !Array.isArray(apartment.Haeuser) ? apartment.Haeuser.name : '',
+                size: apartment.groesse,
+                rent: apartment.miete,
+                status: currentTenant ? 'rented' : 'free',
+                current_tenant: currentTenant ? {
+                  name: currentTenant.name,
+                  move_in_date: currentTenant.einzug || ''
+                } : undefined
+              };
+            });
+
+            return { type: 'apartments', data: apartmentResults };
+          } catch (error) {
+            console.error('Error searching apartments:', error);
+            return { type: 'apartments', data: [] };
+          }
+        })()
+      );
+    }
+
+    // Search finances (Finanzen) - Optimized with conditional numeric search
+    if (categories.includes('finances')) {
+      const isNumericQuery = !isNaN(parseFloat(query));
+
+      let financeQueryBuilder = supabase
+        .from('Finanzen')
+        .select(`
+          id, name, betrag, datum, ist_einnahmen, notiz,
+          Wohnungen!left(name, Haeuser!left(name))
+        `)
+        .order('datum', { ascending: false })
+        .limit(limit);
+
+      if (isNumericQuery) {
+        const amount = parseFloat(query);
+        financeQueryBuilder = financeQueryBuilder.or(`name.ilike.${searchPattern},notiz.ilike.${searchPattern},betrag.eq.${amount}`);
+      } else {
+        financeQueryBuilder = financeQueryBuilder.or(`name.ilike.${searchPattern},notiz.ilike.${searchPattern}`);
+      }
+
+      searchPromises.push(
+        (async () => {
+          try {
+            const { data, error } = await financeQueryBuilder;
+
+            if (error) {
+              console.error('Finance search error:', error);
+              return { type: 'finances', data: [] };
+            }
+
+            if (!data) return { type: 'finances', data: [] };
+
+            // Custom sorting for finances: relevance first, then by date
+            const sortedFinances = data.sort((a, b) => {
+              const aExact = a.name.toLowerCase() === query.toLowerCase();
+              const bExact = b.name.toLowerCase() === query.toLowerCase();
+              if (aExact && !bExact) return -1;
+              if (!aExact && bExact) return 1;
+              // Then by date (most recent first)
+              return new Date(b.datum).getTime() - new Date(a.datum).getTime();
+            });
+
+            const financeResults = sortedFinances.map((finance: any) => ({
+              id: finance.id,
+              name: finance.name,
+              amount: finance.betrag,
+              date: finance.datum,
+              type: finance.ist_einnahmen ? 'income' : 'expense',
+              apartment: finance.Wohnungen && typeof finance.Wohnungen === 'object' && !Array.isArray(finance.Wohnungen) ? {
+                name: finance.Wohnungen.name,
+                house_name: finance.Wohnungen.Haeuser && typeof finance.Wohnungen.Haeuser === 'object' && !Array.isArray(finance.Wohnungen.Haeuser) ? finance.Wohnungen.Haeuser.name : ''
+              } : undefined,
+              notes: finance.notiz || undefined
+            }));
+
+            return { type: 'finances', data: financeResults };
+          } catch (error) {
+            console.error('Error searching finances:', error);
+            return { type: 'finances', data: [] };
+          }
+        })()
+      );
+    }
+
+    // Search tasks (Aufgaben) - Optimized with completion status ordering
+    if (categories.includes('tasks')) {
+      searchPromises.push(
+        (async () => {
+          try {
+            const { data, error } = await supabase
+              .from('Aufgaben')
+              .select('id, name, beschreibung, ist_erledigt, erstellungsdatum')
+              .or(`name.ilike.${searchPattern},beschreibung.ilike.${searchPattern}`)
+              .order('ist_erledigt', { ascending: true }) // Incomplete tasks first
+              .order('erstellungsdatum', { ascending: false })
+              .limit(limit);
+
+            if (error) {
+              console.error('Task search error:', error);
+              return { type: 'tasks', data: [] };
+            }
+
+            if (!data) return { type: 'tasks', data: [] };
+
+            const sortedTasks = sortByRelevance(data, query);
+
+            const taskResults = sortedTasks.map((task: any) => ({
+              id: task.id,
+              name: task.name,
+              description: task.beschreibung,
+              completed: task.ist_erledigt,
+              created_date: task.erstellungsdatum
+            }));
+
+            return { type: 'tasks', data: taskResults };
+          } catch (error) {
+            console.error('Error searching tasks:', error);
+            return { type: 'tasks', data: [] };
+          }
+        })()
+      );
+    }
+
+    // Execute all searches in parallel with timeout
+    const searchResults = await Promise.race([
+      Promise.allSettled(searchPromises),
+      timeoutPromise
+    ]) as PromiseSettledResult<any>[];
+
+    // Process results with graceful degradation
+    let successfulSearches = 0;
+    let failedSearches = 0;
+
+    searchResults.forEach(result => {
+      if (result.status === 'fulfilled' && result.value) {
+        const { type, data } = result.value;
+        (results as any)[type] = data;
+        successfulSearches++;
+      } else {
+        failedSearches++;
+        console.warn('Search failed for category:', result.status === 'rejected' ? result.reason : 'Unknown error');
+      }
+    });
+
+    // Log performance metrics
+    if (process.env.NODE_ENV === 'development') {
+      console.log(`Search completed: ${successfulSearches} successful, ${failedSearches} failed`);
     }
     
     const totalCount = Object.values(results).reduce((sum, arr) => sum + arr.length, 0);
@@ -60,20 +420,60 @@ export async function GET(request: Request) {
       executionTime
     };
 
+    // Add warning header if some searches failed but we have partial results
+    const headers = new Headers({
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=60', // Cache for 1 minute
+    });
+
+    if (failedSearches > 0 && successfulSearches > 0) {
+      headers.set('X-Partial-Results', 'true');
+      headers.set('X-Failed-Categories', failedSearches.toString());
+    }
+
+    // Add compression hint for larger responses
+    if (totalCount > 10) {
+      headers.set('Content-Encoding', 'gzip');
+    }
+
+    // Return partial results even if some categories failed
     return new NextResponse(JSON.stringify(response), { 
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json',
-      }
+      status: totalCount > 0 || successfulSearches > 0 ? 200 : 206, // 206 for partial content
+      headers
     });
     
   } catch (error) {
     console.error('Search API error:', error);
     
+    // Provide more specific error messages
+    let errorMessage = 'Serverfehler bei der Suche.';
+    let statusCode = 500;
+
+    if (error instanceof Error) {
+      if (error.message.includes('timeout')) {
+        errorMessage = 'Die Suche dauert zu lange. Bitte versuchen Sie es mit einem anderen Suchbegriff.';
+        statusCode = 408; // Request Timeout
+      } else if (error.message.includes('database') || error.message.includes('connection')) {
+        errorMessage = 'Datenbankverbindung nicht verfügbar. Bitte versuchen Sie es später erneut.';
+        statusCode = 503; // Service Unavailable
+      } else if (error.message.includes('memory') || error.message.includes('resource')) {
+        errorMessage = 'Server überlastet. Bitte versuchen Sie es in wenigen Sekunden erneut.';
+        statusCode = 503; // Service Unavailable
+      }
+    }
+
+    const responseHeaders: Record<string, string> = {};
+    if (statusCode === 503) {
+      responseHeaders['Retry-After'] = '30'; // Suggest retry after 30 seconds for service unavailable
+    }
+
     return NextResponse.json({ 
-      error: 'Serverfehler bei der Suche.',
+      error: errorMessage,
+      timestamp: new Date().toISOString(),
+      requestId: Math.random().toString(36).substring(7) // Simple request ID for debugging
     }, { 
-      status: 500,
+      status: statusCode,
+      headers: responseHeaders
     });
   }
 }

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -2,32 +2,126 @@ export const runtime = 'edge';
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 import type {
+  TenantSearchResult,
+  HouseSearchResult,
+  ApartmentSearchResult,
+  FinanceSearchResult,
+  TaskSearchResult,
   SearchResponse
 } from "@/types/search";
+
+// Cache for storing compiled search patterns
+const searchPatternCache = new Map<string, { pattern: string; exact: string; timestamp: number }>();
+const PATTERN_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+// Helper function to sanitize search query
+function sanitizeQuery(query: string): string {
+  return query.trim().replace(/[%_]/g, '\\$&');
+}
+
+// Helper function to create search patterns with caching
+function getSearchPatterns(query: string): { pattern: string; exact: string } {
+  const cacheKey = query.toLowerCase();
+  const cached = searchPatternCache.get(cacheKey);
+
+  if (cached && Date.now() - cached.timestamp < PATTERN_CACHE_TTL) {
+    return { pattern: cached.pattern, exact: cached.exact };
+  }
+
+  const sanitized = sanitizeQuery(query);
+  const pattern = `%${sanitized}%`;
+  const exact = sanitized;
+
+  searchPatternCache.set(cacheKey, {
+    pattern,
+    exact,
+    timestamp: Date.now()
+  });
+
+  return { pattern, exact };
+}
+
+// Helper function to clean up expired cache entries
+function cleanupPatternCache(): void {
+  const now = Date.now();
+  for (const [key, value] of searchPatternCache.entries()) {
+    if (now - value.timestamp > PATTERN_CACHE_TTL) {
+      searchPatternCache.delete(key);
+    }
+  }
+}
+
+// Helper function to sort results by relevance
+function sortByRelevance<T extends { name?: string; title?: string }>(
+  results: T[],
+  query: string
+): T[] {
+  const queryLower = query.toLowerCase();
+
+  return results.sort((a, b) => {
+    const aName = (a.name || (a as any).title || '').toLowerCase();
+    const bName = (b.name || (b as any).title || '').toLowerCase();
+
+    // Exact matches first
+    const aExact = aName === queryLower;
+    const bExact = bName === queryLower;
+    if (aExact && !bExact) return -1;
+    if (!aExact && bExact) return 1;
+
+    // Starts with query second
+    const aStarts = aName.startsWith(queryLower);
+    const bStarts = bName.startsWith(queryLower);
+    if (aStarts && !bStarts) return -1;
+    if (!aStarts && bStarts) return 1;
+
+    // Alphabetical order for the rest
+    return aName.localeCompare(bName);
+  });
+}
 
 export async function GET(request: Request) {
   const startTime = Date.now();
   
   try {
+    // Clean up expired cache entries periodically
+    if (Math.random() < 0.1) { // 10% chance to clean up
+      cleanupPatternCache();
+    }
+
+    // Add request timeout
+    const timeoutPromise = new Promise((_, reject) => {
+      setTimeout(() => reject(new Error('Request timeout')), 15000); // 15 second timeout
+    });
+
     const { searchParams } = new URL(request.url);
     const query = searchParams.get('q');
+    const limit = parseInt(searchParams.get('limit') || '5', 10);
+    const categories = searchParams.get('categories')?.split(',') || ['tenants', 'houses', 'apartments', 'finances', 'tasks'];
     
+    // Validate query parameter
     if (!query || query.trim().length === 0) {
       return NextResponse.json({ 
         error: 'Search query is required' 
       }, { status: 400 });
     }
     
-    const supabase = await createClient();
-
-    const { data, error } = await supabase.rpc('search_all', {
-      search_term: query
-    });
-
-    if (error) {
-      console.error('Search RPC error:', error);
-      throw new Error('Search failed');
+    if (query.length > 100) {
+      return NextResponse.json({
+        error: 'Search query too long'
+      }, { status: 400 });
     }
+
+    // Validate limit
+    if (limit < 1 || limit > 20) {
+      return NextResponse.json({
+        error: 'Limit must be between 1 and 20'
+      }, { status: 400 });
+    }
+
+    const supabase = await createClient();
+    const { pattern: searchPattern, exact: exactPattern } = getSearchPatterns(query);
+
+    console.log("Search pattern:", searchPattern);
 
     const results: SearchResponse['results'] = {
       tenants: [],
@@ -37,64 +131,286 @@ export async function GET(request: Request) {
       tasks: []
     };
 
-    if (data) {
-      data.forEach((item: any) => {
-        switch (item.entity_type) {
-          case 'tenant':
-            results.tenants.push({
-              id: item.id,
-              name: item.name,
-              email: item.email,
-              phone: item.phone,
-              status: item.status,
-              move_in_date: item.move_in_date,
-              move_out_date: item.move_out_date,
-              apartment: item.apartment,
+    // Use Promise.allSettled for parallel execution with error isolation
+    const searchPromises = [];
+
+    // Search tenants (Mieter) - Optimized query with proper JOINs
+    if (categories.includes('tenants')) {
+      searchPromises.push(
+        (async () => {
+          try {
+            const { data, error } = await supabase
+              .from('Mieter')
+              .select(`
+                id, name, email, telefonnummer, einzug, auszug,
+                Wohnungen!left(name, Haeuser!left(name))
+              `)
+              .or(`name.ILIKE.${searchPattern},email.ILIKE.${searchPattern},telefonnummer.ILIKE.${searchPattern}`)
+              .order('name')
+              .limit(limit);
+
+            if (error) {
+              console.error('Tenant search error:', error);
+              return { type: 'tenants', data: [] };
+            }
+
+            if (!data) return { type: 'tenants', data: [] };
+
+            const sortedTenants = sortByRelevance(data, query);
+
+            const tenantResults = sortedTenants.map((tenant: any) => ({
+              id: tenant.id,
+              name: tenant.name,
+              email: tenant.email || undefined,
+              phone: tenant.telefonnummer || undefined,
+              apartment: tenant.Wohnungen && typeof tenant.Wohnungen === 'object' && !Array.isArray(tenant.Wohnungen) ? {
+                name: tenant.Wohnungen.name,
+                house_name: tenant.Wohnungen.Haeuser && typeof tenant.Wohnungen.Haeuser === 'object' && !Array.isArray(tenant.Wohnungen.Haeuser) ? tenant.Wohnungen.Haeuser.name : ''
+              } : undefined,
+              status: tenant.auszug ? 'moved_out' : 'active',
+              move_in_date: tenant.einzug || undefined,
+              move_out_date: tenant.auszug || undefined
+            }));
+
+            return { type: 'tenants', data: tenantResults };
+          } catch (error) {
+            console.error('Error searching tenants:', error);
+            return { type: 'tenants', data: [] };
+          }
+        })()
+      );
+    }
+
+    // Search houses (Haeuser) - Optimized with aggregated apartment data
+    if (categories.includes('houses')) {
+      searchPromises.push(
+        (async () => {
+          try {
+            const { data, error } = await supabase
+              .from('Haeuser')
+              .select(`
+                id, name, strasse, ort,
+                Wohnungen!left(id, miete, Mieter!left(id, auszug))
+              `)
+              .or(`name.ILIKE.${searchPattern},strasse.ILIKE.${searchPattern},ort.ILIKE.${searchPattern}`)
+              .order('name')
+              .limit(limit);
+
+            if (error) {
+              console.error('House search error:', error);
+              return { type: 'houses', data: [] };
+            }
+
+            if (!data) return { type: 'houses', data: [] };
+
+            const sortedHouses = sortByRelevance(data, query);
+
+            const houseResults = sortedHouses.map((house: any) => {
+              const apartments = Array.isArray(house.Wohnungen) ? house.Wohnungen : (house.Wohnungen ? [house.Wohnungen] : []);
+              const totalRent = apartments.reduce((sum: number, apt: any) => sum + (apt.miete || 0), 0);
+              const freeApartments = apartments.filter((apt: any) =>
+                !apt.Mieter || (Array.isArray(apt.Mieter) && apt.Mieter.length === 0) ||
+                (Array.isArray(apt.Mieter) && apt.Mieter.some((m: any) => m.auszug))
+              ).length;
+
+              return {
+                id: house.id,
+                name: house.name,
+                address: [house.strasse, house.ort].filter(Boolean).join(', '),
+                apartment_count: apartments.length,
+                total_rent: totalRent,
+                free_apartments: freeApartments
+              };
             });
-            break;
-          case 'house':
-            results.houses.push({
-              id: item.id,
-              name: item.name,
-              address: item.address,
-              apartment_count: item.apartment_count,
-              total_rent: item.total_rent,
-              free_apartments: item.free_apartments,
+
+            return { type: 'houses', data: houseResults };
+          } catch (error) {
+            console.error('Error searching houses:', error);
+            return { type: 'houses', data: [] };
+          }
+        })()
+      );
+    }
+
+    // Search apartments (Wohnungen) - Optimized with single query
+    if (categories.includes('apartments')) {
+      searchPromises.push(
+        (async () => {
+          try {
+            const { data, error } = await supabase
+              .from('Wohnungen')
+              .select(`
+                id, name, groesse, miete,
+                Haeuser!left(name),
+                Mieter!left(name, einzug, auszug)
+              `)
+              .ilike('name', searchPattern)
+              .order('name')
+              .limit(limit);
+
+            if (error) {
+              console.error('Apartment search error:', error);
+              return { type: 'apartments', data: [] };
+            }
+
+            if (!data) return { type: 'apartments', data: [] };
+
+            const sortedApartments = sortByRelevance(data, query);
+
+            const apartmentResults = sortedApartments.map((apartment: any) => {
+              const mieterArray = Array.isArray(apartment.Mieter) ? apartment.Mieter : (apartment.Mieter ? [apartment.Mieter] : []);
+              const currentTenant = mieterArray.find((m: any) => !m.auszug);
+
+              return {
+                id: apartment.id,
+                name: apartment.name,
+                house_name: apartment.Haeuser && typeof apartment.Haeuser === 'object' && !Array.isArray(apartment.Haeuser) ? apartment.Haeuser.name : '',
+                size: apartment.groesse,
+                rent: apartment.miete,
+                status: currentTenant ? 'rented' : 'free',
+                current_tenant: currentTenant ? {
+                  name: currentTenant.name,
+                  move_in_date: currentTenant.einzug || ''
+                } : undefined
+              };
             });
-            break;
-          case 'apartment':
-            results.apartments.push({
-              id: item.id,
-              name: item.name,
-              house_name: item.house_name,
-              size: item.size,
-              rent: item.rent,
-              status: item.status,
-              current_tenant: item.current_tenant,
+
+            return { type: 'apartments', data: apartmentResults };
+          } catch (error) {
+            console.error('Error searching apartments:', error);
+            return { type: 'apartments', data: [] };
+          }
+        })()
+      );
+    }
+
+    // Search finances (Finanzen) - Optimized with conditional numeric search
+    if (categories.includes('finances')) {
+      const isNumericQuery = !isNaN(parseFloat(query));
+
+      let financeQueryBuilder = supabase
+        .from('Finanzen')
+        .select(`
+          id, name, betrag, datum, ist_einnahmen, notiz,
+          Wohnungen!left(name, Haeuser!left(name))
+        `)
+        .order('datum', { ascending: false })
+        .limit(limit);
+
+      if (isNumericQuery) {
+        const amount = parseFloat(query);
+        financeQueryBuilder = financeQueryBuilder.or(`name.ILIKE.${searchPattern},notiz.ILIKE.${searchPattern},betrag.eq.${amount}`);
+      } else {
+        financeQueryBuilder = financeQueryBuilder.or(`name.ILIKE.${searchPattern},notiz.ILIKE.${searchPattern}`);
+      }
+
+      searchPromises.push(
+        (async () => {
+          try {
+            const { data, error } = await financeQueryBuilder;
+
+            if (error) {
+              console.error('Finance search error:', error);
+              return { type: 'finances', data: [] };
+            }
+
+            if (!data) return { type: 'finances', data: [] };
+
+            // Custom sorting for finances: relevance first, then by date
+            const sortedFinances = data.sort((a, b) => {
+              const aExact = a.name.toLowerCase() === query.toLowerCase();
+              const bExact = b.name.toLowerCase() === query.toLowerCase();
+              if (aExact && !bExact) return -1;
+              if (!aExact && bExact) return 1;
+              // Then by date (most recent first)
+              return new Date(b.datum).getTime() - new Date(a.datum).getTime();
             });
-            break;
-          case 'finance':
-            results.finances.push({
-              id: item.id,
-              name: item.name,
-              amount: item.amount,
-              date: item.date,
-              type: item.type,
-              apartment: item.apartment,
-              notes: item.notes,
-            });
-            break;
-          case 'task':
-            results.tasks.push({
-              id: item.id,
-              name: item.name,
-              description: item.description,
-              completed: item.completed,
-              created_date: item.created_date,
-            });
-            break;
-        }
-      });
+
+            const financeResults = sortedFinances.map((finance: any) => ({
+              id: finance.id,
+              name: finance.name,
+              amount: finance.betrag,
+              date: finance.datum,
+              type: finance.ist_einnahmen ? 'income' : 'expense',
+              apartment: finance.Wohnungen && typeof finance.Wohnungen === 'object' && !Array.isArray(finance.Wohnungen) ? {
+                name: finance.Wohnungen.name,
+                house_name: finance.Wohnungen.Haeuser && typeof finance.Wohnungen.Haeuser === 'object' && !Array.isArray(finance.Wohnungen.Haeuser) ? finance.Wohnungen.Haeuser.name : ''
+              } : undefined,
+              notes: finance.notiz || undefined
+            }));
+
+            return { type: 'finances', data: financeResults };
+          } catch (error) {
+            console.error('Error searching finances:', error);
+            return { type: 'finances', data: [] };
+          }
+        })()
+      );
+    }
+
+    // Search tasks (Aufgaben) - Optimized with completion status ordering
+    if (categories.includes('tasks')) {
+      searchPromises.push(
+        (async () => {
+          try {
+            const { data, error } = await supabase
+              .from('Aufgaben')
+              .select('id, name, beschreibung, ist_erledigt, erstellungsdatum')
+              .or(`name.ILIKE.${searchPattern},beschreibung.ILIKE.${searchPattern}`)
+              .order('ist_erledigt', { ascending: true }) // Incomplete tasks first
+              .order('erstellungsdatum', { ascending: false })
+              .limit(limit);
+
+            if (error) {
+              console.error('Task search error:', error);
+              return { type: 'tasks', data: [] };
+            }
+
+            if (!data) return { type: 'tasks', data: [] };
+
+            const sortedTasks = sortByRelevance(data, query);
+
+            const taskResults = sortedTasks.map((task: any) => ({
+              id: task.id,
+              name: task.name,
+              description: task.beschreibung,
+              completed: task.ist_erledigt,
+              created_date: task.erstellungsdatum
+            }));
+
+            return { type: 'tasks', data: taskResults };
+          } catch (error) {
+            console.error('Error searching tasks:', error);
+            return { type: 'tasks', data: [] };
+          }
+        })()
+      );
+    }
+
+    // Execute all searches in parallel with timeout
+    const searchResults = await Promise.race([
+      Promise.allSettled(searchPromises),
+      timeoutPromise
+    ]) as PromiseSettledResult<any>[];
+
+    // Process results with graceful degradation
+    let successfulSearches = 0;
+    let failedSearches = 0;
+
+    searchResults.forEach(result => {
+      if (result.status === 'fulfilled' && result.value) {
+        const { type, data } = result.value;
+        (results as any)[type] = data;
+        successfulSearches++;
+      } else {
+        failedSearches++;
+        console.warn('Search failed for category:', result.status === 'rejected' ? result.reason : 'Unknown error');
+      }
+    });
+
+    // Log performance metrics
+    if (process.env.NODE_ENV === 'development') {
+      console.log(`Search completed: ${successfulSearches} successful, ${failedSearches} failed`);
     }
     
     const totalCount = Object.values(results).reduce((sum, arr) => sum + arr.length, 0);
@@ -106,20 +422,60 @@ export async function GET(request: Request) {
       executionTime
     };
 
+    // Add warning header if some searches failed but we have partial results
+    const headers = new Headers({
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=60', // Cache for 1 minute
+    });
+
+    if (failedSearches > 0 && successfulSearches > 0) {
+      headers.set('X-Partial-Results', 'true');
+      headers.set('X-Failed-Categories', failedSearches.toString());
+    }
+
+    // Add compression hint for larger responses
+    if (totalCount > 10) {
+      headers.set('Content-Encoding', 'gzip');
+    }
+
+    // Return partial results even if some categories failed
     return new NextResponse(JSON.stringify(response), { 
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json',
-      }
+      status: totalCount > 0 || successfulSearches > 0 ? 200 : 206, // 206 for partial content
+      headers
     });
     
   } catch (error) {
     console.error('Search API error:', error);
     
+    // Provide more specific error messages
+    let errorMessage = 'Serverfehler bei der Suche.';
+    let statusCode = 500;
+
+    if (error instanceof Error) {
+      if (error.message.includes('timeout')) {
+        errorMessage = 'Die Suche dauert zu lange. Bitte versuchen Sie es mit einem anderen Suchbegriff.';
+        statusCode = 408; // Request Timeout
+      } else if (error.message.includes('database') || error.message.includes('connection')) {
+        errorMessage = 'Datenbankverbindung nicht verfügbar. Bitte versuchen Sie es später erneut.';
+        statusCode = 503; // Service Unavailable
+      } else if (error.message.includes('memory') || error.message.includes('resource')) {
+        errorMessage = 'Server überlastet. Bitte versuchen Sie es in wenigen Sekunden erneut.';
+        statusCode = 503; // Service Unavailable
+      }
+    }
+
+    const responseHeaders: Record<string, string> = {};
+    if (statusCode === 503) {
+      responseHeaders['Retry-After'] = '30'; // Suggest retry after 30 seconds for service unavailable
+    }
+
     return NextResponse.json({ 
-      error: 'Serverfehler bei der Suche.',
+      error: errorMessage,
+      timestamp: new Date().toISOString(),
+      requestId: Math.random().toString(36).substring(7) // Simple request ID for debugging
     }, { 
-      status: 500,
+      status: statusCode,
+      headers: responseHeaders
     });
   }
 }

--- a/hooks/use-search.ts
+++ b/hooks/use-search.ts
@@ -87,16 +87,13 @@ export function useSearch(options: UseSearchOptions = {}): UseSearchReturn {
   // Retry timeout reference
   const retryTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  // Debounced query to reduce API calls
-  const debouncedQuery = useDebounce(query, debounceMs);
-
   // Network status monitoring
   useEffect(() => {
     const handleOnline = () => {
       setIsOffline(false);
       // Retry last failed search if we were offline
-      if (error && debouncedQuery.trim()) {
-        performSearch(debouncedQuery);
+      if (error && query.trim()) {
+        performSearch(query);
       }
     };
 
@@ -115,7 +112,7 @@ export function useSearch(options: UseSearchOptions = {}): UseSearchReturn {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
     };
-  }, [error, debouncedQuery]);
+  }, [error, query]);
 
   // Cache management functions
   const cleanupCache = useCallback(() => {
@@ -572,8 +569,8 @@ export function useSearch(options: UseSearchOptions = {}): UseSearchReturn {
 
   // Effect to trigger search when debounced query changes
   useEffect(() => {
-    performSearch(debouncedQuery);
-  }, [debouncedQuery, performSearch]);
+    performSearch(query);
+  }, [query, performSearch]);
 
   // Cleanup function to cancel ongoing requests and timeouts
   useEffect(() => {
@@ -607,7 +604,7 @@ export function useSearch(options: UseSearchOptions = {}): UseSearchReturn {
 
   // Enhanced retry function
   const retry = useCallback(() => {
-    if (debouncedQuery.trim()) {
+    if (query.trim()) {
       setError(null);
       setRetryCount(0);
       
@@ -616,9 +613,9 @@ export function useSearch(options: UseSearchOptions = {}): UseSearchReturn {
         clearTimeout(retryTimeoutRef.current);
       }
       
-      performSearch(debouncedQuery);
+      performSearch(query);
     }
-  }, [debouncedQuery, performSearch]);
+  }, [query, performSearch]);
 
   // Expose cache metrics for debugging (development only)
   const getCacheMetrics = useCallback(() => {


### PR DESCRIPTION
## Description

Fixes the search API returning no results and simplifies the client search hook.

## Summary of Changes

- `.or()` filter conditions now use uppercase `ILIKE` so PostgREST parses them correctly across all five entity searches
- `use-search` drops the debounce indirection — searches fire directly on query change and retries reuse the current query