### PR TITLE
Feature/kostenaufstellung pdf export

### DIFF
--- a/NEBENKOSTEN_EXPORT_FEATURE_SUMMARY.md
+++ b/NEBENKOSTEN_EXPORT_FEATURE_SUMMARY.md
@@ -1,0 +1,105 @@
+# Nebenkosten Export Feature Implementation Summary
+
+## Overview
+Successfully implemented a PDF export feature for the Nebenkosten (operating costs) overview modal that allows users to export a comprehensive cost breakdown document.
+
+## Changes Made
+
+### 1. Enhanced OperatingCostsOverviewModal Component
+**File:** `components/operating-costs-overview-modal.tsx`
+
+#### New Features Added:
+- **Export Button**: Added a "Kostenaufstellung exportieren" button at the bottom of the modal
+- **PDF Generation**: Implemented comprehensive PDF export functionality using jsPDF and jspdf-autotable
+- **Loading State**: Added loading state management during PDF generation
+- **Error Handling**: Proper error handling with user-friendly toast notifications
+
+#### PDF Content Includes:
+- **Header Section**: 
+  - Title: "Kostenaufstellung - Betriebskosten"
+  - Period information (start and end dates)
+  - House name
+  
+- **Summary Section**:
+  - Total area (m²)
+  - Number of apartments
+  - Number of tenants
+  - Total costs
+  - Cost per square meter
+
+- **Cost Breakdown Table**:
+  - Position number
+  - Service type (Leistungsart)
+  - Total costs per item
+  - Cost per square meter per item
+  - Bold total row at the bottom
+
+- **Water Costs Section** (if available):
+  - Total consumption in m³
+  - Total water costs
+  - Cost per cubic meter
+
+#### Technical Implementation:
+- Dynamic import of jsPDF and jspdf-autotable for code splitting
+- Proper plugin initialization with fallback handling
+- German number formatting for currency display
+- Automatic filename generation based on house name and period
+- Responsive table styling with proper alignment
+
+### 2. Added Comprehensive Tests
+**File:** `components/__tests__/operating-costs-overview-modal.test.tsx`
+
+#### Test Coverage:
+- Modal rendering with correct data
+- Export button presence and functionality
+- PDF generation process (mocked)
+- Total cost calculations
+- Water costs information display
+- Null data handling
+
+#### Mock Setup:
+- Proper jsPDF and jspdf-autotable mocking
+- Toast notification mocking
+- API structure simulation for testing
+
+## Dependencies Used
+- **jsPDF**: Already installed (^3.0.2) - for PDF document generation
+- **jspdf-autotable**: Already installed (^5.0.2) - for table generation in PDFs
+- **sonner**: For toast notifications
+- **lucide-react**: For the FileDown icon
+
+## User Experience
+1. **Access**: Users can access the export feature from the Nebenkosten overview modal
+2. **Button Location**: Export button is positioned at the bottom of the modal in the footer
+3. **Loading Feedback**: Button shows "PDF wird erstellt..." during generation
+4. **Success Feedback**: Toast notification confirms successful PDF creation
+5. **Error Handling**: Clear error messages if PDF generation fails
+6. **File Naming**: Automatic filename generation: `Kostenaufstellung_{HouseName}_{StartDate}_bis_{EndDate}.pdf`
+
+## File Structure
+```
+components/
+├── operating-costs-overview-modal.tsx (enhanced)
+└── __tests__/
+    └── operating-costs-overview-modal.test.tsx (new)
+```
+
+## Integration Points
+- Seamlessly integrates with existing modal system
+- Uses existing data structures (OptimizedNebenkosten)
+- Follows existing PDF generation patterns from abrechnung-modal.tsx
+- Maintains consistent UI/UX with other export features
+
+## Quality Assurance
+- ✅ All tests passing
+- ✅ Build successful
+- ✅ TypeScript compilation without errors
+- ✅ Follows existing code patterns and conventions
+- ✅ Proper error handling and user feedback
+- ✅ Responsive design considerations
+
+## Future Enhancements (Optional)
+- Add export format options (PDF, Excel, CSV)
+- Include additional metadata in the PDF
+- Add print-friendly styling options
+- Implement batch export for multiple periods

--- a/components/__tests__/operating-costs-overview-modal.test.tsx
+++ b/components/__tests__/operating-costs-overview-modal.test.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { OperatingCostsOverviewModal } from '../operating-costs-overview-modal';
+import { OptimizedNebenkosten } from '@/types/optimized-betriebskosten';
+
+// Mock the toast function
+jest.mock('sonner', () => ({
+  toast: {
+    info: jest.fn(),
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+// Mock jsPDF and jspdf-autotable
+const mockSave = jest.fn();
+const mockText = jest.fn();
+const mockSetFontSize = jest.fn();
+const mockSetFont = jest.fn();
+const mockAutoTable = jest.fn();
+
+const mockJsPDF = jest.fn().mockImplementation(() => {
+  const instance = {
+    save: mockSave,
+    text: mockText,
+    setFontSize: mockSetFontSize,
+    setFont: mockSetFont,
+    internal: {
+      pageSize: {
+        height: 297,
+        getWidth: () => 210,
+      },
+    },
+    lastAutoTable: { finalY: 100 },
+    autoTable: mockAutoTable,
+  };
+  // Add API property for autoTable plugin
+  (instance as any).API = {};
+  return instance;
+});
+
+jest.mock('jspdf', () => ({
+  __esModule: true,
+  default: mockJsPDF,
+}));
+
+jest.mock('jspdf-autotable', () => ({
+  __esModule: true,
+  default: jest.fn(),
+  applyPlugin: jest.fn((jsPDF) => {
+    if (jsPDF.API) {
+      jsPDF.API.autoTable = mockAutoTable;
+    }
+  }),
+}));
+
+const mockNebenkosten: OptimizedNebenkosten = {
+  id: '1',
+  startdatum: '2024-01-01',
+  enddatum: '2024-12-31',
+  haus_name: 'Test Haus',
+  haeuser_id: 'haus1',
+  nebenkostenart: ['Heizung', 'Wasser', 'Müll'],
+  betrag: [1000, 500, 200],
+  berechnungsart: ['pro Flaeche', 'pro Mieter', 'pro Wohnung'],
+  wasserkosten: 500,
+  wasserverbrauch: 100,
+  gesamtFlaeche: 200,
+  anzahlWohnungen: 4,
+  anzahlMieter: 6,
+};
+
+describe('OperatingCostsOverviewModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the modal with correct data', () => {
+    render(
+      <OperatingCostsOverviewModal
+        isOpen={true}
+        onClose={jest.fn()}
+        nebenkosten={mockNebenkosten}
+      />
+    );
+
+    expect(screen.getByText(/Übersicht der Betriebskosten für/)).toBeInTheDocument();
+    expect(screen.getByText('Haus: Test Haus')).toBeInTheDocument();
+    expect(screen.getByText('Heizung')).toBeInTheDocument();
+    expect(screen.getByText('Wasser')).toBeInTheDocument();
+    expect(screen.getByText('Müll')).toBeInTheDocument();
+  });
+
+  it('displays the export button', () => {
+    render(
+      <OperatingCostsOverviewModal
+        isOpen={true}
+        onClose={jest.fn()}
+        nebenkosten={mockNebenkosten}
+      />
+    );
+
+    const exportButton = screen.getByText('Kostenaufstellung exportieren');
+    expect(exportButton).toBeInTheDocument();
+  });
+
+  it('handles PDF export when button is clicked', async () => {
+    const { toast } = require('sonner');
+    
+    render(
+      <OperatingCostsOverviewModal
+        isOpen={true}
+        onClose={jest.fn()}
+        nebenkosten={mockNebenkosten}
+      />
+    );
+
+    const exportButton = screen.getByText('Kostenaufstellung exportieren');
+    fireEvent.click(exportButton);
+
+    // Check that loading state is shown
+    await waitFor(() => {
+      expect(screen.getByText('PDF wird erstellt...')).toBeInTheDocument();
+    });
+
+    // Wait for the PDF generation to complete
+    await waitFor(() => {
+      expect(toast.info).toHaveBeenCalledWith('PDF wird erstellt...');
+    }, { timeout: 3000 });
+  });
+
+  it('calculates total costs correctly', () => {
+    render(
+      <OperatingCostsOverviewModal
+        isOpen={true}
+        onClose={jest.fn()}
+        nebenkosten={mockNebenkosten}
+      />
+    );
+
+    // Total should be 1000 + 500 + 200 = 1700 - check for multiple instances
+    const totalCostElements = screen.getAllByText('1.700,00 €');
+    expect(totalCostElements.length).toBeGreaterThan(0);
+  });
+
+  it('displays water costs information', () => {
+    render(
+      <OperatingCostsOverviewModal
+        isOpen={true}
+        onClose={jest.fn()}
+        nebenkosten={mockNebenkosten}
+      />
+    );
+
+    expect(screen.getByText('Wasserkosten')).toBeInTheDocument();
+    expect(screen.getByText('100 m³')).toBeInTheDocument();
+    // Check for water costs in the water section specifically
+    const waterCostElements = screen.getAllByText('500,00 €');
+    expect(waterCostElements.length).toBeGreaterThan(0);
+  });
+
+  it('does not render when nebenkosten is null', () => {
+    const { container } = render(
+      <OperatingCostsOverviewModal
+        isOpen={true}
+        onClose={jest.fn()}
+        nebenkosten={null as any}
+      />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -593,17 +593,16 @@ export function AbrechnungModal({
             textColor: [0, 0, 0],
             fontStyle: 'bold',
             lineWidth: { bottom: 0.3 }, // Thicker bottom border for header
-            lineColor: { bottom: [0, 0, 0] } // Black color for header bottom border
+            lineColor: [0, 0, 0] // Black color for header bottom border
           },
           styles: { 
             fontSize: 9, 
             cellPadding: 1.5,
-            lineWidth: 0, // Remove all cell borders
-            lineColor: [255, 255, 255] // Make any remaining lines white (invisible)
+            lineWidth: 0 // Remove all cell borders
           },
           bodyStyles: {
             lineWidth: { bottom: 0.1 }, // Only add thin bottom border for rows
-            lineColor: { bottom: [0, 0, 0] } // Black color for row separators
+            lineColor: [0, 0, 0] // Black color for row separators
           },
           columnStyles: {
             1: { halign: 'right' }, // Gesamtkosten in €

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -587,9 +587,23 @@ export function AbrechnungModal({
           head: [tableColumn],
           body: tableRows,
           startY: startY,
-          theme: 'grid',
-          headStyles: { fillColor: [220, 220, 220], textColor: [0,0,0] },
-          styles: { fontSize: 9, cellPadding: 1.5 },
+          theme: 'plain',
+          headStyles: { 
+            fillColor: [255, 255, 255], // White background instead of gray
+            textColor: [0, 0, 0],
+            fontStyle: 'bold',
+            lineWidth: 0 // Remove header borders
+          },
+          styles: { 
+            fontSize: 9, 
+            cellPadding: 1.5,
+            lineWidth: 0, // Remove all cell borders
+            lineColor: [255, 255, 255] // Make any remaining lines white (invisible)
+          },
+          bodyStyles: {
+            lineWidth: { bottom: 0.1 }, // Only add thin bottom border for rows
+            lineColor: { bottom: [0, 0, 0] } // Black color for row separators
+          },
           columnStyles: {
             1: { halign: 'right' }, // Gesamtkosten in €
             2: { halign: 'right' }, // Verteiler

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -592,7 +592,8 @@ export function AbrechnungModal({
             fillColor: [255, 255, 255], // White background instead of gray
             textColor: [0, 0, 0],
             fontStyle: 'bold',
-            lineWidth: 0 // Remove header borders
+            lineWidth: { bottom: 0.3 }, // Thicker bottom border for header
+            lineColor: { bottom: [0, 0, 0] } // Black color for header bottom border
           },
           styles: { 
             fontSize: 9, 

--- a/components/operating-costs-overview-modal.tsx
+++ b/components/operating-costs-overview-modal.tsx
@@ -152,6 +152,14 @@ export function OperatingCostsOverviewModal({
             data.cell.styles.fontStyle = 'bold'
             data.cell.styles.fillColor = [248, 248, 248]
           }
+          // Ensure header columns are properly aligned
+          if (data.section === 'head') {
+            if (data.column.index === 2 || data.column.index === 3) {
+              data.cell.styles.halign = 'right'
+            } else {
+              data.cell.styles.halign = 'left'
+            }
+          }
         }
       })
 

--- a/components/operating-costs-overview-modal.tsx
+++ b/components/operating-costs-overview-modal.tsx
@@ -126,7 +126,8 @@ export function OperatingCostsOverviewModal({
           textColor: [0, 0, 0],
           fontStyle: 'bold',
           lineWidth: { bottom: 0.3 }, // Thicker bottom border for header
-          lineColor: [0, 0, 0] // Black color for header bottom border
+          lineColor: [0, 0, 0], // Black color for header bottom border
+          halign: 'left' // Default left alignment for headers
         },
         styles: { 
           fontSize: 9, 
@@ -138,8 +139,28 @@ export function OperatingCostsOverviewModal({
           lineColor: [0, 0, 0] // Black color for row separators
         },
         columnStyles: {
-          2: { halign: 'right' },
-          3: { halign: 'right' },
+          0: { halign: 'center' }, // Center align position numbers
+          1: { halign: 'left' },   // Left align service descriptions
+          2: { halign: 'right' },  // Right align total costs
+          3: { halign: 'right' },  // Right align costs per sqm
+        },
+        // Custom drawing to properly right-align header text for currency columns
+        willDrawCell: function(data: any) {
+          if (data.section === 'head' && (data.column.index === 2 || data.column.index === 3)) {
+            // Prevent the original header text from being drawn
+            data.cell.text = [''];
+          }
+        },
+        didDrawCell: function(data: any) {
+          if (data.section === 'head' && (data.column.index === 2 || data.column.index === 3)) {
+            // Draw the right-aligned header text manually
+            const cell = data.cell;
+            const originalText = data.column.index === 2 ? 'Gesamtkosten' : 'Kosten pro m²';
+            
+            data.doc.setFont('helvetica', 'bold');
+            data.doc.setFontSize(9);
+            data.doc.text(originalText, cell.x + cell.width - 3, cell.y + cell.height / 2 + 1, { align: 'right' });
+          }
         },
         // Ensure table aligns with left and right content margins
         tableWidth: (doc as any).internal.pageSize.getWidth() - 40,

--- a/components/operating-costs-overview-modal.tsx
+++ b/components/operating-costs-overview-modal.tsx
@@ -126,8 +126,7 @@ export function OperatingCostsOverviewModal({
           textColor: [0, 0, 0],
           fontStyle: 'bold',
           lineWidth: { bottom: 0.3 }, // Thicker bottom border for header
-          lineColor: [0, 0, 0], // Black color for header bottom border
-          halign: 'left' // Default left alignment for headers
+          lineColor: [0, 0, 0] // Black color for header bottom border
         },
         styles: { 
           fontSize: 9, 
@@ -143,24 +142,6 @@ export function OperatingCostsOverviewModal({
           1: { halign: 'left' },   // Left align service descriptions
           2: { halign: 'right' },  // Right align total costs
           3: { halign: 'right' },  // Right align costs per sqm
-        },
-        // Custom drawing to properly right-align header text for currency columns
-        willDrawCell: function(data: any) {
-          if (data.section === 'head' && (data.column.index === 2 || data.column.index === 3)) {
-            // Prevent the original header text from being drawn
-            data.cell.text = [''];
-          }
-        },
-        didDrawCell: function(data: any) {
-          if (data.section === 'head' && (data.column.index === 2 || data.column.index === 3)) {
-            // Draw the right-aligned header text manually
-            const cell = data.cell;
-            const originalText = data.column.index === 2 ? 'Gesamtkosten' : 'Kosten pro m²';
-            
-            data.doc.setFont('helvetica', 'bold');
-            data.doc.setFontSize(9);
-            data.doc.text(originalText, cell.x + cell.width - 3, cell.y + cell.height / 2 + 1, { align: 'right' });
-          }
         },
         // Ensure table aligns with left and right content margins
         tableWidth: (doc as any).internal.pageSize.getWidth() - 40,

--- a/components/operating-costs-overview-modal.tsx
+++ b/components/operating-costs-overview-modal.tsx
@@ -184,7 +184,7 @@ export function OperatingCostsOverviewModal({
       // Generate filename
       const startDate = isoToGermanDate(nebenkosten.startdatum)?.replace(/\./g, '-') || 'unbekannt'
       const endDate = isoToGermanDate(nebenkosten.enddatum)?.replace(/\./g, '-') || 'unbekannt'
-      const houseName = nebenkosten.haus_name?.replace(/[^a-zA-Z0-9]/g, '_') || 'Haus'
+      const houseName = nebenkosten.haus_name?.replace(/[^a-zA-Z0-9äöüÄÖÜß]/g, '_') || 'Haus'
       const filename = `Kostenaufstellung_${houseName}_${startDate}_bis_${endDate}.pdf`
 
       // Save the PDF

--- a/components/operating-costs-overview-modal.tsx
+++ b/components/operating-costs-overview-modal.tsx
@@ -120,15 +120,22 @@ export function OperatingCostsOverviewModal({
         head: [['Pos.', 'Leistungsart', 'Gesamtkosten', 'Kosten pro m²']],
         body: tableData,
         startY: startY,
-        theme: 'grid',
-        styles: {
-          fontSize: 9,
-          cellPadding: 3,
-        },
-        headStyles: {
-          fillColor: [240, 240, 240],
+        theme: 'plain',
+        headStyles: { 
+          fillColor: [255, 255, 255], // White background instead of gray
           textColor: [0, 0, 0],
           fontStyle: 'bold',
+          lineWidth: { bottom: 0.3 }, // Thicker bottom border for header
+          lineColor: [0, 0, 0] // Black color for header bottom border
+        },
+        styles: { 
+          fontSize: 9, 
+          cellPadding: 3,
+          lineWidth: 0 // Remove all cell borders
+        },
+        bodyStyles: {
+          lineWidth: { bottom: 0.1 }, // Only add thin bottom border for rows
+          lineColor: [0, 0, 0] // Black color for row separators
         },
         columnStyles: {
           2: { halign: 'right' },

--- a/components/operating-costs-overview-modal.tsx
+++ b/components/operating-costs-overview-modal.tsx
@@ -1,11 +1,15 @@
 "use client"
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog" // Added DialogDescription
+import { useState } from "react"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog" // Added DialogDescription and DialogFooter
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Button } from "@/components/ui/button"
+import { FileDown } from "lucide-react"
 import { Nebenkosten } from "@/lib/data-fetching"
 import { OptimizedNebenkosten } from "@/types/optimized-betriebskosten"
 import { isoToGermanDate } from "@/utils/date-calculations"
 import { SummaryCards } from "./summary-cards"
+import { toast } from "sonner"
 
 export function OperatingCostsOverviewModal({
   isOpen,
@@ -16,6 +20,8 @@ export function OperatingCostsOverviewModal({
   onClose: () => void
   nebenkosten: OptimizedNebenkosten
 }) {
+  const [isExporting, setIsExporting] = useState(false)
+
   if (!nebenkosten) return null
 
   // Helper function to format currency
@@ -32,6 +38,154 @@ export function OperatingCostsOverviewModal({
   
   // Calculate cost per square meter (rounded to 2 decimal places)
   const costPerSqm = totalArea > 0 ? totalCosts / totalArea : 0
+
+  // PDF export function
+  const exportToPDF = async () => {
+    setIsExporting(true)
+    toast.info("PDF wird erstellt...")
+    
+    try {
+      const { default: jsPDF } = await import('jspdf')
+      const autoTableModule = await import('jspdf-autotable')
+
+      // Initialize autoTable plugin
+      if (autoTableModule && typeof autoTableModule.applyPlugin === 'function') {
+        autoTableModule.applyPlugin(jsPDF)
+      } else if (autoTableModule && typeof autoTableModule.default === 'function') {
+        (jsPDF.API as any).autoTable = autoTableModule.default
+      } else {
+        console.error("Could not initialize jspdf-autotable plugin")
+        toast.error("PDF-Plugin konnte nicht initialisiert werden")
+        return
+      }
+
+      const doc = new jsPDF()
+      let startY = 20
+
+      // Title
+      doc.setFontSize(16)
+      doc.setFont("helvetica", "bold")
+      doc.text("Kostenaufstellung - Betriebskosten", 20, startY)
+      startY += 10
+
+      // Period and house info
+      doc.setFontSize(10)
+      doc.setFont("helvetica", "normal")
+      doc.text(`Zeitraum: ${isoToGermanDate(nebenkosten.startdatum)} bis ${isoToGermanDate(nebenkosten.enddatum)}`, 20, startY)
+      startY += 6
+      if (nebenkosten.haus_name) {
+        doc.text(`Haus: ${nebenkosten.haus_name}`, 20, startY)
+        startY += 6
+      }
+      startY += 10
+
+      // Summary information
+      doc.setFontSize(12)
+      doc.setFont("helvetica", "bold")
+      doc.text("Übersicht", 20, startY)
+      startY += 8
+
+      doc.setFontSize(10)
+      doc.setFont("helvetica", "normal")
+      doc.text(`Gesamtfläche: ${totalArea} m²`, 20, startY)
+      startY += 6
+      doc.text(`Anzahl Wohnungen: ${nebenkosten.anzahlWohnungen || 0}`, 20, startY)
+      startY += 6
+      doc.text(`Anzahl Mieter: ${nebenkosten.anzahlMieter || 0}`, 20, startY)
+      startY += 6
+      doc.text(`Gesamtkosten: ${formatCurrency(totalCosts)}`, 20, startY)
+      startY += 6
+      doc.text(`Kosten pro m²: ${formatCurrency(costPerSqm)}`, 20, startY)
+      startY += 15
+
+      // Cost breakdown table
+      const tableData = nebenkosten.nebenkostenart?.map((art, index) => [
+        (index + 1).toString(),
+        art || '-',
+        formatCurrency(nebenkosten.betrag?.[index] || null),
+        nebenkosten.betrag?.[index] && totalArea > 0 
+          ? formatCurrency((nebenkosten.betrag[index] || 0) / totalArea) 
+          : '-'
+      ]) || []
+
+      // Add total row
+      tableData.push([
+        '',
+        'Gesamtkosten',
+        formatCurrency(totalCosts),
+        formatCurrency(costPerSqm)
+      ])
+
+      ;(doc as any).autoTable({
+        head: [['Pos.', 'Leistungsart', 'Gesamtkosten', 'Kosten pro m²']],
+        body: tableData,
+        startY: startY,
+        theme: 'grid',
+        styles: {
+          fontSize: 9,
+          cellPadding: 3,
+        },
+        headStyles: {
+          fillColor: [240, 240, 240],
+          textColor: [0, 0, 0],
+          fontStyle: 'bold',
+        },
+        columnStyles: {
+          2: { halign: 'right' },
+          3: { halign: 'right' },
+        },
+        didParseCell: function(data: any) {
+          // Make the total row bold
+          if (data.row.index === tableData.length - 1) {
+            data.cell.styles.fontStyle = 'bold'
+            data.cell.styles.fillColor = [248, 248, 248]
+          }
+        }
+      })
+
+      // Water costs section if available
+      if (nebenkosten.wasserkosten && nebenkosten.wasserkosten > 0) {
+        const finalY = (doc as any).lastAutoTable.finalY + 15
+        
+        doc.setFontSize(12)
+        doc.setFont("helvetica", "bold")
+        doc.text("Wasserkosten", 20, finalY)
+        
+        let waterY = finalY + 8
+        doc.setFontSize(10)
+        doc.setFont("helvetica", "normal")
+        
+        if (typeof nebenkosten.wasserverbrauch === 'number') {
+          doc.text(`Gesamtverbrauch: ${nebenkosten.wasserverbrauch} m³`, 20, waterY)
+          waterY += 6
+        }
+        
+        doc.text(`Gesamtkosten: ${formatCurrency(nebenkosten.wasserkosten)}`, 20, waterY)
+        waterY += 6
+        
+        if (nebenkosten.wasserverbrauch && nebenkosten.wasserverbrauch > 0) {
+          const costPerCubicMeter = nebenkosten.wasserkosten / nebenkosten.wasserverbrauch
+          doc.text(`Kosten pro m³: ${formatCurrency(costPerCubicMeter)}`, 20, waterY)
+        }
+      }
+
+      // Generate filename
+      const startDate = isoToGermanDate(nebenkosten.startdatum)?.replace(/\./g, '-') || 'unbekannt'
+      const endDate = isoToGermanDate(nebenkosten.enddatum)?.replace(/\./g, '-') || 'unbekannt'
+      const houseName = nebenkosten.haus_name?.replace(/[^a-zA-Z0-9]/g, '_') || 'Haus'
+      const filename = `Kostenaufstellung_${houseName}_${startDate}_bis_${endDate}.pdf`
+
+      // Save the PDF
+      doc.save(filename)
+      toast.success("PDF erfolgreich erstellt und heruntergeladen!")
+
+    } catch (error) {
+      console.error("PDF export error:", error)
+      toast.error("Fehler beim Erstellen der PDF-Datei")
+    } finally {
+      setIsExporting(false)
+    }
+  }
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -131,6 +285,17 @@ export function OperatingCostsOverviewModal({
             )}
           </div>
         </div>
+        
+        <DialogFooter className="flex justify-end gap-2 pt-4">
+          <Button
+            onClick={exportToPDF}
+            disabled={isExporting}
+            className="flex items-center gap-2"
+          >
+            <FileDown className="h-4 w-4" />
+            {isExporting ? "PDF wird erstellt..." : "Kostenaufstellung exportieren"}
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   )

--- a/components/operating-costs-overview-modal.tsx
+++ b/components/operating-costs-overview-modal.tsx
@@ -139,7 +139,7 @@ export function OperatingCostsOverviewModal({
           lineColor: [0, 0, 0] // Black color for row separators
         },
         columnStyles: {
-          0: { halign: 'center' }, // Center align position numbers
+          0: { halign: 'left' },   // Left align position numbers
           1: { halign: 'left' },   // Left align service descriptions
           2: { halign: 'right' },  // Right align total costs
           3: { halign: 'right' },  // Right align costs per sqm

--- a/components/operating-costs-overview-modal.tsx
+++ b/components/operating-costs-overview-modal.tsx
@@ -141,6 +141,9 @@ export function OperatingCostsOverviewModal({
           2: { halign: 'right' },
           3: { halign: 'right' },
         },
+        // Ensure table aligns with left and right content margins
+        tableWidth: (doc as any).internal.pageSize.getWidth() - 40,
+        margin: { left: 20, right: 20 },
         didParseCell: function(data: any) {
           // Make the total row bold
           if (data.row.index === tableData.length - 1) {


### PR DESCRIPTION
## Description

Adds a PDF export to the Nebenkosten overview modal.

## Summary of Changes

- New "Kostenaufstellung exportieren" button in the modal footer generates a formatted PDF: header with period and house, summary (area, apartments, tenants, total costs, cost per m²), the cost breakdown table with a bold total row, and the water-costs section when present
- jsPDF and jspdf-autotable loaded dynamically; filename derived from house name and period; success/error toasts via sonner
- Abrechnung PDF table switched from `grid` to `plain` styling (white header with a single bottom rule, thin row separators) to match
- Test suite for the modal (173 lines) covering rendering, totals, water costs and the export flow