### PR TITLE
Feature/implement dark mode

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -263,17 +263,18 @@
     border-color: hsl(var(--border));
   }
 
-  /* Sidebar border styling for dark mode - hide borders by matching background */
+  /* Sidebar styling for dark mode - use same background as main to hide borders */
   .dark .sidebar-container {
-    border-right-color: hsl(var(--secondary)); /* Match sidebar background */
+    background-color: hsl(var(--background)); /* Use main background color */
+    border-right-color: hsl(var(--background)); /* Match main background */
   }
 
   .dark .sidebar-header {
-    border-bottom-color: hsl(var(--secondary)); /* Match sidebar background */
+    border-bottom-color: hsl(var(--background)); /* Match main background */
   }
 
   .dark .sidebar-footer {
-    border-top-color: hsl(var(--secondary)); /* Match sidebar background */
+    border-top-color: hsl(var(--background)); /* Match main background */
   }
 
   /* Shimmer animation for loading states */

--- a/app/globals.css
+++ b/app/globals.css
@@ -241,13 +241,8 @@
     background-color: hsl(var(--btn-hover));
   }
 
-
-
   /* Custom input placeholder styling */
-  .dark input::placeholder {
-    color: hsl(var(--input-placeholder));
-  }
-
+  .dark input::placeholder,
   .dark textarea::placeholder {
     color: hsl(var(--input-placeholder));
   }

--- a/app/globals.css
+++ b/app/globals.css
@@ -277,6 +277,11 @@
     border-top-color: hsl(var(--background)); /* Match main background */
   }
 
+  /* Header border styling for dark mode - hide border by matching background */
+  .dark .header-container {
+    border-bottom-color: hsl(var(--background)); /* Match main background */
+  }
+
   /* Shimmer animation for loading states */
   @keyframes shimmer {
     0% {

--- a/app/globals.css
+++ b/app/globals.css
@@ -190,6 +190,9 @@
     --warning: 50 100% 73%; /* #ffe176 - warning */
     --input-placeholder: 0 0% 57%; /* #919191 - input-placeholder */
     --text-disabled: 215 8% 61%; /* #9399a2 - text-disabled */
+    
+    /* Main container color - slightly lighter than background */
+    --main-container: 0 0% 12%; /* #1F1F1F - slightly lighter than #181818 background */
 
     /* Chart Farben */
     --chart-1: 220 39% 25%; /* #2D4A6B - darker blue */
@@ -252,6 +255,12 @@
   /* Custom shadow for dark mode */
   .dark .shadow-custom {
     box-shadow: 0 2px 12px rgba(36, 56, 99, 0.4);
+  }
+
+  /* Main container styling for dark mode */
+  .dark .main-container {
+    background-color: hsl(var(--main-container));
+    border-color: hsl(var(--border));
   }
 
   /* Shimmer animation for loading states */

--- a/app/globals.css
+++ b/app/globals.css
@@ -282,6 +282,22 @@
     border-bottom-color: hsl(var(--background)); /* Match main background */
   }
 
+  /* Enhanced hover styles for dark mode */
+  /* Table row hover - use darker blue instead of muted */
+  .dark .table-row-hover:hover {
+    background-color: hsl(var(--primary) / 0.1); /* Subtle darker blue hover */
+  }
+
+  /* Button hover enhancements for dark mode */
+  .dark .btn-outline-hover:hover {
+    background-color: hsl(var(--primary) / 0.15); /* Darker blue for outline buttons */
+    border-color: hsl(var(--primary) / 0.3);
+  }
+
+  .dark .btn-ghost-hover:hover {
+    background-color: hsl(var(--primary) / 0.12); /* Darker blue for ghost buttons */
+  }
+
   /* Shimmer animation for loading states */
   @keyframes shimmer {
     0% {

--- a/app/globals.css
+++ b/app/globals.css
@@ -263,6 +263,19 @@
     border-color: hsl(var(--border));
   }
 
+  /* Sidebar border styling for dark mode - hide borders by matching background */
+  .dark .sidebar-container {
+    border-right-color: hsl(var(--secondary)); /* Match sidebar background */
+  }
+
+  .dark .sidebar-header {
+    border-bottom-color: hsl(var(--secondary)); /* Match sidebar background */
+  }
+
+  .dark .sidebar-footer {
+    border-top-color: hsl(var(--secondary)); /* Match sidebar background */
+  }
+
   /* Shimmer animation for loading states */
   @keyframes shimmer {
     0% {

--- a/app/globals.css
+++ b/app/globals.css
@@ -298,6 +298,11 @@
     background-color: hsl(var(--primary) / 0.12); /* Darker blue for ghost buttons */
   }
 
+  /* Modal close button hover enhancement */
+  .dark .modal-close-hover:hover {
+    background-color: hsl(var(--primary) / 0.15); /* Darker blue for modal close button */
+  }
+
   /* Shimmer animation for loading states */
   @keyframes shimmer {
     0% {

--- a/app/globals.css
+++ b/app/globals.css
@@ -162,31 +162,40 @@
   }
 
   .dark {
-    --background: 210 29% 24%;
-    --foreground: 210 40% 98%;
-    --card: 210 29% 24%;
-    --card-foreground: 210 40% 98%;
-    --popover: 210 29% 24%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 210 29% 29%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 224.3 76.3% 48%;
+    /* Custom Dark Mode Palette */
+    --background: 0 0% 9.4%; /* #181818 - bg-primary */
+    --foreground: 220 9% 95%; /* #F3F4F6 - text-primary */
+    --card: 210 11% 13.7%; /* #22272e - bg-elevated */
+    --card-foreground: 220 9% 95%; /* #F3F4F6 - text-primary */
+    --popover: 210 11% 13.7%; /* #22272e - bg-elevated */
+    --popover-foreground: 220 9% 95%; /* #F3F4F6 - text-primary */
+    --primary: 221 100% 63%; /* #4D88FF - accent-blue */
+    --primary-foreground: 220 9% 95%; /* #F3F4F6 - text-primary */
+    --secondary: 215 14% 16%; /* #23272a - bg-secondary */
+    --secondary-foreground: 214 15% 76%; /* #BFC8D9 - text-secondary */
+    --muted: 215 14% 16%; /* #23272a - bg-secondary */
+    --muted-foreground: 214 15% 76%; /* #BFC8D9 - text-secondary */
+    --accent: 221 100% 63%; /* #4D88FF - accent-blue */
+    --accent-foreground: 220 9% 95%; /* #F3F4F6 - text-primary */
+    --destructive: 0 100% 67%; /* #FF5757 - error */
+    --destructive-foreground: 220 9% 95%; /* #F3F4F6 - text-primary */
+    --border: 215 15% 26%; /* #3C4251 - border-color */
+    --input: 220 11% 13%; /* #22252b - input-bg */
+    --ring: 221 100% 63%; /* #4D88FF - accent-blue */
+
+    /* Custom variables for specific use cases */
+    --btn-bg: 215 25% 19%; /* #232f3e - btn-bg */
+    --btn-hover: 215 30% 22%; /* #25344a - btn-hover */
+    --success: 162 100% 50%; /* #00ffa3 - success */
+    --warning: 50 100% 73%; /* #ffe176 - warning */
+    --input-placeholder: 0 0% 57%; /* #919191 - input-placeholder */
+    --text-disabled: 215 8% 61%; /* #9399a2 - text-disabled */
 
     /* Chart Farben */
-    --chart-1: 210 29% 29%;
-    --chart-2: 0 62.8% 30.6%;
-    --chart-3: 142.1 70.6% 45.3%;
-    --chart-4: 43.3 89.4% 66.3%;
+    --chart-1: 221 100% 63%; /* #4D88FF - accent-blue */
+    --chart-2: 0 100% 67%; /* #FF5757 - error */
+    --chart-3: 162 100% 50%; /* #00ffa3 - success */
+    --chart-4: 50 100% 73%; /* #ffe176 - warning */
     --chart-5: 262.1 83.3% 67.8%;
   }
 }
@@ -217,6 +226,30 @@
 @layer utilities {
   .summary-card {
     @apply border-2 border-border;
+  }
+
+  /* Custom dark mode button styles */
+  .dark .btn-custom {
+    background-color: hsl(var(--btn-bg));
+    border-color: hsl(var(--border));
+  }
+
+  .dark .btn-custom:hover {
+    background-color: hsl(var(--btn-hover));
+  }
+
+  /* Custom input placeholder styling */
+  .dark input::placeholder {
+    color: hsl(var(--input-placeholder));
+  }
+
+  .dark textarea::placeholder {
+    color: hsl(var(--input-placeholder));
+  }
+
+  /* Custom shadow for dark mode */
+  .dark .shadow-custom {
+    box-shadow: 0 2px 12px rgba(36, 56, 99, 0.4);
   }
 
   /* Shimmer animation for loading states */

--- a/app/globals.css
+++ b/app/globals.css
@@ -162,37 +162,37 @@
   }
 
   .dark {
-    /* Custom Dark Mode Palette */
+    /* Custom Dark Mode Palette - Original colors with darker blue primary/accent */
     --background: 0 0% 9.4%; /* #181818 - bg-primary */
     --foreground: 220 9% 95%; /* #F3F4F6 - text-primary */
     --card: 210 11% 13.7%; /* #22272e - bg-elevated */
     --card-foreground: 220 9% 95%; /* #F3F4F6 - text-primary */
     --popover: 210 11% 13.7%; /* #22272e - bg-elevated */
     --popover-foreground: 220 9% 95%; /* #F3F4F6 - text-primary */
-    --primary: 221 100% 63%; /* #4D88FF - accent-blue */
+    --primary: 220 39% 25%; /* #2D4A6B - darker blue primary for hover states */
     --primary-foreground: 220 9% 95%; /* #F3F4F6 - text-primary */
-    --secondary: 215 14% 16%; /* #23272a - bg-secondary */
+    --secondary: 215 14% 16%; /* #23272a - bg-secondary (original) */
     --secondary-foreground: 214 15% 76%; /* #BFC8D9 - text-secondary */
-    --muted: 215 14% 16%; /* #23272a - bg-secondary */
+    --muted: 215 14% 16%; /* #23272a - bg-secondary (original) */
     --muted-foreground: 214 15% 76%; /* #BFC8D9 - text-secondary */
-    --accent: 221 100% 63%; /* #4D88FF - accent-blue */
+    --accent: 220 39% 25%; /* #2D4A6B - darker blue accent for hover states */
     --accent-foreground: 220 9% 95%; /* #F3F4F6 - text-primary */
     --destructive: 0 100% 67%; /* #FF5757 - error */
     --destructive-foreground: 220 9% 95%; /* #F3F4F6 - text-primary */
-    --border: 215 15% 26%; /* #3C4251 - border-color */
-    --input: 220 11% 13%; /* #22252b - input-bg */
-    --ring: 221 100% 63%; /* #4D88FF - accent-blue */
+    --border: 215 15% 26%; /* #3C4251 - border-color (original) */
+    --input: 220 11% 13%; /* #22252b - input-bg (original) */
+    --ring: 220 39% 25%; /* #2D4A6B - darker blue ring */
 
     /* Custom variables for specific use cases */
-    --btn-bg: 215 25% 19%; /* #232f3e - btn-bg */
-    --btn-hover: 215 30% 22%; /* #25344a - btn-hover */
+    --btn-bg: 215 25% 19%; /* #232f3e - btn-bg (original) */
+    --btn-hover: 215 30% 22%; /* #25344a - btn-hover (original) */
     --success: 162 100% 50%; /* #00ffa3 - success */
     --warning: 50 100% 73%; /* #ffe176 - warning */
     --input-placeholder: 0 0% 57%; /* #919191 - input-placeholder */
     --text-disabled: 215 8% 61%; /* #9399a2 - text-disabled */
 
     /* Chart Farben */
-    --chart-1: 221 100% 63%; /* #4D88FF - accent-blue */
+    --chart-1: 220 39% 25%; /* #2D4A6B - darker blue */
     --chart-2: 0 100% 67%; /* #FF5757 - error */
     --chart-3: 162 100% 50%; /* #00ffa3 - success */
     --chart-4: 50 100% 73%; /* #ffe176 - warning */
@@ -237,6 +237,8 @@
   .dark .btn-custom:hover {
     background-color: hsl(var(--btn-hover));
   }
+
+
 
   /* Custom input placeholder styling */
   .dark input::placeholder {

--- a/app/globals.css
+++ b/app/globals.css
@@ -298,6 +298,21 @@
     background-color: hsl(var(--primary) / 0.12); /* Darker blue for ghost buttons */
   }
 
+  /* Context menu hover enhancements for dark mode */
+  .dark .context-menu-item:focus {
+    background-color: hsl(var(--primary) / 0.15); /* Darker blue for context menu items */
+  }
+
+  .dark .context-menu-subtrigger:focus,
+  .dark .context-menu-subtrigger[data-state="open"] {
+    background-color: hsl(var(--primary) / 0.15); /* Darker blue for submenu triggers */
+  }
+
+  .dark .context-menu-checkbox:focus,
+  .dark .context-menu-radio:focus {
+    background-color: hsl(var(--primary) / 0.15); /* Darker blue for checkbox/radio items */
+  }
+
   /* Modal close button hover enhancement */
   .dark .modal-close-hover:hover {
     background-color: hsl(var(--primary) / 0.15); /* Darker blue for modal close button */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning className="light">
       <body className={inter.className}>
-        <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem={true}>
           <PostHogProvider>
             {children}
             <Toaster />

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -1077,8 +1077,8 @@ export function AbrechnungModal({
                   <TableRow className="font-semibold bg-primary/10 border-t-2 border-border">
                     <TableCell className="py-3 px-3 text-primary">Gesamtkosten Mieter</TableCell>
                     <TableCell className="py-3 px-3 text-primary"></TableCell> {/* For Abrechnungsart */}
-                    <TableCell className="py-3 px-3 text-blue-700"></TableCell> {/* New empty cell for Preis/qm */}
-                    <TableCell className="text-right py-3 px-3 text-blue-700">{formatCurrency(tenantData.totalTenantCost)}</TableCell>
+                    <TableCell className="py-3 px-3 text-primary"></TableCell> {/* New empty cell for Preis/qm */}
+                    <TableCell className="text-right py-3 px-3 text-primary">{formatCurrency(tenantData.totalTenantCost)}</TableCell>
                   </TableRow>
                 </TableBody>
               </Table>

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -805,7 +805,7 @@ export function AbrechnungModal({
 
         {tenants && tenants.length > 0 && (
           <div className="mt-4 mb-4"> {/* Adjusted margin for consistency */}
-            <label htmlFor="tenant-combobox-trigger" className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="tenant-combobox-trigger" className="block text-sm font-medium text-foreground mb-1">
               Mieter auswählen
             </label>
             <div className="flex items-center space-x-2">
@@ -847,16 +847,16 @@ export function AbrechnungModal({
 
           {calculatedTenantData.map((tenantData) => (
             <div key={tenantData.tenantId} className="mb-6 p-4 border rounded-lg shadow-sm">
-              <h3 className="text-xl font-semibold mb-3 text-gray-800">
+              <h3 className="text-xl font-semibold mb-3 text-foreground">
                 Mieter: <span className="font-bold">{tenantData.tenantName}</span>
               </h3>
-              <p className="text-sm text-gray-600 mb-1">Wohnung: {tenantData.apartmentName}</p>
-              <p className="text-sm text-gray-600 mb-3">Fläche: {tenantData.apartmentSize} qm</p>
+              <p className="text-sm text-muted-foreground mb-1">Wohnung: {tenantData.apartmentName}</p>
+              <p className="text-sm text-muted-foreground mb-3">Fläche: {tenantData.apartmentSize} qm</p>
 
               {/* WG Roommates Info */}
               {!loadAllRelevantTenants && (
-                <div className="mb-4 p-3 bg-gray-50 rounded-md border border-gray-200">
-                  <h4 className="text-sm font-medium text-gray-700 mb-2">Wohngemeinschaft (WG) Aufteilung</h4>
+                <div className="mb-4 p-3 bg-muted/50 rounded-md border border-border">
+                  <h4 className="text-sm font-medium text-foreground mb-2">Wohngemeinschaft (WG) Aufteilung</h4>
                   <div className="space-y-2">
                     {(() => {
                       // Get all roommates in this apartment
@@ -864,7 +864,7 @@ export function AbrechnungModal({
                       
                       if (roommates.length <= 1) {
                         return (
-                          <p className="text-sm text-gray-600">
+                          <p className="text-sm text-muted-foreground">
                             Keine Mitbewohner in dieser Wohnung gefunden.
                           </p>
                         );
@@ -874,14 +874,14 @@ export function AbrechnungModal({
                       
                       return (
                         <>
-                          <p className="text-sm text-gray-600">
+                          <p className="text-sm text-muted-foreground">
                             Diese Wohnung wird von {roommates.length} Personen bewohnt. 
                             Die Flächenkosten werden entsprechend der Anwesenheit aufgeteilt:
                           </p>
                           <div className="mt-2 space-y-1">
                             {roommates.map(rm => (
                               <div key={rm.id} className="flex justify-between items-center text-sm">
-                                <span className={rm.id === tenantData.tenantId ? "font-medium text-blue-700" : "text-gray-600"}>
+                                <span className={rm.id === tenantData.tenantId ? "font-medium text-primary" : "text-muted-foreground"}>
                                   {rm.name} {rm.id === tenantData.tenantId && "(Sie)"}
                                 </span>
                                 <span className="font-mono">
@@ -890,7 +890,7 @@ export function AbrechnungModal({
                               </div>
                             ))}
                           </div>
-                          <p className="text-xs text-gray-500 mt-2">
+                          <p className="text-xs text-muted-foreground mt-2">
                             <span className="font-medium">Hinweis:</span> Die Prozentsätze ergeben zusammen 100% der Wohnungskosten.
                             Die Aufteilung basiert auf der Anwesenheit im Abrechnungszeitraum.
                           </p>
@@ -904,17 +904,17 @@ export function AbrechnungModal({
               {/* Occupancy Progress Bar and Text */}
               <div className="my-3">
                 <div className="flex justify-between mb-1">
-                  <span className="text-sm font-medium text-gray-700">
+                  <span className="text-sm font-medium text-foreground">
                     Anwesenheit im Abrechnungszeitraum ({tenantData.daysOccupied} / {tenantData.daysInBillingPeriod} Tage)
                   </span>
-                  <span className="text-sm font-medium text-gray-700">
+                  <span className="text-sm font-medium text-foreground">
                     {formatNumber(tenantData.occupancyPercentage)}%
                   </span>
                 </div>
                 <Progress value={tenantData.occupancyPercentage} className="w-full h-2" />
               </div>
 
-              <hr className="my-3 border-gray-200" />
+              <hr className="my-3 border-border" />
               {/* Container for Info Cards */}
               <div className="flex flex-wrap justify-start gap-4 my-4">
                 {/* Wasserkosten Info Card */}
@@ -926,7 +926,7 @@ export function AbrechnungModal({
                         <Droplet className="h-5 w-5 text-muted-foreground" />
                       </CardHeader>
                       <CardContent>
-                        <div className="text-2xl font-semibold text-gray-800">
+                        <div className="text-2xl font-semibold text-foreground">
                           {formatCurrency(tenantData.waterCost.tenantShare)}
                         </div>
                       </CardContent>
@@ -960,7 +960,7 @@ export function AbrechnungModal({
                         <Landmark className="h-5 w-5 text-muted-foreground" />
                       </CardHeader>
                       <CardContent>
-                        <div className="text-2xl font-semibold text-gray-800">
+                        <div className="text-2xl font-semibold text-foreground">
                           {formatCurrency(tenantData.vorauszahlungen)}
                         </div>
                       </CardContent>
@@ -1024,7 +1024,7 @@ export function AbrechnungModal({
                             <span>Geleistete Vorauszahlungen:</span>
                             <span>{formatCurrency(tenantData.vorauszahlungen)}</span>
                           </div>
-                          <div className="h-px bg-gray-200 my-2"></div>
+                          <div className="h-px bg-border my-2"></div>
                           <div className="flex justify-between font-semibold">
                             <span>{isNachzahlung ? "Nachzahlung" : "Guthaben"}:</span>
                             <span className={amountColor}>{formatCurrency(tenantData.finalSettlement)}</span>
@@ -1032,18 +1032,18 @@ export function AbrechnungModal({
                           
                           {tenantData.recommendedPrepayment !== undefined && (
                             <>
-                              <div className="h-px bg-gray-200 my-2"></div>
+                              <div className="h-px bg-border my-2"></div>
                               <h4 className="font-semibold mt-3 mb-2">Empfehlung für nächsten Zeitraum</h4>
                               <div className="space-y-1">
                                 <div className="flex justify-between">
                                   <span>Empfohlene Vorauszahlung:</span>
                                   <span className="font-semibold">{formatCurrency(tenantData.recommendedPrepayment)}</span>
                                 </div>
-                                <div className="flex justify-between text-sm text-gray-600">
+                                <div className="flex justify-between text-sm text-muted-foreground">
                                   <span>Monatliche Rate:</span>
                                   <span>{formatCurrency(tenantData.recommendedPrepayment / 12)}</span>
                                 </div>
-                                <div className="text-xs text-gray-500 mt-1">
+                                <div className="text-xs text-muted-foreground mt-1">
                                   (basierend auf {formatCurrency(tenantData.totalTenantCost)} + {Math.round((PREPAYMENT_BUFFER_MULTIPLIER - 1) * 100)}% Puffer)
                                 </div>
                               </div>
@@ -1058,15 +1058,15 @@ export function AbrechnungModal({
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead className="text-gray-700">Kostenart</TableHead>
-                    <TableHead className="text-gray-700">Abrechnungsart</TableHead>
-                    <TableHead className="text-gray-700">Preis/qm</TableHead> {/* New Header */}
-                    <TableHead className="text-right text-gray-700">Anteil Mieter</TableHead>
+                    <TableHead className="text-foreground">Kostenart</TableHead>
+                    <TableHead className="text-foreground">Abrechnungsart</TableHead>
+                    <TableHead className="text-foreground">Preis/qm</TableHead> {/* New Header */}
+                    <TableHead className="text-right text-foreground">Anteil Mieter</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   {tenantData.costItems.map((item, index) => (
-                    <TableRow key={index} className={index % 2 === 0 ? "bg-gray-50" : ""}>
+                    <TableRow key={index} className={index % 2 === 0 ? "bg-muted/30" : ""}>
                       <TableCell className="py-2 px-3 align-top">{item.costName}</TableCell>
                       <TableCell className="py-2 px-3 align-top">{item.calculationType}</TableCell>
                       <TableCell className="py-2 px-3 align-top">{item.pricePerSqm ? formatCurrency(item.pricePerSqm) : '-'}</TableCell> {/* New Cell */}
@@ -1074,9 +1074,9 @@ export function AbrechnungModal({
                     </TableRow>
                   ))}
                   {/* Wasserkosten row removed from here */}
-                  <TableRow className="font-semibold bg-blue-50 border-t-2 border-gray-200">
-                    <TableCell className="py-3 px-3 text-blue-700">Gesamtkosten Mieter</TableCell>
-                    <TableCell className="py-3 px-3 text-blue-700"></TableCell> {/* For Abrechnungsart */}
+                  <TableRow className="font-semibold bg-primary/10 border-t-2 border-border">
+                    <TableCell className="py-3 px-3 text-primary">Gesamtkosten Mieter</TableCell>
+                    <TableCell className="py-3 px-3 text-primary"></TableCell> {/* For Abrechnungsart */}
                     <TableCell className="py-3 px-3 text-blue-700"></TableCell> {/* New empty cell for Preis/qm */}
                     <TableCell className="text-right py-3 px-3 text-blue-700">{formatCurrency(tenantData.totalTenantCost)}</TableCell>
                   </TableRow>

--- a/components/betriebskosten-edit-modal.tsx
+++ b/components/betriebskosten-edit-modal.tsx
@@ -605,7 +605,7 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
           
           <div className="space-y-6 overflow-y-auto max-h-[70vh] p-4">
             {/* Property & Period Selection Section */}
-            <div className="bg-gray-50 rounded-lg p-4 space-y-4">
+            <div className="bg-muted/50 rounded-lg p-4 space-y-4">
               {/* House Selection */}
               <div className="space-y-2">
                 <LabelWithTooltip htmlFor="formHausId" infoText="Wählen Sie das Haus aus, für das die Nebenkostenabrechnung erstellt wird.">
@@ -680,7 +680,7 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
                       return (
                         <div className="space-y-2">
                           {validation.isValid && validation.periodDays && (
-                            <div className="text-sm text-gray-600 bg-gray-50 p-2 rounded">
+                            <div className="text-sm text-muted-foreground bg-muted/50 p-2 rounded">
                               <strong>Abrechnungszeitraum:</strong> {formatPeriodDuration(startdatum, enddatum)}
                             </div>
                           )}

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -25,7 +25,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
     <div className="flex h-screen overflow-hidden bg-background">
       <DashboardSidebar />
       <div className="flex flex-1 flex-col overflow-hidden">
-        <header className="flex h-14 items-center gap-4 border-b bg-background px-6">
+        <header className="flex h-14 items-center gap-4 border-b bg-background px-6 dark:header-container">
           <div className="mx-auto w-full max-w-3xl">
             <Button
               variant="outline"

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -41,7 +41,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
           </div>
         </header>
         <main className="flex flex-1 flex-col min-h-0 p-6">
-          <div className="flex-1 overflow-y-auto rounded-xl bg-white border shadow-sm">
+          <div className="flex-1 overflow-y-auto rounded-xl bg-white dark:main-container border shadow-sm">
             {children}
           </div>
         </main>

--- a/components/dashboard-sidebar.tsx
+++ b/components/dashboard-sidebar.tsx
@@ -90,8 +90,8 @@ export function DashboardSidebar() {
           isOpen ? "translate-x-0" : "-translate-x-full",
         )}
       >
-        <div className="h-full w-full flex flex-col bg-background border-r border-border">
-          <div className="border-b px-6 py-4">
+        <div className="h-full w-full flex flex-col bg-background border-r border-border dark:sidebar-container">
+          <div className="border-b px-6 py-4 dark:sidebar-header">
             <Link href="/" className="flex items-center gap-2 font-semibold">
               <div className="relative w-8 h-8 rounded-full overflow-hidden">
                 <Image
@@ -133,7 +133,7 @@ export function DashboardSidebar() {
               })}
             </nav>
           </ScrollArea>
-          <div className="mt-auto border-t p-4 pb-6">
+          <div className="mt-auto border-t p-4 pb-6 dark:sidebar-footer">
             {/* The UserSettings component itself is now the sole display for user info in this area */}
             <UserSettings />
           </div>

--- a/components/last-transactions-container.tsx
+++ b/components/last-transactions-container.tsx
@@ -141,13 +141,13 @@ export function LastTransactionsContainer() {
               transactions.map((transaction) => (
                 <div
                   key={transaction.id}
-                  className="flex items-center justify-between p-3 rounded-lg border bg-white hover:bg-gray-50 transition-colors"
+                  className="flex items-center justify-between p-3 rounded-lg border bg-card hover:bg-muted/50 dark:table-row-hover transition-colors"
                 >
                   <div className="flex items-center gap-3 flex-1 min-w-0">
                     <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${
                       transaction.ist_einnahmen 
-                        ? 'bg-green-100 text-green-600' 
-                        : 'bg-red-100 text-red-600'
+                        ? 'bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400' 
+                        : 'bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400'
                     }`}>
                       {transaction.ist_einnahmen ? (
                         <ArrowUpRight className="h-4 w-4" />
@@ -172,7 +172,7 @@ export function LastTransactionsContainer() {
                   </div>
                   <div className="flex-shrink-0 text-right">
                     <p className={`text-sm font-semibold ${
-                      transaction.ist_einnahmen ? 'text-green-600' : 'text-red-600'
+                      transaction.ist_einnahmen ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
                     }`}>
                       {transaction.ist_einnahmen ? '+' : '-'}{formatCurrency(transaction.betrag)}
                     </p>
@@ -181,8 +181,8 @@ export function LastTransactionsContainer() {
               ))
             ) : (
               <div className="flex flex-col items-center justify-center h-full text-center">
-                <div className="w-12 h-12 rounded-full bg-gray-100 flex items-center justify-center mb-3">
-                  <ArrowUpRight className="h-6 w-6 text-gray-400" />
+                <div className="w-12 h-12 rounded-full bg-muted flex items-center justify-center mb-3">
+                  <ArrowUpRight className="h-6 w-6 text-muted-foreground" />
                 </div>
                 <p className="text-sm text-muted-foreground">Keine Transaktionen gefunden</p>
               </div>

--- a/components/settings-modal.tsx
+++ b/components/settings-modal.tsx
@@ -20,6 +20,7 @@ import Pricing from "@/app/modern/components/pricing"; // Corrected: Import Pric
 import { useDataExport } from '@/hooks/useDataExport'; // Import the custom hook
 import { useToast } from "@/hooks/use-toast"; // Import the custom toast hook
 import { Switch } from "@/components/ui/switch";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { getCookie, setCookie } from "@/utils/cookies";
 import { BETRIEBSKOSTEN_GUIDE_COOKIE, BETRIEBSKOSTEN_GUIDE_VISIBILITY_CHANGED } from "@/constants/guide";
 
@@ -689,27 +690,40 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
           {darkModeEnabled && (
             <div className="mt-6 p-4 bg-muted/30 rounded-lg transition-colors hover:bg-muted/50">
               <div className="flex items-start justify-between gap-4">
-                <div className="space-y-1">
+                <div className="space-y-1 flex-1">
                   <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-                    Dunkler Modus
+                    Design-Modus
                   </label>
                   <p className="text-xs text-muted-foreground">
-                    Wechseln Sie zwischen hellem und dunklem Design für bessere Sichtbarkeit.
+                    Wählen Sie zwischen hellem, dunklem Design oder folgen Sie den Systemeinstellungen.
                   </p>
                 </div>
-                <div className="flex-shrink-0">
-                  <Switch
-                    checked={theme === 'dark'}
-                    onCheckedChange={(checked) => {
-                      setTheme(checked ? 'dark' : 'light');
+                <div className="flex-shrink-0 w-32">
+                  <Select
+                    value={theme}
+                    onValueChange={(value) => {
+                      setTheme(value);
+                      const themeLabels = {
+                        light: 'Heller Modus',
+                        dark: 'Dunkler Modus',
+                        system: 'System-Modus'
+                      };
                       toast({
                         title: "Design geändert",
-                        description: `${checked ? 'Dunkler' : 'Heller'} Modus aktiviert.`,
+                        description: `${themeLabels[value as keyof typeof themeLabels]} aktiviert.`,
                         variant: "success",
                       });
                     }}
-                    className="data-[state=checked]:bg-primary data-[state=unchecked]:bg-input"
-                  />
+                  >
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder="Wählen Sie ein Design" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="light">Hell</SelectItem>
+                      <SelectItem value="dark">Dunkel</SelectItem>
+                      <SelectItem value="system">System</SelectItem>
+                    </SelectContent>
+                  </Select>
                 </div>
               </div>
             </div>

--- a/components/settings-modal.tsx
+++ b/components/settings-modal.tsx
@@ -82,6 +82,13 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
   const activeFlags = useActiveFeatureFlags()
   const darkModeEnabled = useFeatureFlagEnabled('dark-mode')
 
+  // Theme labels for toast messages
+  const themeLabels = {
+    light: 'Heller Modus',
+    dark: 'Dunkler Modus',
+    system: 'System-Modus'
+  };
+
   type EarlyAccessStage = 'concept' | 'beta' | 'alpha' | 'other'
   interface EarlyAccessFeature {
     flagKey: string
@@ -703,11 +710,6 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
                     value={theme}
                     onValueChange={(value) => {
                       setTheme(value);
-                      const themeLabels = {
-                        light: 'Heller Modus',
-                        dark: 'Dunkler Modus',
-                        system: 'System-Modus'
-                      };
                       toast({
                         title: "Design geändert",
                         description: `${themeLabels[value as keyof typeof themeLabels]} aktiviert.`,

--- a/components/settings-modal.tsx
+++ b/components/settings-modal.tsx
@@ -1,8 +1,9 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import { usePostHog, useActiveFeatureFlags } from 'posthog-js/react'
+import { usePostHog, useActiveFeatureFlags, useFeatureFlagEnabled } from 'posthog-js/react'
 import { useRouter } from 'next/navigation'
+import { useTheme } from "next-themes"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog" // DialogOverlay removed, DialogDescription added
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
@@ -64,6 +65,7 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
   const supabase = createClient()
   const { toast } = useToast()
   const router = useRouter()
+  const { theme, setTheme } = useTheme()
   const [activeTab, setActiveTab] = useState<string>("profile")
   const [firstName, setFirstName] = useState<string>("")
   const [lastName, setLastName] = useState<string>("")
@@ -77,6 +79,7 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
   // PostHog early access features
   const posthog = usePostHog()
   const activeFlags = useActiveFeatureFlags()
+  const darkModeEnabled = useFeatureFlagEnabled('dark-mode')
 
   type EarlyAccessStage = 'concept' | 'beta' | 'alpha' | 'other'
   interface EarlyAccessFeature {
@@ -683,6 +686,34 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
           <p className="text-sm text-muted-foreground">
             Passen Sie das Aussehen der Anwendung an Ihre Vorlieben an.
           </p>
+          {darkModeEnabled && (
+            <div className="mt-6 p-4 bg-muted/30 rounded-lg transition-colors hover:bg-muted/50">
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                    Dunkler Modus
+                  </label>
+                  <p className="text-xs text-muted-foreground">
+                    Wechseln Sie zwischen hellem und dunklem Design für bessere Sichtbarkeit.
+                  </p>
+                </div>
+                <div className="flex-shrink-0">
+                  <Switch
+                    checked={theme === 'dark'}
+                    onCheckedChange={(checked) => {
+                      setTheme(checked ? 'dark' : 'light');
+                      toast({
+                        title: "Design geändert",
+                        description: `${checked ? 'Dunkler' : 'Heller'} Modus aktiviert.`,
+                        variant: "success",
+                      });
+                    }}
+                    className="data-[state=checked]:bg-primary data-[state=unchecked]:bg-input"
+                  />
+                </div>
+              </div>
+            </div>
+          )}
           <div className="mt-6 p-4 bg-muted/30 rounded-lg transition-colors hover:bg-muted/50">
             <div className="flex items-start justify-between gap-4">
               <div className="space-y-1">

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -184,10 +184,10 @@ export function TenantPaymentBento() {
               data.map((tenant) => (
                 <div
                   key={tenant.id}
-                  className={`w-full flex items-center justify-between p-4 rounded-lg shadow-md bg-white border transition-colors duration-200 ${
+                  className={`w-full flex items-center justify-between p-4 rounded-lg shadow-md bg-card border transition-colors duration-200 ${
                     tenant.paid
-                      ? 'border-green-200 hover:bg-green-50/50'
-                      : 'border-red-200 hover:bg-red-50/50'
+                      ? 'border-green-200 dark:border-green-800 hover:bg-green-50/50 dark:hover:bg-green-900/20'
+                      : 'border-red-200 dark:border-red-800 hover:bg-red-50/50 dark:hover:bg-red-900/20'
                   }`}
                 >
                   {/* Left side: Tenant name and apartment */}
@@ -205,7 +205,7 @@ export function TenantPaymentBento() {
                   {/* Right side: Price and payment button */}
                   <div className="flex flex-col items-end gap-2">
                     <div className={`flex items-center gap-1 font-medium ${
-                      tenant.paid ? 'text-green-600' : 'text-red-600'
+                      tenant.paid ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
                     }`}>
                       <Tag className="h-3 w-3" />
                       <span>{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(tenant.mieteRaw)}</span>
@@ -215,8 +215,8 @@ export function TenantPaymentBento() {
                       className={
                         `px-3 py-1 rounded-full text-xs font-medium border transition-colors duration-150 ${
                           tenant.paid
-                            ? 'bg-green-50 text-green-700 border-green-200 hover:bg-green-100'
-                            : 'bg-red-50 text-red-700 border-red-200 hover:bg-red-100'
+                            ? 'bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300 border-green-200 dark:border-green-700 hover:bg-green-100 dark:hover:bg-green-900/50'
+                            : 'bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 border-red-200 dark:border-red-700 hover:bg-red-100 dark:hover:bg-red-900/50'
                         }`
                       }
                       disabled={updatingStatus === tenant.id}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -13,10 +13,10 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-gray-200 hover:text-foreground",
+          "border border-input bg-background hover:bg-gray-200 hover:text-foreground dark:btn-outline-hover",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-gray-200 hover:text-foreground",
+        ghost: "hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/components/ui/context-menu.tsx
+++ b/components/ui/context-menu.tsx
@@ -27,7 +27,7 @@ const ContextMenuSubTrigger = React.forwardRef<
   <ContextMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-gray-200 focus:text-foreground data-[state=open]:bg-gray-200 data-[state=open]:text-foreground",
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-gray-200 focus:text-foreground data-[state=open]:bg-gray-200 data-[state=open]:text-foreground dark:context-menu-subtrigger",
       inset && "pl-8",
       className
     )}
@@ -80,7 +80,7 @@ const ContextMenuItem = React.forwardRef<
   <ContextMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-gray-200 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-gray-200 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:context-menu-item",
       inset && "pl-8",
       className
     )}
@@ -96,7 +96,7 @@ const ContextMenuCheckboxItem = React.forwardRef<
   <ContextMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-gray-200 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-gray-200 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:context-menu-checkbox",
       className
     )}
     checked={checked}
@@ -120,7 +120,7 @@ const ContextMenuRadioItem = React.forwardRef<
   <ContextMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-gray-200 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-gray-200 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:context-menu-radio",
       className
     )}
     {...props}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -81,7 +81,7 @@ const DialogContent = React.forwardRef<
         {!hideCloseButton && (
           <DialogPrimitive.Close
             onClick={handleCloseButtonClick}
-            className="absolute right-4 top-4 rounded-full p-3 opacity-70 ring-offset-background transition-all hover:opacity-100 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
+            className="absolute right-4 top-4 rounded-full p-3 opacity-70 ring-offset-background transition-all hover:opacity-100 hover:bg-gray-200 dark:modal-close-hover focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
           >
             <X className="h-4 w-4" />
             <span className="sr-only">Close</span>

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -58,7 +58,7 @@ const TableRow = React.forwardRef<
   <tr
     ref={ref}
     className={cn(
-      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      "border-b transition-colors hover:bg-muted/50 dark:table-row-hover data-[state=selected]:bg-muted",
       className
     )}
     {...props}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -46,6 +46,7 @@ foreground: "hsl(var(--destructive-foreground))",
         "btn-hover": "hsl(var(--btn-hover))",
         "text-disabled": "hsl(var(--text-disabled))",
         "input-placeholder": "hsl(var(--input-placeholder))",
+        "main-container": "hsl(var(--main-container))",
         muted: {
           DEFAULT: "hsl(var(--muted))",
           foreground: "hsl(var(--muted-foreground))",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -57,6 +57,11 @@ foreground: "hsl(var(--destructive-foreground))",
         "table-row-hover": "hsl(var(--primary) / 0.1)",
         "btn-outline-hover": "hsl(var(--primary) / 0.15)",
         "btn-ghost-hover": "hsl(var(--primary) / 0.12)",
+        // Context menu styles
+        "context-menu-item": "hsl(var(--primary) / 0.15)",
+        "context-menu-subtrigger": "hsl(var(--primary) / 0.15)",
+        "context-menu-checkbox": "hsl(var(--primary) / 0.15)",
+        "context-menu-radio": "hsl(var(--primary) / 0.15)",
         "modal-close-hover": "hsl(var(--primary) / 0.15)",
         muted: {
           DEFAULT: "hsl(var(--muted))",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -48,9 +48,9 @@ foreground: "hsl(var(--destructive-foreground))",
         "input-placeholder": "hsl(var(--input-placeholder))",
         "main-container": "hsl(var(--main-container))",
         // Sidebar styling
-        "sidebar-container": "hsl(var(--secondary))",
-        "sidebar-header": "hsl(var(--secondary))",
-        "sidebar-footer": "hsl(var(--secondary))",
+        "sidebar-container": "hsl(var(--background))",
+        "sidebar-header": "hsl(var(--background))",
+        "sidebar-footer": "hsl(var(--background))",
         muted: {
           DEFAULT: "hsl(var(--muted))",
           foreground: "hsl(var(--muted-foreground))",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -41,6 +41,11 @@ foreground: "hsl(var(--destructive-foreground))",
           DEFAULT: "#22c55e", // green-500
           foreground: "#ffffff", // white
         },
+        // Custom dark mode colors
+        "btn-bg": "hsl(var(--btn-bg))",
+        "btn-hover": "hsl(var(--btn-hover))",
+        "text-disabled": "hsl(var(--text-disabled))",
+        "input-placeholder": "hsl(var(--input-placeholder))",
         muted: {
           DEFAULT: "hsl(var(--muted))",
           foreground: "hsl(var(--muted-foreground))",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -53,6 +53,10 @@ foreground: "hsl(var(--destructive-foreground))",
         "sidebar-footer": "hsl(var(--background))",
         // Header styling
         "header-container": "hsl(var(--background))",
+        // Enhanced hover styles
+        "table-row-hover": "hsl(var(--primary) / 0.1)",
+        "btn-outline-hover": "hsl(var(--primary) / 0.15)",
+        "btn-ghost-hover": "hsl(var(--primary) / 0.12)",
         muted: {
           DEFAULT: "hsl(var(--muted))",
           foreground: "hsl(var(--muted-foreground))",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -47,6 +47,10 @@ foreground: "hsl(var(--destructive-foreground))",
         "text-disabled": "hsl(var(--text-disabled))",
         "input-placeholder": "hsl(var(--input-placeholder))",
         "main-container": "hsl(var(--main-container))",
+        // Sidebar styling
+        "sidebar-container": "hsl(var(--secondary))",
+        "sidebar-header": "hsl(var(--secondary))",
+        "sidebar-footer": "hsl(var(--secondary))",
         muted: {
           DEFAULT: "hsl(var(--muted))",
           foreground: "hsl(var(--muted-foreground))",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -51,6 +51,8 @@ foreground: "hsl(var(--destructive-foreground))",
         "sidebar-container": "hsl(var(--background))",
         "sidebar-header": "hsl(var(--background))",
         "sidebar-footer": "hsl(var(--background))",
+        // Header styling
+        "header-container": "hsl(var(--background))",
         muted: {
           DEFAULT: "hsl(var(--muted))",
           foreground: "hsl(var(--muted-foreground))",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -57,6 +57,7 @@ foreground: "hsl(var(--destructive-foreground))",
         "table-row-hover": "hsl(var(--primary) / 0.1)",
         "btn-outline-hover": "hsl(var(--primary) / 0.15)",
         "btn-ghost-hover": "hsl(var(--primary) / 0.12)",
+        "modal-close-hover": "hsl(var(--primary) / 0.15)",
         muted: {
           DEFAULT: "hsl(var(--muted))",
           foreground: "hsl(var(--muted-foreground))",


### PR DESCRIPTION
## Description

Adds the dark theme: custom palette, a theme switcher in settings, and dark variants across the app.

## Summary of Changes

- Complete dark palette in `globals.css`: `#181818` background, `#22272e` elevated cards, darker-blue primary/accent for hovers, plus helper classes for sidebar/header borders, table-row/button/context-menu/modal-close hovers and the main container
- Settings → Darstellung: theme select (Hell/Dunkel/System) behind the `dark-mode` feature flag, with a confirmation toast; the theme provider now follows the system preference (`enableSystem`)
- Hard-coded grays replaced with theme tokens (`text-foreground`, `bg-muted/50`, `bg-card`, `border-border`) across the Abrechnung/Betriebskosten modals, dashboard, transactions, payment bento, buttons, context menus, dialog and table; green/red status colors get dark variants
- `tailwind.config.ts`: new color tokens for the custom dark utilities