### PR TITLE
Fix/scroll mention template suggestions

### DIFF
--- a/components/mention-suggestion-list.tsx
+++ b/components/mention-suggestion-list.tsx
@@ -263,12 +263,15 @@ export const MentionSuggestionList = forwardRef<
 
   // Handle keyboard events for TipTap integration
   const onKeyDown = useCallback(({ event }: { event: KeyboardEvent }) => {
+    console.log('Suggestion list onKeyDown called with:', event.key, 'selectedIndex:', selectedIndex, 'flatItems.length:', flatItems.length);
     // Handle arrow keys for navigation
     if (event.key === 'ArrowDown') {
+      console.log('Handling ArrowDown');
       event.preventDefault();
       event.stopPropagation();
       if (flatItems.length > 0) {
         const nextIndex = selectedIndex < flatItems.length - 1 ? selectedIndex + 1 : 0;
+        console.log('Setting next index to:', nextIndex);
         setSelectedIndex(nextIndex);
       }
       return true;

--- a/components/mention-suggestion-list.tsx
+++ b/components/mention-suggestion-list.tsx
@@ -413,7 +413,7 @@ export const MentionSuggestionList = forwardRef<
       {/* Header with search indicator */}
       <div className="flex items-center gap-2 border-b px-4 py-3">
         <Search className="h-4 w-4 text-muted-foreground" />
-        <span className="text-sm font-medium">Template Variables</span>
+        <span className="text-sm font-medium">Vorlage-Variablen</span>
         {query && (
           <span className="ml-auto text-xs text-muted-foreground">
             "{query}"

--- a/components/mention-suggestion-list.tsx
+++ b/components/mention-suggestion-list.tsx
@@ -68,7 +68,7 @@ const MemoizedSuggestionItem = memo<{
   <div
     id={`suggestion-${item.id}`}
     className={cn(
-      "relative flex cursor-pointer select-none items-start gap-3 rounded-lg px-3 py-2.5 text-sm outline-none transition-all duration-150",
+      "group relative flex cursor-pointer select-none items-start gap-3 rounded-lg px-3 py-2.5 text-sm outline-none transition-all duration-150",
       "hover:bg-accent hover:text-accent-foreground hover:scale-[1.01]",
       isSelected && "bg-accent text-accent-foreground shadow-sm"
     )}
@@ -79,7 +79,12 @@ const MemoizedSuggestionItem = memo<{
     onClick={onSelect}
     onMouseEnter={onMouseEnter}
   >
-    <div className="flex h-6 w-6 items-center justify-center rounded-md bg-primary/10 text-primary flex-shrink-0 mt-0.5">
+    <div className={cn(
+      "flex h-6 w-6 items-center justify-center rounded-md flex-shrink-0 mt-0.5 transition-all duration-150",
+      "bg-primary/10 text-primary",
+      "group-hover:bg-accent-foreground/10 group-hover:text-accent-foreground",
+      isSelected && "bg-accent-foreground/15 text-accent-foreground"
+    )}>
       <Hash className="h-3.5 w-3.5" />
     </div>
     <div className="flex-1 space-y-1 min-w-0">

--- a/components/mention-suggestion-list.tsx
+++ b/components/mention-suggestion-list.tsx
@@ -263,7 +263,10 @@ export const MentionSuggestionList = forwardRef<
 
   // Handle keyboard events for TipTap integration
   const onKeyDown = useCallback(({ event }: { event: KeyboardEvent }) => {
-    return handleKeyDown(event);
+    console.log('MentionSuggestionList received key:', event.key); // Debug log
+    const handled = handleKeyDown(event);
+    console.log('Key handled:', handled); // Debug log
+    return handled;
   }, [handleKeyDown]);
 
   // Expose keyboard navigation methods via ref
@@ -376,16 +379,8 @@ export const MentionSuggestionList = forwardRef<
         aria-activedescendant={selectedItem ? `suggestion-${selectedItem.id}` : undefined}
         aria-multiselectable="false"
         aria-describedby="suggestion-instructions"
-        tabIndex={0}
+        tabIndex={-1}
         onWheel={handleWheel}
-        onKeyDown={(e) => {
-          // Handle keyboard events directly on the container
-          const handled = handleKeyDown(e.nativeEvent);
-          if (handled) {
-            e.preventDefault();
-            e.stopPropagation();
-          }
-        }}
       >
       {/* Header with search indicator */}
       <div className="flex items-center gap-2 border-b px-4 py-3">

--- a/components/mention-suggestion-list.tsx
+++ b/components/mention-suggestion-list.tsx
@@ -263,20 +263,28 @@ export const MentionSuggestionList = forwardRef<
 
   // Handle keyboard events for TipTap integration
   const onKeyDown = useCallback(({ event }: { event: KeyboardEvent }) => {
+    console.log('Suggestion list received key:', event.key, 'selectedIndex:', selectedIndex, 'flatItems.length:', flatItems.length);
+    
     // Handle arrow keys for navigation
     if (event.key === 'ArrowDown') {
+      console.log('Handling ArrowDown');
       event.preventDefault();
+      event.stopPropagation();
       if (flatItems.length > 0) {
         const nextIndex = selectedIndex < flatItems.length - 1 ? selectedIndex + 1 : 0;
+        console.log('Setting next index to:', nextIndex);
         setSelectedIndex(nextIndex);
       }
       return true;
     }
     
     if (event.key === 'ArrowUp') {
+      console.log('Handling ArrowUp');
       event.preventDefault();
+      event.stopPropagation();
       if (flatItems.length > 0) {
         const prevIndex = selectedIndex > 0 ? selectedIndex - 1 : flatItems.length - 1;
+        console.log('Setting prev index to:', prevIndex);
         setSelectedIndex(prevIndex);
       }
       return true;
@@ -284,13 +292,16 @@ export const MentionSuggestionList = forwardRef<
     
     // Handle selection
     if (event.key === 'Enter' || event.key === 'Tab') {
+      console.log('Handling selection');
       event.preventDefault();
+      event.stopPropagation();
       if (flatItems[selectedIndex]) {
         handleSelect(selectedIndex);
       }
       return true;
     }
     
+    console.log('Key not handled:', event.key);
     return false;
   }, [flatItems, selectedIndex, setSelectedIndex, handleSelect]);
 

--- a/components/mention-suggestion-list.tsx
+++ b/components/mention-suggestion-list.tsx
@@ -263,15 +263,12 @@ export const MentionSuggestionList = forwardRef<
 
   // Handle keyboard events for TipTap integration
   const onKeyDown = useCallback(({ event }: { event: KeyboardEvent }) => {
-    console.log('Suggestion list onKeyDown called with:', event.key, 'selectedIndex:', selectedIndex, 'flatItems.length:', flatItems.length);
     // Handle arrow keys for navigation
     if (event.key === 'ArrowDown') {
-      console.log('Handling ArrowDown');
       event.preventDefault();
       event.stopPropagation();
       if (flatItems.length > 0) {
         const nextIndex = selectedIndex < flatItems.length - 1 ? selectedIndex + 1 : 0;
-        console.log('Setting next index to:', nextIndex);
         setSelectedIndex(nextIndex);
       }
       return true;

--- a/components/mention-suggestion-list.tsx
+++ b/components/mention-suggestion-list.tsx
@@ -263,11 +263,36 @@ export const MentionSuggestionList = forwardRef<
 
   // Handle keyboard events for TipTap integration
   const onKeyDown = useCallback(({ event }: { event: KeyboardEvent }) => {
-    console.log('MentionSuggestionList received key:', event.key); // Debug log
-    const handled = handleKeyDown(event);
-    console.log('Key handled:', handled); // Debug log
-    return handled;
-  }, [handleKeyDown]);
+    // Handle arrow keys for navigation
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      if (flatItems.length > 0) {
+        const nextIndex = selectedIndex < flatItems.length - 1 ? selectedIndex + 1 : 0;
+        setSelectedIndex(nextIndex);
+      }
+      return true;
+    }
+    
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (flatItems.length > 0) {
+        const prevIndex = selectedIndex > 0 ? selectedIndex - 1 : flatItems.length - 1;
+        setSelectedIndex(prevIndex);
+      }
+      return true;
+    }
+    
+    // Handle selection
+    if (event.key === 'Enter' || event.key === 'Tab') {
+      event.preventDefault();
+      if (flatItems[selectedIndex]) {
+        handleSelect(selectedIndex);
+      }
+      return true;
+    }
+    
+    return false;
+  }, [flatItems, selectedIndex, setSelectedIndex, handleSelect]);
 
   // Expose keyboard navigation methods via ref
   useImperativeHandle(ref, () => ({

--- a/components/mention-suggestion-list.tsx
+++ b/components/mention-suggestion-list.tsx
@@ -361,7 +361,7 @@ export const MentionSuggestionList = forwardRef<
 
       {/* Scrollable content */}
       <div
-        className="max-h-[320px] overflow-y-auto p-2"
+        className="max-h-[320px] overflow-y-auto overflow-x-hidden"
         style={{
           overflowY: 'auto',
           overflowX: 'hidden',
@@ -406,7 +406,7 @@ export const MentionSuggestionList = forwardRef<
             </div>
           </div>
         ) : (
-          <div className="space-y-1">
+          <div className="pb-2">
             {orderedCategories.map((categoryId, categoryIndex) => {
               const categoryItems = groupedItems[categoryId] || [];
               const categoryConfig = getCategoryConfig(categoryId);
@@ -416,14 +416,14 @@ export const MentionSuggestionList = forwardRef<
               const IconComponent = categoryConfig?.icon ? ICON_MAP[categoryConfig.icon] : null;
               
               return (
-                <div key={categoryId} className="space-y-1">
+                <div key={categoryId}>
                   {/* Category separator - only show if not first category */}
                   {categoryIndex > 0 && (
-                    <div className="mx-2 my-2 h-px bg-border" />
+                    <div className="mx-2 my-1 h-px bg-border" />
                   )}
                   
                   {/* Category header */}
-                  <div className="sticky top-0 z-10 flex items-center gap-2 bg-popover/95 backdrop-blur-sm px-3 py-2 text-xs font-semibold text-muted-foreground">
+                  <div className="sticky top-0 z-20 flex items-center gap-2 bg-popover border-b border-border/50 px-3 py-2 text-xs font-semibold text-muted-foreground shadow-sm backdrop-blur-sm">
                     {IconComponent && (
                       <IconComponent className="h-3.5 w-3.5" />
                     )}
@@ -431,7 +431,7 @@ export const MentionSuggestionList = forwardRef<
                   </div>
                   
                   {/* Category items */}
-                  <div className="space-y-0.5">
+                  <div className="px-2 py-1 space-y-0.5">
                     {categoryItems.map((item) => {
                       const flatIndex = getFlatIndex(item);
                       const isSelected = flatIndex === selectedIndex;

--- a/components/mention-suggestion-list.tsx
+++ b/components/mention-suggestion-list.tsx
@@ -184,6 +184,26 @@ export const MentionSuggestionList = forwardRef<
     initialIndex: 0,
   });
 
+  // Scroll selected item into view
+  useEffect(() => {
+    if (selectedIndex >= 0 && flatItems.length > 0) {
+      const selectedElement = document.getElementById(`suggestion-${flatItems[selectedIndex]?.id}`);
+      if (selectedElement) {
+        selectedElement.scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+          inline: 'nearest'
+        });
+      }
+    }
+  }, [selectedIndex, flatItems]);
+
+  // Ensure mouse wheel events work properly
+  const handleWheel = useCallback((event: React.WheelEvent) => {
+    // Allow the event to bubble up to the scrollable container
+    event.stopPropagation();
+  }, []);
+
   // Wrap keyboard handling with error recovery
   const handleKeyDown = useCallback((event: KeyboardEvent) => {
     try {
@@ -303,8 +323,21 @@ export const MentionSuggestionList = forwardRef<
       aria-activedescendant={selectedItem ? `suggestion-${selectedItem.id}` : undefined}
       aria-multiselectable="false"
       tabIndex={-1}
+      onWheel={handleWheel}
     >
-      <div>
+      <div
+        onWheel={(e) => {
+          // Ensure wheel events are handled by this scrollable container
+          e.stopPropagation();
+        }}
+        style={{
+          // Ensure the container is scrollable and handles mouse wheel
+          overflowY: 'auto',
+          overflowX: 'hidden',
+          pointerEvents: 'auto',
+          touchAction: 'pan-y'
+        }}
+      >
         {loading ? (
           <>
             <div className="mention-suggestion-loading" role="status" aria-live="polite">

--- a/components/mention-suggestion-list.tsx
+++ b/components/mention-suggestion-list.tsx
@@ -263,28 +263,22 @@ export const MentionSuggestionList = forwardRef<
 
   // Handle keyboard events for TipTap integration
   const onKeyDown = useCallback(({ event }: { event: KeyboardEvent }) => {
-    console.log('Suggestion list received key:', event.key, 'selectedIndex:', selectedIndex, 'flatItems.length:', flatItems.length);
-    
     // Handle arrow keys for navigation
     if (event.key === 'ArrowDown') {
-      console.log('Handling ArrowDown');
       event.preventDefault();
       event.stopPropagation();
       if (flatItems.length > 0) {
         const nextIndex = selectedIndex < flatItems.length - 1 ? selectedIndex + 1 : 0;
-        console.log('Setting next index to:', nextIndex);
         setSelectedIndex(nextIndex);
       }
       return true;
     }
     
     if (event.key === 'ArrowUp') {
-      console.log('Handling ArrowUp');
       event.preventDefault();
       event.stopPropagation();
       if (flatItems.length > 0) {
         const prevIndex = selectedIndex > 0 ? selectedIndex - 1 : flatItems.length - 1;
-        console.log('Setting prev index to:', prevIndex);
         setSelectedIndex(prevIndex);
       }
       return true;
@@ -292,7 +286,6 @@ export const MentionSuggestionList = forwardRef<
     
     // Handle selection
     if (event.key === 'Enter' || event.key === 'Tab') {
-      console.log('Handling selection');
       event.preventDefault();
       event.stopPropagation();
       if (flatItems[selectedIndex]) {
@@ -301,7 +294,6 @@ export const MentionSuggestionList = forwardRef<
       return true;
     }
     
-    console.log('Key not handled:', event.key);
     return false;
   }, [flatItems, selectedIndex, setSelectedIndex, handleSelect]);
 

--- a/components/template-editor.tsx
+++ b/components/template-editor.tsx
@@ -173,39 +173,27 @@ export function TemplateEditor({
                     },
                   });
 
-                  // Add keyboard event listener directly to the popup element
-                  const popupElement = component.element as HTMLElement;
-                  if (popupElement) {
-                    const handlePopupKeyDown = (event: KeyboardEvent) => {
-                      console.log('Popup received key:', event.key);
-                      if (['ArrowDown', 'ArrowUp', 'Enter', 'Tab', 'Escape'].includes(event.key)) {
-                        console.log('Handling navigation key:', event.key);
-                        const handled = component?.ref?.onKeyDown({ event });
-                        console.log('Key handled by component:', handled);
-                        if (handled) {
-                          event.preventDefault();
-                          event.stopPropagation();
-                        }
+                  // Add global keyboard event listener while popup is open
+                  const handleGlobalKeyDown = (event: KeyboardEvent) => {
+                    if (['ArrowDown', 'ArrowUp', 'Enter', 'Tab', 'Escape'].includes(event.key)) {
+                      const handled = component?.ref?.onKeyDown({ event });
+                      if (handled) {
+                        event.preventDefault();
+                        event.stopPropagation();
                       }
-                    };
-
-                    // Make the popup element focusable and add event listener
-                    popupElement.tabIndex = 0;
-                    popupElement.addEventListener('keydown', handlePopupKeyDown, true);
-                    
-                    // Focus the popup element so it can receive keyboard events
-                    setTimeout(() => {
-                      popupElement.focus();
-                    }, 0);
-                    
-                    // Store the cleanup function
-                    if (popup) {
-                      const originalDestroy = popup.destroy;
-                      popup.destroy = () => {
-                        popupElement.removeEventListener('keydown', handlePopupKeyDown, true);
-                        originalDestroy();
-                      };
                     }
+                  };
+
+                  // Add global event listener with capture
+                  document.addEventListener('keydown', handleGlobalKeyDown, true);
+                  
+                  // Store the cleanup function
+                  if (popup) {
+                    const originalDestroy = popup.destroy;
+                    popup.destroy = () => {
+                      document.removeEventListener('keydown', handleGlobalKeyDown, true);
+                      originalDestroy();
+                    };
                   }
                 } catch (error) {
                   const suggestionError = handleSuggestionInitializationError(

--- a/components/template-editor.tsx
+++ b/components/template-editor.tsx
@@ -177,9 +177,7 @@ export function TemplateEditor({
                   const popupElement = component.element as HTMLElement;
                   if (popupElement) {
                     const handlePopupKeyDown = (event: KeyboardEvent) => {
-                      console.log('Popup key captured:', event.key);
                       if (['ArrowDown', 'ArrowUp', 'Enter', 'Tab', 'Escape'].includes(event.key)) {
-                        console.log('Handling popup navigation key:', event.key);
                         const handled = component?.ref?.onKeyDown({ event });
                         if (handled) {
                           event.preventDefault();
@@ -242,36 +240,13 @@ export function TemplateEditor({
                 }
               },
               onKeyDown: (props) => {
-                console.log('Template editor received key:', props.event.key);
-                
-                // Always try to handle navigation keys first
-                if (props.event.key === 'ArrowDown') {
-                  console.log('Intercepting ArrowDown');
-                  const handled = component?.ref?.onKeyDown(props);
-                  console.log('ArrowDown handled:', handled);
-                  return handled || false;
-                }
-                
-                if (props.event.key === 'ArrowUp') {
-                  console.log('Intercepting ArrowUp');
-                  const handled = component?.ref?.onKeyDown(props);
-                  console.log('ArrowUp handled:', handled);
-                  return handled || false;
-                }
-                
-                if (props.event.key === 'Enter' || props.event.key === 'Tab') {
-                  console.log('Intercepting selection key:', props.event.key);
-                  const handled = component?.ref?.onKeyDown(props);
-                  console.log('Selection key handled:', handled);
-                  return handled || false;
-                }
-                
+                // This is now handled by the direct popup event listener
+                // Keep this as fallback for any edge cases
                 if (props.event.key === 'Escape') {
                   popup?.hide();
                   return true;
                 }
 
-                // For other keys, let TipTap handle them
                 return false;
               },
               onExit: () => {

--- a/components/template-editor.tsx
+++ b/components/template-editor.tsx
@@ -208,6 +208,7 @@ export function TemplateEditor({
                 }
               },
               onKeyDown: (props) => {
+                console.log('Template editor received key:', props.event.key);
                 try {
                   // Handle escape key first
                   if (props.event.key === 'Escape') {
@@ -216,7 +217,9 @@ export function TemplateEditor({
                   }
 
                   // Pass keyboard events to the suggestion list component
+                  console.log('Passing key to suggestion list component');
                   const handled = component?.ref?.onKeyDown(props);
+                  console.log('Suggestion list handled:', handled);
                   if (handled) {
                     return true;
                   }

--- a/components/template-editor.tsx
+++ b/components/template-editor.tsx
@@ -209,33 +209,36 @@ export function TemplateEditor({
               },
               onKeyDown: (props) => {
                 console.log('Template editor received key:', props.event.key);
-                try {
-                  // Handle escape key first
-                  if (props.event.key === 'Escape') {
-                    popup?.hide();
-                    return true;
-                  }
-
-                  // Pass keyboard events to the suggestion list component
-                  console.log('Passing key to suggestion list component');
+                
+                // Always try to handle navigation keys first
+                if (props.event.key === 'ArrowDown') {
+                  console.log('Intercepting ArrowDown');
                   const handled = component?.ref?.onKeyDown(props);
-                  console.log('Suggestion list handled:', handled);
-                  if (handled) {
-                    return true;
-                  }
-
-                  return false;
-                } catch (error) {
-                  console.warn('Suggestion keyboard handling failed:', error);
-                  
-                  // Fallback keyboard handling
-                  if (props.event.key === 'Escape') {
-                    popup?.hide();
-                    return true;
-                  }
-                  
-                  return false;
+                  console.log('ArrowDown handled:', handled);
+                  return handled || false;
                 }
+                
+                if (props.event.key === 'ArrowUp') {
+                  console.log('Intercepting ArrowUp');
+                  const handled = component?.ref?.onKeyDown(props);
+                  console.log('ArrowUp handled:', handled);
+                  return handled || false;
+                }
+                
+                if (props.event.key === 'Enter' || props.event.key === 'Tab') {
+                  console.log('Intercepting selection key:', props.event.key);
+                  const handled = component?.ref?.onKeyDown(props);
+                  console.log('Selection key handled:', handled);
+                  return handled || false;
+                }
+                
+                if (props.event.key === 'Escape') {
+                  popup?.hide();
+                  return true;
+                }
+
+                // For other keys, let TipTap handle them
+                return false;
               },
               onExit: () => {
                 try {

--- a/components/template-editor.tsx
+++ b/components/template-editor.tsx
@@ -177,8 +177,11 @@ export function TemplateEditor({
                   const popupElement = component.element as HTMLElement;
                   if (popupElement) {
                     const handlePopupKeyDown = (event: KeyboardEvent) => {
+                      console.log('Popup received key:', event.key);
                       if (['ArrowDown', 'ArrowUp', 'Enter', 'Tab', 'Escape'].includes(event.key)) {
+                        console.log('Handling navigation key:', event.key);
                         const handled = component?.ref?.onKeyDown({ event });
+                        console.log('Key handled by component:', handled);
                         if (handled) {
                           event.preventDefault();
                           event.stopPropagation();

--- a/components/template-editor.tsx
+++ b/components/template-editor.tsx
@@ -209,12 +209,19 @@ export function TemplateEditor({
               },
               onKeyDown: (props) => {
                 try {
+                  // Handle escape key first
                   if (props.event.key === 'Escape') {
                     popup?.hide();
                     return true;
                   }
 
-                  return component?.ref?.onKeyDown(props) || false;
+                  // Pass keyboard events to the suggestion list component
+                  const handled = component?.ref?.onKeyDown(props);
+                  if (handled) {
+                    return true;
+                  }
+
+                  return false;
                 } catch (error) {
                   console.warn('Suggestion keyboard handling failed:', error);
                   

--- a/components/template-editor.tsx
+++ b/components/template-editor.tsx
@@ -172,6 +172,40 @@ export function TemplateEditor({
                       component?.destroy();
                     },
                   });
+
+                  // Add keyboard event listener directly to the popup element
+                  const popupElement = component.element as HTMLElement;
+                  if (popupElement) {
+                    const handlePopupKeyDown = (event: KeyboardEvent) => {
+                      console.log('Popup key captured:', event.key);
+                      if (['ArrowDown', 'ArrowUp', 'Enter', 'Tab', 'Escape'].includes(event.key)) {
+                        console.log('Handling popup navigation key:', event.key);
+                        const handled = component?.ref?.onKeyDown({ event });
+                        if (handled) {
+                          event.preventDefault();
+                          event.stopPropagation();
+                        }
+                      }
+                    };
+
+                    // Make the popup element focusable and add event listener
+                    popupElement.tabIndex = 0;
+                    popupElement.addEventListener('keydown', handlePopupKeyDown, true);
+                    
+                    // Focus the popup element so it can receive keyboard events
+                    setTimeout(() => {
+                      popupElement.focus();
+                    }, 0);
+                    
+                    // Store the cleanup function
+                    if (popup) {
+                      const originalDestroy = popup.destroy;
+                      popup.destroy = () => {
+                        popupElement.removeEventListener('keydown', handlePopupKeyDown, true);
+                        originalDestroy();
+                      };
+                    }
+                  }
                 } catch (error) {
                   const suggestionError = handleSuggestionInitializationError(
                     error instanceof Error ? error : new Error('Suggestion initialization failed'),

--- a/hooks/use-keyboard-navigation.ts
+++ b/hooks/use-keyboard-navigation.ts
@@ -61,22 +61,66 @@ export function useKeyboardNavigation({
     switch (event.key) {
       case 'ArrowDown':
         event.preventDefault();
+        event.stopPropagation();
         selectNext();
         return true;
 
       case 'ArrowUp':
         event.preventDefault();
+        event.stopPropagation();
         selectPrevious();
+        return true;
+
+      case 'Home':
+        event.preventDefault();
+        event.stopPropagation();
+        if (itemCount > 0) {
+          setSelectedIndex(0);
+        }
+        return true;
+
+      case 'End':
+        event.preventDefault();
+        event.stopPropagation();
+        if (itemCount > 0) {
+          setSelectedIndex(itemCount - 1);
+        }
+        return true;
+
+      case 'PageDown':
+        event.preventDefault();
+        event.stopPropagation();
+        if (itemCount > 0) {
+          const jumpSize = Math.min(5, itemCount - 1);
+          setSelectedIndex((prev) => Math.min(prev + jumpSize, itemCount - 1));
+        }
+        return true;
+
+      case 'PageUp':
+        event.preventDefault();
+        event.stopPropagation();
+        if (itemCount > 0) {
+          const jumpSize = Math.min(5, itemCount - 1);
+          setSelectedIndex((prev) => Math.max(prev - jumpSize, 0));
+        }
         return true;
 
       case 'Enter':
       case 'Tab':
         event.preventDefault();
+        event.stopPropagation();
+        selectCurrentItem();
+        return true;
+
+      case ' ': // Space key
+        event.preventDefault();
+        event.stopPropagation();
         selectCurrentItem();
         return true;
 
       case 'Escape':
         event.preventDefault();
+        event.stopPropagation();
         if (onEscape) {
           onEscape();
         }
@@ -85,7 +129,7 @@ export function useKeyboardNavigation({
       default:
         return false;
     }
-  }, [selectNext, selectPrevious, selectCurrentItem, onEscape]);
+  }, [selectNext, selectPrevious, selectCurrentItem, onEscape, itemCount, setSelectedIndex]);
 
   return {
     selectedIndex,

--- a/lib/mention-suggestion-popup.ts
+++ b/lib/mention-suggestion-popup.ts
@@ -176,6 +176,10 @@ export function createSuggestionPopup(config: SuggestionPopupConfig): PopupInsta
       animation: 'shift-away-subtle',
       duration: [150, 100],
       zIndex: parseInt(getComputedStyle(document.documentElement).getPropertyValue('--z-index-tooltip').trim()) || 1070,
+      // Allow mouse wheel events to pass through to scrollable content
+      allowHTML: true,
+      interactiveBorder: 0,
+      interactiveDebounce: 0,
       ...( isMobile && initialRect 
         ? getMobileConfig() 
         : getDesktopConfig(initialRect || new DOMRect())
@@ -326,14 +330,23 @@ export const mentionSuggestionTheme = `
     border: none;
     box-shadow: none;
     padding: 0;
+    pointer-events: auto !important;
+    overflow: visible !important;
   }
   
   .tippy-box[data-theme~='mention-suggestion'] .tippy-content {
     padding: 0;
+    pointer-events: auto !important;
+    overflow: visible !important;
   }
   
   .tippy-box[data-theme~='mention-suggestion'] .tippy-arrow {
     display: none;
+  }
+  
+  /* Ensure mouse wheel events work */
+  .tippy-box[data-theme~='mention-suggestion'] * {
+    pointer-events: auto !important;
   }
 `;
 

--- a/styles/template-editor.css
+++ b/styles/template-editor.css
@@ -60,51 +60,30 @@
 
 
 
-/* Beautiful Mention Suggestion Dropdown */
-.mention-suggestion-modal {
-  background: hsl(var(--popover));
-  border: 1px solid hsl(var(--border));
-  border-radius: 0.75rem;
-  box-shadow: 0 10px 38px -10px hsla(222, 47%, 11%, 0.35), 0 10px 20px -15px hsla(222, 47%, 11%, 0.2);
-  max-height: 24rem;
-  min-width: 18rem;
-  max-width: 28rem;
-  overflow: hidden;
-  z-index: 50;
-  backdrop-filter: blur(8px);
-  animation: mention-dropdown-enter 200ms ease-out;
-  position: relative;
-  -webkit-overflow-scrolling: touch; /* Smooth scrolling on iOS */
-  pointer-events: auto; /* Ensure mouse events work */
-  display: flex;
-  flex-direction: column;
-}
+/* Modern Template Mention Suggestions Dropdown - Application Style */
+/* This dropdown now uses the same styling as other application dropdowns */
 
-/* Ensure Tippy.js container allows scrolling */
+/* Tippy.js integration for mention suggestions */
 .tippy-box[data-theme~='mention-suggestion'] {
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+  padding: 0 !important;
   pointer-events: auto !important;
   overflow: visible !important;
 }
 
 .tippy-box[data-theme~='mention-suggestion'] .tippy-content {
-  pointer-events: auto !important;
-  overflow: visible !important;
   padding: 0 !important;
-}
-
-/* Ensure interactive Tippy instances allow scrolling */
-.tippy-box[data-interactive] {
   pointer-events: auto !important;
   overflow: visible !important;
 }
 
-.tippy-box[data-interactive] .tippy-content {
-  pointer-events: auto !important;
-  overflow: visible !important;
-  padding: 0 !important;
+.tippy-box[data-theme~='mention-suggestion'] .tippy-arrow {
+  display: none !important;
 }
 
-/* Force mouse wheel events to work on the dropdown */
+/* Ensure all interactive elements work properly */
 .tippy-box[data-theme~='mention-suggestion'] * {
   pointer-events: auto !important;
 }
@@ -445,54 +424,22 @@
   background-color: hsl(var(--muted-foreground) / 0.7);
 }
 
-/* Responsive Design */
-@media (max-width: 640px) {
-  .mention-suggestion-modal {
-    max-height: 20rem;
-    min-width: 16rem;
-    max-width: calc(100vw - 2rem);
-    border-radius: 0.5rem;
-  }
-  
-  .mention-suggestion-modal > div {
-    max-height: 20rem;
-    padding: 0.125rem 0;
-  }
-  
-  .mention-category-header {
-    padding: 0.5rem 0.75rem 0.375rem;
-    font-size: 0.6875rem;
-    margin: 0 -0.125rem;
-  }
-  
-  .mention-category-icon {
-    width: 0.75rem;
-    height: 0.75rem;
-  }
-  
-  .mention-suggestion-item {
-    padding: 0.75rem 0.75rem;
-    margin: 0 0.125rem;
-    gap: 0.1875rem;
-  }
-  
-  .mention-suggestion-label {
-    font-size: 0.8125rem;
-  }
-  
-  .mention-suggestion-description {
-    font-size: 0.6875rem;
-  }
-  
-  .mention-suggestion-empty {
-    padding: 1.5rem 0.75rem;
-    gap: 0.5rem;
-  }
-  
-  .mention-suggestion-empty-icon {
-    width: 1.5rem;
-    height: 1.5rem;
-  }
+/* Modern scrollbar styling for mention dropdown */
+.mention-suggestion-dropdown::-webkit-scrollbar {
+  width: 8px;
+}
+
+.mention-suggestion-dropdown::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.mention-suggestion-dropdown::-webkit-scrollbar-thumb {
+  background-color: hsl(var(--muted-foreground) / 0.3);
+  border-radius: 4px;
+}
+
+.mention-suggestion-dropdown::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(var(--muted-foreground) / 0.5);
 }
 
 /* Focus and accessibility improvements */
@@ -525,41 +472,11 @@
 
 /* Reduced motion support */
 @media (prefers-reduced-motion: reduce) {
-  .mention-suggestion-modal {
-    animation: none;
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
-  
-  .mention-suggestion-item {
-    transition: none;
-  }
-  
-  .mention-suggestion-item.selected {
-    animation: none;
-  }
-  
-  .mention-suggestion-loading-spinner {
-    animation: none;
-  }
-  
-  .mention-suggestion-skeleton-label,
-  .mention-suggestion-skeleton-description {
-    animation: none;
-    opacity: 0.6;
-  }
-}
-
-/* Final fix for mouse wheel scrolling - highest priority */
-.tippy-box[data-theme~='mention-suggestion'],
-.tippy-box[data-theme~='mention-suggestion'] .tippy-content,
-.mention-suggestion-modal,
-.mention-suggestion-modal > div {
-  pointer-events: auto !important;
-  overflow: visible !important;
-}
-
-.mention-suggestion-modal > div {
-  overflow-y: auto !important;
-  overflow-x: hidden !important;
 }
 
 /* Editor toolbar styling */

--- a/styles/template-editor.css
+++ b/styles/template-editor.css
@@ -66,9 +66,9 @@
   border: 1px solid hsl(var(--border));
   border-radius: 0.75rem;
   box-shadow: 0 10px 38px -10px hsla(222, 47%, 11%, 0.35), 0 10px 20px -15px hsla(222, 47%, 11%, 0.2);
-  max-height: 20rem;
-  min-width: 16rem;
-  max-width: 24rem;
+  max-height: 24rem;
+  min-width: 18rem;
+  max-width: 28rem;
   overflow: hidden;
   z-index: 50;
   backdrop-filter: blur(8px);
@@ -76,24 +76,36 @@
   position: relative;
   -webkit-overflow-scrolling: touch; /* Smooth scrolling on iOS */
   pointer-events: auto; /* Ensure mouse events work */
+  display: flex;
+  flex-direction: column;
 }
 
 /* Ensure Tippy.js container allows scrolling */
 .tippy-box[data-theme~='mention-suggestion'] {
   pointer-events: auto !important;
+  overflow: visible !important;
 }
 
 .tippy-box[data-theme~='mention-suggestion'] .tippy-content {
   pointer-events: auto !important;
   overflow: visible !important;
+  padding: 0 !important;
 }
 
 /* Ensure interactive Tippy instances allow scrolling */
 .tippy-box[data-interactive] {
   pointer-events: auto !important;
+  overflow: visible !important;
 }
 
 .tippy-box[data-interactive] .tippy-content {
+  pointer-events: auto !important;
+  overflow: visible !important;
+  padding: 0 !important;
+}
+
+/* Force mouse wheel events to work on the dropdown */
+.tippy-box[data-theme~='mention-suggestion'] * {
   pointer-events: auto !important;
 }
 
@@ -109,48 +121,55 @@
 }
 
 /* Scrollable container for items */
-.mention-suggestion-modal {
-  display: block; /* Changed from flex to block for simpler layout */
-  position: relative;
-}
-
 .mention-suggestion-modal > div {
-  max-height: 20rem;
-  overflow-y: auto;
+  flex: 1;
+  max-height: 24rem;
+  overflow-y: auto !important;
   overflow-x: hidden;
   scrollbar-width: thin;
-  scrollbar-color: hsl(var(--muted-foreground) / 0.3) transparent;
+  scrollbar-color: hsl(var(--muted-foreground) / 0.4) hsl(var(--muted) / 0.2);
   scroll-behavior: smooth;
   -webkit-overflow-scrolling: touch; /* Smooth scrolling on iOS */
-  pointer-events: auto; /* Ensure scrolling works */
+  pointer-events: auto !important; /* Ensure scrolling works */
   overscroll-behavior: contain; /* Prevent scroll chaining */
   position: relative;
   z-index: 1;
+  padding: 0.25rem 0;
+  /* Force mouse wheel events */
+  touch-action: pan-y;
+  -ms-overflow-style: auto;
 }
 
-/* Scrollbar styling for the dropdown content */
+/* Enhanced scrollbar styling for the dropdown content */
 .mention-suggestion-modal > div::-webkit-scrollbar,
 .mention-suggestion-modal div[role="listbox"] > div::-webkit-scrollbar {
-  width: 8px;
+  width: 10px;
 }
 
 .mention-suggestion-modal > div::-webkit-scrollbar-track,
 .mention-suggestion-modal div[role="listbox"] > div::-webkit-scrollbar-track {
-  background: transparent;
-  border-radius: 4px;
+  background: hsl(var(--muted) / 0.2);
+  border-radius: 6px;
+  margin: 4px 0;
 }
 
 .mention-suggestion-modal > div::-webkit-scrollbar-thumb,
 .mention-suggestion-modal div[role="listbox"] > div::-webkit-scrollbar-thumb {
-  background-color: hsl(var(--muted-foreground) / 0.3);
-  border-radius: 4px;
-  border: 2px solid transparent;
+  background-color: hsl(var(--muted-foreground) / 0.4);
+  border-radius: 6px;
+  border: 2px solid hsl(var(--popover));
   background-clip: content-box;
+  min-height: 20px;
 }
 
 .mention-suggestion-modal > div::-webkit-scrollbar-thumb:hover,
 .mention-suggestion-modal div[role="listbox"] > div::-webkit-scrollbar-thumb:hover {
-  background-color: hsl(var(--muted-foreground) / 0.5);
+  background-color: hsl(var(--muted-foreground) / 0.6);
+}
+
+.mention-suggestion-modal > div::-webkit-scrollbar-thumb:active,
+.mention-suggestion-modal div[role="listbox"] > div::-webkit-scrollbar-thumb:active {
+  background-color: hsl(var(--muted-foreground) / 0.8);
 }
 
 .mention-suggestion-modal > div::-webkit-scrollbar-corner,
@@ -160,12 +179,50 @@
 
 /* Additional scrolling support */
 .mention-suggestion-modal div[role="listbox"] {
-  max-height: 20rem;
-  overflow-y: auto;
+  max-height: 24rem;
+  overflow-y: auto !important;
   overflow-x: hidden;
   scroll-behavior: smooth;
   -webkit-overflow-scrolling: touch;
-  pointer-events: auto;
+  pointer-events: auto !important;
+  scroll-padding: 0.5rem;
+  touch-action: pan-y;
+}
+
+/* Ensure all child elements allow pointer events for scrolling */
+.mention-suggestion-modal * {
+  pointer-events: auto !important;
+}
+
+/* Specific fix for mouse wheel scrolling */
+.mention-suggestion-modal {
+  contain: layout style paint;
+}
+
+.mention-suggestion-modal > div {
+  will-change: scroll-position;
+}
+
+/* Ensure smooth scrolling for keyboard navigation */
+.mention-suggestion-item {
+  scroll-margin: 0.5rem;
+}
+
+/* Add subtle animation for better UX */
+.mention-suggestion-item.selected {
+  animation: mention-item-select 200ms ease-out;
+}
+
+@keyframes mention-item-select {
+  0% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.02);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 /* Category Headers */
@@ -179,11 +236,13 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: hsl(var(--muted-foreground));
-  background: hsl(var(--muted) / 0.3);
-  border-bottom: 1px solid hsl(var(--border) / 0.5);
+  background: hsl(var(--muted) / 0.4);
+  border-bottom: 1px solid hsl(var(--border) / 0.6);
   position: sticky;
   top: 0;
   z-index: 10;
+  backdrop-filter: blur(4px);
+  margin: 0 -0.25rem;
 }
 
 .mention-category-icon {
@@ -204,51 +263,53 @@
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  padding: 0.75rem 1rem;
+  padding: 0.875rem 1rem;
+  margin: 0 0.25rem;
+  border-radius: 0.5rem;
   cursor: pointer;
   transition: all 150ms ease;
-  border-bottom: 1px solid hsl(var(--border) / 0.3);
   position: relative;
   pointer-events: auto; /* Ensure click events work */
   user-select: none; /* Prevent text selection during scrolling */
+  border: 1px solid transparent;
 }
 
-.mention-suggestion-item:last-child {
-  border-bottom: none;
-}
-
-.mention-suggestion-item:hover,
-.mention-suggestion-item.selected {
-  background: hsl(var(--accent) / 0.08);
-  border-left: 3px solid hsl(var(--primary));
-  padding-left: calc(1rem - 3px);
+.mention-suggestion-item:hover {
+  background: hsl(var(--accent) / 0.1);
+  border-color: hsl(var(--border) / 0.5);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px -2px hsl(var(--foreground) / 0.1);
 }
 
 .mention-suggestion-item.selected {
-  background: hsl(var(--primary) / 0.1);
+  background: hsl(var(--primary) / 0.12);
+  border-color: hsl(var(--primary) / 0.3);
+  box-shadow: 0 0 0 2px hsl(var(--primary) / 0.2);
 }
 
 /* Item Labels and Descriptions */
 .mention-suggestion-label {
-  font-weight: 500;
+  font-weight: 600;
   font-size: 0.875rem;
   color: hsl(var(--foreground));
-  line-height: 1.2;
+  line-height: 1.3;
 }
 
 .mention-suggestion-description {
   font-size: 0.75rem;
   color: hsl(var(--muted-foreground));
-  line-height: 1.3;
+  line-height: 1.4;
+  opacity: 0.9;
 }
 
 /* Highlight matching text */
 .mention-suggestion-item mark {
-  background: hsl(var(--primary) / 0.2);
+  background: hsl(var(--primary) / 0.25);
   color: hsl(var(--primary));
-  padding: 0.0625rem 0.125rem;
-  border-radius: 0.1875rem;
-  font-weight: 600;
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
+  font-weight: 700;
+  box-shadow: 0 0 0 1px hsl(var(--primary) / 0.2);
 }
 
 /* Loading State */
@@ -345,41 +406,63 @@
 .dark .mention-suggestion-modal {
   background: hsl(var(--popover));
   border-color: hsl(var(--border));
-  box-shadow: 0 10px 38px -10px hsla(0, 0%, 0%, 0.5), 0 10px 20px -15px hsla(0, 0%, 0%, 0.3);
+  box-shadow: 0 10px 38px -10px hsla(0, 0%, 0%, 0.6), 0 10px 20px -15px hsla(0, 0%, 0%, 0.4);
 }
 
 .dark .mention-category-header {
-  background: hsl(var(--muted) / 0.5);
-  border-bottom-color: hsl(var(--border) / 0.7);
+  background: hsl(var(--muted) / 0.6);
+  border-bottom-color: hsl(var(--border) / 0.8);
 }
 
-.dark .mention-suggestion-item:hover,
-.dark .mention-suggestion-item.selected {
-  background: hsl(var(--accent) / 0.12);
-  border-left-color: hsl(var(--primary));
+.dark .mention-suggestion-item:hover {
+  background: hsl(var(--accent) / 0.15);
+  border-color: hsl(var(--border) / 0.7);
+  box-shadow: 0 2px 8px -2px hsl(var(--foreground) / 0.2);
 }
 
 .dark .mention-suggestion-item.selected {
-  background: hsl(var(--primary) / 0.15);
+  background: hsl(var(--primary) / 0.18);
+  border-color: hsl(var(--primary) / 0.4);
+  box-shadow: 0 0 0 2px hsl(var(--primary) / 0.3);
 }
 
 .dark .mention-suggestion-item mark {
-  background: hsl(var(--primary) / 0.3);
+  background: hsl(var(--primary) / 0.35);
   color: hsl(var(--primary-foreground));
+  box-shadow: 0 0 0 1px hsl(var(--primary) / 0.3);
+}
+
+.dark .mention-suggestion-modal > div::-webkit-scrollbar-track {
+  background: hsl(var(--muted) / 0.3);
+}
+
+.dark .mention-suggestion-modal > div::-webkit-scrollbar-thumb {
+  background-color: hsl(var(--muted-foreground) / 0.5);
+  border-color: hsl(var(--popover));
+}
+
+.dark .mention-suggestion-modal > div::-webkit-scrollbar-thumb:hover {
+  background-color: hsl(var(--muted-foreground) / 0.7);
 }
 
 /* Responsive Design */
 @media (max-width: 640px) {
   .mention-suggestion-modal {
-    max-height: 16rem;
-    min-width: 14rem;
-    max-width: 20rem;
+    max-height: 20rem;
+    min-width: 16rem;
+    max-width: calc(100vw - 2rem);
     border-radius: 0.5rem;
+  }
+  
+  .mention-suggestion-modal > div {
+    max-height: 20rem;
+    padding: 0.125rem 0;
   }
   
   .mention-category-header {
     padding: 0.5rem 0.75rem 0.375rem;
     font-size: 0.6875rem;
+    margin: 0 -0.125rem;
   }
   
   .mention-category-icon {
@@ -388,13 +471,9 @@
   }
   
   .mention-suggestion-item {
-    padding: 0.5rem 0.75rem;
+    padding: 0.75rem 0.75rem;
+    margin: 0 0.125rem;
     gap: 0.1875rem;
-  }
-  
-  .mention-suggestion-item:hover,
-  .mention-suggestion-item.selected {
-    padding-left: calc(0.75rem - 3px);
   }
   
   .mention-suggestion-label {
@@ -416,6 +495,18 @@
   }
 }
 
+/* Focus and accessibility improvements */
+.mention-suggestion-modal:focus-within {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 2px;
+}
+
+.mention-suggestion-item:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 2px;
+  border-radius: 0.5rem;
+}
+
 /* High contrast mode support */
 @media (prefers-contrast: high) {
   .mention-suggestion-modal {
@@ -424,7 +515,7 @@
   
   .mention-suggestion-item:hover,
   .mention-suggestion-item.selected {
-    border-left-width: 4px;
+    border-width: 2px;
   }
   
   .mention-suggestion-item mark {
@@ -442,6 +533,10 @@
     transition: none;
   }
   
+  .mention-suggestion-item.selected {
+    animation: none;
+  }
+  
   .mention-suggestion-loading-spinner {
     animation: none;
   }
@@ -451,6 +546,20 @@
     animation: none;
     opacity: 0.6;
   }
+}
+
+/* Final fix for mouse wheel scrolling - highest priority */
+.tippy-box[data-theme~='mention-suggestion'],
+.tippy-box[data-theme~='mention-suggestion'] .tippy-content,
+.mention-suggestion-modal,
+.mention-suggestion-modal > div {
+  pointer-events: auto !important;
+  overflow: visible !important;
+}
+
+.mention-suggestion-modal > div {
+  overflow-y: auto !important;
+  overflow-x: hidden !important;
 }
 
 /* Editor toolbar styling */


### PR DESCRIPTION
## Description

Rebuilds the template mention dropdown to match the application's dropdown style, with full keyboard navigation and working scroll.

## Summary of Changes

- `mention-suggestion-list.tsx` rewritten (+234/−85): popover-styled panel with a search header, hash-icon items, sticky category headers, skeleton rows, highlighted query matches and a live region announcing selections to screen readers
- Keyboard navigation completed: ArrowUp/Down with wrap-around, Home/End, PageUp/PageDown (jump 5), Enter/Tab/Space to select, Escape to close — wired via a global capture-phase listener while the popup is open, and the shared `use-keyboard-navigation` hook gained the new keys
- Selected item scrolls smoothly into view; mouse-wheel scrolling fixed via pointer-events/touch-action CSS and Tippy config
- `template-editor.css`: dropdown restyled to app conventions (rounded, subtle borders, ring on selection), refreshed scrollbars, dark-mode, high-contrast and reduced-motion support