### PR TITLE
fix: restore 'Transaktion hinzufügen' button in Finanzen

### DIFF
--- a/app/(dashboard)/finanzen/client-wrapper.tsx
+++ b/app/(dashboard)/finanzen/client-wrapper.tsx
@@ -393,7 +393,6 @@ export default function FinanzenClientWrapper({ finances: initialFinances, wohnu
         wohnungen={wohnungen}
         availableYears={availableYears}
         onEdit={handleEdit}
-        onAdd={handleAddFinance}
         onAddTransaction={handleAddTransaction}
         loadFinances={() => loadMoreTransactions(false)}
         reloadRef={reloadRef}

--- a/components/finance-transactions.tsx
+++ b/components/finance-transactions.tsx
@@ -44,7 +44,6 @@ interface FinanceTransactionsProps {
   availableYears: number[]
   reloadRef?: any
   onEdit?: (finance: Finanz) => void
-  onAdd?: (finance: Finanz) => void
   onAddTransaction?: () => void
   loadFinances?: () => void
   hasMore: boolean
@@ -72,7 +71,6 @@ export function FinanceTransactions({
   availableYears,
   reloadRef,
   onEdit,
-  onAdd,
   onAddTransaction,
   loadFinances,
   hasMore,


### PR DESCRIPTION
- Added missing onAddTransaction prop to FinanceTransactions component\n- Button now appears next to 'Übersicht aller Einnahmen und Ausgaben'

fix #563 