### PR TITLE
Feature/pro wohnung verteilerschluessel

### DIFF
--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -275,10 +275,9 @@ export function AbrechnungModal({
               break;
             case 'pro mieter':
             case 'pro person':
-              // Divide total cost by number of apartments for per-apartment calculation
-              const uniqueApartmentIds = new Set(tenants.map(t => t.wohnung_id).filter(Boolean));
-              const apartmentCount = Math.max(1, uniqueApartmentIds.size || tenants.length);
-              share = totalCostForItem / apartmentCount;
+              // Divide total cost by number of tenants for per-tenant calculation
+              const activeTenantsCount = Math.max(1, tenants.length);
+              share = totalCostForItem / activeTenantsCount;
               break;
             case 'pro wohnung':
               // For 'pro Wohnung', split total cost equally among all apartments first

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -296,12 +296,14 @@ export function AbrechnungModal({
           // Apply tenant-level proration
           let tenantShareForItem = 0;
           const type = calcType.toLowerCase();
-          if (type === 'pro qm' || type === 'qm' || type === 'pro flaeche' || type === 'pro fläche' || type === 'pro wohnung') {
-            // For area-based and 'pro wohnung' items, split the apartment's share among roommates by WG factor
+          // Define all calculation types that use area/WG factor split
+          const areaBasedCalcTypes = ['pro qm', 'qm', 'pro flaeche', 'pro fläche', 'pro wohnung'];
+          if (areaBasedCalcTypes.includes(type)) {
+            // Use the precomputed WG factor for area-based and 'pro wohnung' calculations
             const wgFactor = wgFactorsByTenant[tenant.id] ?? (occupancyPercentage / 100);
             tenantShareForItem = share * wgFactor;
           } else {
-            // For all other types, keep occupancy-based proration
+            // For all other types, use occupancy proration
             tenantShareForItem = share * (occupancyPercentage / 100);
           }
 

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -178,9 +178,9 @@ export function AbrechnungModal({
       ? nebenkostenItem.wasserkosten / nebenkostenItem.wasserverbrauch
       : 0;
 
-    // Precompute WG factors per tenant for this billing year (per apartment, monthly-weighted) - moved outside to avoid redundant calculations
+    // Use the precomputed wgFactors from the useMemo hook
+    const wgFactorsByTenant = wgFactors;
     const abrechnungsjahr = Number(nebenkostenItem?.jahr);
-    const wgFactorsByTenant = computeWgFactorsByTenant(tenants, abrechnungsjahr);
 
     // Helper function for calculation logic (extracted to avoid repetition)
     const calculateCostsForTenant = (tenant: Mieter, pricePerCubicMeter: number): TenantCostDetails => {
@@ -384,7 +384,7 @@ export function AbrechnungModal({
       const singleTenantCalculatedData = calculateCostsForTenant(activeTenant, pricePerCubicMeter);
       setCalculatedTenantData([singleTenantCalculatedData]);
     }
-  }, [isOpen, nebenkostenItem, tenants, rechnungen, selectedTenantId, loadAllRelevantTenants, wasserzaehlerReadings]); // Added rechnungen to dependency array
+  }, [isOpen, nebenkostenItem, tenants, rechnungen, selectedTenantId, loadAllRelevantTenants, wasserzaehlerReadings, wgFactors]); // Added wgFactors to dependency array
 
   const generateSettlementPDF = async ( // Changed to async
     tenantData: TenantCostDetails | TenantCostDetails[],

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { HoverCard, HoverCardTrigger, HoverCardContent } from "@/components/ui/hover-card";
 import { CustomCombobox, ComboboxOption } from "@/components/ui/custom-combobox";
 import { Nebenkosten, Mieter, Wohnung, Rechnung, Wasserzaehler } from "@/lib/data-fetching"; // Added Rechnung to import
-import { useEffect, useState } from "react"; // Import useEffect and useState
+import { useEffect, useState, useMemo } from "react"; // Import useEffect, useState, and useMemo
 import { useToast } from "@/hooks/use-toast";
 import { FileDown, Droplet, Landmark, CheckCircle2, AlertCircle } from 'lucide-react'; // Added FileDown and other icon imports
 import { Progress } from "@/components/ui/progress";
@@ -747,8 +747,11 @@ export function AbrechnungModal({
                         );
                       }
 
-                      // Get WG factors for this apartment
-                      const wgFactors = computeWgFactorsByTenant(tenants, Number(nebenkostenItem?.jahr || new Date().getFullYear()));
+                      // Get WG factors for this apartment (memoized to prevent unnecessary recalculations)
+                      const wgFactors = useMemo(
+                        () => computeWgFactorsByTenant(tenants, Number(nebenkostenItem?.jahr || new Date().getFullYear())),
+                        [tenants, nebenkostenItem?.jahr]
+                      );
                       
                       return (
                         <>

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -169,6 +169,10 @@ export function AbrechnungModal({
       ? nebenkostenItem.wasserkosten / nebenkostenItem.wasserverbrauch
       : 0;
 
+    // Precompute WG factors per tenant for this billing year (per apartment, monthly-weighted) - moved outside to avoid redundant calculations
+    const abrechnungsjahr = Number(nebenkostenItem?.jahr);
+    const wgFactorsByTenant = computeWgFactorsByTenant(tenants, abrechnungsjahr);
+
     // Helper function for calculation logic (extracted to avoid repetition)
     const calculateCostsForTenant = (tenant: Mieter, pricePerCubicMeter: number): TenantCostDetails => {
       const {
@@ -180,10 +184,6 @@ export function AbrechnungModal({
         wasserkosten, // Total building water cost
         gesamtFlaeche,
       } = nebenkostenItem!;
-
-      const abrechnungsjahr = Number(jahr);
-      // Precompute WG factors per tenant for this billing year (per apartment, monthly-weighted)
-      const wgFactorsByTenant = computeWgFactorsByTenant(tenants, abrechnungsjahr);
 
       // 1. Call calculateOccupancy
       const { percentage: occupancyPercentage, daysOccupied, daysInYear: daysInBillingYear } = calculateOccupancy(tenant.einzug, tenant.auszug, abrechnungsjahr);

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -280,6 +280,13 @@ export function AbrechnungModal({
               const apartmentCount = Math.max(1, uniqueApartmentIds.size || tenants.length);
               share = totalCostForItem / apartmentCount;
               break;
+            case 'pro wohnung':
+              // For 'pro Wohnung', split total cost equally among all apartments first
+              const uniqueAptIds = new Set(tenants.map(t => t.wohnung_id).filter(Boolean));
+              const totalApartments = Math.max(1, uniqueAptIds.size || 1);
+              const costPerApartment = totalCostForItem / totalApartments;
+              share = costPerApartment; // This will be further split by WG factor
+              break;
             case 'pro einheit':
             case 'fix':
             default:
@@ -290,8 +297,8 @@ export function AbrechnungModal({
           // Apply tenant-level proration
           let tenantShareForItem = 0;
           const type = calcType.toLowerCase();
-          if (type === 'pro qm' || type === 'qm' || type === 'pro flaeche' || type === 'pro fläche') {
-            // For area-based items, split the apartment's annual share among roommates by WG factor
+          if (type === 'pro qm' || type === 'qm' || type === 'pro flaeche' || type === 'pro fläche' || type === 'pro wohnung') {
+            // For area-based and 'pro wohnung' items, split the apartment's share among roommates by WG factor
             const wgFactor = wgFactorsByTenant[tenant.id] ?? (occupancyPercentage / 100);
             tenantShareForItem = share * wgFactor;
           } else {

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -156,6 +156,15 @@ export function AbrechnungModal({
 }: AbrechnungModalProps) {
   const { toast } = useToast();
   const [calculatedTenantData, setCalculatedTenantData] = useState<TenantCostDetails[]>([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [isGeneratingPDF, setIsGeneratingPDF] = useState(false);
+  
+  // Calculate WG factors for all tenants (memoized to prevent unnecessary recalculations)
+  const wgFactors = useMemo(
+    () => computeWgFactorsByTenant(tenants, Number(nebenkostenItem?.jahr || new Date().getFullYear())),
+    [tenants, nebenkostenItem?.jahr]
+  );
+
   const [selectedTenantId, setSelectedTenantId] = useState<string | null>(null);
   const [loadAllRelevantTenants, setLoadAllRelevantTenants] = useState<boolean>(false); // New state variable
 
@@ -747,11 +756,7 @@ export function AbrechnungModal({
                         );
                       }
 
-                      // Get WG factors for this apartment (memoized to prevent unnecessary recalculations)
-                      const wgFactors = useMemo(
-                        () => computeWgFactorsByTenant(tenants, Number(nebenkostenItem?.jahr || new Date().getFullYear())),
-                        [tenants, nebenkostenItem?.jahr]
-                      );
+                      // Use the pre-computed wgFactors
                       
                       return (
                         <>

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -309,7 +309,7 @@ export function AbrechnungModal({
           const areaBasedCalcTypes = ['pro qm', 'qm', 'pro flaeche', 'pro fläche', 'pro wohnung'];
           if (areaBasedCalcTypes.includes(type)) {
             // Use the precomputed WG factor for area-based and 'pro wohnung' calculations
-            const wgFactor = wgFactorsByTenant[tenant.id] ?? (occupancyPercentage / 100);
+            const wgFactor = wgFactors[tenant.id] ?? (occupancyPercentage / 100);
             tenantShareForItem = share * wgFactor;
           } else {
             // For all other types, use occupancy proration

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -282,8 +282,8 @@ export function AbrechnungModal({
             case 'pro wohnung':
               // For 'pro Wohnung', split total cost equally among all apartments first
               const uniqueAptIds = new Set(tenants.map(t => t.wohnung_id).filter(Boolean));
-              const totalApartments = Math.max(1, uniqueAptIds.size || 1);
-              const costPerApartment = totalCostForItem / totalApartments;
+              const totalApartments = uniqueAptIds.size;
+              const costPerApartment = totalApartments > 0 ? totalCostForItem / totalApartments : 0;
               share = costPerApartment; // This will be further split by WG factor
               break;
             case 'pro einheit':

--- a/components/betriebskosten-edit-modal.tsx
+++ b/components/betriebskosten-edit-modal.tsx
@@ -11,6 +11,7 @@ const normalizeBerechnungsart = (rawValue: string): BerechnungsartValue => {
     'pro fläche': 'pro Flaeche',
     'pro qm': 'pro Flaeche',
     'qm': 'pro Flaeche',
+    'pro wohnung': 'pro Wohnung',
     'nach rechnung': 'nach Rechnung',
   };
   

--- a/lib/constants.test.ts
+++ b/lib/constants.test.ts
@@ -3,11 +3,12 @@ import { BERECHNUNGSART_OPTIONS, BERECHNUNGSART_VALUES } from './constants';
 describe('lib/constants', () => {
   describe('BERECHNUNGSART_OPTIONS', () => {
     it('should contain all expected calculation types', () => {
-      expect(BERECHNUNGSART_OPTIONS).toHaveLength(3);
+      expect(BERECHNUNGSART_OPTIONS).toHaveLength(4);
       
       const expectedOptions = [
         { value: 'pro Flaeche', label: 'pro Fläche' },
         { value: 'pro Mieter', label: 'pro Mieter' },
+        { value: 'pro Wohnung', label: 'pro Wohnung' },
         { value: 'nach Rechnung', label: 'nach Rechnung' }
       ];
       
@@ -47,6 +48,7 @@ describe('lib/constants', () => {
     it('should contain expected calculation types', () => {
       expect(BERECHNUNGSART_VALUES).toContain('pro Flaeche');
       expect(BERECHNUNGSART_VALUES).toContain('pro Mieter');
+      expect(BERECHNUNGSART_VALUES).toContain('pro Wohnung');
       expect(BERECHNUNGSART_VALUES).toContain('nach Rechnung');
     });
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,6 +1,7 @@
 export const BERECHNUNGSART_OPTIONS = [
   { value: 'pro Flaeche', label: 'pro Fläche' },
   { value: 'pro Mieter', label: 'pro Mieter' },
+  { value: 'pro Wohnung', label: 'pro Wohnung' },
   { value: 'nach Rechnung', label: 'nach Rechnung' },
 ] as const;
 


### PR DESCRIPTION
## Description

Adds "pro Wohnung" as a distribution type and memoizes the WG-factor computation in the Abrechnung modal.

## Summary of Changes

- `BERECHNUNGSART_OPTIONS` gains "pro Wohnung": the cost is first split equally among apartments, then distributed to roommates via the WG factor; legacy value normalized when loading
- "pro Mieter" in the Abrechnung now divides by the actual tenant count (was incorrectly dividing by apartments)
- WG factors computed once with `useMemo` instead of state + effect recalculation; area-based types extended to include pro Wohnung
- Constants tests updated for the new option