### PR TITLE
Feature/use more tooltips

### DIFF
--- a/app/(dashboard)/haeuser/actions.ts
+++ b/app/(dashboard)/haeuser/actions.ts
@@ -26,13 +26,9 @@ export async function handleSubmit(id: string | null, formData: FormData): Promi
       }
     }
 
-    // Validate required fields
-    const name = formData.get('name')?.toString();
-    const ort = formData.get('ort')?.toString();
-
-    if (!name || !ort) {
-      return { success: false, error: { message: 'Name und Ort sind Pflichtfelder.' } };
-    }
+    // Get form data
+    const name = formData.get('name')?.toString() || '';
+    const ort = formData.get('ort')?.toString() || '';
 
     // Explicitly pick only the expected fields
     const houseData: HouseData = {

--- a/app/(dashboard)/haeuser/actions.ts
+++ b/app/(dashboard)/haeuser/actions.ts
@@ -27,8 +27,13 @@ export async function handleSubmit(id: string | null, formData: FormData): Promi
     }
 
     // Get form data
-    const name = formData.get('name')?.toString() || '';
+    const name = formData.get('name')?.toString();
     const ort = formData.get('ort')?.toString() || '';
+
+    // Validate required field
+    if (!name) {
+      return { success: false, error: { message: 'Name ist ein Pflichtfeld.' } };
+    }
 
     // Explicitly pick only the expected fields
     const houseData: HouseData = {

--- a/app/(dashboard)/wohnungen/actions.ts
+++ b/app/(dashboard)/wohnungen/actions.ts
@@ -15,6 +15,15 @@ type WohnungFormData = {
   haus_id: string;
 };
 
+// Interface for the Wohnung data that will be inserted into the database
+interface WohnungData {
+  name: string | null;
+  miete: number;
+  haus_id: string | null;
+  user_id: string;
+  groesse?: number;
+}
+
 /**
  * Server Action zum Speichern einer neuen Wohnung
  */
@@ -129,8 +138,8 @@ export async function speichereWohnung(formData: WohnungFormData) {
         }
     }
 
-    const wohnungData: any = {
-      name: formData.name || null, // Make name optional
+    const wohnungData: WohnungData = {
+      name: formData.name || null,
       miete: parseFloat(formData.miete),
       haus_id: formData.haus_id || null,
       user_id: userId

--- a/app/(dashboard)/wohnungen/actions.ts
+++ b/app/(dashboard)/wohnungen/actions.ts
@@ -129,13 +129,20 @@ export async function speichereWohnung(formData: WohnungFormData) {
         }
     }
 
-    const { error } = await supabase.from('Wohnungen').insert({
-      name: formData.name,
-      groesse: parseFloat(formData.groesse), // Ensure this is a number
+    const wohnungData: any = {
+      name: formData.name || null, // Make name optional
       miete: parseFloat(formData.miete),
       haus_id: formData.haus_id || null,
       user_id: userId
-    });
+    };
+    
+    // Only add groesse if it's provided and a valid number
+    const groesse = parseFloat(formData.groesse);
+    if (!isNaN(groesse) && groesse > 0) {
+      wohnungData.groesse = groesse;
+    }
+
+    const { error } = await supabase.from('Wohnungen').insert(wohnungData);
     
     if (error) {
       return { error: error.message };

--- a/components/betriebskosten-edit-modal.tsx
+++ b/components/betriebskosten-edit-modal.tsx
@@ -97,10 +97,31 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
 
   // Tooltip next to dropdown: track hovered verteilerschlüssel, dropdown rect, and hovered item position
   const [hoveredBerechnungsart, setHoveredBerechnungsart] = useState<BerechnungsartValue | ''>('');
+  
+  // Map of tooltip texts for each Berechnungsart
+  const tooltipMap: Record<BerechnungsartValue | '', string> = {
+    'pro Flaeche': 'Kosten werden anteilig nach Wohnungsfläche verteilt.',
+    'pro Mieter': 'Kosten werden gleichmäßig auf alle Mieter aufgeteilt.',
+    'pro Wohnung': 'Kosten werden gleichmäßig auf alle Wohnungen aufgeteilt.',
+    'nach Rechnung': 'Beträge werden je Mieter manuell erfasst.',
+    '': ''
+  };
   const [hoveredItemRect, setHoveredItemRect] = useState<DOMRect | null>(null);
   const hoveredItemElRef = useRef<HTMLElement | null>(null);
   const selectContentRef = useRef<HTMLDivElement | null>(null);
   const [selectContentRect, setSelectContentRect] = useState<DOMRect | null>(null);
+
+  const handleItemHover = (e: React.MouseEvent<HTMLDivElement> | React.FocusEvent<HTMLDivElement>, value: BerechnungsartValue) => {
+    setHoveredBerechnungsart(value);
+    hoveredItemElRef.current = e.currentTarget as HTMLElement;
+    setHoveredItemRect(e.currentTarget.getBoundingClientRect());
+  };
+
+  const handleItemLeave = () => {
+    setHoveredBerechnungsart('');
+    hoveredItemElRef.current = null;
+    setHoveredItemRect(null);
+  };
 
   useEffect(() => {
     if (!selectContentRef.current) {
@@ -579,26 +600,10 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
                                 <SelectItem
                                   key={opt.value}
                                   value={opt.value}
-                                  onMouseEnter={(e) => {
-                                    setHoveredBerechnungsart(opt.value);
-                                    hoveredItemElRef.current = e.currentTarget as unknown as HTMLElement;
-                                    setHoveredItemRect(e.currentTarget.getBoundingClientRect());
-                                  }}
-                                  onMouseLeave={() => {
-                                    setHoveredBerechnungsart('');
-                                    hoveredItemElRef.current = null;
-                                    setHoveredItemRect(null);
-                                  }}
-                                  onFocus={(e) => {
-                                    setHoveredBerechnungsart(opt.value);
-                                    hoveredItemElRef.current = e.currentTarget as unknown as HTMLElement;
-                                    setHoveredItemRect(e.currentTarget.getBoundingClientRect());
-                                  }}
-                                  onBlur={() => {
-                                    setHoveredBerechnungsart('');
-                                    hoveredItemElRef.current = null;
-                                    setHoveredItemRect(null);
-                                  }}
+                                  onMouseEnter={(e) => handleItemHover(e, opt.value)}
+                                  onMouseLeave={handleItemLeave}
+                                  onFocus={(e) => handleItemHover(e, opt.value)}
+                                  onBlur={handleItemLeave}
                                 >
                                   {opt.label}
                                 </SelectItem>
@@ -616,10 +621,7 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
                               }}
                             >
                               <div className="h-full rounded-md border bg-popover text-popover-foreground shadow-sm p-3 text-sm flex items-center">
-                                {hoveredBerechnungsart === 'pro Flaeche' && 'Kosten werden anteilig nach Wohnungsfläche verteilt.'}
-                                {hoveredBerechnungsart === 'pro Mieter' && 'Kosten werden gleichmäßig auf alle Mieter aufgeteilt.'}
-                                {hoveredBerechnungsart === 'pro Wohnung' && 'Kosten werden gleichmäßig auf alle Wohnungen aufgeteilt.'}
-                                {hoveredBerechnungsart === 'nach Rechnung' && 'Beträge werden je Mieter manuell erfasst.'}
+                                {tooltipMap[hoveredBerechnungsart]}
                               </div>
                             </div>,
                             document.body

--- a/components/betriebskosten-edit-modal.tsx
+++ b/components/betriebskosten-edit-modal.tsx
@@ -615,10 +615,10 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
                               }}
                             >
                               <div className="rounded-md border bg-popover text-popover-foreground shadow-md p-3 text-sm">
-                                {hoveredBerechnungsart === 'pro Flaeche' && 'Kosten werden entsprechend der Wohnungsfläche anteilig verteilt.'}
+                                {hoveredBerechnungsart === 'pro Flaeche' && 'Kosten werden anteilig nach Wohnungsfläche verteilt.'}
                                 {hoveredBerechnungsart === 'pro Mieter' && 'Kosten werden gleichmäßig auf alle Mieter aufgeteilt.'}
                                 {hoveredBerechnungsart === 'pro Wohnung' && 'Kosten werden gleichmäßig auf alle Wohnungen aufgeteilt.'}
-                                {hoveredBerechnungsart === 'nach Rechnung' && 'Individuelle Beträge werden je Mieter manuell eingetragen.'}
+                                {hoveredBerechnungsart === 'nach Rechnung' && 'Beträge werden je Mieter manuell erfasst.'}
                               </div>
                             </div>,
                             document.body

--- a/components/betriebskosten-edit-modal.tsx
+++ b/components/betriebskosten-edit-modal.tsx
@@ -605,16 +605,17 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
                               ))}
                             </SelectContent>
                           </Select>
-                          {selectContentRect && hoveredBerechnungsart && createPortal(
+                          {selectContentRect && hoveredBerechnungsart && hoveredItemRect && createPortal(
                             <div
                               className="fixed z-[60] transition-none"
                               style={{
-                                top: `${Math.round(selectContentRect.top)}px`,
+                                top: `${Math.round(hoveredItemRect.top)}px`,
                                 right: `${window.innerWidth - Math.round(selectContentRect.left) + 8}px`,
                                 width: '280px',
+                                minHeight: `${Math.round(hoveredItemRect.height)}px`,
                               }}
                             >
-                              <div className="rounded-md border bg-popover text-popover-foreground shadow-md p-3 text-sm">
+                              <div className="h-full rounded-md border bg-popover text-popover-foreground shadow-md p-3 text-sm flex items-center">
                                 {hoveredBerechnungsart === 'pro Flaeche' && 'Kosten werden anteilig nach Wohnungsfläche verteilt.'}
                                 {hoveredBerechnungsart === 'pro Mieter' && 'Kosten werden gleichmäßig auf alle Mieter aufgeteilt.'}
                                 {hoveredBerechnungsart === 'pro Wohnung' && 'Kosten werden gleichmäßig auf alle Wohnungen aufgeteilt.'}

--- a/components/betriebskosten-edit-modal.tsx
+++ b/components/betriebskosten-edit-modal.tsx
@@ -95,8 +95,9 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
   const [modalNebenkostenData, setModalNebenkostenData] = useState<Nebenkosten | null>(null);
   const currentlyLoadedNebenkostenId = React.useRef<string | null | undefined>(null);
 
-  // Tooltip next to dropdown: track hovered verteilerschlüssel and dropdown rect
+  // Tooltip next to dropdown: track hovered verteilerschlüssel, dropdown rect, and hovered item position
   const [hoveredBerechnungsart, setHoveredBerechnungsart] = useState<BerechnungsartValue | ''>('');
+  const [hoveredItemRect, setHoveredItemRect] = useState<DOMRect | null>(null);
   const selectContentRef = useRef<HTMLDivElement | null>(null);
   const [selectContentRect, setSelectContentRect] = useState<DOMRect | null>(null);
 
@@ -574,23 +575,39 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
                                 <SelectItem
                                   key={opt.value}
                                   value={opt.value}
-                                  onMouseEnter={() => setHoveredBerechnungsart(opt.value)}
-                                  onMouseLeave={() => setHoveredBerechnungsart('')}
+                                  onMouseEnter={(e) => {
+                                    setHoveredBerechnungsart(opt.value);
+                                    setHoveredItemRect(e.currentTarget.getBoundingClientRect());
+                                  }}
+                                  onMouseLeave={() => {
+                                    setHoveredBerechnungsart('');
+                                    setHoveredItemRect(null);
+                                  }}
+                                  onFocus={(e) => {
+                                    setHoveredBerechnungsart(opt.value);
+                                    setHoveredItemRect(e.currentTarget.getBoundingClientRect());
+                                  }}
+                                  onBlur={() => {
+                                    setHoveredBerechnungsart('');
+                                    setHoveredItemRect(null);
+                                  }}
                                 >
                                   {opt.label}
                                 </SelectItem>
                               ))}
                             </SelectContent>
                           </Select>
-                          {selectContentRect && hoveredBerechnungsart && createPortal(
+                          {selectContentRect && hoveredBerechnungsart && hoveredItemRect && createPortal(
                             <div
-                              className="fixed z-[60]"
+                              className="fixed z-[60] transition-none"
                               style={{
-                                top: Math.round(selectContentRect.top),
-                                left: Math.round(selectContentRect.right + 8),
+                                top: `${Math.round(hoveredItemRect.top)}px`,
+                                right: `${window.innerWidth - Math.round(selectContentRect.left) + 8}px`,
+                                width: '280px',
+                                transform: 'translateY(-50%)',
                               }}
                             >
-                              <div className="max-w-[280px] rounded-md border bg-popover text-popover-foreground shadow-md p-3 text-sm">
+                              <div className="rounded-md border bg-popover text-popover-foreground shadow-md p-3 text-sm">
                                 {hoveredBerechnungsart === 'pro Flaeche' && 'Kosten werden anteilig nach Wohnungsfläche verteilt (z.B. für Heiz- und Wasserkosten).'}
                                 {hoveredBerechnungsart === 'pro Mieter' && 'Kosten werden gleichmäßig auf alle Mieter aufgeteilt (z.B. für Müllgebühren).'}
                                 {hoveredBerechnungsart === 'pro Wohnung' && 'Kosten werden gleichmäßig auf alle Wohnungen aufgeteilt (z.B. für Grundgebühren).'}

--- a/components/betriebskosten-edit-modal.tsx
+++ b/components/betriebskosten-edit-modal.tsx
@@ -123,7 +123,7 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
       window.removeEventListener('scroll', update, true);
       setSelectContentRect(null);
     };
-  }, [selectContentRef.current]);
+  }, [hoveredBerechnungsart]);
 
   const houseOptions: ComboboxOption[] = (betriebskostenModalHaeuser || []).map(h => ({ value: h.id, label: h.name }));
 

--- a/components/betriebskosten-edit-modal.tsx
+++ b/components/betriebskosten-edit-modal.tsx
@@ -597,14 +597,14 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
                               ))}
                             </SelectContent>
                           </Select>
-                          {selectContentRect && hoveredBerechnungsart && hoveredItemRect && createPortal(
+                          {selectContentRect && hoveredBerechnungsart && createPortal(
                             <div
                               className="fixed z-[60] transition-none"
                               style={{
-                                top: `${Math.round(hoveredItemRect.top)}px`,
+                                top: `${Math.round(selectContentRect.top)}px`,
+                                bottom: `${Math.round(window.innerHeight - selectContentRect.bottom)}px`,
                                 right: `${window.innerWidth - Math.round(selectContentRect.left) + 8}px`,
                                 width: '280px',
-                                transform: 'translateY(-50%)',
                               }}
                             >
                               <div className="rounded-md border bg-popover text-popover-foreground shadow-md p-3 text-sm">

--- a/components/betriebskosten-edit-modal.tsx
+++ b/components/betriebskosten-edit-modal.tsx
@@ -615,7 +615,7 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
                                 minHeight: `${Math.round(hoveredItemRect.height)}px`,
                               }}
                             >
-                              <div className="h-full rounded-md border bg-popover text-popover-foreground shadow-md p-3 text-sm flex items-center">
+                              <div className="h-full rounded-md border bg-popover text-popover-foreground shadow-sm p-3 text-sm flex items-center">
                                 {hoveredBerechnungsart === 'pro Flaeche' && 'Kosten werden anteilig nach Wohnungsfläche verteilt.'}
                                 {hoveredBerechnungsart === 'pro Mieter' && 'Kosten werden gleichmäßig auf alle Mieter aufgeteilt.'}
                                 {hoveredBerechnungsart === 'pro Wohnung' && 'Kosten werden gleichmäßig auf alle Wohnungen aufgeteilt.'}

--- a/components/betriebskosten-edit-modal.tsx
+++ b/components/betriebskosten-edit-modal.tsx
@@ -98,6 +98,7 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
   // Tooltip next to dropdown: track hovered verteilerschlüssel, dropdown rect, and hovered item position
   const [hoveredBerechnungsart, setHoveredBerechnungsart] = useState<BerechnungsartValue | ''>('');
   const [hoveredItemRect, setHoveredItemRect] = useState<DOMRect | null>(null);
+  const hoveredItemElRef = useRef<HTMLElement | null>(null);
   const selectContentRef = useRef<HTMLDivElement | null>(null);
   const [selectContentRect, setSelectContentRect] = useState<DOMRect | null>(null);
 
@@ -109,6 +110,9 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
     const update = () => {
       if (selectContentRef.current) {
         setSelectContentRect(selectContentRef.current.getBoundingClientRect());
+      }
+      if (hoveredItemElRef.current) {
+        setHoveredItemRect(hoveredItemElRef.current.getBoundingClientRect());
       }
     };
     update();
@@ -577,18 +581,22 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
                                   value={opt.value}
                                   onMouseEnter={(e) => {
                                     setHoveredBerechnungsart(opt.value);
+                                    hoveredItemElRef.current = e.currentTarget as unknown as HTMLElement;
                                     setHoveredItemRect(e.currentTarget.getBoundingClientRect());
                                   }}
                                   onMouseLeave={() => {
                                     setHoveredBerechnungsart('');
+                                    hoveredItemElRef.current = null;
                                     setHoveredItemRect(null);
                                   }}
                                   onFocus={(e) => {
                                     setHoveredBerechnungsart(opt.value);
+                                    hoveredItemElRef.current = e.currentTarget as unknown as HTMLElement;
                                     setHoveredItemRect(e.currentTarget.getBoundingClientRect());
                                   }}
                                   onBlur={() => {
                                     setHoveredBerechnungsart('');
+                                    hoveredItemElRef.current = null;
                                     setHoveredItemRect(null);
                                   }}
                                 >
@@ -602,16 +610,15 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
                               className="fixed z-[60] transition-none"
                               style={{
                                 top: `${Math.round(selectContentRect.top)}px`,
-                                bottom: `${Math.round(window.innerHeight - selectContentRect.bottom)}px`,
                                 right: `${window.innerWidth - Math.round(selectContentRect.left) + 8}px`,
                                 width: '280px',
                               }}
                             >
                               <div className="rounded-md border bg-popover text-popover-foreground shadow-md p-3 text-sm">
-                                {hoveredBerechnungsart === 'pro Flaeche' && 'Kosten werden anteilig nach Wohnungsfläche verteilt (z.B. für Heiz- und Wasserkosten).'}
-                                {hoveredBerechnungsart === 'pro Mieter' && 'Kosten werden gleichmäßig auf alle Mieter aufgeteilt (z.B. für Müllgebühren).'}
-                                {hoveredBerechnungsart === 'pro Wohnung' && 'Kosten werden gleichmäßig auf alle Wohnungen aufgeteilt (z.B. für Grundgebühren).'}
-                                {hoveredBerechnungsart === 'nach Rechnung' && 'Individuelle Beträge pro Mieter manuell eintragen (z.B. für Sonderabrechnungen).'}
+                                {hoveredBerechnungsart === 'pro Flaeche' && 'Kosten werden entsprechend der Wohnungsfläche anteilig verteilt.'}
+                                {hoveredBerechnungsart === 'pro Mieter' && 'Kosten werden gleichmäßig auf alle Mieter aufgeteilt.'}
+                                {hoveredBerechnungsart === 'pro Wohnung' && 'Kosten werden gleichmäßig auf alle Wohnungen aufgeteilt.'}
+                                {hoveredBerechnungsart === 'nach Rechnung' && 'Individuelle Beträge werden je Mieter manuell eingetragen.'}
                               </div>
                             </div>,
                             document.body

--- a/components/finance-edit-modal.tsx
+++ b/components/finance-edit-modal.tsx
@@ -206,7 +206,7 @@ export function FinanceEditModal(props: FinanceEditModalProps) {
         <form onSubmit={handleSubmit} className="grid gap-4 pt-4 pb-2">
           <div className="grid grid-cols-2 gap-4">
             <div className="col-span-2 space-y-2">
-              <LabelWithTooltip htmlFor="name" infoText="Kurze, allgemeine Bezeichnung (z.B. 'Handwerker', 'Hausverwaltung', 'Mieteinnahme'). Erleichtert die spätere Suche und Kategorisierung.">
+              <LabelWithTooltip htmlFor="name" infoText="Kurze, allgemeine Bezeichnung (z.B. 'Handwerker', 'Hausverwaltung'). Detaillierte Informationen können im Notizfeld ergänzt werden. Erleichtert die spätere Suche und Kategorisierung.">
                 Bezeichnung
               </LabelWithTooltip>
               <Input id="name" name="name" value={formData.name} onChange={handleChange} required disabled={isSubmitting} />

--- a/components/finance-edit-modal.tsx
+++ b/components/finance-edit-modal.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { LabelWithTooltip } from "@/components/ui/label-with-tooltip";
 import {
   Select,
   SelectTrigger,
@@ -206,15 +206,21 @@ export function FinanceEditModal(props: FinanceEditModalProps) {
         <form onSubmit={handleSubmit} className="grid gap-4 pt-4 pb-2">
           <div className="grid grid-cols-2 gap-4">
             <div className="col-span-2 space-y-2">
-              <Label htmlFor="name">Bezeichnung</Label>
+              <LabelWithTooltip htmlFor="name" infoText="Bezeichnung der Transaktion. Hilft bei der Zuordnung.">
+                Bezeichnung
+              </LabelWithTooltip>
               <Input id="name" name="name" value={formData.name} onChange={handleChange} required disabled={isSubmitting} />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="betrag">Betrag (€)</Label>
+              <LabelWithTooltip htmlFor="betrag" infoText="Betrag der Transaktion in Euro.">
+                Betrag (€)
+              </LabelWithTooltip>
               <Input id="betrag" name="betrag" type="number" step="0.01" value={formData.betrag} onChange={handleChange} required disabled={isSubmitting} />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="datum">Datum</Label>
+              <LabelWithTooltip htmlFor="datum" infoText="Buchungs- oder Zahlungsdatum. Wird für Auswertungen genutzt.">
+                Datum
+              </LabelWithTooltip>
               <DatePicker
                 id="datum"
                 value={formData.datum}
@@ -224,7 +230,9 @@ export function FinanceEditModal(props: FinanceEditModalProps) {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="wohnung_id">Wohnung</Label>
+              <LabelWithTooltip htmlFor="wohnung_id" infoText="Optionale Zuordnung zu einer Wohnung. Erleichtert die Auswertung pro Objekt.">
+                Wohnung
+              </LabelWithTooltip>
               <CustomCombobox
                 id="wohnung_id"
                 width="w-full"
@@ -238,7 +246,9 @@ export function FinanceEditModal(props: FinanceEditModalProps) {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="ist_einnahmen">Typ</Label>
+              <LabelWithTooltip htmlFor="ist_einnahmen" infoText="Einnahmen oder Ausgaben auswählen. Beeinflusst Auswertungen.">
+                Typ
+              </LabelWithTooltip>
               <Select
                 name="ist_einnahmen"
                 value={formData.ist_einnahmen ? "Einnahmen" : "Ausgaben"}
@@ -255,7 +265,9 @@ export function FinanceEditModal(props: FinanceEditModalProps) {
               </Select>
             </div>
             <div className="col-span-2 space-y-2">
-              <Label htmlFor="notiz">Notiz</Label>
+              <LabelWithTooltip htmlFor="notiz" infoText="Optionale interne Notiz.">
+                Notiz
+              </LabelWithTooltip>
               <Input id="notiz" name="notiz" value={formData.notiz || ""} onChange={handleChange} disabled={isSubmitting} />
             </div>
           </div>

--- a/components/finance-edit-modal.tsx
+++ b/components/finance-edit-modal.tsx
@@ -206,7 +206,7 @@ export function FinanceEditModal(props: FinanceEditModalProps) {
         <form onSubmit={handleSubmit} className="grid gap-4 pt-4 pb-2">
           <div className="grid grid-cols-2 gap-4">
             <div className="col-span-2 space-y-2">
-              <LabelWithTooltip htmlFor="name" infoText="Bezeichnung der Transaktion. Hilft bei der Zuordnung.">
+              <LabelWithTooltip htmlFor="name" infoText="Kurze, allgemeine Bezeichnung (z.B. 'Handwerker', 'Hausverwaltung', 'Mieteinnahme'). Erleichtert die spätere Suche und Kategorisierung.">
                 Bezeichnung
               </LabelWithTooltip>
               <Input id="name" name="name" value={formData.name} onChange={handleChange} required disabled={isSubmitting} />

--- a/components/finance-edit-modal.tsx
+++ b/components/finance-edit-modal.tsx
@@ -218,7 +218,7 @@ export function FinanceEditModal(props: FinanceEditModalProps) {
               <Input id="betrag" name="betrag" type="number" step="0.01" value={formData.betrag} onChange={handleChange} required disabled={isSubmitting} />
             </div>
             <div className="space-y-2">
-              <LabelWithTooltip htmlFor="datum" infoText="Buchungs- oder Zahlungsdatum. Wird für Auswertungen genutzt.">
+              <LabelWithTooltip htmlFor="datum" infoText="Buchungs- oder Zahlungsdatum. Wird für Monats- und Jahresauswertungen, Cashflow-Berechnungen und die korrekte Zuordnung von Transaktionen verwendet.">
                 Datum
               </LabelWithTooltip>
               <DatePicker

--- a/components/finance-edit-modal.tsx
+++ b/components/finance-edit-modal.tsx
@@ -265,7 +265,10 @@ export function FinanceEditModal(props: FinanceEditModalProps) {
               </Select>
             </div>
             <div className="col-span-2 space-y-2">
-              <LabelWithTooltip htmlFor="notiz" infoText="Optionale interne Notiz.">
+              <LabelWithTooltip 
+                htmlFor="notiz" 
+                infoText="Optionale interne Notiz. Hier können zusätzliche Details wie Rechnungsnummern, spezifische Leistungen oder weitere Informationen eingetragen werden. Der Inhalt ist durchsuchbar und erleichtert das spätere Auffinden spezifischer Transaktionen."
+              >
                 Notiz
               </LabelWithTooltip>
               <Input id="notiz" name="notiz" value={formData.notiz || ""} onChange={handleChange} disabled={isSubmitting} />

--- a/components/house-edit-modal.tsx
+++ b/components/house-edit-modal.tsx
@@ -234,7 +234,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
           <div className="space-y-2">
             <LabelWithTooltip 
               htmlFor="ort"
-              infoText="Geben Sie den Ort des Hauses ein. Dies ist ein Pflichtfeld und wird für die korrekte Zuordnung benötigt."
+              infoText="Geben Sie den Ort des Hauses ein. Dieses Feld ist optional, wird aber für die Abrechnung und die generierte PDF benötigt. Die Ortsangabe erscheint in den offiziellen Dokumenten und wird für die korrekte Zuordnung verwendet."
             >
               Ort
             </LabelWithTooltip>
@@ -244,7 +244,6 @@ export function HouseEditModal(props: HouseEditModalProps) {
               value={formData.ort}
               onChange={handleInputChange}
               placeholder="z.B. Berlin"
-              required
               disabled={isSubmitting}
             />
           </div>

--- a/components/house-edit-modal.tsx
+++ b/components/house-edit-modal.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { LabelWithTooltip } from "@/components/ui/label-with-tooltip";
 import { useRouter } from "next/navigation";
 import { toast } from "@/hooks/use-toast";
 import { useModalStore } from "@/hooks/use-modal-store"; // Import the modal store
@@ -198,37 +199,51 @@ export function HouseEditModal(props: HouseEditModalProps) {
         </DialogHeader>
         <form onSubmit={handleSubmit} className="grid gap-4 pt-4 pb-2">
           <div className="space-y-2">
-            <Label htmlFor="name">Name</Label>
+            <LabelWithTooltip 
+              htmlFor="name"
+              infoText="Geben Sie einen eindeutigen Namen für das Haus ein. Dieser wird in der Übersicht und in Dropdown-Menüs angezeigt."
+            >
+              Name
+            </LabelWithTooltip>
             <Input
-              type="text"
               id="name"
               name="name"
               value={formData.name}
               onChange={handleInputChange}
+              placeholder="z.B. Hauptstraße 1"
               required
               disabled={isSubmitting}
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="strasse">Straße</Label>
+            <LabelWithTooltip 
+              htmlFor="strasse"
+              infoText="Geben Sie die vollständige Adresse des Hauses ein. Dies ist optional, wird aber für Rechnungen und Dokumente benötigt."
+            >
+              Straße
+            </LabelWithTooltip>
             <Input
-              type="text"
               id="strasse"
               name="strasse"
               value={formData.strasse}
               onChange={handleInputChange}
-              required
+              placeholder="z.B. Hauptstraße 1"
               disabled={isSubmitting}
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="ort">Ort</Label>
+            <LabelWithTooltip 
+              htmlFor="ort"
+              infoText="Geben Sie den Ort des Hauses ein. Dies ist ein Pflichtfeld und wird für die korrekte Zuordnung benötigt."
+            >
+              Ort
+            </LabelWithTooltip>
             <Input
-              type="text"
               id="ort"
               name="ort"
               value={formData.ort}
               onChange={handleInputChange}
+              placeholder="z.B. Berlin"
               required
               disabled={isSubmitting}
             />
@@ -240,14 +255,24 @@ export function HouseEditModal(props: HouseEditModalProps) {
               onCheckedChange={(checked) => handleCheckboxChange(Boolean(checked))}
               disabled={isSubmitting}
             />
-            <Label htmlFor="automaticSize">Automatische Größe</Label>
+            <LabelWithTooltip 
+              htmlFor="automaticSize"
+              infoText="Wenn aktiviert, wird die Gesamtgröße des Hauses automatisch aus der Summe der Wohnungsflächen berechnet. Deaktivieren Sie diese Option, um die Größe manuell festzulegen."
+            >
+              Größe automatisch berechnen
+            </LabelWithTooltip>
           </div>
           <div className="space-y-2">
-            <Label htmlFor="manualGroesse">Größe (m²)</Label>
+            <LabelWithTooltip 
+              htmlFor="manualGroesse"
+              infoText="Geben Sie die Gesamtfläche des Hauses in Quadratmetern ein. Dieser Wert wird für die Berechnung von Betriebskosten pro Quadratmeter verwendet."
+            >
+              Größe in m²
+            </LabelWithTooltip>
             <Input
-              type="number"
               id="manualGroesse"
               name="manualGroesse"
+              type="number"
               value={manualGroesse}
               onChange={handleManualGroesseChange}
               disabled={automaticSize || isSubmitting}

--- a/components/house-edit-modal.tsx
+++ b/components/house-edit-modal.tsx
@@ -218,7 +218,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
           <div className="space-y-2">
             <LabelWithTooltip 
               htmlFor="strasse"
-              infoText="Geben Sie die vollständige Adresse des Hauses ein. Dies ist optional, wird aber für Rechnungen und Dokumente benötigt."
+              infoText="Geben Sie die vollständige Adresse des Hauses ein. Dieses Feld wird für die Abrechnung und die generierte PDF benötigt. Wir empfehlen dringend, die Adresse anzugeben, da sie in den offiziellen Dokumenten erscheint."
             >
               Straße
             </LabelWithTooltip>

--- a/components/house-edit-modal.tsx
+++ b/components/house-edit-modal.tsx
@@ -262,12 +262,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
             </LabelWithTooltip>
           </div>
           <div className="space-y-2">
-            <LabelWithTooltip 
-              htmlFor="manualGroesse"
-              infoText="Geben Sie die Gesamtfläche des Hauses in Quadratmetern ein. Dieser Wert wird für die Berechnung von Betriebskosten pro Quadratmeter verwendet."
-            >
-              Größe in m²
-            </LabelWithTooltip>
+            <Label htmlFor="manualGroesse">Größe in m²</Label>
             <Input
               id="manualGroesse"
               name="manualGroesse"

--- a/components/house-edit-modal.tsx
+++ b/components/house-edit-modal.tsx
@@ -210,8 +210,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
               name="name"
               value={formData.name}
               onChange={handleInputChange}
-              placeholder="z.B. Hauptstraße 1"
-              required
+              placeholder="z.B. Hauptstraße"
               disabled={isSubmitting}
             />
           </div>

--- a/components/tenant-edit-modal.tsx
+++ b/components/tenant-edit-modal.tsx
@@ -10,7 +10,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { LabelWithTooltip } from "@/components/ui/label-with-tooltip"
+import { InfoTooltip } from "@/components/ui/info-tooltip"
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select"
 import { CustomCombobox, ComboboxOption } from "@/components/ui/custom-combobox";
 import { DatePicker } from "@/components/ui/date-picker" // Added DatePicker import
@@ -265,9 +265,10 @@ export function TenantEditModal({ serverAction }: TenantEditModalProps) {
           {/* Removed hidden id input, it's added to FormData directly if editing */}
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
-              <LabelWithTooltip htmlFor="wohnung_id" infoText="Zugehörige Wohnung auswählen, der der Mieter zugeordnet wird.">
-                Wohnung
-              </LabelWithTooltip>
+              <div className="flex items-center gap-2">
+                <Label htmlFor="wohnung_id">Wohnung</Label>
+                <InfoTooltip infoText="Wählen Sie die Wohnung aus, die der Mieter bewohnt. Die Liste zeigt nur Wohnungen des ausgewählten Hauses an." />
+              </div>
               <CustomCombobox
                 width="w-full"
                 options={apartmentOptions}
@@ -281,15 +282,17 @@ export function TenantEditModal({ serverAction }: TenantEditModalProps) {
               />
             </div>
             <div className="space-y-2">
-              <LabelWithTooltip htmlFor="name" infoText="Vollständiger Name des Mieters (z.B. 'Max Mustermann').">
-                Name
-              </LabelWithTooltip>
+              <div className="flex items-center gap-2">
+                <Label htmlFor="name">Name</Label>
+                <InfoTooltip infoText="Vollständiger Name des Mieters (z.B. 'Max Mustermann')." />
+              </div>
               <Input id="name" name="name" value={formData.name} onChange={handleChange} required disabled={isSubmitting}/>
             </div>
             <div className="space-y-2">
-              <LabelWithTooltip htmlFor="einzug" infoText="Einzugsdatum im Format TT.MM.JJJJ. Wird für Mietbeginn und Abrechnungen verwendet.">
-                Einzug
-              </LabelWithTooltip>
+              <div className="flex items-center gap-2">
+                <Label htmlFor="einzug">Einzug</Label>
+                <InfoTooltip infoText="Einzugsdatum im Format TT.MM.JJJJ. Wird für Mietbeginn und Abrechnungen verwendet." />
+              </div>
               <DatePicker 
                 id="einzug"
                 value={formData.einzug} 
@@ -300,9 +303,10 @@ export function TenantEditModal({ serverAction }: TenantEditModalProps) {
               <input type="hidden" name="einzug" value={formData.einzug} />
             </div>
             <div className="space-y-2">
-              <LabelWithTooltip htmlFor="auszug" infoText="Auszugsdatum (optional). Leer lassen, wenn der Mietvertrag noch aktiv ist.">
-                Auszug
-              </LabelWithTooltip>
+              <div className="flex items-center gap-2">
+                <Label htmlFor="auszug">Auszug</Label>
+                <InfoTooltip infoText="Auszugsdatum (optional). Leer lassen, wenn der Mietvertrag noch aktiv ist." />
+              </div>
               <DatePicker 
                 id="auszug"
                 value={formData.auszug} 
@@ -313,27 +317,33 @@ export function TenantEditModal({ serverAction }: TenantEditModalProps) {
               <input type="hidden" name="auszug" value={formData.auszug} />
             </div>
             <div className="space-y-2">
-              <LabelWithTooltip htmlFor="email" infoText="Kontakt-E-Mail (empfohlen für bessere Organisation und schnelle Erreichbarkeit).">
-                E-Mail
-              </LabelWithTooltip>
+              <div className="flex items-center gap-2">
+                <Label htmlFor="email">E-Mail</Label>
+                <InfoTooltip infoText="Kontakt-E-Mail (empfohlen für bessere Organisation und schnelle Erreichbarkeit)." />
+              </div>
               <Input id="email" name="email" type="email" value={formData.email} onChange={handleChange} disabled={isSubmitting}/>
             </div>
             <div className="space-y-2">
-              <LabelWithTooltip htmlFor="telefonnummer" infoText="Telefonnummer (hilft bei der Organisation und schnellen Kontaktaufnahme).">
-                Telefon
-              </LabelWithTooltip>
+              <div className="flex items-center gap-2">
+                <Label htmlFor="telefonnummer">Telefon</Label>
+                <InfoTooltip infoText="Telefonnummer (hilft bei der Organisation und schnellen Kontaktaufnahme)." />
+              </div>
               <Input id="telefonnummer" name="telefonnummer" value={formData.telefonnummer} onChange={handleChange} disabled={isSubmitting}/>
             </div>
             <div className="col-span-2 space-y-2">
-              <LabelWithTooltip htmlFor="notiz" infoText="Interne Notiz (nur für Sie sichtbar).">
-                Notiz
-              </LabelWithTooltip>
+              <div className="flex items-center gap-2">
+                <Label htmlFor="notiz">Notiz</Label>
+                <InfoTooltip infoText="Hier können Sie zusätzliche Informationen oder Anmerkungen zum Mieter erfassen." />
+              </div>
               <Input id="notiz" name="notiz" value={formData.notiz} onChange={handleChange} disabled={isSubmitting}/>
             </div>
             <div className="col-span-2 space-y-2">
-              <LabelWithTooltip htmlFor="nebenkosten-section" infoText="Monatliche Vorauszahlungen für Nebenkosten. Bitte geben Sie den Betrag und das Zahlungsdatum ein. Einträge ohne Betrag werden ignoriert.">
-                Nebenkosten Vorauszahlungen
-              </LabelWithTooltip>
+              <div className="flex items-center gap-2">
+                <h3 className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                  Nebenkosten Vorauszahlungen
+                </h3>
+                <InfoTooltip infoText="Monatliche Vorauszahlungen für Nebenkosten. Bitte geben Sie den Betrag und das Zahlungsdatum ein. Einträge ohne Betrag werden ignoriert." />
+              </div>
               {nebenkostenEntries.map((entry) => ( // Removed index from map as entry.id is unique
                 <div key={entry.id} className="p-2 border rounded-md space-y-1">
                   <div className="flex items-center gap-2">

--- a/components/tenant-edit-modal.tsx
+++ b/components/tenant-edit-modal.tsx
@@ -10,6 +10,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { LabelWithTooltip } from "@/components/ui/label-with-tooltip"
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select"
 import { CustomCombobox, ComboboxOption } from "@/components/ui/custom-combobox";
 import { DatePicker } from "@/components/ui/date-picker" // Added DatePicker import
@@ -264,7 +265,9 @@ export function TenantEditModal({ serverAction }: TenantEditModalProps) {
           {/* Removed hidden id input, it's added to FormData directly if editing */}
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label htmlFor="wohnung_id">Wohnung</Label>
+              <LabelWithTooltip htmlFor="wohnung_id" infoText="Zugehörige Wohnung auswählen, der der Mieter zugeordnet wird.">
+                Wohnung
+              </LabelWithTooltip>
               <CustomCombobox
                 width="w-full"
                 options={apartmentOptions}
@@ -274,36 +277,51 @@ export function TenantEditModal({ serverAction }: TenantEditModalProps) {
                 searchPlaceholder="Wohnung suchen..."
                 emptyText="Keine Wohnung gefunden."
                 disabled={isLoadingWohnungen || isSubmitting}
+                id="wohnung_id"
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="name">Name</Label>
+              <LabelWithTooltip htmlFor="name" infoText="Vollständiger Name des Mieters (z.B. 'Max Mustermann').">
+                Name
+              </LabelWithTooltip>
               <Input id="name" name="name" value={formData.name} onChange={handleChange} required disabled={isSubmitting}/>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="einzug">Einzug</Label>
+              <LabelWithTooltip htmlFor="einzug" infoText="Einzugsdatum im Format TT.MM.JJJJ. Wird für Mietbeginn und Abrechnungen verwendet.">
+                Einzug
+              </LabelWithTooltip>
               <DatePicker value={formData.einzug} onChange={(date) => handleDateChange('einzug', date)} placeholder="TT.MM.JJJJ" disabled={isSubmitting}/>
-              <input type="hidden" name="einzug" value={formData.einzug} />
+              <input type="hidden" id="einzug" name="einzug" value={formData.einzug} />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="auszug">Auszug</Label>
+              <LabelWithTooltip htmlFor="auszug" infoText="Auszugsdatum (optional). Leer lassen, wenn der Mietvertrag noch aktiv ist.">
+                Auszug
+              </LabelWithTooltip>
               <DatePicker value={formData.auszug} onChange={(date) => handleDateChange('auszug', date)} placeholder="TT.MM.JJJJ" disabled={isSubmitting}/>
-              <input type="hidden" name="auszug" value={formData.auszug} />
+              <input type="hidden" id="auszug" name="auszug" value={formData.auszug} />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="email">E-Mail</Label>
+              <LabelWithTooltip htmlFor="email" infoText="Optionale Kontakt-E-Mail des Mieters.">
+                E-Mail
+              </LabelWithTooltip>
               <Input id="email" name="email" type="email" value={formData.email} onChange={handleChange} disabled={isSubmitting}/>
             </div>
             <div className="space-y-2">
-              <Label htmlFor="telefonnummer">Telefon</Label>
+              <LabelWithTooltip htmlFor="telefonnummer" infoText="Optionale Telefonnummer des Mieters.">
+                Telefon
+              </LabelWithTooltip>
               <Input id="telefonnummer" name="telefonnummer" value={formData.telefonnummer} onChange={handleChange} disabled={isSubmitting}/>
             </div>
             <div className="col-span-2 space-y-2">
-              <Label htmlFor="notiz">Notiz</Label>
+              <LabelWithTooltip htmlFor="notiz" infoText="Interne Notiz (nur für Sie sichtbar).">
+                Notiz
+              </LabelWithTooltip>
               <Input id="notiz" name="notiz" value={formData.notiz} onChange={handleChange} disabled={isSubmitting}/>
             </div>
             <div className="col-span-2 space-y-2">
-              <Label>Nebenkosten Einträge</Label>
+              <LabelWithTooltip htmlFor="nebenkosten-section" infoText="Optionale Nebenkosten (z.B. Hausmeister, Stellplatz). Einträge ohne Betrag werden ignoriert. Bitte Betrag und Datum angeben, wenn relevant.">
+                Nebenkosten Einträge
+              </LabelWithTooltip>
               {nebenkostenEntries.map((entry) => ( // Removed index from map as entry.id is unique
                 <div key={entry.id} className="p-2 border rounded-md space-y-1">
                   <div className="flex items-center gap-2">

--- a/components/tenant-edit-modal.tsx
+++ b/components/tenant-edit-modal.tsx
@@ -301,13 +301,13 @@ export function TenantEditModal({ serverAction }: TenantEditModalProps) {
               <input type="hidden" id="auszug" name="auszug" value={formData.auszug} />
             </div>
             <div className="space-y-2">
-              <LabelWithTooltip htmlFor="email" infoText="Optionale Kontakt-E-Mail des Mieters.">
+              <LabelWithTooltip htmlFor="email" infoText="Kontakt-E-Mail (empfohlen für bessere Organisation und schnelle Erreichbarkeit).">
                 E-Mail
               </LabelWithTooltip>
               <Input id="email" name="email" type="email" value={formData.email} onChange={handleChange} disabled={isSubmitting}/>
             </div>
             <div className="space-y-2">
-              <LabelWithTooltip htmlFor="telefonnummer" infoText="Optionale Telefonnummer des Mieters.">
+              <LabelWithTooltip htmlFor="telefonnummer" infoText="Telefonnummer (hilft bei der Organisation und schnellen Kontaktaufnahme).">
                 Telefon
               </LabelWithTooltip>
               <Input id="telefonnummer" name="telefonnummer" value={formData.telefonnummer} onChange={handleChange} disabled={isSubmitting}/>

--- a/components/tenant-edit-modal.tsx
+++ b/components/tenant-edit-modal.tsx
@@ -290,15 +290,27 @@ export function TenantEditModal({ serverAction }: TenantEditModalProps) {
               <LabelWithTooltip htmlFor="einzug" infoText="Einzugsdatum im Format TT.MM.JJJJ. Wird für Mietbeginn und Abrechnungen verwendet.">
                 Einzug
               </LabelWithTooltip>
-              <DatePicker value={formData.einzug} onChange={(date) => handleDateChange('einzug', date)} placeholder="TT.MM.JJJJ" disabled={isSubmitting}/>
-              <input type="hidden" id="einzug" name="einzug" value={formData.einzug} />
+              <DatePicker 
+                id="einzug"
+                value={formData.einzug} 
+                onChange={(date) => handleDateChange('einzug', date)} 
+                placeholder="TT.MM.JJJJ" 
+                disabled={isSubmitting}
+              />
+              <input type="hidden" name="einzug" value={formData.einzug} />
             </div>
             <div className="space-y-2">
               <LabelWithTooltip htmlFor="auszug" infoText="Auszugsdatum (optional). Leer lassen, wenn der Mietvertrag noch aktiv ist.">
                 Auszug
               </LabelWithTooltip>
-              <DatePicker value={formData.auszug} onChange={(date) => handleDateChange('auszug', date)} placeholder="TT.MM.JJJJ" disabled={isSubmitting}/>
-              <input type="hidden" id="auszug" name="auszug" value={formData.auszug} />
+              <DatePicker 
+                id="auszug"
+                value={formData.auszug} 
+                onChange={(date) => handleDateChange('auszug', date)} 
+                placeholder="TT.MM.JJJJ" 
+                disabled={isSubmitting}
+              />
+              <input type="hidden" name="auszug" value={formData.auszug} />
             </div>
             <div className="space-y-2">
               <LabelWithTooltip htmlFor="email" infoText="Kontakt-E-Mail (empfohlen für bessere Organisation und schnelle Erreichbarkeit).">

--- a/components/tenant-edit-modal.tsx
+++ b/components/tenant-edit-modal.tsx
@@ -319,8 +319,8 @@ export function TenantEditModal({ serverAction }: TenantEditModalProps) {
               <Input id="notiz" name="notiz" value={formData.notiz} onChange={handleChange} disabled={isSubmitting}/>
             </div>
             <div className="col-span-2 space-y-2">
-              <LabelWithTooltip htmlFor="nebenkosten-section" infoText="Optionale Nebenkosten (z.B. Hausmeister, Stellplatz). Einträge ohne Betrag werden ignoriert. Bitte Betrag und Datum angeben, wenn relevant.">
-                Nebenkosten Einträge
+              <LabelWithTooltip htmlFor="nebenkosten-section" infoText="Monatliche Vorauszahlungen für Nebenkosten. Bitte geben Sie den Betrag und das Zahlungsdatum ein. Einträge ohne Betrag werden ignoriert.">
+                Nebenkosten Vorauszahlungen
               </LabelWithTooltip>
               {nebenkostenEntries.map((entry) => ( // Removed index from map as entry.id is unique
                 <div key={entry.id} className="p-2 border rounded-md space-y-1">

--- a/components/wohnung-edit-modal.tsx
+++ b/components/wohnung-edit-modal.tsx
@@ -13,6 +13,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { LabelWithTooltip } from "@/components/ui/label-with-tooltip";
 import {
   Select,
   SelectContent,
@@ -284,7 +285,9 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
         </DialogHeader>
         <form onSubmit={handleSubmit} className="grid gap-4 pt-4 pb-2">
           <div className="space-y-2">
-            <Label htmlFor="name">Name der Wohnung</Label>
+            <LabelWithTooltip htmlFor="name" infoText="Eindeutiger Name für die Wohnung (z.B. 'EG Links' oder '1. OG rechts')">
+              Name der Wohnung
+            </LabelWithTooltip>
             <Input
               id="name"
               name="name"
@@ -296,7 +299,9 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="groesse">Größe (m²)</Label>
+            <LabelWithTooltip htmlFor="groesse" infoText="Wohnfläche in Quadratmetern (z.B. 65.5 für 65,5 m²)">
+              Größe (m²)
+            </LabelWithTooltip>
             <Input
               id="groesse"
               name="groesse"
@@ -311,7 +316,9 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="miete">Miete (€)</Label>
+            <LabelWithTooltip htmlFor="miete" infoText="Monatliche Miete in Euro (z.B. 650.50 für 650,50 €)">
+              Miete (€)
+            </LabelWithTooltip>
             <Input
               id="miete"
               name="miete"
@@ -326,7 +333,9 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="haus_id">Zugehöriges Haus</Label>
+            <LabelWithTooltip htmlFor="haus_id" infoText="Zugeordnetes Gebäude (z.B. 'Hauptgebäude' oder 'Nebengebäude')">
+              Zugehöriges Haus
+            </LabelWithTooltip>
             <CustomCombobox
               width="w-full"
               options={houseOptions}

--- a/components/wohnung-edit-modal.tsx
+++ b/components/wohnung-edit-modal.tsx
@@ -333,7 +333,7 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
             />
           </div>
           <div className="space-y-2">
-            <LabelWithTooltip htmlFor="haus_id" infoText="Zugeordnetes Gebäude (z.B. 'Hauptgebäude' oder 'Nebengebäude')">
+            <LabelWithTooltip htmlFor="haus_id" infoText="Zugeordnetes Haus (z.B. 'Haus A' oder 'Haus B')">
               Zugehöriges Haus
             </LabelWithTooltip>
             <CustomCombobox


### PR DESCRIPTION
## Description

Adds explanatory tooltips to all edit modals and relaxes overly strict required fields.

## Summary of Changes

- `LabelWithTooltip` / `InfoTooltip` added to the finance, house, apartment and tenant edit modals — every field now explains what it does and how it is used (e.g. in the PDF or evaluations)
- Betriebskosten modal: hovering a Verteilerschlüssel option shows an explanatory tooltip in a portal next to the dropdown (position tracked on scroll/resize)
- House form: Ort is no longer required (server-side too); Straße/Ort get placeholders and note they appear on the PDF; "Automatische Größe" label clarified
- Apartment form: name optional, Größe only saved when valid (> 0) — the server action now builds the insert object conditionally
- Tenant modal: "Nebenkosten Einträge" renamed to "Nebenkosten Vorauszahlungen" with an explanation