### PR TITLE
Feature/change filter tag order

### DIFF
--- a/app/(dashboard)/mieter/client-wrapper.tsx
+++ b/app/(dashboard)/mieter/client-wrapper.tsx
@@ -36,7 +36,7 @@ export default function MieterClientView({
   initialWohnungen,
   serverAction,
 }: MieterClientViewProps) {
-  const [filter, setFilter] = useState<string>("current");
+  const [filter, setFilter] = useState<"current" | "previous" | "all">("current");
   const [searchQuery, setSearchQuery] = useState<string>("");
   const { openTenantModal } = useModalStore();
 
@@ -126,7 +126,11 @@ export default function MieterClientView({
           </div>
         </CardHeader>
         <CardContent className="flex flex-col gap-6">
-          <TenantFilters onFilterChange={setFilter} onSearchChange={setSearchQuery} />
+          <TenantFilters 
+            activeFilter={filter}
+            onFilterChange={setFilter}
+            onSearchChange={setSearchQuery}
+          />
           <TenantTable
             tenants={initialTenants} // Directly use initialTenants or manage a separate 'filteredTenants' state if needed
             wohnungen={initialWohnungen}

--- a/app/(dashboard)/mieter/client-wrapper.tsx
+++ b/app/(dashboard)/mieter/client-wrapper.tsx
@@ -36,7 +36,7 @@ export default function MieterClientView({
   initialWohnungen,
   serverAction,
 }: MieterClientViewProps) {
-  const [filter, setFilter] = useState<string>("all");
+  const [filter, setFilter] = useState<string>("current");
   const [searchQuery, setSearchQuery] = useState<string>("");
   const { openTenantModal } = useModalStore();
 

--- a/app/(dashboard)/todos/client-wrapper.tsx
+++ b/app/(dashboard)/todos/client-wrapper.tsx
@@ -14,7 +14,7 @@ interface TodosClientWrapperProps {
 }
 
 export default function TodosClientWrapper({ tasks: initialTasks }: TodosClientWrapperProps) {
-  const [filter, setFilter] = useState("all");
+  const [filter, setFilter] = useState("open");
   const [searchQuery, setSearchQuery] = useState("");
   const [tasks, setTasks] = useState<TaskBoardTask[]>(initialTasks);
 

--- a/app/(dashboard)/todos/client-wrapper.tsx
+++ b/app/(dashboard)/todos/client-wrapper.tsx
@@ -14,7 +14,7 @@ interface TodosClientWrapperProps {
 }
 
 export default function TodosClientWrapper({ tasks: initialTasks }: TodosClientWrapperProps) {
-  const [filter, setFilter] = useState("open");
+  const [filter, setFilter] = useState<"open" | "done" | "all">("open");
   const [searchQuery, setSearchQuery] = useState("");
   const [tasks, setTasks] = useState<TaskBoardTask[]>(initialTasks);
 
@@ -53,14 +53,20 @@ export default function TodosClientWrapper({ tasks: initialTasks }: TodosClientW
           </div>
         </CardHeader>
         <CardContent className="flex flex-col gap-6">
-          <TaskFilters onFilterChange={setFilter} onSearchChange={setSearchQuery} />
-          <TaskBoard 
-            filter={filter} 
-            searchQuery={searchQuery} 
-            tasks={tasks}
-            onTaskUpdated={handleTaskUpdated}
-            onTaskDeleted={handleTaskDeleted}
-          />
+          <div className="flex flex-col gap-4">
+            <TaskFilters 
+              activeFilter={filter}
+              onFilterChange={setFilter}
+              onSearchChange={setSearchQuery}
+            />
+            <TaskBoard 
+              filter={filter} 
+              searchQuery={searchQuery} 
+              tasks={tasks}
+              onTaskUpdated={handleTaskUpdated}
+              onTaskDeleted={handleTaskDeleted}
+            />
+          </div>
         </CardContent>
       </Card>
       <Toaster />

--- a/components/task-board.tsx
+++ b/components/task-board.tsx
@@ -36,7 +36,7 @@ export function TaskBoard({
     const matchesFilter = 
       filter === 'all' || 
       (filter === 'done' && task.ist_erledigt) || 
-      (filter === 'pending' && !task.ist_erledigt)
+      (filter === 'open' && !task.ist_erledigt)
       
     const taskDescription = task.beschreibung || ''
     const searchQueryLower = searchQuery.toLowerCase()

--- a/components/task-filters.tsx
+++ b/components/task-filters.tsx
@@ -11,7 +11,7 @@ interface TaskFiltersProps {
 }
 
 export function TaskFilters({ onFilterChange, onSearchChange }: TaskFiltersProps) {
-  const [activeFilter, setActiveFilter] = useState("all")
+  const [activeFilter, setActiveFilter] = useState("open")
 
   const handleFilterClick = (filter: string) => {
     setActiveFilter(filter)
@@ -22,13 +22,6 @@ export function TaskFilters({ onFilterChange, onSearchChange }: TaskFiltersProps
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-wrap gap-2">
-          <Button
-            variant={activeFilter === "all" ? "default" : "outline"}
-            onClick={() => handleFilterClick("all")}
-            className="h-9"
-          >
-            Alle
-          </Button>
           <Button
             variant={activeFilter === "open" ? "default" : "outline"}
             onClick={() => handleFilterClick("open")}
@@ -42,6 +35,13 @@ export function TaskFilters({ onFilterChange, onSearchChange }: TaskFiltersProps
             className="h-9"
           >
             Erledigt
+          </Button>
+          <Button
+            variant={activeFilter === "all" ? "default" : "outline"}
+            onClick={() => handleFilterClick("all")}
+            className="h-9"
+          >
+            Alle
           </Button>
         </div>
         <div className="relative w-full sm:w-auto sm:min-w-[300px]">

--- a/components/task-filters.tsx
+++ b/components/task-filters.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useMemo } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Search } from "lucide-react"
@@ -16,11 +16,11 @@ export function TaskFilters({ activeFilter, onFilterChange, onSearchChange }: Ta
     onFilterChange(filter)
   }
 
-  const filterOptions = [
+  const filterOptions = useMemo(() => [
     { value: "open" as const, label: "Offen" },
     { value: "done" as const, label: "Erledigt" },
     { value: "all" as const, label: "Alle" },
-  ];
+  ], []);
 
   return (
     <div className="flex flex-col gap-4">

--- a/components/task-filters.tsx
+++ b/components/task-filters.tsx
@@ -16,31 +16,26 @@ export function TaskFilters({ activeFilter, onFilterChange, onSearchChange }: Ta
     onFilterChange(filter)
   }
 
+  const filterOptions = [
+    { value: "open" as const, label: "Offen" },
+    { value: "done" as const, label: "Erledigt" },
+    { value: "all" as const, label: "Alle" },
+  ];
+
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-wrap gap-2">
-          <Button
-            variant={activeFilter === "open" ? "default" : "outline"}
-            onClick={() => handleFilterClick("open")}
-            className="h-9"
-          >
-            Offen
-          </Button>
-          <Button
-            variant={activeFilter === "done" ? "default" : "outline"}
-            onClick={() => handleFilterClick("done")}
-            className="h-9"
-          >
-            Erledigt
-          </Button>
-          <Button
-            variant={activeFilter === "all" ? "default" : "outline"}
-            onClick={() => handleFilterClick("all")}
-            className="h-9"
-          >
-            Alle
-          </Button>
+          {filterOptions.map(({ value, label }) => (
+            <Button
+              key={value}
+              variant={activeFilter === value ? "default" : "outline"}
+              onClick={() => handleFilterClick(value)}
+              className="h-9"
+            >
+              {label}
+            </Button>
+          ))}
         </div>
         <div className="relative w-full sm:w-auto sm:min-w-[300px]">
           <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />

--- a/components/task-filters.tsx
+++ b/components/task-filters.tsx
@@ -6,15 +6,13 @@ import { Input } from "@/components/ui/input"
 import { Search } from "lucide-react"
 
 interface TaskFiltersProps {
-  onFilterChange: (filter: string) => void
-  onSearchChange: (search: string) => void
+  activeFilter: "open" | "done" | "all";
+  onFilterChange: (filter: "open" | "done" | "all") => void;
+  onSearchChange: (search: string) => void;
 }
 
-export function TaskFilters({ onFilterChange, onSearchChange }: TaskFiltersProps) {
-  const [activeFilter, setActiveFilter] = useState("open")
-
-  const handleFilterClick = (filter: string) => {
-    setActiveFilter(filter)
+export function TaskFilters({ activeFilter, onFilterChange, onSearchChange }: TaskFiltersProps) {
+  const handleFilterClick = (filter: "open" | "done" | "all") => {
     onFilterChange(filter)
   }
 

--- a/components/tenant-filters.tsx
+++ b/components/tenant-filters.tsx
@@ -16,31 +16,26 @@ export function TenantFilters({ activeFilter, onFilterChange, onSearchChange }: 
     onFilterChange(filter)
   }
 
+  const filterOptions = [
+    { value: "current" as const, label: "Aktuelle Mieter" },
+    { value: "previous" as const, label: "Vorherige Mieter" },
+    { value: "all" as const, label: "Alle Mieter" },
+  ];
+
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-wrap gap-2">
-          <Button
-            variant={activeFilter === "current" ? "default" : "outline"}
-            onClick={() => handleFilterClick("current")}
-            className="h-9"
-          >
-            Aktuelle Mieter
-          </Button>
-          <Button
-            variant={activeFilter === "previous" ? "default" : "outline"}
-            onClick={() => handleFilterClick("previous")}
-            className="h-9"
-          >
-            Vorherige Mieter
-          </Button>
-          <Button
-            variant={activeFilter === "all" ? "default" : "outline"}
-            onClick={() => handleFilterClick("all")}
-            className="h-9"
-          >
-            Alle Mieter
-          </Button>
+          {filterOptions.map(({ value, label }) => (
+            <Button
+              key={value}
+              variant={activeFilter === value ? "default" : "outline"}
+              onClick={() => handleFilterClick(value)}
+              className="h-9"
+            >
+              {label}
+            </Button>
+          ))}
         </div>
         <div className="relative w-full sm:w-auto sm:min-w-[300px]">
           <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />

--- a/components/tenant-filters.tsx
+++ b/components/tenant-filters.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useMemo } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Search } from "lucide-react"
@@ -16,11 +16,11 @@ export function TenantFilters({ activeFilter, onFilterChange, onSearchChange }: 
     onFilterChange(filter)
   }
 
-  const filterOptions = [
+  const filterOptions = useMemo(() => [
     { value: "current" as const, label: "Aktuelle Mieter" },
     { value: "previous" as const, label: "Vorherige Mieter" },
     { value: "all" as const, label: "Alle Mieter" },
-  ];
+  ], []);
 
   return (
     <div className="flex flex-col gap-4">

--- a/components/tenant-filters.tsx
+++ b/components/tenant-filters.tsx
@@ -11,7 +11,7 @@ interface TenantFiltersProps {
 }
 
 export function TenantFilters({ onFilterChange, onSearchChange }: TenantFiltersProps) {
-  const [activeFilter, setActiveFilter] = useState("all")
+  const [activeFilter, setActiveFilter] = useState("current")
 
   const handleFilterClick = (filter: string) => {
     setActiveFilter(filter)
@@ -22,13 +22,6 @@ export function TenantFilters({ onFilterChange, onSearchChange }: TenantFiltersP
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-wrap gap-2">
-          <Button
-            variant={activeFilter === "all" ? "default" : "outline"}
-            onClick={() => handleFilterClick("all")}
-            className="h-9"
-          >
-            Alle Mieter
-          </Button>
           <Button
             variant={activeFilter === "current" ? "default" : "outline"}
             onClick={() => handleFilterClick("current")}
@@ -42,6 +35,13 @@ export function TenantFilters({ onFilterChange, onSearchChange }: TenantFiltersP
             className="h-9"
           >
             Vorherige Mieter
+          </Button>
+          <Button
+            variant={activeFilter === "all" ? "default" : "outline"}
+            onClick={() => handleFilterClick("all")}
+            className="h-9"
+          >
+            Alle Mieter
           </Button>
         </div>
         <div className="relative w-full sm:w-auto sm:min-w-[300px]">

--- a/components/tenant-filters.tsx
+++ b/components/tenant-filters.tsx
@@ -6,15 +6,13 @@ import { Input } from "@/components/ui/input"
 import { Search } from "lucide-react"
 
 interface TenantFiltersProps {
-  onFilterChange: (filter: string) => void
+  activeFilter: "current" | "previous" | "all";
+  onFilterChange: (filter: "current" | "previous" | "all") => void;
   onSearchChange: (search: string) => void
 }
 
-export function TenantFilters({ onFilterChange, onSearchChange }: TenantFiltersProps) {
-  const [activeFilter, setActiveFilter] = useState("current")
-
-  const handleFilterClick = (filter: string) => {
-    setActiveFilter(filter)
+export function TenantFilters({ activeFilter, onFilterChange, onSearchChange }: TenantFiltersProps) {
+  const handleFilterClick = (filter: "current" | "previous" | "all") => {
     onFilterChange(filter)
   }
 


### PR DESCRIPTION
## Description

Makes the tenant and task filters default to the relevant subset and turns the filter components into controlled, typed components.

## Summary of Changes

- Tenants page now defaults to "Aktuelle Mieter", tasks page to "Offen" (previously both showed "Alle")
- `TenantFilters`/`TaskFilters` are controlled via an `activeFilter` prop with literal union types; options rendered from a memoized array
- Task board filter key aligned (`pending` → `open`)