### PR TITLE
Fix/pro person abrechnung

### DIFF
--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -269,6 +269,7 @@ export function AbrechnungModal({
                 share = 0;
               }
               break;
+            case 'pro mieter':
             case 'pro person':
               // Divide total cost by number of apartments for per-apartment calculation
               const uniqueApartmentIds = new Set(tenants.map(t => t.wohnung_id).filter(Boolean));

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -270,8 +270,10 @@ export function AbrechnungModal({
               }
               break;
             case 'pro person':
-              // Divide total cost by number of tenants for per-person calculation
-              share = totalCostForItem / Math.max(1, tenants?.length || 0);
+              // Divide total cost by number of apartments for per-apartment calculation
+              const uniqueApartmentIds = new Set(tenants.map(t => t.wohnung_id).filter(Boolean));
+              const apartmentCount = Math.max(1, uniqueApartmentIds.size || tenants.length);
+              share = totalCostForItem / apartmentCount;
               break;
             case 'pro einheit':
             case 'fix':

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -270,6 +270,9 @@ export function AbrechnungModal({
               }
               break;
             case 'pro person':
+              // Divide total cost by number of tenants for per-person calculation
+              share = totalCostForItem / Math.max(1, tenants?.length || 0);
+              break;
             case 'pro einheit':
             case 'fix':
             default:

--- a/components/betriebskosten-edit-modal.tsx
+++ b/components/betriebskosten-edit-modal.tsx
@@ -2,6 +2,23 @@
 
 import React, { useState, useEffect, useRef } from "react";
 import { formatNumber } from "@/utils/format";
+
+const normalizeBerechnungsart = (rawValue: string): BerechnungsartValue => {
+  const berechnungsartMap: Record<string, BerechnungsartValue> = {
+    'pro person': 'pro Mieter',
+    'pro mieter': 'pro Mieter',
+    'pro flaeche': 'pro Flaeche',
+    'pro fläche': 'pro Flaeche',
+    'pro qm': 'pro Flaeche',
+    'qm': 'pro Flaeche',
+    'nach rechnung': 'nach Rechnung',
+  };
+  
+  const lower = rawValue.toLowerCase();
+  const normalized = berechnungsartMap[lower] || rawValue;
+  return (BERECHNUNGSART_OPTIONS.find(opt => opt.value === normalized)?.value as BerechnungsartValue) || '';
+};
+
 import {
   Dialog,
   DialogContent,
@@ -210,19 +227,7 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
                 id: generateId(),
                 art: art,
                 betrag: fetchedData.berechnungsart?.[idx] === 'nach Rechnung' ? '' : fetchedData.betrag?.[idx]?.toString() || "",
-                berechnungsart: (() => {
-                  const raw = fetchedData.berechnungsart?.[idx] || '';
-                  const lower = raw.toLowerCase();
-                  let normalized = raw;
-                  if (lower === 'pro person' || lower === 'pro mieter') {
-                    normalized = 'pro Mieter';
-                  } else if (lower === 'pro flaeche' || lower === 'pro fläche' || lower === 'pro qm' || lower === 'qm') {
-                    normalized = 'pro Flaeche';
-                  } else if (lower === 'nach rechnung') {
-                    normalized = 'nach Rechnung';
-                  }
-                  return (BERECHNUNGSART_OPTIONS.find(opt => opt.value === normalized)?.value as BerechnungsartValue) || '';
-                })(),
+                berechnungsart: normalizeBerechnungsart(fetchedData.berechnungsart?.[idx] || ''),
               }));
               setCostItems(newCostItems.length > 0 ? newCostItems : [{ id: generateId(), art: '', betrag: '', berechnungsart: BERECHNUNGSART_OPTIONS[0]?.value || '' }]);
               setBetriebskostenModalDirty(false);

--- a/components/betriebskosten-edit-modal.tsx
+++ b/components/betriebskosten-edit-modal.tsx
@@ -210,7 +210,19 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
                 id: generateId(),
                 art: art,
                 betrag: fetchedData.berechnungsart?.[idx] === 'nach Rechnung' ? '' : fetchedData.betrag?.[idx]?.toString() || "",
-                berechnungsart: (BERECHNUNGSART_OPTIONS.find(opt => opt.value === fetchedData.berechnungsart?.[idx])?.value as BerechnungsartValue) || '',
+                berechnungsart: (() => {
+                  const raw = fetchedData.berechnungsart?.[idx] || '';
+                  const lower = raw.toLowerCase();
+                  let normalized = raw;
+                  if (lower === 'pro person' || lower === 'pro mieter') {
+                    normalized = 'pro Mieter';
+                  } else if (lower === 'pro flaeche' || lower === 'pro fläche' || lower === 'pro qm' || lower === 'qm') {
+                    normalized = 'pro Flaeche';
+                  } else if (lower === 'nach rechnung') {
+                    normalized = 'nach Rechnung';
+                  }
+                  return (BERECHNUNGSART_OPTIONS.find(opt => opt.value === normalized)?.value as BerechnungsartValue) || '';
+                })(),
               }));
               setCostItems(newCostItems.length > 0 ? newCostItems : [{ id: generateId(), art: '', betrag: '', berechnungsart: BERECHNUNGSART_OPTIONS[0]?.value || '' }]);
               setBetriebskostenModalDirty(false);


### PR DESCRIPTION
## Description

Changes the "pro Mieter"/"pro Person" distribution to split costs per apartment first, and normalizes legacy calculation-type values on load.

## Summary of Changes

- Abrechnung modal: `pro mieter`/`pro person` now divides the total cost by the number of distinct apartments (falling back to tenant count) instead of per tenant
- Betriebskosten edit modal: new `normalizeBerechnungsart` helper maps legacy/lowercase values ("pro qm", "pro fläche", "qm", …) to the canonical options when loading existing records, so old entries select correctly