### PR TITLE
Refactor/max depth

### DIFF
--- a/components/cloud-storage-quick-actions.tsx
+++ b/components/cloud-storage-quick-actions.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useMemo } from "react"
+import { useState } from "react"
 import { 
   Upload, 
   FolderPlus, 

--- a/components/dashboard-sidebar.tsx
+++ b/components/dashboard-sidebar.tsx
@@ -105,7 +105,7 @@ export function DashboardSidebar() {
               <span className="text-lg">Mietfluss</span>
             </Link>
           </div>
-          <SimpleScrollArea className="flex-1 pt-4 pb-4" key="sidebar-scroll">
+          <SimpleScrollArea className="flex-1 pt-4 pb-4">
             <nav className="grid gap-1 px-2 pr-4">
               {sidebarNavItems.map((item) => {
                 const isActive = isRouteActive(item.href)

--- a/components/dashboard-sidebar.tsx
+++ b/components/dashboard-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useMemo } from "react"
+import { useState } from "react"
 import Link from "next/link"
 import Image from "next/image"
 import { usePathname } from "next/navigation"

--- a/components/ui/custom-dropdown.tsx
+++ b/components/ui/custom-dropdown.tsx
@@ -36,6 +36,20 @@ export function CustomDropdown({ children, trigger, align = "end", className }: 
   const dropdownRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLDivElement>(null)
 
+  // Focus management effect
+  useEffect(() => {
+    if (isOpen && dropdownRef.current) {
+      // Focus first menu item when dropdown opens
+      const firstMenuItem = dropdownRef.current.querySelector('[role="menuitem"]:not([aria-disabled="true"])') as HTMLElement
+      if (firstMenuItem) {
+        firstMenuItem.focus()
+      }
+    } else if (!isOpen && triggerRef.current) {
+      // Return focus to trigger when dropdown closes
+      triggerRef.current.focus()
+    }
+  }, [isOpen])
+
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (
@@ -96,7 +110,20 @@ export function CustomDropdown({ children, trigger, align = "end", className }: 
 
   return (
     <div className="relative">
-      <div ref={triggerRef} onClick={handleTriggerClick}>
+      <div 
+        ref={triggerRef} 
+        onClick={handleTriggerClick}
+        role="button"
+        tabIndex={0}
+        aria-expanded={isOpen}
+        aria-haspopup="menu"
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleTriggerClick();
+          }
+        }}
+      >
         {trigger}
       </div>
       

--- a/components/ui/custom-dropdown.tsx
+++ b/components/ui/custom-dropdown.tsx
@@ -100,6 +100,7 @@ export function CustomDropdown({ children, trigger, align = "end", className }: 
       {isOpen && (
         <div
           ref={dropdownRef}
+          role="menu"
           className={cn(
             "absolute z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
             "animate-in fade-in-0 zoom-in-95 duration-200",
@@ -121,7 +122,7 @@ export function CustomDropdown({ children, trigger, align = "end", className }: 
 
 const CustomDropdownContext = React.createContext<{ closeDropdown: () => void } | null>(null)
 
-export function CustomDropdownItem({ children, onClick, disabled = false, className }: CustomDropdownItemProps) {
+export function CustomDropdownItem({ children, onClick, disabled = false, className, ...props }: CustomDropdownItemProps & React.HTMLAttributes<HTMLDivElement>) {
   const context = React.useContext(CustomDropdownContext)
   
   const handleClick = () => {
@@ -131,8 +132,18 @@ export function CustomDropdownItem({ children, onClick, disabled = false, classN
     }
   }
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleClick();
+    }
+  };
+
   return (
     <div
+      role="menuitem"
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled}
       className={cn(
         "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors",
         disabled
@@ -141,6 +152,8 @@ export function CustomDropdownItem({ children, onClick, disabled = false, classN
         className
       )}
       onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      {...props}
     >
       {children}
     </div>

--- a/components/ui/custom-dropdown.tsx
+++ b/components/ui/custom-dropdown.tsx
@@ -4,6 +4,9 @@ import * as React from "react"
 import { useState, useRef, useEffect } from "react"
 import { cn } from "@/lib/utils"
 
+// Minimum space required below trigger before opening dropdown upward
+const DROPDOWN_MIN_SPACE_BELOW = 200
+
 interface CustomDropdownProps {
   children: React.ReactNode
   trigger: React.ReactNode
@@ -71,7 +74,7 @@ export function CustomDropdown({ children, trigger, align = "end", className }: 
       const spaceAbove = triggerRect.top
       
       // If there's more space above and not enough space below, open upward
-      if (spaceAbove > spaceBelow && spaceBelow < 200) {
+      if (spaceAbove > spaceBelow && spaceBelow < DROPDOWN_MIN_SPACE_BELOW) {
         setPosition("top")
       } else {
         setPosition("bottom")

--- a/components/user-settings.tsx
+++ b/components/user-settings.tsx
@@ -115,6 +115,7 @@ export function UserSettings() {
         {templateModalEnabled && (
           <CustomDropdownItem 
             onClick={openTemplatesModal}
+            aria-label={ARIA_LABELS.templatesModal}
           >
             <FileText className="mr-2 h-4 w-4" aria-hidden="true" />
             <span>Vorlagen</span>

--- a/components/user-settings.tsx
+++ b/components/user-settings.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useMemo } from "react"
+import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { createClient } from "@/utils/supabase/client"
 import type { User } from "@supabase/supabase-js"


### PR DESCRIPTION
## Description

Polishes the custom dropdown: focus management, keyboard support and small cleanups.

## Summary of Changes

- CustomDropdown: focus moves to the first enabled menu item on open and returns to the trigger on close; trigger and items get proper menu/menuitem roles, `aria-expanded`/`-disabled` and Enter/Space handling; the upward-flip threshold is a named constant
- User settings: templates item gets an aria-label; unused `useMemo` imports removed (sidebar, quick actions, user settings); leftover `key` prop dropped from the sidebar scroll area