### PR TITLE
Refactor/template categories

### DIFF
--- a/lib/template-constants.ts
+++ b/lib/template-constants.ts
@@ -1,12 +1,7 @@
 // Template categories for German property management
 export const TEMPLATE_CATEGORIES = [
   'Mail',
-  'Brief', 
-  'Vertrag',
-  'Rechnung',
-  'Mahnung',
-  'Kündigung',
-  'Sonstiges'
+  'Dokumente'
 ] as const;
 
 export type TemplateCategory = typeof TEMPLATE_CATEGORIES[number];

--- a/lib/template-constants.ts
+++ b/lib/template-constants.ts
@@ -1,7 +1,8 @@
 // Template categories for German property management
 export const TEMPLATE_CATEGORIES = [
   'Mail',
-  'Dokumente'
+  'Dokumente',
+  'Sonstiges'
 ] as const;
 
 export type TemplateCategory = typeof TEMPLATE_CATEGORIES[number];


### PR DESCRIPTION
## Description

Simplifies the template categories to the ones actually used.

## Summary of Changes

- `TEMPLATE_CATEGORIES` reduced from seven entries (Mail, Brief, Vertrag, Rechnung, Mahnung, Kündigung, Sonstiges) to three: Mail, Dokumente, Sonstiges