### PR TITLE
Remove hero and navbar animations to improve web vitals (LCP) - fix #643

### DIFF
--- a/app/modern/components/hero.tsx
+++ b/app/modern/components/hero.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { motion } from "framer-motion"
 import { Sparkles } from "lucide-react"
 import { CallToAction } from "./call-to-action"
 import { VideoPlayer } from "@/components/ui/video-player"
@@ -13,13 +12,7 @@ interface HeroProps {
 export default function Hero({ onGetStarted }: HeroProps) {
   return (
     <section className="relative min-h-screen flex items-center justify-center overflow-hidden bg-background text-foreground">
-      <style jsx>{`
-  @keyframes spin {
-    from { transform: rotate(0deg); }
-    to { transform: rotate(360deg); }
-  }
-`}</style>
-      {/* Animated Background Pattern - Adjusted for theme */}
+      {/* Static Background Pattern - Adjusted for theme */}
       <div className="absolute inset-0 opacity-20 dark:opacity-10">
         <div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-secondary/10 to-background" />
         <div
@@ -32,66 +25,23 @@ export default function Hero({ onGetStarted }: HeroProps) {
         />
       </div>
 
-      {/* Floating Elements - Adjusted for theme */}
-      <motion.div
-        className="absolute top-20 left-20 w-4 h-4 bg-primary/50 rounded-full"
-        animate={{
-          y: [0, -20, 0],
-          opacity: [0.3, 0.8, 0.3],
-        }}
-        transition={{
-          duration: 3,
-          repeat: Number.POSITIVE_INFINITY,
-          ease: "easeInOut",
-        }}
-      />
-      <motion.div
-        className="absolute top-40 right-32 w-6 h-6 border-2 border-secondary/50 rotate-45"
-        animate={{
-          rotate: [45, 225, 45],
-          scale: [1, 1.2, 1],
-        }}
-        transition={{
-          duration: 4,
-          repeat: Number.POSITIVE_INFINITY,
-          ease: "easeInOut",
-        }}
-      />
-      <motion.div
-        className="absolute bottom-32 left-32 w-8 h-8 bg-gradient-to-r from-primary/60 to-secondary/60 rounded-full"
-        animate={{
-          x: [0, 30, 0],
-          y: [0, -15, 0],
-        }}
-        transition={{
-          duration: 5,
-          repeat: Number.POSITIVE_INFINITY,
-          ease: "easeInOut",
-        }}
-      />
+      {/* Static Decorative Elements - Adjusted for theme */}
+      <div className="absolute top-20 left-20 w-4 h-4 bg-primary/50 rounded-full opacity-60" />
+      <div className="absolute top-40 right-32 w-6 h-6 border-2 border-secondary/50 rotate-45 opacity-60" />
+      <div className="absolute bottom-32 left-32 w-8 h-8 bg-gradient-to-r from-primary/60 to-secondary/60 rounded-full opacity-60" />
 
       <div className="relative z-10 w-full px-4 sm:px-6 lg:px-8 pt-28 md:pt-32 pb-16">
         <div className="max-w-7xl mx-auto grid grid-cols-1 gap-12 items-center">
           {/* Left: Headline and CTA */}
           <div className="text-center w-full">
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.8, delay: 0.4 }}
-              className="mb-6"
-            >
+            <div className="mb-6">
               <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-card/80 border border-border backdrop-blur-sm">
                 <Sparkles className="w-4 h-4 text-primary" />
                 <span className="text-sm text-muted-foreground">Vereinfachen Sie Ihre Abrechnung</span>
               </div>
-            </motion.div>
+            </div>
 
-            <motion.h1
-              initial={{ opacity: 0, y: 30 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.8, delay: 0.2 }}
-              className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-6 bg-gradient-to-r from-foreground via-foreground/80 to-muted-foreground bg-clip-text text-transparent leading-tight tracking-tight"
-            >
+            <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold mb-6 bg-gradient-to-r from-foreground via-foreground/80 to-muted-foreground bg-clip-text text-transparent leading-tight tracking-tight">
               <span className="bg-gradient-to-r from-primary via-primary/80 to-secondary bg-clip-text text-transparent">
                 Abrechnung in 5 Minuten
               </span>
@@ -99,35 +49,19 @@ export default function Hero({ onGetStarted }: HeroProps) {
               <span className="text-foreground/80">
                 statt Stunden mit Excel
               </span>
-            </motion.h1>
+            </h1>
 
-            <motion.p
-              initial={{ opacity: 0, y: 30 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.8, delay: 0.4 }}
-              className="text-lg sm:text-xl md:text-2xl text-muted-foreground mb-10 max-w-2xl mx-auto leading-relaxed text-center"
-            >
+            <p className="text-lg sm:text-xl md:text-2xl text-muted-foreground mb-10 max-w-2xl mx-auto leading-relaxed text-center">
               Erstellen Sie mühelos korrekte und transparente Abrechnungen. Sparen Sie Zeit und vermeiden Sie Fehler mit unserer benutzerfreundlichen Lösung für Vermieter und Immobilienverwalter.
-            </motion.p>
+            </p>
 
-            <motion.div
-              initial={{ opacity: 0, y: 30 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.8, delay: 0.6 }}
-            >
-              <div className="flex flex-col items-center">
-                <CallToAction variant="hero" onGetStarted={onGetStarted} />
-              </div>
-            </motion.div>
+            <div className="flex flex-col items-center">
+              <CallToAction variant="hero" onGetStarted={onGetStarted} />
+            </div>
           </div>
 
           {/* Right: Product mockup */}
-          <motion.div
-            className="w-full"
-            initial={{ opacity: 0, y: 20, scale: 0.98 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            transition={{ duration: 0.8, delay: 0.25 }}
-          >
+          <div className="w-full">
             <div className="relative">
               <div className="absolute -inset-6 bg-gradient-to-r from-primary/20 to-secondary/20 blur-2xl rounded-3xl" aria-hidden />
               <div className="relative overflow-hidden rounded-2xl border border-border bg-card shadow-2xl">
@@ -158,7 +92,7 @@ export default function Hero({ onGetStarted }: HeroProps) {
                 </div>
               </div>
             </div>
-          </motion.div>
+          </div>
         </div>
       </div>
 

--- a/app/modern/components/navigation.tsx
+++ b/app/modern/components/navigation.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import { motion, AnimatePresence } from "framer-motion"
+import { AnimatePresence, motion } from "framer-motion"
 import { Menu, X, DollarSign, Home, User as UserIcon, LogIn, LogOut, Check, LayoutDashboard, BookOpen } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
@@ -116,12 +116,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
   };
 
   return (
-    <motion.nav
-      initial={{ y: -100 }}
-      animate={{ y: 0 }}
-      transition={{ duration: 0.6 }}
-      className="fixed top-2 sm:top-4 left-0 right-0 z-50 px-2 sm:px-4"
-    >
+    <nav className="fixed top-2 sm:top-4 left-0 right-0 z-50 px-2 sm:px-4">
       <div className="max-w-7xl mx-auto flex items-center justify-between relative">
         {/* Mobile Header with Menu Button and Logo */}
         <div className="flex-shrink-0 z-10 md:hidden flex items-center space-x-2">
@@ -399,6 +394,6 @@ export default function Navigation({ onLogin }: NavigationProps) {
           </>
         )}
       </AnimatePresence>
-    </motion.nav>
+    </nav>
   )
 }


### PR DESCRIPTION
## Description

Simplifies the landing hero and navigation by removing the entrance/float animations.

## Summary of Changes

- Hero: floating decorative elements and all Framer Motion wrappers replaced with static markup; the custom spin keyframe removed (82 lines deleted)
- Navigation: the slide-in nav animation dropped — the bar renders statically; import order tidied