### PR TITLE
Fix/summary cards border radius

### DIFF
--- a/app/(dashboard)/betriebskosten/client-wrapper-layout.test.tsx
+++ b/app/(dashboard)/betriebskosten/client-wrapper-layout.test.tsx
@@ -138,7 +138,7 @@ describe('BetriebskostenClientView - Layout Changes', () => {
       const { container } = render(<BetriebskostenClientView {...defaultProps} />);
 
       // Verify card structure
-      const card = container.querySelector('[class*="rounded-xl"][class*="shadow-md"]');
+      const card = container.querySelector('[class*="rounded-2xl"][class*="shadow-md"]');
       expect(card).toBeInTheDocument();
     });
   });

--- a/app/(dashboard)/betriebskosten/client-wrapper.tsx
+++ b/app/(dashboard)/betriebskosten/client-wrapper.tsx
@@ -256,7 +256,7 @@ export default function BetriebskostenClientView({
               return (
                 <Card 
                   key={card.id}
-                  className="relative overflow-hidden rounded-xl shadow-md border summary-card"
+                  className="relative overflow-hidden rounded-2xl shadow-md border summary-card"
                 >
                   <CardHeader className="pb-2">
                     <CardTitle className="flex items-center gap-2 text-base">

--- a/components/__tests__/summary-card.test.tsx
+++ b/components/__tests__/summary-card.test.tsx
@@ -94,7 +94,7 @@ describe('SummaryCard', () => {
     render(<SummaryCard {...defaultProps} />);
     
     // Find the card container
-    const card = screen.getByText('Total Rent').closest('[class*="rounded-xl"]');
+    const card = screen.getByText('Total Rent').closest('[class*="rounded-2xl"]');
     expect(card).not.toHaveClass('cursor-pointer');
   });
 

--- a/components/summary-card-skeleton.tsx
+++ b/components/summary-card-skeleton.tsx
@@ -8,7 +8,7 @@ interface SummaryCardSkeletonProps {
 
 export function SummaryCardSkeleton({ title, icon }: SummaryCardSkeletonProps) {
   return (
-    <Card className="overflow-hidden rounded-xl shadow-md flex-1">
+    <Card className="overflow-hidden rounded-2xl shadow-md flex-1">
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         {title ? (
           <span className="text-sm font-medium text-muted-foreground">{title}</span>

--- a/components/summary-card.tsx
+++ b/components/summary-card.tsx
@@ -106,7 +106,7 @@ export function SummaryCard({
       <Card
         className={cn(
           // Main-Style-Äquivalent: abgeleitet von main, ohne Opacity-Loading (Skeleton übernimmt)
-          "relative overflow-hidden rounded-xl shadow-md transition-opacity duration-200 summary-card",
+          "relative overflow-hidden rounded-2xl shadow-md transition-opacity duration-200 summary-card",
           // sichtbare Border wie im Main-Design
           "border",
           // Add cursor pointer and hover scale when onClick is provided
@@ -156,7 +156,7 @@ export function SummaryCardSkeleton({ className }: { className?: string }) {
   return (
     <Card
       className={cn(
-        "relative overflow-hidden rounded-xl shadow-md transition-opacity duration-200 summary-card",
+        "relative overflow-hidden rounded-2xl shadow-md transition-opacity duration-200 summary-card",
         // konsistent zur Hauptkarte: sichtbare Border
         "border",
         className


### PR DESCRIPTION
## Description

Standardizes the summary-card corner radius to `rounded-2xl`.

## Summary of Changes

- Betriebskosten guide cards, `SummaryCard` (+ its skeleton) and `SummaryCardSkeleton` move from `rounded-xl` to `rounded-2xl`
- Tests updated to match the new radius class