### PR TITLE
Fix/dropdown menus

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -419,6 +419,31 @@
     }
   }
 
+  /* Custom scrollbar styling for combobox dropdowns */
+  [data-scroll-area]::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  [data-scroll-area]::-webkit-scrollbar-track {
+    background: transparent;
+    border-radius: 4px;
+  }
+
+  [data-scroll-area]::-webkit-scrollbar-thumb {
+    background-color: hsl(var(--muted-foreground) / 0.3);
+    border-radius: 4px;
+    border: 2px solid transparent;
+    background-clip: content-box;
+  }
+
+  [data-scroll-area]::-webkit-scrollbar-thumb:hover {
+    background-color: hsl(var(--muted-foreground) / 0.5);
+  }
+
+  [data-scroll-area]::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+
   /* Responsive text truncation */
   .truncate-mobile {
     max-width: 120px;

--- a/app/globals.css
+++ b/app/globals.css
@@ -130,6 +130,17 @@
 
 @layer base {
   :root {
+    /* Z-index management */
+    --z-index-dropdown: 1000;
+    --z-index-sticky: 1020;
+    --z-index-fixed: 1030;
+    --z-index-modal-backdrop: 1040;
+    --z-index-modal: 1050;
+    --z-index-popover: 1060;
+    --z-index-tooltip: 1070;
+    --z-index-toast: 1080;
+    --z-index-portal-dropdown: 99999;
+
     /* Neue Farbpalette */
     --primary-color: #2c3e50;
     --secondary-color: #34495e;

--- a/app/globals.css
+++ b/app/globals.css
@@ -139,7 +139,8 @@
     --z-index-popover: 1060;
     --z-index-tooltip: 1070;
     --z-index-toast: 1080;
-    --z-index-portal-dropdown: 99999;
+    /* Portal dropdowns need to be above all other UI elements to prevent clipping */
+    --z-index-portal-dropdown: 1100;
 
     /* Neue Farbpalette */
     --primary-color: #2c3e50;

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -107,15 +107,15 @@ function Calendar({
           };
 
           // Check if we can navigate to previous/next month based on year constraints
-          const canGoPrevious = () => {
+          const canGoPrevious = React.useCallback(() => {
             const prevMonth = subMonths(displayMonth, 1);
             return getYear(prevMonth) >= startYear;
-          };
+          }, [displayMonth, startYear]);
 
-          const canGoNext = () => {
+          const canGoNext = React.useCallback(() => {
             const nextMonth = addMonths(displayMonth, 1);
             return getYear(nextMonth) <= endYear;
-          };
+          }, [displayMonth, endYear]);
 
           const years = [];
           for (let i = startYear; i <= endYear; i++) {

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -117,10 +117,7 @@ function Calendar({
             return getYear(nextMonth) <= endYear;
           }, [displayMonth, endYear]);
 
-          const years = [];
-          for (let i = startYear; i <= endYear; i++) {
-            years.push(i);
-          }
+          const years = Array.from({ length: endYear - startYear + 1 }, (_, i) => startYear + i);
 
           const months = Array.from({ length: 12 }, (_, i) => ({
             value: i,

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { ChevronLeft, ChevronRight } from "lucide-react"
 import { DayPicker, DropdownProps, CaptionProps, useNavigation } from "react-day-picker" // Import useNavigation
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+// Removed Radix Select imports - using native select elements instead
 import { getYear, getMonth, setYear, setMonth } from "date-fns"
 import { de } from "date-fns/locale"
 
@@ -73,7 +73,7 @@ function Calendar({
       components={{
         IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" />,
         IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" />,
-        // Provide a custom Caption component
+        // Provide a custom Caption component with native select elements
         Caption: ({ displayMonth }: CaptionProps) => {
           const { goToMonth } = useNavigation(); // Use useNavigation hook
           const currentYear = getYear(displayMonth);
@@ -82,14 +82,16 @@ function Calendar({
           const startYear = fromYear;
           const endYear = toYear;
 
-          const handleMonthChange = (newMonthIndex: string) => {
-            const newDate = setMonth(displayMonth, parseInt(newMonthIndex, 10));
-            goToMonth(newDate); // Use goToMonth from useNavigation
+          const handleMonthChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+            const newMonthIndex = parseInt(e.target.value, 10);
+            const newDate = setMonth(displayMonth, newMonthIndex);
+            goToMonth(newDate);
           };
 
-          const handleYearChange = (newYear: string) => {
-            const newDate = setYear(displayMonth, parseInt(newYear, 10));
-            goToMonth(newDate); // Use goToMonth from useNavigation
+          const handleYearChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+            const newYear = parseInt(e.target.value, 10);
+            const newDate = setYear(displayMonth, newYear);
+            goToMonth(newDate);
           };
 
           const years = [];
@@ -99,41 +101,35 @@ function Calendar({
 
           const months = Array.from({ length: 12 }, (_, i) => ({
             value: i,
-            label: de.localize?.month(i, { width: 'wide' }) ?? i + 1
+            label: de.localize?.month(i, { width: 'wide' }) ?? `Monat ${i + 1}`
           }));
 
           return (
             <div className="flex justify-center pt-1 relative items-center space-x-2">
-              <Select
-                value={currentMonth.toString()}
-                onValueChange={handleMonthChange}
+              <select
+                value={currentMonth}
+                onChange={handleMonthChange}
+                className="h-7 w-[100px] px-2 py-1 text-xs rounded-md border border-input bg-background text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 relative z-[70] pointer-events-auto"
+                style={{ pointerEvents: 'auto' }}
               >
-                <SelectTrigger className="h-7 w-[100px] px-2 py-1 text-xs">
-                  <SelectValue placeholder="Monat" />
-                </SelectTrigger>
-                <SelectContent>
-                  {months.map((month) => (
-                    <SelectItem key={month.value} value={month.value.toString()}>
-                      {month.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <Select
-                value={currentYear.toString()}
-                onValueChange={handleYearChange}
+                {months.map((month) => (
+                  <option key={month.value} value={month.value}>
+                    {month.label}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={currentYear}
+                onChange={handleYearChange}
+                className="h-7 w-[70px] px-2 py-1 text-xs rounded-md border border-input bg-background text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 relative z-[70] pointer-events-auto"
+                style={{ pointerEvents: 'auto' }}
               >
-                <SelectTrigger className="h-7 w-[70px] px-2 py-1 text-xs">
-                  <SelectValue placeholder="Jahr" />
-                </SelectTrigger>
-                <SelectContent>
-                  {years.map((year) => (
-                    <SelectItem key={year} value={year.toString()}>
-                      {year}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                {years.map((year) => (
+                  <option key={year} value={year}>
+                    {year}
+                  </option>
+                ))}
+              </select>
             </div>
           );
         },

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -2,13 +2,19 @@
 
 import * as React from "react"
 import { ChevronLeft, ChevronRight } from "lucide-react"
-import { DayPicker, DropdownProps, CaptionProps, useNavigation } from "react-day-picker" // Import useNavigation
-// Removed Radix Select imports - using native select elements instead
+import { DayPicker, DropdownProps, CaptionProps, useNavigation } from "react-day-picker"
 import { getYear, getMonth, setYear, setMonth } from "date-fns"
 import { de } from "date-fns/locale"
 
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker> & {
   captionLayout?: "buttons" | "dropdown" // Keep this prop for potential future use or compatibility, but custom Caption handles dropdown logic
@@ -73,23 +79,22 @@ function Calendar({
       components={{
         IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" />,
         IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" />,
-        // Provide a custom Caption component with native select elements
+        // Provide a custom Caption component with custom Select dropdowns
         Caption: ({ displayMonth }: CaptionProps) => {
-          const { goToMonth } = useNavigation(); // Use useNavigation hook
+          const { goToMonth } = useNavigation();
           const currentYear = getYear(displayMonth);
           const currentMonth = getMonth(displayMonth);
-          // Use fromYear and toYear from the outer Calendar component props
           const startYear = fromYear;
           const endYear = toYear;
 
-          const handleMonthChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-            const newMonthIndex = parseInt(e.target.value, 10);
+          const handleMonthChange = (value: string) => {
+            const newMonthIndex = parseInt(value, 10);
             const newDate = setMonth(displayMonth, newMonthIndex);
             goToMonth(newDate);
           };
 
-          const handleYearChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-            const newYear = parseInt(e.target.value, 10);
+          const handleYearChange = (value: string) => {
+            const newYear = parseInt(value, 10);
             const newDate = setYear(displayMonth, newYear);
             goToMonth(newDate);
           };
@@ -106,30 +111,30 @@ function Calendar({
 
           return (
             <div className="flex justify-center pt-1 relative items-center space-x-2">
-              <select
-                value={currentMonth}
-                onChange={handleMonthChange}
-                className="h-7 w-[100px] px-2 py-1 text-xs rounded-md border border-input bg-background text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 relative z-[70] pointer-events-auto"
-                style={{ pointerEvents: 'auto' }}
-              >
-                {months.map((month) => (
-                  <option key={month.value} value={month.value}>
-                    {month.label}
-                  </option>
-                ))}
-              </select>
-              <select
-                value={currentYear}
-                onChange={handleYearChange}
-                className="h-7 w-[70px] px-2 py-1 text-xs rounded-md border border-input bg-background text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 relative z-[70] pointer-events-auto"
-                style={{ pointerEvents: 'auto' }}
-              >
-                {years.map((year) => (
-                  <option key={year} value={year}>
-                    {year}
-                  </option>
-                ))}
-              </select>
+              <Select value={currentMonth.toString()} onValueChange={handleMonthChange}>
+                <SelectTrigger className="h-7 w-[120px] text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {months.map((month) => (
+                    <SelectItem key={month.value} value={month.value.toString()}>
+                      {month.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <Select value={currentYear.toString()} onValueChange={handleYearChange}>
+                <SelectTrigger className="h-7 w-[80px] text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {years.map((year) => (
+                    <SelectItem key={year} value={year.toString()}>
+                      {year}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
           );
         },

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -3,11 +3,11 @@
 import * as React from "react"
 import { ChevronLeft, ChevronRight } from "lucide-react"
 import { DayPicker, DropdownProps, CaptionProps, useNavigation } from "react-day-picker"
-import { getYear, getMonth, setYear, setMonth } from "date-fns"
+import { getYear, getMonth, setYear, setMonth, addMonths, subMonths } from "date-fns"
 import { de } from "date-fns/locale"
 
 import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import { buttonVariants, Button } from "@/components/ui/button"
 import {
   Select,
   SelectContent,
@@ -47,13 +47,10 @@ function Calendar({
         //   "hidden": captionLayout === 'dropdown',
         // }),
         // caption_dropdowns: "flex space-x-2",
-        nav: "space-x-1 flex items-center",
-        nav_button: cn(
-          buttonVariants({ variant: "outline" }),
-          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
-        ),
-        nav_button_previous: "absolute left-1",
-        nav_button_next: "absolute right-1",
+        nav: "hidden", // Hide default navigation since we have custom navigation in Caption
+        nav_button: "hidden",
+        nav_button_previous: "hidden",
+        nav_button_next: "hidden",
         table: "w-full border-collapse space-y-1",
         head_row: "flex",
         head_cell:
@@ -79,7 +76,7 @@ function Calendar({
       components={{
         IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" />,
         IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" />,
-        // Provide a custom Caption component with custom Select dropdowns
+        // Provide a custom Caption component with navigation arrows and dropdowns
         Caption: ({ displayMonth }: CaptionProps) => {
           const { goToMonth } = useNavigation();
           const currentYear = getYear(displayMonth);
@@ -99,6 +96,27 @@ function Calendar({
             goToMonth(newDate);
           };
 
+          const handlePreviousMonth = () => {
+            const previousMonth = subMonths(displayMonth, 1);
+            goToMonth(previousMonth);
+          };
+
+          const handleNextMonth = () => {
+            const nextMonth = addMonths(displayMonth, 1);
+            goToMonth(nextMonth);
+          };
+
+          // Check if we can navigate to previous/next month based on year constraints
+          const canGoPrevious = () => {
+            const prevMonth = subMonths(displayMonth, 1);
+            return getYear(prevMonth) >= startYear;
+          };
+
+          const canGoNext = () => {
+            const nextMonth = addMonths(displayMonth, 1);
+            return getYear(nextMonth) <= endYear;
+          };
+
           const years = [];
           for (let i = startYear; i <= endYear; i++) {
             years.push(i);
@@ -110,31 +128,60 @@ function Calendar({
           }));
 
           return (
-            <div className="flex justify-center pt-1 relative items-center space-x-2">
-              <Select value={currentMonth.toString()} onValueChange={handleMonthChange}>
-                <SelectTrigger className="h-7 w-[120px] text-xs">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {months.map((month) => (
-                    <SelectItem key={month.value} value={month.value.toString()}>
-                      {month.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <Select value={currentYear.toString()} onValueChange={handleYearChange}>
-                <SelectTrigger className="h-7 w-[80px] text-xs">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {years.map((year) => (
-                    <SelectItem key={year} value={year.toString()}>
-                      {year}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+            <div className="flex justify-between items-center pt-1 relative w-full">
+              {/* Left arrow button */}
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 disabled:opacity-25"
+                onClick={handlePreviousMonth}
+                disabled={!canGoPrevious()}
+                type="button"
+                aria-label="Vorheriger Monat"
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+
+              {/* Center dropdowns */}
+              <div className="flex items-center space-x-2">
+                <Select value={currentMonth.toString()} onValueChange={handleMonthChange}>
+                  <SelectTrigger className="h-7 w-[120px] text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {months.map((month) => (
+                      <SelectItem key={month.value} value={month.value.toString()}>
+                        {month.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Select value={currentYear.toString()} onValueChange={handleYearChange}>
+                  <SelectTrigger className="h-7 w-[80px] text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {years.map((year) => (
+                      <SelectItem key={year} value={year.toString()}>
+                        {year}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Right arrow button */}
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 disabled:opacity-25"
+                onClick={handleNextMonth}
+                disabled={!canGoNext()}
+                type="button"
+                aria-label="Nächster Monat"
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
             </div>
           );
         },

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -18,7 +18,6 @@ const Command = React.forwardRef<
       "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground pointer-events-auto",
       className
     )}
-    style={{ pointerEvents: 'auto' }}
     {...props}
   />
 ))
@@ -45,7 +44,6 @@ const CommandInput = React.forwardRef<
     className="flex items-center border-b px-3 pointer-events-auto" 
     cmdk-input-wrapper=""
     cmdk-input=""
-    style={{ pointerEvents: 'auto' }}
   >
     <Search className="mr-2 h-4 w-4 shrink-0 opacity-50 pointer-events-none" />
     <CommandPrimitive.Input
@@ -54,7 +52,6 @@ const CommandInput = React.forwardRef<
         "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 pointer-events-auto",
         className
       )}
-      style={{ pointerEvents: 'auto' }}
       cmdk-input=""
       {...props}
     />
@@ -70,7 +67,6 @@ const CommandList = React.forwardRef<
   <CommandPrimitive.List
     ref={ref}
     className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden pointer-events-auto", className)}
-    style={{ pointerEvents: 'auto' }}
     cmdk-list=""
     onWheel={(event) => event.stopPropagation()}
     {...props}
@@ -130,7 +126,6 @@ const CommandItem = React.forwardRef<
       "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:!bg-muted data-[selected=true]:!text-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 pointer-events-auto",
       className
     )}
-    style={{ pointerEvents: 'auto' }}
     cmdk-item=""
     {...props}
   />

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -43,7 +43,6 @@ const CommandInput = React.forwardRef<
   <div 
     className="flex items-center border-b px-3 pointer-events-auto" 
     cmdk-input-wrapper=""
-    cmdk-input=""
   >
     <Search className="mr-2 h-4 w-4 shrink-0 opacity-50 pointer-events-none" />
     <CommandPrimitive.Input

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -15,9 +15,10 @@ const Command = React.forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn(
-      "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+      "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground pointer-events-auto",
       className
     )}
+    style={{ pointerEvents: 'auto' }}
     {...props}
   />
 ))
@@ -40,14 +41,21 @@ const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
-  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+  <div 
+    className="flex items-center border-b px-3 pointer-events-auto" 
+    cmdk-input-wrapper=""
+    cmdk-input=""
+    style={{ pointerEvents: 'auto' }}
+  >
+    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50 pointer-events-none" />
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 pointer-events-auto",
         className
       )}
+      style={{ pointerEvents: 'auto' }}
+      cmdk-input=""
       {...props}
     />
   </div>
@@ -61,7 +69,9 @@ const CommandList = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.List
     ref={ref}
-    className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+    className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden pointer-events-auto", className)}
+    style={{ pointerEvents: 'auto' }}
+    cmdk-list=""
     onWheel={(event) => event.stopPropagation()}
     {...props}
   />
@@ -117,9 +127,11 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:!bg-muted data-[selected=true]:!text-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected='true']:!bg-muted data-[selected=true]:!text-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 pointer-events-auto",
       className
     )}
+    style={{ pointerEvents: 'auto' }}
+    cmdk-item=""
     {...props}
   />
 ))

--- a/components/ui/custom-combobox.tsx
+++ b/components/ui/custom-combobox.tsx
@@ -74,7 +74,9 @@ export function CustomCombobox({
       const focusInput = () => {
         if (inputRef.current) {
           // Remove any existing focus
-          document.activeElement?.blur?.()
+          if (document.activeElement && 'blur' in document.activeElement) {
+            (document.activeElement as HTMLElement).blur()
+          }
           
           // Force focus with multiple attempts
           inputRef.current.focus()

--- a/components/ui/custom-combobox.tsx
+++ b/components/ui/custom-combobox.tsx
@@ -78,9 +78,8 @@ export function CustomCombobox({
             (document.activeElement as HTMLElement).blur()
           }
           
-          // Force focus with multiple attempts
+          // Force focus
           inputRef.current.focus()
-          inputRef.current.click()
           
           // Set cursor to end
           const len = inputRef.current.value.length
@@ -88,13 +87,9 @@ export function CustomCombobox({
         }
       }
 
-      // Try focusing immediately
+      // Try focusing immediately and again after a short delay to handle race conditions
       focusInput()
-      
-      // Try again after a short delay
-      setTimeout(focusInput, 10)
       setTimeout(focusInput, 50)
-      setTimeout(focusInput, 100)
     }
   }, [open])
 

--- a/components/ui/custom-combobox.tsx
+++ b/components/ui/custom-combobox.tsx
@@ -68,7 +68,11 @@ export function CustomCombobox({
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className={cn("p-0", width)} align="start">
+      <PopoverContent 
+        className={cn("p-0 pointer-events-auto", width)} 
+        align="start"
+        style={{ zIndex: 9999, pointerEvents: 'auto' }}
+      >
         <Command>
           <CommandInput placeholder={searchPlaceholder} />
           <CommandList>

--- a/components/ui/custom-combobox.tsx
+++ b/components/ui/custom-combobox.tsx
@@ -185,7 +185,7 @@ export function CustomCombobox({
             top: buttonRect.bottom + window.scrollY + 4,
             left: buttonRect.left + window.scrollX,
             width: buttonRect.width,
-            zIndex: 99999, // Even higher z-index
+            zIndex: 'var(--z-index-portal-dropdown)',
             pointerEvents: 'auto'
           }}
           onMouseDown={(e) => {

--- a/components/ui/custom-combobox.tsx
+++ b/components/ui/custom-combobox.tsx
@@ -87,9 +87,9 @@ export function CustomCombobox({
         }
       }
 
-      // Try focusing immediately and again after a short delay to handle race conditions
+      // Try focusing immediately and again after the next frame to handle race conditions
       focusInput()
-      setTimeout(focusInput, 50)
+      requestAnimationFrame(focusInput)
     }
   }, [open])
 

--- a/components/ui/custom-combobox.tsx
+++ b/components/ui/custom-combobox.tsx
@@ -3,6 +3,7 @@
 
 import * as React from "react"
 import { Check, ChevronsUpDown } from "lucide-react"
+import { createPortal } from "react-dom"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -50,57 +51,209 @@ export function CustomCombobox({
   id,
 }: CustomComboboxProps) {
   const [open, setOpen] = React.useState(false)
+  const [inputValue, setInputValue] = React.useState("")
+  const [buttonRect, setButtonRect] = React.useState<DOMRect | null>(null)
+  const buttonRef = React.useRef<HTMLButtonElement>(null)
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  const dropdownRef = React.useRef<HTMLDivElement>(null)
 
   const selectedOption = options.find((option) => option.value === value)
 
+  // Reset input when opening/closing
+  React.useEffect(() => {
+    if (!open) {
+      setInputValue("")
+    } else {
+      // Get button position when opening
+      if (buttonRef.current) {
+        const rect = buttonRef.current.getBoundingClientRect()
+        setButtonRect(rect)
+      }
+      
+      // AGGRESSIVE focus management - try multiple approaches
+      const focusInput = () => {
+        if (inputRef.current) {
+          // Remove any existing focus
+          document.activeElement?.blur?.()
+          
+          // Force focus with multiple attempts
+          inputRef.current.focus()
+          inputRef.current.click()
+          
+          // Set cursor to end
+          const len = inputRef.current.value.length
+          inputRef.current.setSelectionRange(len, len)
+        }
+      }
+
+      // Try focusing immediately
+      focusInput()
+      
+      // Try again after a short delay
+      setTimeout(focusInput, 10)
+      setTimeout(focusInput, 50)
+      setTimeout(focusInput, 100)
+    }
+  }, [open])
+
+  // Close dropdown when clicking outside
+  React.useEffect(() => {
+    if (!open) return
+
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Element
+      if (!dropdownRef.current?.contains(target as Node) && 
+          !buttonRef.current?.contains(target as Node)) {
+        setOpen(false)
+      }
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false)
+        buttonRef.current?.focus()
+      }
+    }
+
+    // Use capture phase to ensure we get the events first
+    document.addEventListener('mousedown', handleClickOutside, true)
+    document.addEventListener('keydown', handleKeyDown, true)
+    
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside, true)
+      document.removeEventListener('keydown', handleKeyDown, true)
+    }
+  }, [open])
+
+  const filteredOptions = options.filter(option => 
+    inputValue === "" || 
+    option.label.toLowerCase().includes(inputValue.toLowerCase())
+  )
+
+  const handleButtonClick = (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    
+    if (!disabled) {
+      setOpen(!open)
+    }
+  }
+
+  const handleInputFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    e.stopPropagation()
+    // Ensure the input stays focused
+    if (e.target !== document.activeElement) {
+      e.target.focus()
+    }
+  }
+
+  const handleInputClick = (e: React.MouseEvent<HTMLInputElement>) => {
+    e.stopPropagation()
+    e.preventDefault()
+    
+    // Force focus
+    const input = e.currentTarget
+    input.focus()
+    
+    // Set cursor to end
+    const len = input.value.length
+    input.setSelectionRange(len, len)
+  }
+
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          className={cn("justify-between", width, !value && "text-muted-foreground")}
-          disabled={disabled}
-          id={id}
-        >
-          {selectedOption ? selectedOption.label : placeholder}
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent 
-        className={cn("p-0 pointer-events-auto", width)} 
-        align="start"
-        style={{ zIndex: 9999, pointerEvents: 'auto' }}
+    <>
+      <Button
+        ref={buttonRef}
+        variant="outline"
+        role="combobox"
+        aria-expanded={open}
+        className={cn("justify-between", width, !value && "text-muted-foreground")}
+        disabled={disabled}
+        id={id}
+        onClick={handleButtonClick}
+        onMouseDown={(e) => e.preventDefault()} // Prevent focus issues
       >
-        <Command>
-          <CommandInput placeholder={searchPlaceholder} />
-          <CommandList>
-            <CommandEmpty>{emptyText}</CommandEmpty>
-            <CommandGroup>
-              {options.map((option) => (
-                <CommandItem
-                  key={option.value}
-                  value={option.label} // cmdk uses the display label for search by default
-                  onSelect={() => {
-                    onChange(option.value === value ? null : option.value)
-                    setOpen(false)
-                  }}
-                  disabled={option.disabled} // Use the disabled property from the option
-                >
-                  <Check
+        {selectedOption ? selectedOption.label : placeholder}
+        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+      </Button>
+
+      {open && buttonRect && createPortal(
+        <div
+          ref={dropdownRef}
+          className={cn(
+            "fixed bg-popover border border-border rounded-md shadow-lg p-0 pointer-events-auto",
+            width
+          )}
+          style={{
+            top: buttonRect.bottom + window.scrollY + 4,
+            left: buttonRect.left + window.scrollX,
+            width: buttonRect.width,
+            zIndex: 99999, // Even higher z-index
+            pointerEvents: 'auto'
+          }}
+          onMouseDown={(e) => e.stopPropagation()} // Prevent event bubbling
+        >
+          <div className="flex flex-col">
+            {/* Custom search input with aggressive focus management */}
+            <div className="flex items-center border-b px-3 py-2">
+              <input
+                ref={inputRef}
+                type="text"
+                placeholder={searchPlaceholder}
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onFocus={handleInputFocus}
+                onClick={handleInputClick}
+                onMouseDown={(e) => e.stopPropagation()}
+                className="flex h-8 w-full rounded-md bg-transparent text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                style={{ 
+                  pointerEvents: 'auto',
+                  userSelect: 'text',
+                  WebkitUserSelect: 'text'
+                }}
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck="false"
+                tabIndex={0}
+              />
+            </div>
+            
+            {/* Custom options list */}
+            <div className="max-h-[300px] overflow-y-auto p-1">
+              {filteredOptions.length === 0 ? (
+                <div className="py-6 text-center text-sm text-muted-foreground">{emptyText}</div>
+              ) : (
+                filteredOptions.map((option) => (
+                  <div
+                    key={option.value}
                     className={cn(
-                      "mr-2 h-4 w-4",
-                      value === option.value ? "opacity-100" : "opacity-0"
+                      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground",
+                      option.disabled && "pointer-events-none opacity-50"
                     )}
-                  />
-                  {option.label}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+                    onClick={() => {
+                      if (!option.disabled) {
+                        onChange(option.value === value ? null : option.value)
+                        setOpen(false)
+                      }
+                    }}
+                    onMouseDown={(e) => e.preventDefault()} // Prevent focus loss
+                  >
+                    <Check
+                      className={cn(
+                        "mr-2 h-4 w-4",
+                        value === option.value ? "opacity-100" : "opacity-0"
+                      )}
+                    />
+                    {option.label}
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>,
+        document.body
+      )}
+    </>
   )
 }

--- a/components/ui/custom-combobox.tsx
+++ b/components/ui/custom-combobox.tsx
@@ -191,7 +191,17 @@ export function CustomCombobox({
             zIndex: 99999, // Even higher z-index
             pointerEvents: 'auto'
           }}
-          onMouseDown={(e) => e.stopPropagation()} // Prevent event bubbling
+          onMouseDown={(e) => {
+            // Only stop propagation for non-scroll interactions
+            const target = e.target as Element
+            if (!target.closest('[data-scroll-area]')) {
+              e.stopPropagation()
+            }
+          }}
+          onWheel={(e) => {
+            // Allow wheel events to pass through for scrolling
+            e.stopPropagation()
+          }}
         >
           <div className="flex flex-col">
             {/* Custom search input with aggressive focus management */}
@@ -219,8 +229,30 @@ export function CustomCombobox({
               />
             </div>
             
-            {/* Custom options list */}
-            <div className="max-h-[300px] overflow-y-auto p-1">
+            {/* Custom options list with proper scrolling */}
+            <div 
+              data-scroll-area=""
+              className="max-h-[300px] overflow-y-auto p-1"
+              style={{ 
+                pointerEvents: 'auto',
+                overscrollBehavior: 'contain',
+                WebkitOverflowScrolling: 'touch',
+                scrollbarWidth: 'thin',
+                scrollbarColor: 'hsl(var(--muted-foreground) / 0.3) transparent'
+              }}
+              onWheel={(e) => {
+                // Allow wheel events for scrolling and prevent them from closing the dropdown
+                e.stopPropagation()
+              }}
+              onScroll={(e) => {
+                // Allow scroll events
+                e.stopPropagation()
+              }}
+              onMouseDown={(e) => {
+                // Don't prevent default on the scroll area itself
+                e.stopPropagation()
+              }}
+            >
               {filteredOptions.length === 0 ? (
                 <div className="py-6 text-center text-sm text-muted-foreground">{emptyText}</div>
               ) : (
@@ -237,7 +269,13 @@ export function CustomCombobox({
                         setOpen(false)
                       }
                     }}
-                    onMouseDown={(e) => e.preventDefault()} // Prevent focus loss
+                    onMouseDown={(e) => {
+                      // Only prevent default for selection, not scrolling
+                      if (e.button === 0) { // Left click only
+                        e.preventDefault()
+                      }
+                    }}
+                    style={{ pointerEvents: 'auto' }}
                   >
                     <Check
                       className={cn(

--- a/components/ui/date-picker.tsx
+++ b/components/ui/date-picker.tsx
@@ -28,14 +28,14 @@ interface DatePickerProps {
 export function DatePicker({ value, onChange, placeholder = "Datum auswählen", className, disabled, id }: DatePickerProps) {
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(undefined);
   const [inputValue, setInputValue] = useState<string>("");
-  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
 
   // Effect to synchronize internal state with external value prop
   useEffect(() => {
     let initialDate: Date | undefined = undefined;
     if (value instanceof Date) {
       initialDate = value;
-    } else if (typeof value === 'string') {
+    } else if (typeof value === 'string' && value.trim() !== '') {
       // Try parsing DD.MM.YYYY first
       try {
         const parsedDate = parse(value, "dd.MM.yyyy", new Date());
@@ -65,7 +65,7 @@ export function DatePicker({ value, onChange, placeholder = "Datum auswählen", 
     setSelectedDate(date);
     setInputValue(date ? format(date, "dd.MM.yyyy", { locale: de }) : "");
     onChange?.(date);
-    setPopoverOpen(false); // Close popover on selection
+    setIsOpen(false); // Close popover on selection
   }
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -96,52 +96,83 @@ export function DatePicker({ value, onChange, placeholder = "Datum auswählen", 
   }
 
   return (
-    <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-      <PopoverTrigger asChild>
-        <div className={cn("relative w-full", className)}>
-          <Input
-            id={id}
-            type="text"
-            placeholder={placeholder}
-            value={inputValue}
-            onChange={handleInputChange}
-            className={cn("pr-10", !selectedDate && "text-muted-foreground")}
+    <div className={cn("relative w-full", className)}>
+      <Popover open={isOpen} onOpenChange={setIsOpen}>
+        <PopoverTrigger asChild>
+          <div className="relative">
+            <Input
+              id={id}
+              type="text"
+              placeholder={placeholder}
+              value={inputValue}
+              onChange={handleInputChange}
+              className={cn("pr-10", !selectedDate && "text-muted-foreground")}
+              disabled={disabled}
+              onClick={(e) => {
+                e.preventDefault();
+                if (!disabled) {
+                  setIsOpen(true);
+                }
+              }}
+            />
+            <Button
+              variant="outline"
+              size="icon"
+              className={cn(
+                "absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2 rounded-md text-muted-foreground hover:text-foreground",
+                disabled && "cursor-not-allowed opacity-50"
+              )}
+              disabled={disabled}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (!disabled) {
+                  setIsOpen(!isOpen);
+                }
+              }}
+              type="button"
+              aria-label="Kalender öffnen"
+            >
+              <CalendarIcon className="h-4 w-4" />
+            </Button>
+          </div>
+        </PopoverTrigger>
+        <PopoverContent 
+          className="w-auto p-0 pointer-events-auto" 
+          align="start"
+          style={{ zIndex: 9999, pointerEvents: 'auto' }}
+          onInteractOutside={(e) => {
+            // Prevent closing when interacting with native select elements
+            const target = e.target as Element;
+            if (target?.tagName === 'SELECT' || 
+                target?.closest('select') ||
+                target?.tagName === 'OPTION') {
+              e.preventDefault();
+            }
+          }}
+          onPointerDownOutside={(e) => {
+            // Also prevent on pointer down
+            const target = e.target as Element;
+            if (target?.tagName === 'SELECT' || 
+                target?.closest('select') ||
+                target?.tagName === 'OPTION') {
+              e.preventDefault();
+            }
+          }}
+        >
+          <Calendar
+            mode="single"
+            selected={selectedDate}
+            onSelect={handleSelect}
             disabled={disabled}
+            locale={de}
+            fromYear={1900}
+            toYear={2100}
+            captionLayout="dropdown"
+            initialFocus
           />
-          <Button
-            variant={"outline"}
-            size="icon"
-            className={cn(
-              "absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2 rounded-md text-muted-foreground hover:text-foreground",
-              disabled && "cursor-not-allowed opacity-50"
-            )}
-            disabled={disabled}
-            onClick={(event) => { // Added event parameter
-              event.preventDefault(); // Prevent default button behavior
-              if (!disabled) {
-                const today = new Date();
-                setSelectedDate(today);
-                setInputValue(format(today, "dd.MM.yyyy", { locale: de }));
-                onChange?.(today);
-                setPopoverOpen(true); // Open popover after setting date
-              }
-            }}
-            aria-label="Kalender öffnen und heutiges Datum auswählen"
-          >
-            <CalendarIcon className="h-4 w-4" />
-          </Button>
-        </div>
-      </PopoverTrigger>
-      <PopoverContent className="w-auto p-0">
-        <Calendar
-          mode="single"
-          selected={selectedDate}
-          onSelect={handleSelect}
-          initialFocus
-          locale={de}
-          disabled={disabled}
-        />
-      </PopoverContent>
-    </Popover>
+        </PopoverContent>
+      </Popover>
+    </div>
   )
 }

--- a/components/ui/date-picker.tsx
+++ b/components/ui/date-picker.tsx
@@ -138,27 +138,8 @@ export function DatePicker({ value, onChange, placeholder = "Datum auswählen", 
           </div>
         </PopoverTrigger>
         <PopoverContent 
-          className="w-auto p-0 pointer-events-auto" 
+          className="w-auto p-0" 
           align="start"
-          style={{ zIndex: 9999, pointerEvents: 'auto' }}
-          onInteractOutside={(e) => {
-            // Prevent closing when interacting with native select elements
-            const target = e.target as Element;
-            if (target?.tagName === 'SELECT' || 
-                target?.closest('select') ||
-                target?.tagName === 'OPTION') {
-              e.preventDefault();
-            }
-          }}
-          onPointerDownOutside={(e) => {
-            // Also prevent on pointer down
-            const target = e.target as Element;
-            if (target?.tagName === 'SELECT' || 
-                target?.closest('select') ||
-                target?.tagName === 'OPTION') {
-              e.preventDefault();
-            }
-          }}
         >
           <Calendar
             mode="single"

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -46,6 +46,25 @@ const DialogContent = React.forwardRef<
   ) => {
     if (!event) return;
 
+    // Check if the interaction is with a combobox or popover element
+    const target = event.target as Element;
+    
+    // More comprehensive check for combobox elements
+    if (target?.closest('[data-radix-popover-content]') || 
+        target?.closest('[data-radix-popper-content-wrapper]') ||
+        target?.hasAttribute('cmdk-input') ||
+        target?.hasAttribute('cmdk-item') ||
+        target?.hasAttribute('cmdk-list') ||
+        target?.closest('[role="combobox"]') ||
+        target?.closest('[role="option"]') ||
+        target?.closest('[role="listbox"]') ||
+        target?.closest('input[placeholder*="suchen"]') ||
+        target?.closest('input[placeholder*="Search"]') ||
+        target?.tagName === 'INPUT' && target?.closest('[data-radix-popover-content]')) {
+      // Allow interactions with combobox elements - just return without preventing
+      return;
+    }
+
     if (isDirty && onAttemptClose) {
       event.preventDefault();
       onAttemptClose();
@@ -75,6 +94,14 @@ const DialogContent = React.forwardRef<
           className
         )}
         onInteractOutside={handleInteraction} // Assign the correctly typed handler
+        onOpenAutoFocus={(e) => {
+          // Prevent auto focus to allow combobox inputs to work
+          e.preventDefault();
+        }}
+        onCloseAutoFocus={(e) => {
+          // Prevent auto focus on close
+          e.preventDefault();
+        }}
         {...props}
       >
         {/* Always add a fallback DialogTitle for accessibility - will be overridden by actual DialogTitle if present */}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -83,7 +83,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -27,14 +27,14 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
       inset && "pl-8",
       className
     )}
     {...props}
   >
     {children}
-    <ChevronRight className="ml-auto" />
+    <ChevronRight className="ml-auto h-4 w-4" />
   </DropdownMenuPrimitive.SubTrigger>
 ))
 DropdownMenuSubTrigger.displayName =
@@ -65,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-[52] min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}
@@ -83,7 +83,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className
     )}

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -12,16 +12,20 @@ const PopoverTrigger = PopoverPrimitive.Trigger
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+>(({ className, align = "center", sideOffset = 4, style, ...props }, ref) => (
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       ref={ref}
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 pointer-events-auto",
         className
       )}
+      style={{
+        pointerEvents: 'auto',
+        ...style
+      }}
       {...props}
     />
   </PopoverPrimitive.Portal>

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -22,10 +22,7 @@ const PopoverContent = React.forwardRef<
         "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 pointer-events-auto",
         className
       )}
-      style={{
-        pointerEvents: 'auto',
-        ...style
-      }}
+      style={style}
       {...props}
     />
   </PopoverPrimitive.Portal>

--- a/lib/mention-suggestion-popup.ts
+++ b/lib/mention-suggestion-popup.ts
@@ -175,7 +175,7 @@ export function createSuggestionPopup(config: SuggestionPopupConfig): PopupInsta
       theme: 'mention-suggestion',
       animation: 'shift-away-subtle',
       duration: [150, 100],
-      zIndex: 9999,
+      zIndex: parseInt(getComputedStyle(document.documentElement).getPropertyValue('--z-index-tooltip').trim()) || 1070,
       ...( isMobile && initialRect 
         ? getMobileConfig() 
         : getDesktopConfig(initialRect || new DOMRect())

--- a/styles/mention-suggestion.css
+++ b/styles/mention-suggestion.css
@@ -8,7 +8,7 @@
   @apply animate-in fade-in-0 zoom-in-95 duration-200;
   
   /* Ensure proper z-index for Tippy.js */
-  z-index: 9999;
+  z-index: var(--z-index-tooltip);
   
   /* Smooth scrolling */
   scroll-behavior: smooth;


### PR DESCRIPTION
## Description

Fixes dropdown interactions inside dialogs: portal-based combobox, calendar navigation, and a z-index scale.

## Summary of Changes

- CustomCombobox rebuilt on a body portal with its own search input and scrollable list — no more clipping/focus loss inside modals; aggressive focus management and outside-click/Escape handling
- Calendar: custom caption with prev/next arrow buttons (year-range aware) flanking the month/year dropdowns; default nav hidden
- DatePicker: the calendar icon now toggles the popover instead of setting today's date; the input itself opens the calendar
- Dialog: interactions with combobox/popover content no longer trigger the dirty-close guard; open/close auto-focus suppressed so embedded inputs work
- `globals.css`: documented `--z-index-*` scale (dropdown → portal-dropdown 1100) and themed scrollbars for `[data-scroll-area]`; popover/command/dropdown-menu pointer-events and z fixes; mention popup uses the tooltip token