### PR TITLE
Feature/enhance pdf UI

### DIFF
--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -114,6 +114,7 @@ interface TenantCostDetails {
     calculationType: string;
     tenantShare: number;
     pricePerSqm?: number; // New field added here
+    verteiler?: string | number; // Added for distribution basis display
   }>;
   waterCost: {
     totalWaterCostOverall: number; // Renamed for clarity
@@ -253,23 +254,28 @@ export function AbrechnungModal({
       const costItemsDetails: TenantCostDetails['costItems'] = [];
 
       if (nebenkostenart && betrag && berechnungsart) {
+        const totalHouseArea = gesamtFlaeche && gesamtFlaeche > 0
+          ? gesamtFlaeche
+          : tenants.reduce((sum, t) => sum + (t.Wohnungen?.groesse || 0), 0);
+        const uniqueAptIds = new Set(tenants.map(t => t.wohnung_id).filter(Boolean));
+        const activeTenantsCount = Math.max(1, tenants.length);
+
         nebenkostenart.forEach((costName, index) => {
           const totalCostForItem = betrag[index] || 0;
-          const calcType = berechnungsart[index] || 'fix';
+          const calcType = (berechnungsart[index] || 'fix').toLowerCase();
           let share = 0;
           let itemPricePerSqm: number | undefined = undefined;
+          let verteiler: string | number = '-';
 
-          switch (calcType.toLowerCase()) {
+          switch (calcType) {
             case 'pro qm':
             case 'qm':
             case 'pro flaeche':
             case 'pro fläche':
+              verteiler = formatNumber(totalHouseArea);
               if (totalHouseArea > 0) {
-                  itemPricePerSqm = totalCostForItem / totalHouseArea;
-                  // Apartment annual share before tenant-level WG split
-                  share = itemPricePerSqm * apartmentSize;
-              } else {
-                  share = 0;
+                itemPricePerSqm = totalCostForItem / totalHouseArea;
+                share = itemPricePerSqm * apartmentSize;
               }
               break;
             case 'nach rechnung':
@@ -278,27 +284,30 @@ export function AbrechnungModal({
                   (r) => r.mieter_id === tenant.id && r.name === costName
                 );
                 share = relevantRechnung?.betrag || 0;
+                verteiler = '-';
               } else {
                 share = 0;
               }
               break;
             case 'pro mieter':
             case 'pro person':
-              // Divide total cost by number of tenants for per-tenant calculation
-              const activeTenantsCount = Math.max(1, tenants.length);
+              verteiler = String(activeTenantsCount);
               share = totalCostForItem / activeTenantsCount;
               break;
             case 'pro wohnung':
-              // For 'pro Wohnung', split total cost equally among all apartments first
-              const uniqueAptIds = new Set(tenants.map(t => t.wohnung_id).filter(Boolean));
+              verteiler = String(uniqueAptIds.size || 0);
               const totalApartments = uniqueAptIds.size;
               const costPerApartment = totalApartments > 0 ? totalCostForItem / totalApartments : 0;
-              share = costPerApartment; // This will be further split by WG factor
+              share = costPerApartment;
               break;
             case 'pro einheit':
             case 'fix':
-            default:
+              verteiler = '1';
               share = totalCostForItem;
+              break;
+            default:
+              verteiler = '-';
+              share = 0;
               break;
           }
 
@@ -322,6 +331,7 @@ export function AbrechnungModal({
             calculationType: calcType,
             tenantShare: tenantShareForItem,
             pricePerSqm: itemPricePerSqm,
+            verteiler,
           });
         });
       }
@@ -458,33 +468,10 @@ export function AbrechnungModal({
       const tableRows: any[][] = [];
 
       singleTenantData.costItems.forEach(item => {
-        // Compute actual distribution basis (Verteiler) for the item
-        const type = (item.calculationType || '').toLowerCase();
-        let verteilerDisplay: string = '-';
-
-        if (["pro qm", "qm", "pro flaeche", "pro fläche"].includes(type)) {
-          const totalHouseArea = (nebenkostenItem.gesamtFlaeche && nebenkostenItem.gesamtFlaeche > 0)
-            ? nebenkostenItem.gesamtFlaeche
-            : tenants.reduce((sum, t) => sum + (t.Wohnungen?.groesse || 0), 0);
-          verteilerDisplay = formatNumber(totalHouseArea);
-        } else if (type === 'pro wohnung') {
-          const uniqueAptIds = new Set(tenants.map(t => t.wohnung_id).filter(Boolean));
-          verteilerDisplay = String(uniqueAptIds.size || 0);
-        } else if (type === 'pro mieter' || type === 'pro person') {
-          const activeTenantsCount = Math.max(1, tenants.length);
-          verteilerDisplay = String(activeTenantsCount);
-        } else if (type === 'pro einheit' || type === 'fix') {
-          verteilerDisplay = '1';
-        } else if (type === 'nach rechnung') {
-          verteilerDisplay = '-';
-        } else {
-          verteilerDisplay = '-';
-        }
-
         const row = [
           item.costName,
           formatCurrency(item.totalCostForItem), // Gesamtkosten in €
-          verteilerDisplay, // Actual distribution basis instead of type
+          item.verteiler || '-', // Use pre-calculated distribution basis
           item.pricePerSqm ? formatCurrency(item.pricePerSqm) : '-', // Kosten Pro qm
           formatCurrency(item.tenantShare) // Kostenanteil In €
         ];

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -516,7 +516,9 @@ export function AbrechnungModal({
             3: { halign: 'right' }, // Kosten Pro qm
             4: { halign: 'right' }  // Kostenanteil In €
           },
-          margin: { left: 20 } // Set left margin for the table
+          // Ensure table aligns with left and right content margins
+          tableWidth: (doc as any).internal.pageSize.getWidth() - 40,
+          margin: { left: 20, right: 20 }
         });
 
       let tableFinalY = (doc as any).lastAutoTable?.finalY;

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -254,9 +254,6 @@ export function AbrechnungModal({
       const costItemsDetails: TenantCostDetails['costItems'] = [];
 
       if (nebenkostenart && betrag && berechnungsart) {
-        const totalHouseArea = gesamtFlaeche && gesamtFlaeche > 0
-          ? gesamtFlaeche
-          : tenants.reduce((sum, t) => sum + (t.Wohnungen?.groesse || 0), 0);
         const uniqueAptIds = new Set(tenants.map(t => t.wohnung_id).filter(Boolean));
         const activeTenantsCount = Math.max(1, tenants.length);
 

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -292,7 +292,7 @@ export function AbrechnungModal({
               share = totalCostForItem / activeTenantsCount;
               break;
             case 'pro wohnung':
-              verteiler = String(uniqueAptIds.size || 0);
+              verteiler = String(uniqueAptIds.size);
               const totalApartments = uniqueAptIds.size;
               const costPerApartment = totalApartments > 0 ? totalCostForItem / totalApartments : 0;
               share = costPerApartment;


### PR DESCRIPTION
## Description

Improves the Abrechnung PDF table: the Verteiler column now shows the actual distribution basis instead of the raw calculation type.

## Summary of Changes

- New `verteiler` field per cost item: total house area (m²) for pro Fläche, tenant count for pro Mieter, apartment count for pro Wohnung, "1" for fixed, "-" otherwise
- PDF column renamed to "Verteiler" and right-aligned; table width now matches the content margins
- Calculation lookup hoisted (apartment and tenant counts computed once per run); unknown calculation types now fall back to 0 instead of silently using the full amount