### PR TITLE
Feature/wasserzaehler auto calculation

### DIFF
--- a/app/betriebskosten-actions.ts
+++ b/app/betriebskosten-actions.ts
@@ -439,7 +439,7 @@ export async function saveWasserzaehlerData(
   const recordsToInsert = entries
     .filter(entry => {
       // Skip entries with missing required fields
-      const isValid = entry.mieter_id && !isNaN(parseFloat(entry.zaehlerstand as any));
+      const isValid = entry.mieter_id && !isNaN(parseFloat(String(entry.zaehlerstand)));
       if (!isValid) {
         console.warn('Skipping invalid entry:', entry);
       }

--- a/app/betriebskosten-actions.ts
+++ b/app/betriebskosten-actions.ts
@@ -247,6 +247,7 @@ export async function getPreviousWasserzaehlerRecordAction(
       .from("Wasserzaehler")
       .select("*")
       .eq("mieter_id", mieterId)
+      .eq("user_id", user.id) // Add explicit user filter for security
       .order("ablese_datum", { ascending: false })
       .limit(1)
       .single();

--- a/app/betriebskosten-actions.ts
+++ b/app/betriebskosten-actions.ts
@@ -2,7 +2,7 @@
 
 import { createClient } from "@/utils/supabase/server"; // Adjusted based on common project structure
 import { revalidatePath } from "next/cache";
-import { Nebenkosten, fetchNebenkostenDetailsById, WasserzaehlerFormData, Mieter, Wasserzaehler, Rechnung } from "../lib/data-fetching"; // Adjusted path, Added Rechnung
+import { Nebenkosten, fetchNebenkostenDetailsById, WasserzaehlerFormData, Mieter, Wasserzaehler, Rechnung, fetchWasserzaehlerByHausAndYear } from "../lib/data-fetching"; // Adjusted path, Added Rechnung
 
 // Define an input type for Nebenkosten data
 export type NebenkostenFormData = {
@@ -303,6 +303,39 @@ export async function getRechnungenForNebenkostenAction(nebenkostenId: string): 
   } catch (error: any) {
     console.error('Unexpected error in getRechnungenForNebenkostenAction:', error);
     return { success: false, message: `Ein unerwarteter Fehler ist aufgetreten: ${error.message}` };
+  }
+}
+
+export async function getWasserzaehlerByHausAndYearAction(
+  hausId: string,
+  year: string
+): Promise<{ success: boolean; data?: { mieterList: Mieter[]; existingReadings: Wasserzaehler[] }; message?: string }> {
+  try {
+    if (!hausId || !year) {
+      return { success: false, message: "Haus-ID und Jahr sind erforderlich." };
+    }
+
+    // Validate year format (basic check for YYYY)
+    if (!/^\d{4}$/.test(year)) {
+      return { success: false, message: "Ungültiges Jahr. Bitte verwenden Sie das Format YYYY." };
+    }
+
+    const { mieterList, existingReadings } = await fetchWasserzaehlerByHausAndYear(hausId, year);
+    
+    return { 
+      success: true, 
+      data: { 
+        mieterList,
+        existingReadings 
+      } 
+    };
+
+  } catch (error: any) {
+    console.error('Error in getWasserzaehlerByHausAndYearAction:', error);
+    return { 
+      success: false, 
+      message: `Ein Fehler ist beim Abrufen der Wasserzählerdaten aufgetreten: ${error.message || 'Unbekannter Fehler'}` 
+    };
   }
 }
 

--- a/app/betriebskosten-actions.ts
+++ b/app/betriebskosten-actions.ts
@@ -369,7 +369,7 @@ export async function saveWasserzaehlerData(
   const recordsToInsert = entries
     .filter(entry => {
       // Skip entries with missing required fields
-      const isValid = entry.mieter_id && entry.ablese_datum && !isNaN(parseFloat(entry.zaehlerstand as any));
+      const isValid = entry.mieter_id && !isNaN(parseFloat(entry.zaehlerstand as any));
       if (!isValid) {
         console.warn('Skipping invalid entry:', entry);
       }
@@ -388,6 +388,10 @@ export async function saveWasserzaehlerData(
         } catch (e) {
           console.error('Error formatting date:', e);
         }
+      } else {
+        // No date provided: default to today's date in YYYY-MM-DD
+        const today = new Date();
+        formattedDate = today.toISOString().split('T')[0];
       }
 
       return {

--- a/components/betriebskosten-edit-modal.tsx
+++ b/components/betriebskosten-edit-modal.tsx
@@ -334,8 +334,13 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
       let currentBetragValue: number;
 
       if (!art) {
-        toast({ title: "Validierungsfehler", description: `Art der Kosten darf nicht leer sein.`, variant: "destructive" });
-        setIsSaving(false); setBetriebskostenModalDirty(true);
+        toast({ 
+          title: "Validierungsfehler", 
+          description: `Art der Kosten darf nicht leer sein. Bitte überprüfen Sie Posten ${costItems.indexOf(item) + 1}.`, 
+          variant: "destructive" 
+        });
+        setIsSaving(false);
+        setBetriebskostenModalDirty(true);
         return;
       }
       if (!berechnungsart) { 

--- a/components/betriebskosten-edit-modal.tsx
+++ b/components/betriebskosten-edit-modal.tsx
@@ -407,10 +407,20 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
         if (rechnungenToSave.length > 0) {
           const rechnungenSaveResponse = await createRechnungenBatch(rechnungenToSave);
           if (!rechnungenSaveResponse.success) {
-            toast({ title: "Fehler beim Speichern der Einzelrechnungen", description: rechnungenSaveResponse.message, variant: "destructive" });
+            toast({ 
+              title: "Fehler beim Speichern der Einzelrechnungen", 
+              description: rechnungenSaveResponse.message, 
+              variant: "destructive" 
+            });
+            setIsSaving(false);
+            setBetriebskostenModalDirty(true);
+            return; // Stop execution if saving individual bills fails
           }
         }
+        
       }
+      
+      // Only show success and close if everything was successful
       toast({ title: "Betriebskosten erfolgreich gespeichert" });
       if (betriebskostenModalOnSuccess) betriebskostenModalOnSuccess();
       closeBetriebskostenModal();

--- a/components/betriebskosten-edit-modal.tsx
+++ b/components/betriebskosten-edit-modal.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useRef, useCallback } from "react";
-import { useRouter } from "next/navigation";
-import { createClient } from "@/utils/supabase/client";
+import React, { useState, useEffect, useRef } from "react";
 import { formatNumber } from "@/utils/format";
 import {
   Dialog,
@@ -15,7 +13,6 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
   SelectContent,
@@ -24,8 +21,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { CustomCombobox, ComboboxOption } from "@/components/ui/custom-combobox";
-import { Skeleton } from "@/components/ui/skeleton"; // Added Skeleton
-import { Nebenkosten, Haus, Mieter, Wasserzaehler } from "../lib/data-fetching";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Nebenkosten, Haus, Mieter } from "../lib/data-fetching";
 import { 
   getNebenkostenDetailsAction,
   createNebenkosten, 
@@ -33,22 +30,19 @@ import {
   createRechnungenBatch, 
   RechnungData,
   deleteRechnungenByNebenkostenId,
-  getPreviousWasserzaehlerRecordAction,
-  saveWasserzaehlerData,
-  getWasserzaehlerRecordsAction
 } from "../app/betriebskosten-actions";
 import { getMieterByHausIdAction } from "../app/mieter-actions"; 
 import { useToast } from "../hooks/use-toast";
 import { BERECHNUNGSART_OPTIONS, BerechnungsartValue } from "../lib/constants";
 import { PlusCircle, Trash2 } from "lucide-react";
-import { useModalStore } from "@/hooks/use-modal-store"; // Added import
+import { useModalStore } from "@/hooks/use-modal-store";
 import { LabelWithTooltip } from "./ui/label-with-tooltip";
 
 interface CostItem {
-  id: string; // For React key, temporary client-side ID
+  id: string;
   art: string;
-  betrag: string; // Keep as string for input binding
-  berechnungsart: BerechnungsartValue | ''; // Use '' for unselected state
+  betrag: string;
+  berechnungsart: BerechnungsartValue | '';
 }
 
 interface RechnungEinzel {
@@ -56,33 +50,9 @@ interface RechnungEinzel {
   betrag: string;
 }
 
-interface WasserzaehlerEntry {
-  id: string; // Temporary client-side ID
-  mieter_id: string;
-  ablese_datum: string;
-  zaehlerstand: string;
-  verbrauch: string;
-  previous_reading: Wasserzaehler | null;
-  warning?: string;
-}
+interface BetriebskostenEditModalPropsRefactored {}
 
-interface BetriebskostenEditModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  nebenkostenToEdit?: Nebenkosten | { id: string } | null | undefined; // Updated prop type
-  haeuser: Haus[];
-  userId: string; // userId might not be needed if RLS is fully relied upon for mutations
-}
-
-interface BetriebskostenEditModalPropsRefactored {
-  // All props like isOpen, onClose, nebenkostenToEdit, haeuser will be removed
-  // and sourced from the useModalStore.
-  // We might keep `userId` if it's truly essential and not derivable elsewhere,
-  // but the comment suggests it might be removed. For now, let's assume it's not needed.
-}
-
-
-export function BetriebskostenEditModal({/* Props are now from store */ }: BetriebskostenEditModalPropsRefactored) {
+export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactored) {
   const {
     isBetriebskostenModalOpen,
     closeBetriebskostenModal,
@@ -91,7 +61,6 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
     betriebskostenModalOnSuccess,
     isBetriebskostenModalDirty,
     setBetriebskostenModalDirty,
-    openConfirmationModal,
   } = useModalStore();
 
   const [jahr, setJahr] = useState("");
@@ -103,21 +72,14 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
   const [selectedHausMieter, setSelectedHausMieter] = useState<Mieter[]>([]);
   const [rechnungen, setRechnungen] = useState<Record<string, RechnungEinzel[]>>({});
   const [isFetchingTenants, setIsFetchingTenants] = useState(false);
-  const [wasserzaehlerEntries, setWasserzaehlerEntries] = useState<WasserzaehlerEntry[]>([]);
-  const [isFetchingPreviousReadings, setIsFetchingPreviousReadings] = useState(false);
+  const [isLoadingDetails, setIsLoadingDetails] = useState(false);
+  const [modalNebenkostenData, setModalNebenkostenData] = useState<Nebenkosten | null>(null);
+  const currentlyLoadedNebenkostenId = React.useRef<string | null | undefined>(null);
 
   const houseOptions: ComboboxOption[] = (betriebskostenModalHaeuser || []).map(h => ({ value: h.id, label: h.name }));
 
-  // New states for details loading
-  const [isLoadingDetails, setIsLoadingDetails] = useState(false);
-  const [modalNebenkostenData, setModalNebenkostenData] = useState<Nebenkosten | null>(null);
-
-  // Ref for tracking currently loaded Nebenkosten ID to avoid redundant fetches/re-initializations
-  const currentlyLoadedNebenkostenId = React.useRef<string | null | undefined>(null);
-
   const generateId = () => Math.random().toString(36).substr(2, 9);
 
-  // Part 1.3: Create handleRechnungChange function
   const handleRechnungChange = (costItemId: string, mieterId: string, newBetrag: string) => {
     setRechnungen(prevRechnungen => {
       const costItemRechnungen = prevRechnungen[costItemId] || selectedHausMieter.map(m => ({ mieterId: m.id, betrag: '' }));
@@ -203,14 +165,13 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
   };
 
   const attemptClose = () => {
-    closeBetriebskostenModal(); // Store handles confirmation for outside click/X
+    closeBetriebskostenModal();
   };
 
   const handleCancelClick = () => {
-    closeBetriebskostenModal({ force: true }); // Force close for "Abbrechen" button
+    closeBetriebskostenModal({ force: true });
   };
 
-  // Main useEffect for Data Fetching and Initialization
   useEffect(() => {
     const resetAllStates = (forNewEntry: boolean = true) => {
       setJahr(forNewEntry ? new Date().getFullYear().toString() : "");
@@ -221,10 +182,9 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
       setRechnungen({});
       setIsSaving(false);
       setIsFetchingTenants(false);
-      // Do not reset isLoadingDetails here as it's controlled by the fetch logic
       setModalNebenkostenData(null);
       currentlyLoadedNebenkostenId.current = null;
-      if (isBetriebskostenModalOpen) setBetriebskostenModalDirty(false); // Reset dirty state when modal opens/data loads
+      if (isBetriebskostenModalOpen) setBetriebskostenModalDirty(false);
     };
 
     if (isBetriebskostenModalOpen) {
@@ -232,9 +192,9 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
 
       if (editId && editId !== currentlyLoadedNebenkostenId.current) {
         setIsLoadingDetails(true);
-        resetAllStates(false); // Reset states, but not to "new entry" defaults yet
+        resetAllStates(false);
         setModalNebenkostenData(null);
-        setCostItems([]); // Show skeleton for cost items
+        setCostItems([]);
         setRechnungen({});
 
         getNebenkostenDetailsAction(editId)
@@ -253,119 +213,56 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
                 berechnungsart: (BERECHNUNGSART_OPTIONS.find(opt => opt.value === fetchedData.berechnungsart?.[idx])?.value as BerechnungsartValue) || '',
               }));
               setCostItems(newCostItems.length > 0 ? newCostItems : [{ id: generateId(), art: '', betrag: '', berechnungsart: BERECHNUNGSART_OPTIONS[0]?.value || '' }]);
-              setBetriebskostenModalDirty(false); // Data loaded, not dirty yet
+              setBetriebskostenModalDirty(false);
             } else {
-              toast({
-                title: "Fehler beim Laden der Details",
-                description: response.message || "Die Nebenkostendetails konnten nicht geladen werden. Das Fenster wird geschlossen.",
-                variant: "destructive",
-              });
-              setModalNebenkostenData(null);
+              toast({ title: "Fehler beim Laden der Details", description: response.message || "Die Nebenkostendetails konnten nicht geladen werden.", variant: "destructive" });
               attemptClose();
             }
           })
-          .catch(error => {
-            toast({
-              title: "Systemfehler",
-              description: "Ein unerwarteter Fehler ist beim Laden der Nebenkostendetails aufgetreten. Das Fenster wird geschlossen.",
-              variant: "destructive",
-            });
-            setModalNebenkostenData(null);
-            if (editId) {
-              attemptClose();
-            }
+          .catch(() => {
+            toast({ title: "Systemfehler", description: "Ein unerwarteter Fehler ist beim Laden der Nebenkostendetails aufgetreten.", variant: "destructive" });
+            if (editId) attemptClose();
           })
           .finally(() => {
             setIsLoadingDetails(false);
             currentlyLoadedNebenkostenId.current = editId;
           });
       } else if (!editId) {
-        resetAllStates(true); // Creating a new entry
+        resetAllStates(true);
         setIsLoadingDetails(false);
         currentlyLoadedNebenkostenId.current = null;
         setBetriebskostenModalDirty(false);
-      } else { // Modal reopened for the same item
-        if (modalNebenkostenData && haeuserId && !(betriebskostenModalHaeuser || []).find(h => h.id === haeuserId)) {
-           setHaeuserId(betriebskostenModalHaeuser.length > 0 ? betriebskostenModalHaeuser[0].id : "");
-           setBetriebskostenModalDirty(true); // Haus selection changed due to available list, consider dirty
-        }
-        // Reset dirty state if modal is just reopened without data change
-        if (!isBetriebskostenModalDirty) setBetriebskostenModalDirty(false);
       }
     } else {
-      resetAllStates(false); // Modal is closed
+      resetAllStates(false);
     }
   }, [isBetriebskostenModalOpen, betriebskostenInitialData, betriebskostenModalHaeuser, toast, setBetriebskostenModalDirty]);
 
-
-  // useEffect for Tenant and Wasserzaehler Data Fetching
   useEffect(() => {
     if (isBetriebskostenModalOpen && haeuserId && jahr) {
-      const fetchTenantsAndReadings = async () => {
+      const fetchTenants = async () => {
         setIsFetchingTenants(true);
-        setIsFetchingPreviousReadings(true);
-        setWasserzaehlerEntries([]);
-
         try {
           const tenantResponse = await getMieterByHausIdAction(haeuserId, jahr);
-          if (!tenantResponse.success || !tenantResponse.data) {
+          if (tenantResponse.success && tenantResponse.data) {
+            setSelectedHausMieter(tenantResponse.data);
+          } else {
             toast({ title: "Fehler beim Laden der Mieter", description: tenantResponse.error || "Unbekannter Fehler", variant: "destructive" });
             setSelectedHausMieter([]);
-            setWasserzaehlerEntries([]);
-            return;
           }
-
-          setSelectedHausMieter(tenantResponse.data);
-
-          const editId = betriebskostenInitialData?.id;
-          let existingEntries: Wasserzaehler[] = [];
-          if (editId) {
-            const existingWasserzaehlerResponse = await getWasserzaehlerRecordsAction(editId);
-            if (existingWasserzaehlerResponse.success && existingWasserzaehlerResponse.data) {
-              existingEntries = existingWasserzaehlerResponse.data;
-            }
-          }
-
-          const newEntriesPromises = tenantResponse.data.map(async (mieter) => {
-            const previousReadingResponse = await getPreviousWasserzaehlerRecordAction(mieter.id);
-            const existingEntry = existingEntries.find(e => e.mieter_id === mieter.id);
-
-            return {
-              id: generateId(),
-              mieter_id: mieter.id,
-              ablese_datum: existingEntry?.ablese_datum || '',
-              zaehlerstand: existingEntry?.zaehlerstand?.toString() || '',
-              verbrauch: existingEntry?.verbrauch?.toString() || '',
-              previous_reading: previousReadingResponse.data || null,
-              warning: '',
-            };
-          });
-
-          const newEntries = await Promise.all(newEntriesPromises);
-          setWasserzaehlerEntries(newEntries);
-
         } catch (error: any) {
-          console.error("Error fetching tenants or readings:", error);
-          toast({ title: "Systemfehler", description: "Daten für Mieter oder Zählerstände konnten nicht geladen werden.", variant: "destructive" });
+          toast({ title: "Systemfehler", description: "Daten für Mieter konnten nicht geladen werden.", variant: "destructive" });
           setSelectedHausMieter([]);
-          setWasserzaehlerEntries([]);
         } finally {
           setIsFetchingTenants(false);
-          setIsFetchingPreviousReadings(false);
         }
       };
-
-      fetchTenantsAndReadings();
+      fetchTenants();
     } else if (!isBetriebskostenModalOpen || !haeuserId) {
       setSelectedHausMieter([]);
-      setWasserzaehlerEntries([]);
-      setIsFetchingTenants(false);
-      setIsFetchingPreviousReadings(false);
     }
-  }, [isBetriebskostenModalOpen, haeuserId, jahr, betriebskostenInitialData?.id, toast]);
+  }, [isBetriebskostenModalOpen, haeuserId, jahr, toast]);
 
-
-  // Modified useEffect for Rechnungen Synchronization
   const syncRechnungenState = (
     currentTenants: Mieter[], 
     currentCostItems: CostItem[],
@@ -394,7 +291,6 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
       });
       return newRechnungenState;
     });
-    // Do not set dirty here, this is data sync. User actions will set dirty.
   };
 
   useEffect(() => {
@@ -403,16 +299,15 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
     }
   }, [selectedHausMieter, costItems, modalNebenkostenData, isBetriebskostenModalOpen, isLoadingDetails]);
 
-
   const handleSubmit = async () => {
     setIsSaving(true);
-    setBetriebskostenModalDirty(false); // Assume save will succeed or fail, reset dirty state preemptively
+    setBetriebskostenModalDirty(false);
 
     const currentEditId = modalNebenkostenData?.id || betriebskostenInitialData?.id;
 
     if (!jahr || !haeuserId) {
       toast({ title: "Fehlende Eingaben", description: "Jahr und Haus sind Pflichtfelder.", variant: "destructive" });
-      setIsSaving(false); setBetriebskostenModalDirty(true); // Save failed, it's dirty again
+      setIsSaving(false); setBetriebskostenModalDirty(true);
       return;
     }
     
@@ -439,7 +334,7 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
       let currentBetragValue: number;
 
       if (!art) {
-        toast({ title: "Validierungsfehler", description: `Art der Kosten darf nicht leer sein. Bitte überprüfen Sie Posten ${costItems.indexOf(item) + 1}.`, variant: "destructive" });
+        toast({ title: "Validierungsfehler", description: `Art der Kosten darf nicht leer sein.`, variant: "destructive" });
         setIsSaving(false); setBetriebskostenModalDirty(true);
         return;
       }
@@ -484,39 +379,18 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
     if (response.success) {
       const nebenkosten_id = currentEditId || response.data?.id;
       if (nebenkosten_id) {
-        // Save Wasserzaehler data
-        const entriesToSave = wasserzaehlerEntries
-          .filter(e => e.ablese_datum && e.zaehlerstand)
-          .map(entry => {
-            const mieter = selectedHausMieter.find(m => m.id === entry.mieter_id);
-            return {
-              ...entry,
-              mieter_name: mieter?.name || 'Unbekannter Mieter',
-            };
-          });
-
-        const wasserzaehlerDataToSave = {
-          nebenkosten_id: nebenkosten_id,
-          entries: entriesToSave,
-        };
-        const wasserzaehlerResponse = await saveWasserzaehlerData(wasserzaehlerDataToSave);
-        if (!wasserzaehlerResponse.success) {
-          toast({ title: "Fehler beim Speichern der Zählerstände", description: wasserzaehlerResponse.message, variant: "destructive" });
-        }
-
         if (currentEditId) {
           const deleteResponse = await deleteRechnungenByNebenkostenId(nebenkosten_id);
           if (!deleteResponse.success) {
-            toast({ title: "Fehler beim Aktualisieren der Einzelrechnungen", description: `Die alten Einzelrechnungen konnten nicht gelöscht werden. Neue Rechnungen wurden nicht erstellt. Fehler: ${deleteResponse.message || "Unbekannter Fehler."}`, variant: "destructive" });
-            setIsSaving(false); /* Don't set dirty here, main save was ok */ return;
+            toast({ title: "Fehler beim Aktualisieren der Einzelrechnungen", description: deleteResponse.message, variant: "destructive" });
+            setIsSaving(false); return;
           }
         }
 
         const rechnungenToSave: RechnungData[] = [];
         costItems.forEach(item => {
           if (item.berechnungsart === 'nach Rechnung') {
-            const individualRechnungen = rechnungen[item.id] || [];
-            individualRechnungen.forEach(rechnungEinzel => {
+            (rechnungen[item.id] || []).forEach(rechnungEinzel => {
               const parsedAmount = parseFloat(rechnungEinzel.betrag);
               if (!isNaN(parsedAmount)) {
                 rechnungenToSave.push({
@@ -533,56 +407,23 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
         if (rechnungenToSave.length > 0) {
           const rechnungenSaveResponse = await createRechnungenBatch(rechnungenToSave);
           if (!rechnungenSaveResponse.success) {
-            toast({ title: "Fehler beim Speichern der Einzelrechnungen", description: rechnungenSaveResponse.message || "Ein unbekannter Fehler ist aufgetreten.", variant: "destructive" });
-          } else {
-            toast({ title: "Erfolgreich gespeichert", description: "Die Betriebskosten und alle zugehörigen Einzelrechnungen wurden erfolgreich gespeichert." });
-            if (betriebskostenModalOnSuccess) betriebskostenModalOnSuccess();
-            closeBetriebskostenModal(); // Will close directly as dirty is false
-            setIsSaving(false);
-            return;
+            toast({ title: "Fehler beim Speichern der Einzelrechnungen", description: rechnungenSaveResponse.message, variant: "destructive" });
           }
         }
       }
-      toast({ title: "Betriebskosten erfolgreich gespeichert", description: "Die Hauptdaten der Betriebskosten und Zählerstände wurden gespeichert." });
+      toast({ title: "Betriebskosten erfolgreich gespeichert" });
       if (betriebskostenModalOnSuccess) betriebskostenModalOnSuccess();
       closeBetriebskostenModal();
     } else {
-      toast({ title: "Fehler beim Speichern", description: response.message || "Ein unbekannter Fehler ist aufgetreten.", variant: "destructive" });
-      setBetriebskostenModalDirty(true); // Save failed, mark as dirty
+      toast({ title: "Fehler beim Speichern", description: response.message, variant: "destructive" });
+      setBetriebskostenModalDirty(true);
     }
     setIsSaving(false);
   };
 
-  const handleWasserzaehlerChange = (index: number, field: keyof Omit<WasserzaehlerEntry, 'id' | 'mieter_id' | 'previous_reading'>, value: string) => {
-    const newEntries = [...wasserzaehlerEntries];
-    const entry = newEntries[index];
-    (entry as any)[field] = value;
-
-    if (field === 'zaehlerstand') {
-      const currentReading = parseFloat(value);
-      const previousReading = entry.previous_reading?.zaehlerstand;
-      if (!isNaN(currentReading) && previousReading !== null && previousReading !== undefined) {
-        const consumption = currentReading - previousReading;
-        entry.verbrauch = consumption.toString();
-        if (consumption < 0) {
-          entry.warning = "Verbrauch ist negativ.";
-        } else if (consumption > 1000) { // Example of a high value
-          entry.warning = "Verbrauch ist ungewöhnlich hoch.";
-        } else {
-          entry.warning = '';
-        }
-      }
-    }
-
-    setWasserzaehlerEntries(newEntries);
-    setBetriebskostenModalDirty(true);
-  };
-
-  // Handle input changes to set dirty flag
   const handleJahrChange = (e: React.ChangeEvent<HTMLInputElement>) => { setJahr(e.target.value); setBetriebskostenModalDirty(true); };
   const handleWasserkostenChange = (e: React.ChangeEvent<HTMLInputElement>) => { setWasserkosten(e.target.value); setBetriebskostenModalDirty(true); };
   const handleHausChange = (value: string | null) => { setHaeuserId(value || ""); setBetriebskostenModalDirty(true); };
-
 
   if (!isBetriebskostenModalOpen) {
     return null;
@@ -598,7 +439,7 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
         <form onSubmit={(e) => { e.preventDefault(); handleSubmit(); }}>
           <DialogHeader>
             <DialogTitle>
-              {betriebskostenInitialData?.id || modalNebenkostenData?.id ? "Betriebskosten bearbeiten" : "Neue Betriebskostenabrechnung"}
+              {betriebskostenInitialData?.id ? "Betriebskosten bearbeiten" : "Neue Betriebskostenabrechnung"}
             </DialogTitle>
             <DialogDescription>
               {isLoadingDetails ? "Lade Details..." : "Füllen Sie die Details für die Betriebskostenabrechnung aus."}
@@ -608,70 +449,36 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
           <div className="space-y-4 overflow-y-auto max-h-[70vh] p-4">
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div className="space-y-2">
-                <LabelWithTooltip 
-                  htmlFor="formJahr" 
-                  infoText="Das Jahr, für das die Nebenkostenabrechnung gilt."
-                >
+                <LabelWithTooltip htmlFor="formJahr" infoText="Das Jahr, für das die Nebenkostenabrechnung gilt.">
                   Jahr *
                 </LabelWithTooltip>
                 {isLoadingDetails ? <Skeleton className="h-10 w-full" /> : (
-                  <Input
-                    id="formJahr"
-                    value={jahr}
-                    onChange={handleJahrChange}
-                    placeholder="z.B. 2023"
-                    required
-                    disabled={isSaving}
-                  />
+                  <Input id="formJahr" value={jahr} onChange={handleJahrChange} placeholder="z.B. 2023" required disabled={isSaving} />
                 )}
               </div>
               <div className="space-y-2">
-                <LabelWithTooltip 
-                  htmlFor="formHausId" 
-                  infoText="Wählen Sie das Haus aus, für das die Nebenkostenabrechnung erstellt wird."
-                >
+                <LabelWithTooltip htmlFor="formHausId" infoText="Wählen Sie das Haus aus, für das die Nebenkostenabrechnung erstellt wird.">
                   Haus *
                 </LabelWithTooltip>
                 {isLoadingDetails ? <Skeleton className="h-10 w-full" /> : (
-                  <CustomCombobox
-                    width="w-full"
-                    options={houseOptions}
-                    value={haeuserId}
-                    onChange={handleHausChange}
-                    placeholder="Haus auswählen..."
-                    searchPlaceholder="Haus suchen..."
-                    emptyText="Kein Haus gefunden."
-                    disabled={isSaving}
-                  />
+                  <CustomCombobox width="w-full" options={houseOptions} value={haeuserId} onChange={handleHausChange} placeholder="Haus auswählen..." searchPlaceholder="Haus suchen..." emptyText="Kein Haus gefunden." disabled={isSaving} />
                 )}
               </div>
             </div>
 
             <div className="space-y-2">
-              <LabelWithTooltip 
-                htmlFor="formWasserkosten" 
-                infoText="Die gesamten Wasserkosten für das ausgewählte Haus in diesem Jahr."
-              >
+              <LabelWithTooltip htmlFor="formWasserkosten" infoText="Die gesamten Wasserkosten für das ausgewählte Haus in diesem Jahr.">
                 Wasserkosten (€)
               </LabelWithTooltip>
               {isLoadingDetails ? <Skeleton className="h-10 w-full" /> : (
-                <Input
-                  id="formWasserkosten"
-                  type="number"
-                  value={wasserkosten}
-                  onChange={handleWasserkostenChange}
-                  placeholder="z.B. 500.00"
-                  step="0.01"
-                  disabled={isSaving}
-                />
+                <Input id="formWasserkosten" type="number" value={wasserkosten} onChange={handleWasserkostenChange} placeholder="z.B. 500.00" step="0.01" disabled={isSaving} />
               )}
             </div>
 
-            {/* Kostenpositionen Section */}
             <div className="space-y-2">
               <h3 className="text-lg font-semibold tracking-tight">Kostenaufstellung</h3>
               <div className="rounded-md border p-4 space-y-0 shadow-sm">
-                {isLoadingDetails && (betriebskostenInitialData?.id || modalNebenkostenData?.id) ? (
+                {isLoadingDetails ? (
                   Array.from({ length: 3 }).map((_, idx) => (
                     <div key={`skel-cost-${idx}`} className="flex flex-col gap-3 py-2 border-b last:border-b-0">
                       <div className="flex flex-col sm:flex-row items-start gap-3">
@@ -684,21 +491,10 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
                   ))
                 ) : (
                   costItems.map((item, index) => (
-                    <div
-                      key={item.id}
-                      className="flex flex-col gap-3 py-2 border-b last:border-b-0"
-                      role="group"
-                      aria-label={`Kostenposition ${index + 1}`}
-                    >
+                    <div key={item.id} className="flex flex-col gap-3 py-2 border-b last:border-b-0" role="group" aria-label={`Kostenposition ${index + 1}`}>
                       <div className="flex flex-col sm:flex-row items-start gap-3">
                         <div className="w-full sm:flex-[4_1_0%]">
-                          <Input 
-                            id={`art-${item.id}`}
-                            placeholder="Kostenart"
-                            value={item.art}
-                            onChange={(e) => handleCostItemChange(index, 'art', e.target.value)}
-                            disabled={isSaving}
-                          />
+                          <Input id={`art-${item.id}`} placeholder="Kostenart" value={item.art} onChange={(e) => handleCostItemChange(index, 'art', e.target.value)} disabled={isSaving} />
                         </div>
                         <div className="w-full sm:flex-[3_1_0%]">
                           {item.berechnungsart === 'nach Rechnung' ? (
@@ -706,23 +502,11 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
                               Beträge pro Mieter unten
                             </div>
                           ) : (
-                            <Input
-                              id={`betrag-${item.id}`}
-                              type="number"
-                              placeholder="Betrag (€)"
-                              value={item.betrag}
-                              onChange={(e) => handleCostItemChange(index, 'betrag', e.target.value)}
-                              step="0.01"
-                              disabled={isSaving}
-                            />
+                            <Input id={`betrag-${item.id}`} type="number" placeholder="Betrag (€)" value={item.betrag} onChange={(e) => handleCostItemChange(index, 'betrag', e.target.value)} step="0.01" disabled={isSaving} />
                           )}
                         </div>
                         <div className="w-full sm:flex-[4_1_0%]">
-                          <Select
-                            value={item.berechnungsart}
-                            onValueChange={(value) => handleCostItemChange(index, 'berechnungsart', value as BerechnungsartValue)}
-                            disabled={isSaving}
-                          >
+                          <Select value={item.berechnungsart} onValueChange={(value) => handleCostItemChange(index, 'berechnungsart', value as BerechnungsartValue)} disabled={isSaving}>
                             <SelectTrigger id={`berechnungsart-${item.id}`}>
                               <SelectValue placeholder="Berechnungsart..." />
                             </SelectTrigger>
@@ -734,14 +518,7 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
                           </Select>
                         </div>
                         <div className="flex-none self-center sm:self-start pt-1 sm:pt-0">
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => removeCostItem(index)}
-                            disabled={costItems.length <= 1 || isLoadingDetails || isSaving}
-                            aria-label="Kostenposition entfernen"
-                          >
+                          <Button type="button" variant="ghost" size="icon" onClick={() => removeCostItem(index)} disabled={costItems.length <= 1 || isLoadingDetails || isSaving} aria-label="Kostenposition entfernen">
                             <Trash2 className="h-5 w-5 text-destructive" />
                           </Button>
                         </div>
@@ -752,7 +529,7 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
                           <h4 className="text-md font-semibold text-gray-700">
                             Einzelbeträge für: <span className="font-normal italic">"{item.art || 'Unbenannte Kostenart'}"</span>
                           </h4>
-                          {(isLoadingDetails || isFetchingTenants) && (!selectedHausMieter || selectedHausMieter.length === 0) ? (
+                          {isFetchingTenants ? (
                               Array.from({ length: 3 }).map((_, skelIdx) => (
                                 <div key={`skel-tenant-${skelIdx}`} className="grid grid-cols-10 gap-2 items-center py-1">
                                   <Skeleton className="h-8 w-full col-span-6 sm:col-span-7" />
@@ -765,9 +542,9 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
                                 <p className="text-sm text-orange-600 p-2 bg-orange-50 border border-orange-200 rounded-md">Bitte wählen Sie zuerst ein Haus aus, um Mieter zu laden.</p>
                               )}
                               {!isFetchingTenants && haeuserId && selectedHausMieter.length === 0 && !isLoadingDetails && (
-                                <p className="text-sm text-orange-600 p-2 bg-orange-50 border border-orange-200 rounded-md">Für das ausgewählte Haus wurden keine Mieter gefunden oder es sind keine Mieter dem Haus direkt zugeordnet.</p>
+                                <p className="text-sm text-orange-600 p-2 bg-orange-50 border border-orange-200 rounded-md">Für das ausgewählte Haus wurden keine Mieter gefunden.</p>
                               )}
-                              {!isFetchingTenants && haeuserId && selectedHausMieter.length > 0 && (
+                              {selectedHausMieter.length > 0 && (
                                 <div className="space-y-2 max-h-60 overflow-y-auto pr-2">
                                   {selectedHausMieter.map(mieter => {
                                     const rechnungForMieter = (rechnungen[item.id] || []).find(r => r.mieterId === mieter.id);
@@ -777,31 +554,17 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
                                           {mieter.name}
                                         </Label>
                                         <div className="col-span-4 sm:col-span-3">
-                                          <Input
-                                            id={`rechnung-${item.id}-${mieter.id}`}
-                                            type="number"
-                                            step="0.01"
-                                            placeholder="Betrag (€)"
-                                            value={rechnungForMieter?.betrag || ''}
-                                            onChange={(e) => handleRechnungChange(item.id, mieter.id, e.target.value)}
-                                            className="w-full text-sm"
-                                            disabled={isLoadingDetails || isSaving}
-                                          />
+                                          <Input id={`rechnung-${item.id}-${mieter.id}`} type="number" step="0.01" placeholder="Betrag (€)" value={rechnungForMieter?.betrag || ''} onChange={(e) => handleRechnungChange(item.id, mieter.id, e.target.value)} className="w-full text-sm" disabled={isLoadingDetails || isSaving} />
                                         </div>
                                       </div>
                                     );
                                   })}
                                 </div>
                               )}
-                              {item.berechnungsart === 'nach Rechnung' && rechnungen[item.id] && selectedHausMieter.length > 0 && !isLoadingDetails && (
+                              {rechnungen[item.id] && selectedHausMieter.length > 0 && (
                                   <div className="pt-2 mt-2 border-t border-gray-300 flex justify-end">
                                       <p className="text-sm font-semibold text-gray-700">
-                                          Summe Einzelbeträge: {
-                                              formatNumber(
-                                                  (rechnungen[item.id] || [])
-                                                      .reduce((sum, r) => sum + (parseFloat(r.betrag) || 0), 0)
-                                              )
-                                          } €
+                                          Summe: {formatNumber((rechnungen[item.id] || []).reduce((sum, r) => sum + (parseFloat(r.betrag) || 0), 0))} €
                                       </p>
                                   </div>
                               )}
@@ -812,82 +575,10 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
                     </div>
                   ))
                 )}
-                <Button
-                  type="button"
-                  onClick={addCostItem}
-                  variant="outline"
-                  size="sm"
-                  className="mt-2"
-                  disabled={isLoadingDetails || isSaving}
-                >
+                <Button type="button" onClick={addCostItem} variant="outline" size="sm" className="mt-2" disabled={isLoadingDetails || isSaving}>
                   <PlusCircle className="mr-2 h-4 w-4" />
                   Kostenposition hinzufügen
                 </Button>
-              </div>
-            </div>
-
-            {/* Wasserzähler Section */}
-            <div className="space-y-2">
-              <h3 className="text-lg font-semibold tracking-tight">Wasserzählerstände</h3>
-              <div className="rounded-md border p-4 space-y-4 shadow-sm">
-                {isFetchingTenants || isFetchingPreviousReadings ? (
-                  <p>Lade Mieter und Zählerstände...</p>
-                ) : wasserzaehlerEntries.length > 0 ? (
-                  <div className="space-y-4">
-                    {wasserzaehlerEntries.map((entry, index) => {
-                      const mieter = selectedHausMieter.find(m => m.id === entry.mieter_id);
-                      return (
-                        <div key={entry.id} className="p-3 bg-gray-50 border rounded-md">
-                          <p className="font-semibold">{mieter?.name}</p>
-                          {entry.previous_reading ? (
-                            <p className="text-sm text-gray-500">
-                              Vorherige Ablesung: {entry.previous_reading.ablese_datum ? new Date(entry.previous_reading.ablese_datum).toLocaleDateString() : 'Datum unbekannt'} - {entry.previous_reading.zaehlerstand}
-                            </p>
-                          ) : (
-                            <p className="text-sm text-gray-500">Keine vorherige Ablesung gefunden</p>
-                          )}
-                          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-2">
-                            <div className="space-y-1">
-                              <Label htmlFor={`ablesedatum-${entry.id}`}>Ablesedatum</Label>
-                              <Input
-                                id={`ablesedatum-${entry.id}`}
-                                type="date"
-                                value={entry.ablese_datum}
-                                onChange={(e) => handleWasserzaehlerChange(index, 'ablese_datum', e.target.value)}
-                                disabled={isSaving}
-                              />
-                            </div>
-                            <div className="space-y-1">
-                              <Label htmlFor={`zaehlerstand-${entry.id}`}>Zählerstand</Label>
-                              <Input
-                                id={`zaehlerstand-${entry.id}`}
-                                type="number"
-                                value={entry.zaehlerstand}
-                                onChange={(e) => handleWasserzaehlerChange(index, 'zaehlerstand', e.target.value)}
-                                disabled={isSaving}
-                              />
-                            </div>
-                            <div className="space-y-1">
-                              <Label htmlFor={`verbrauch-${entry.id}`}>Verbrauch</Label>
-                              <Input
-                                id={`verbrauch-${entry.id}`}
-                                type="number"
-                                value={entry.verbrauch}
-                                onChange={(e) => handleWasserzaehlerChange(index, 'verbrauch', e.target.value)}
-                                disabled={isSaving}
-                              />
-                            </div>
-                          </div>
-                          {entry.warning && <p className="text-sm text-red-500 mt-1">{entry.warning}</p>}
-                        </div>
-                      );
-                    })}
-                  </div>
-                ) : (
-                  <p className="text-sm text-gray-500">
-                    Für das ausgewählte Haus und Jahr wurden keine Mieter gefunden.
-                  </p>
-                )}
               </div>
             </div>
           </div>
@@ -896,8 +587,8 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
             <Button type="button" variant="outline" onClick={handleCancelClick} disabled={isSaving || isLoadingDetails}>
               Abbrechen
             </Button>
-            <Button type="submit" disabled={isSaving || isLoadingDetails}>
-              {isSaving ? "Speichern..." : (isLoadingDetails ? "Laden..." : "Speichern")}
+            <Button type="submit" disabled={isSaving || isFetchingTenants}>
+              {isSaving ? "Speichern..." : (isLoadingDetails || isFetchingTenants ? "Laden..." : "Speichern")}
             </Button>
           </DialogFooter>
         </form>

--- a/components/betriebskosten-edit-modal.tsx
+++ b/components/betriebskosten-edit-modal.tsx
@@ -485,9 +485,19 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
       const nebenkosten_id = currentEditId || response.data?.id;
       if (nebenkosten_id) {
         // Save Wasserzaehler data
+        const entriesToSave = wasserzaehlerEntries
+          .filter(e => e.ablese_datum && e.zaehlerstand)
+          .map(entry => {
+            const mieter = selectedHausMieter.find(m => m.id === entry.mieter_id);
+            return {
+              ...entry,
+              mieter_name: mieter?.name || 'Unbekannter Mieter',
+            };
+          });
+
         const wasserzaehlerDataToSave = {
           nebenkosten_id: nebenkosten_id,
-          entries: wasserzaehlerEntries.filter(e => e.ablese_datum && e.zaehlerstand),
+          entries: entriesToSave,
         };
         const wasserzaehlerResponse = await saveWasserzaehlerData(wasserzaehlerDataToSave);
         if (!wasserzaehlerResponse.success) {
@@ -831,7 +841,7 @@ export function BetriebskostenEditModal({/* Props are now from store */ }: Betri
                           <p className="font-semibold">{mieter?.name}</p>
                           {entry.previous_reading ? (
                             <p className="text-sm text-gray-500">
-                              Vorherige Ablesung: {new Date(entry.previous_reading.ablese_datum).toLocaleDateString()} - {entry.previous_reading.zaehlerstand}
+                              Vorherige Ablesung: {entry.previous_reading.ablese_datum ? new Date(entry.previous_reading.ablese_datum).toLocaleDateString() : 'Datum unbekannt'} - {entry.previous_reading.zaehlerstand}
                             </p>
                           ) : (
                             <p className="text-sm text-gray-500">Keine vorherige Ablesung gefunden</p>

--- a/components/operating-costs-table.tsx
+++ b/components/operating-costs-table.tsx
@@ -101,21 +101,24 @@ export function OperatingCostsTable({
     }
   };
 
-  const handleSaveWasserzaehler = async (data: WasserzaehlerFormData) => {
+  const handleSaveWasserzaehler = async (data: WasserzaehlerFormData): Promise<{ success: boolean; message?: string }> => {
     try {
       const result = await saveWasserzaehlerData(data);
       if (result.success) {
         toast.success("Wasserzählerdaten erfolgreich gespeichert!");
-        // Modal will be closed by the modal component itself
+        // Return success result to the modal
+        return { success: true };
       } else {
-        throw new Error(result.message); // Re-throw to prevent modal from closing
+        const errorMessage = result.message || "Die Wasserzählerstände konnten nicht gespeichert werden.";
+        throw new Error(errorMessage);
       }
     } catch (error) {
       console.error("Error calling saveWasserzaehlerData:", error);
       if (error instanceof Error) {
-        throw error; // Re-throw to prevent modal from closing
+        // Return error result to the modal
+        return { success: false, message: error.message };
       } else {
-        throw new Error("Ein unerwarteter Fehler ist aufgetreten.");
+        return { success: false, message: "Ein unerwarteter Fehler ist aufgetreten." };
       }
     }
   };

--- a/components/wasserzaehler-modal.tsx
+++ b/components/wasserzaehler-modal.tsx
@@ -285,16 +285,17 @@ export function WasserzaehlerModal() {
     };
 
     try {
-      console.log("Saving data:", dataToSave);
-
-      // Call the save function using the typed handleSave
-      const result = await handleSave(dataToSave);
+      console.log('Saving Wasserzaehler data:', dataToSave);
       
-      if (result?.success) {
+      // Call the save function and handle the response
+      const result = await handleSave(dataToSave);
+
+      if (result.success) {
         // If we get here, the save was successful
         toast({
           title: "Erfolgreich gespeichert",
           description: `Die Wasserzählerstände für ${entriesToSave.length} Mieter wurden erfolgreich aktualisiert.`,
+          variant: "success"
         });
         
         // Close the modal after a short delay to show the success message
@@ -302,11 +303,8 @@ export function WasserzaehlerModal() {
           closeWasserzaehlerModal({ force: true });
         }, 1000);
       } else {
-        // Handle case where save was not successful but didn't throw an error
-        const errorMessage = result?.message || 'Die Wasserzählerstände konnten nicht gespeichert werden.';
-        throw new Error(errorMessage);
+        throw new Error(result.message || 'Die Wasserzählerstände konnten nicht gespeichert werden.');
       }
-      
     } catch (error) {
       console.error("Error saving Wasserzaehler data:", error);
       let errorMessage = "Die Wasserzählerstände konnten nicht gespeichert werden.";

--- a/components/wasserzaehler-modal.tsx
+++ b/components/wasserzaehler-modal.tsx
@@ -79,7 +79,11 @@ export function WasserzaehlerModal() {
                   reading => reading.mieter_id === mieter.id
                 );
 
-                const previousReadingResponse = await getPreviousWasserzaehlerRecordAction(mieter.id);
+                // Get the current year from the nebenkosten data
+                const currentYear = wasserzaehlerNebenkosten?.jahr;
+                
+                // Pass the current year to get the previous year's reading
+                const previousReadingResponse = await getPreviousWasserzaehlerRecordAction(mieter.id, currentYear);
                 const previous_reading = previousReadingResponse.success 
                   ? (previousReadingResponse.data || null) 
                   : null;

--- a/components/wasserzaehler-modal.tsx
+++ b/components/wasserzaehler-modal.tsx
@@ -43,6 +43,7 @@ export function WasserzaehlerModal() {
   const [formData, setFormData] = useState<ModalWasserzaehlerEntry[]>([]);
   const [initialFormData, setInitialFormData] = useState<ModalWasserzaehlerEntry[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [generalDate, setGeneralDate] = useState<Date | undefined>(new Date());
   const { toast } = useToast();
   
   // Threshold for high consumption warning (50% more than previous year)
@@ -208,6 +209,24 @@ export function WasserzaehlerModal() {
     setFormData(newFormData);
   };
 
+  // Apply the general date to all entries
+  const applyGeneralDateToAll = () => {
+    if (!generalDate) return;
+    
+    const newFormData = [...formData];
+    const formattedDate = format(generalDate, "yyyy-MM-dd");
+    
+    newFormData.forEach(entry => {
+      entry.ablese_datum = formattedDate;
+    });
+    setFormData(newFormData);
+    
+    toast({
+      title: "Datum übernommen",
+      description: `Das Datum wurde für alle ${newFormData.length} Mieter übernommen.`,
+    });
+  };
+
   const handleSubmit = async () => {
     if (!wasserzaehlerNebenkosten || !wasserzaehlerOnSave) {
       toast({
@@ -328,6 +347,35 @@ export function WasserzaehlerModal() {
         </DialogHeader>
 
         <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-4 py-4">
+          {/* General Date Picker */}
+          {formData.length > 0 && (
+            <div className="flex flex-col sm:flex-row items-start sm:items-end gap-3 mb-6 p-4 bg-muted/50 border rounded-lg">
+              <div className="w-full">
+                <Label htmlFor="general-date-picker" className="block mb-1">
+                  Gemeinsames Ablesedatum für alle Mieter:
+                </Label>
+                <div className="flex flex-col sm:flex-row gap-2">
+                  <div className="flex-1">
+                    <DatePicker
+                      id="general-date-picker"
+                      value={generalDate}
+                      onChange={(date) => setGeneralDate(date || new Date())}
+                      placeholder="Datum für alle Mieter auswählen"
+                    />
+                  </div>
+                  <Button 
+                    type="button" 
+                    onClick={applyGeneralDateToAll} 
+                    variant="outline" 
+                    className="whitespace-nowrap"
+                  >
+                    Auf alle Mieter anwenden
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+
           {isLoading ? (
             <div className="flex justify-center items-center h-40">
               <p>Lade Daten...</p>

--- a/components/wasserzaehler-modal.tsx
+++ b/components/wasserzaehler-modal.tsx
@@ -114,7 +114,7 @@ export function WasserzaehlerModal() {
         entry.verbrauch = consumption.toString();
         if (consumption < 0) {
           entry.warning = "Verbrauch ist negativ.";
-        } else if (entry.previous_reading?.verbrauch) {
+        } else if (entry.previous_reading?.verbrauch !== undefined && entry.previous_reading.verbrauch > 0) {
           const previousConsumption = entry.previous_reading.verbrauch;
           if (consumption > previousConsumption * HIGH_CONSUMPTION_INCREASE_THRESHOLD) {
             entry.warning = `Achtung: Verbrauch (${consumption}) ist mehr als ${Math.round((HIGH_CONSUMPTION_INCREASE_THRESHOLD - 1) * 100)}% höher als im Vorjahr (${previousConsumption}).`;

--- a/components/wasserzaehler-modal.tsx
+++ b/components/wasserzaehler-modal.tsx
@@ -42,6 +42,9 @@ export function WasserzaehlerModal() {
   const [initialFormData, setInitialFormData] = useState<ModalWasserzaehlerEntry[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const { toast } = useToast();
+  
+  // Threshold for high consumption warning (50% more than previous year)
+  const HIGH_CONSUMPTION_INCREASE_THRESHOLD = 1.5; // 50% increase
 
   useEffect(() => {
     if (isWasserzaehlerModalOpen && wasserzaehlerNebenkosten && wasserzaehlerMieterList) {
@@ -111,7 +114,15 @@ export function WasserzaehlerModal() {
         entry.verbrauch = consumption.toString();
         if (consumption < 0) {
           entry.warning = "Verbrauch ist negativ.";
+        } else if (entry.previous_reading?.verbrauch) {
+          const previousConsumption = entry.previous_reading.verbrauch;
+          if (consumption > previousConsumption * HIGH_CONSUMPTION_INCREASE_THRESHOLD) {
+            entry.warning = `Achtung: Verbrauch (${consumption}) ist mehr als ${Math.round((HIGH_CONSUMPTION_INCREASE_THRESHOLD - 1) * 100)}% höher als im Vorjahr (${previousConsumption}).`;
+          } else {
+            entry.warning = '';
+          }
         } else if (consumption > 1000) {
+          // Fallback check if no previous consumption data is available
           entry.warning = "Verbrauch ist ungewöhnlich hoch.";
         } else {
           entry.warning = '';

--- a/hooks/use-modal-store.tsx
+++ b/hooks/use-modal-store.tsx
@@ -104,9 +104,9 @@ interface ModalState {
   wasserzaehlerNebenkosten?: Nebenkosten;
   wasserzaehlerMieterList: Mieter[];
   wasserzaehlerExistingReadings?: Wasserzaehler[] | null;
-  wasserzaehlerOnSave?: (data: WasserzaehlerFormData) => Promise<void>;
+  wasserzaehlerOnSave?: (data: WasserzaehlerFormData) => Promise<{ success: boolean; message?: string }>;
   isWasserzaehlerModalDirty: boolean;
-  openWasserzaehlerModal: (nebenkosten?: Nebenkosten, mieterList?: Mieter[], existingReadings?: Wasserzaehler[] | null, onSave?: (data: WasserzaehlerFormData) => Promise<void>) => void;
+  openWasserzaehlerModal: (nebenkosten?: Nebenkosten, mieterList?: Mieter[], existingReadings?: Wasserzaehler[] | null, onSave?: (data: WasserzaehlerFormData) => Promise<{ success: boolean; message?: string }>) => void;
   closeWasserzaehlerModal: (options?: CloseModalOptions) => void;
   setWasserzaehlerModalDirty: (isDirty: boolean) => void;
 

--- a/lib/data-fetching.ts
+++ b/lib/data-fetching.ts
@@ -375,7 +375,15 @@ export async function fetchNebenkostenList(): Promise<Nebenkosten[]> {
       }
     }
     
-    return nebendkostenWithArea as Nebenkosten[];
+    // Sort the results by year in descending order (newest first)
+    const sortedNebenkosten = nebendkostenWithArea.sort((a, b) => {
+      // Convert years to numbers for proper numeric comparison
+      const yearA = parseInt(a.jahr || '0', 10);
+      const yearB = parseInt(b.jahr || '0', 10);
+      return yearB - yearA; // Sort in descending order (newest first)
+    });
+    
+    return sortedNebenkosten as Nebenkosten[];
   } catch (error) {
     console.error('Unexpected error in fetchNebenkostenList:', error);
     return [];


### PR DESCRIPTION
## Description

Improves the water-meter workflow: previous-year reading lookup, shared house/year fetching and a cleaner edit modal.

## Summary of Changes

- New `getPreviousWasserzaehlerRecordAction`: prefers the reading from the previous billing year (via Nebenkosten join), falls back to the tenant's most recent reading
- New `getWasserzaehlerByHausAndYearAction` backed by the extracted `fetchWasserzaehlerByHausAndYear` (tenants active in the year + readings in range); modal data fetch now reuses it
- `saveWasserzaehlerData` validates entries, normalizes reading dates (defaults to today) and rejects fully invalid payloads
- Betriebskosten edit modal cleaned up (~210 lines removed): dead imports/branches, compact error handling; water-meter save button is disabled until the form is dirty and reads "Änderungen speichern"