### PR TITLE
Fix/border radius overview modal

### DIFF
--- a/components/operating-costs-overview-modal.tsx
+++ b/components/operating-costs-overview-modal.tsx
@@ -235,7 +235,7 @@ export function OperatingCostsOverviewModal({
         </div>
         
         <div className="space-y-6">
-          <div className="rounded-md border">
+          <div className="rounded-2xl border">
             <Table>
               <TableHeader>
                 <TableRow>
@@ -270,7 +270,7 @@ export function OperatingCostsOverviewModal({
           </div>
 
           {/* Water costs section */}
-          <div className="rounded-md border p-4">
+          <div className="rounded-2xl border p-4">
             <h3 className="font-semibold mb-4">Wasserkosten</h3>
             {(nebenkosten.wasserkosten && nebenkosten.wasserkosten > 0) || typeof nebenkosten.wasserverbrauch === 'number' ? (
               <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">

--- a/components/operating-costs-overview-modal.tsx
+++ b/components/operating-costs-overview-modal.tsx
@@ -235,7 +235,7 @@ export function OperatingCostsOverviewModal({
         </div>
         
         <div className="space-y-6">
-          <div className="rounded-2xl border">
+          <div className="rounded-2xl border overflow-hidden">
             <Table>
               <TableHeader>
                 <TableRow>

--- a/components/summary-cards.tsx
+++ b/components/summary-cards.tsx
@@ -44,8 +44,8 @@ export function SummaryCards({ totalArea, apartmentCount, tenantCount, totalCost
 
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-      {cards.map((card, index) => (
-        <Card key={index} className="rounded-2xl shadow-md">
+      {cards.map((card) => (
+        <Card key={card.title} className="rounded-2xl shadow-md">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">{card.title}</CardTitle>
             <div className="h-5 w-5 text-muted-foreground">

--- a/components/summary-cards.tsx
+++ b/components/summary-cards.tsx
@@ -45,7 +45,7 @@ export function SummaryCards({ totalArea, apartmentCount, tenantCount, totalCost
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
       {cards.map((card, index) => (
-        <Card key={index}>
+        <Card key={index} className="rounded-2xl shadow-md">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">{card.title}</CardTitle>
             <div className="h-5 w-5 text-muted-foreground">


### PR DESCRIPTION
## Description

Aligns the operating-costs overview surfaces with the rounded card design.

## Summary of Changes

- Overview modal: costs table and water-costs section now use `rounded-2xl` containers (table clipped with `overflow-hidden`)
- Summary cards keyed by title instead of index and styled with `rounded-2xl shadow-md`