### PR TITLE
feat: increase global search results limit to 15

### DIFF
--- a/components/command-menu.tsx
+++ b/components/command-menu.tsx
@@ -28,6 +28,9 @@ import {
 import { Button } from "@/components/ui/button"
 import { toast } from "@/hooks/use-toast"
 import { SearchResult } from "@/types/search"
+
+const GLOBAL_SEARCH_RESULT_LIMIT = 15;
+
 import {
   getUserSubscriptionContext,
   getPlanApartmentLimit,
@@ -103,7 +106,7 @@ export function CommandMenu() {
     addToRecentSearches
   } = useSearch({
     debounceMs: 300,
-    limit: 15
+    limit: GLOBAL_SEARCH_RESULT_LIMIT
   })
 
   // Determine if we should show search results or navigation


### PR DESCRIPTION
- Updated useSearch hook in CommandMenu to show 15 results instead of 5
- Improves search usability by showing more relevant results
- The API already supports up to 20 results per category

fix #535 