### PR TITLE
Fix/runtime errors max depth

### DIFF
--- a/components/settings-modal.tsx
+++ b/components/settings-modal.tsx
@@ -18,7 +18,6 @@ import type { Profile as SupabaseProfile } from '@/types/supabase'; // Import an
 import { getUserProfileForSettings } from '@/app/user-profile-actions'; // Import the server action
 import Pricing from "@/app/modern/components/pricing"; // Corrected: Import Pricing component as default
 import { useDataExport } from '@/hooks/useDataExport'; // Import the custom hook
-import SubscriptionManagement from '@/components/subscription-management';
 import SubscriptionPaymentMethods from '@/components/subscription-payment-methods';
 import SubscriptionPaymentHistory from '@/components/subscription-payment-history';
 import { useToast } from "@/hooks/use-toast"; // Import the custom toast hook

--- a/hooks/use-active-state-manager.tsx
+++ b/hooks/use-active-state-manager.tsx
@@ -134,7 +134,7 @@ export function useActiveStateManager() {
   // Sync with Next.js router changes
   useEffect(() => {
     store.updateActiveRoute(pathname)
-  }, [pathname, store])
+  }, [pathname, store.updateActiveRoute])
   
   return store
 }
@@ -149,7 +149,7 @@ export function useSidebarActiveState() {
   // Update active route when pathname changes
   useEffect(() => {
     store.updateActiveRoute(pathname)
-  }, [pathname, store])
+  }, [pathname, store.updateActiveRoute])
   
   return {
     isRouteActive: store.isRouteActive,
@@ -198,15 +198,15 @@ export function useActiveStateSync() {
   
   const syncActiveState = useCallback((currentPath: string, breadcrumbs: BreadcrumbItem[]) => {
     store.syncWithNavigation(currentPath, breadcrumbs)
-  }, [store])
+  }, [store.syncWithNavigation])
   
   const updateActiveDirectory = useCallback((path: string, breadcrumbs?: BreadcrumbItem[]) => {
     store.updateActiveDirectory(path, breadcrumbs)
-  }, [store])
+  }, [store.updateActiveDirectory])
   
   const updateBreadcrumbs = useCallback((breadcrumbs: BreadcrumbItem[]) => {
     store.updateBreadcrumbs(breadcrumbs)
-  }, [store])
+  }, [store.updateBreadcrumbs])
   
   return {
     syncActiveState,
@@ -227,7 +227,7 @@ export function useComprehensiveActiveState() {
   // Auto-sync with router
   useEffect(() => {
     store.updateActiveRoute(pathname)
-  }, [pathname, store])
+  }, [pathname, store.updateActiveRoute])
   
   return {
     // Current state

--- a/hooks/use-active-state-manager.tsx
+++ b/hooks/use-active-state-manager.tsx
@@ -124,14 +124,12 @@ export const useActiveStateStore = create<ActiveStateManager>()(
 )
 
 /**
- * Hook for managing active states across the application
- * Automatically syncs with Next.js router and navigation changes
+ * Custom hook to sync pathname with store - DRY principle
  */
-export function useActiveStateManager() {
+function useSyncPathnameWithStore() {
   const store = useActiveStateStore()
   const pathname = usePathname()
   
-  // Sync with Next.js router changes
   useEffect(() => {
     store.updateActiveRoute(pathname)
   }, [pathname, store.updateActiveRoute])
@@ -140,16 +138,18 @@ export function useActiveStateManager() {
 }
 
 /**
+ * Hook for managing active states across the application
+ * Automatically syncs with Next.js router and navigation changes
+ */
+export function useActiveStateManager() {
+  return useSyncPathnameWithStore()
+}
+
+/**
  * Hook specifically for sidebar navigation active states
  */
 export function useSidebarActiveState() {
-  const store = useActiveStateStore()
-  const pathname = usePathname()
-  
-  // Update active route when pathname changes
-  useEffect(() => {
-    store.updateActiveRoute(pathname)
-  }, [pathname, store.updateActiveRoute])
+  const store = useSyncPathnameWithStore()
   
   return {
     isRouteActive: store.isRouteActive,
@@ -221,13 +221,7 @@ export function useActiveStateSync() {
  * for components that need full active state functionality
  */
 export function useComprehensiveActiveState() {
-  const store = useActiveStateStore()
-  const pathname = usePathname()
-  
-  // Auto-sync with router
-  useEffect(() => {
-    store.updateActiveRoute(pathname)
-  }, [pathname, store.updateActiveRoute])
+  const store = useSyncPathnameWithStore()
   
   return {
     // Current state


### PR DESCRIPTION
## Description

Removes the superseded SubscriptionManagement import and deduplicates the active-state hooks.

## Summary of Changes

- Settings modal: unused `SubscriptionManagement` import dropped (the tab now uses the payment-methods/history components)
- `use-active-state-manager.tsx`: the three hooks that each synced the pathname with the store now share a single `useSyncPathnameWithStore` helper; effect dependencies narrowed to the stable store actions