### PR TITLE
fix: clear tooltip after selecting verteilerschlüssel

### DIFF
--- a/components/sortable-cost-item.tsx
+++ b/components/sortable-cost-item.tsx
@@ -135,11 +135,7 @@ export function SortableCostItem({
         <div className="w-full sm:flex-[4_1_0%]">
           <Select
             value={item.berechnungsart}
-            onValueChange={(value) => {
-              onCostItemChange(index, 'berechnungsart', value as BerechnungsartValue);
-              // Clear tooltip after selecting a value
-              onItemLeave();
-            }}
+            onValueChange={(value) => onCostItemChange(index, 'berechnungsart', value as BerechnungsartValue)}
             onOpenChange={(open) => {
               // When the dropdown closes (e.g. after selection), ensure tooltip is cleared
               if (!open) onItemLeave();


### PR DESCRIPTION
- Added onValueChange to clear tooltip after selection
- Added onOpenChange to clear tooltip when dropdown closes


Fix #580