### PR TITLE
Feature/use templates mail

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -37,6 +37,7 @@ import { FileMoveModal } from "@/components/file-move-modal"; // Added
 import { ShareDocumentModal } from "@/components/share-document-modal"; // Added
 import { MarkdownEditorModal } from "@/components/markdown-editor-modal"; // Added
 import { TemplatesModal } from "@/components/templates-modal"; // Added
+import { TenantMailTemplatesModal } from "@/components/tenant-mail-templates-modal"; // Added
 import { GlobalDragDropProvider } from "@/components/global-drag-drop-provider"; // Added
 import { NestedDialogProvider } from "@/components/ui/nested-dialog"; // Added
 import { AIAssistantModal } from "@/components/ai-assistant-modal"; // Added
@@ -120,6 +121,10 @@ export default function DashboardRootLayout({
     isTemplatesModalOpen,
     templatesModalInitialCategory,
     closeTemplatesModal,
+    // Tenant Mail Templates Modal state
+    isTenantMailTemplatesModalOpen,
+    tenantMailTemplatesModalData,
+    closeTenantMailTemplatesModal,
     // AI Assistant Modal state
     isAIAssistantModalOpen,
   } = useModalStore()
@@ -239,6 +244,12 @@ export default function DashboardRootLayout({
         isOpen={isTemplatesModalOpen}
         onClose={closeTemplatesModal}
         initialCategory={templatesModalInitialCategory}
+      />
+      {/* TenantMailTemplatesModal - Read-only mail templates for tenants */}
+      <TenantMailTemplatesModal
+        isOpen={isTenantMailTemplatesModalOpen}
+        onClose={closeTenantMailTemplatesModal}
+        tenantName={tenantMailTemplatesModalData?.tenantName}
       />
       {/* AI Assistant Modal - Global AI assistant modal */}
       <AIAssistantModal />

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -118,6 +118,7 @@ export default function DashboardRootLayout({
     closeMarkdownEditorModal,
     // Templates Modal state
     isTemplatesModalOpen,
+    templatesModalInitialCategory,
     closeTemplatesModal,
     // AI Assistant Modal state
     isAIAssistantModalOpen,
@@ -237,6 +238,7 @@ export default function DashboardRootLayout({
       <TemplatesModal
         isOpen={isTemplatesModalOpen}
         onClose={closeTemplatesModal}
+        initialCategory={templatesModalInitialCategory}
       />
       {/* AI Assistant Modal - Global AI assistant modal */}
       <AIAssistantModal />

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -250,6 +250,7 @@ export default function DashboardRootLayout({
         isOpen={isTenantMailTemplatesModalOpen}
         onClose={closeTenantMailTemplatesModal}
         tenantName={tenantMailTemplatesModalData?.tenantName}
+        tenantEmail={tenantMailTemplatesModalData?.tenantEmail}
       />
       {/* AI Assistant Modal - Global AI assistant modal */}
       <AIAssistantModal />

--- a/components/templates-modal.tsx
+++ b/components/templates-modal.tsx
@@ -41,9 +41,10 @@ import { toast } from '@/hooks/use-toast';
 interface TemplatesModalProps {
   isOpen: boolean;
   onClose: () => void;
+  initialCategory?: string;
 }
 
-export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
+export function TemplatesModal({ isOpen, onClose, initialCategory }: TemplatesModalProps) {
   const [isDeleting, setIsDeleting] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -77,6 +78,13 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
     filteredTemplates,
     groupedTemplates,
   } = useTemplateFilters(templates);
+
+  // Set initial category when modal opens
+  useEffect(() => {
+    if (isOpen && initialCategory && initialCategory !== selectedCategory) {
+      setSelectedCategory(initialCategory);
+    }
+  }, [isOpen, initialCategory, selectedCategory, setSelectedCategory]);
 
   // Get available categories from templates
   const availableCategories = useMemo(() => {

--- a/components/tenant-context-menu.tsx
+++ b/components/tenant-context-menu.tsx
@@ -124,8 +124,8 @@ export function TenantContextMenu({
 
   const handleTemplates = () => {
     try {
-      // Open tenant mail templates modal with tenant name
-      openTenantMailTemplatesModal(tenant.name);
+      // Open tenant mail templates modal with tenant name and email
+      openTenantMailTemplatesModal(tenant.name, tenant.email);
     } catch (error) {
       console.error('Error opening mail templates modal:', error);
       toast({

--- a/components/tenant-context-menu.tsx
+++ b/components/tenant-context-menu.tsx
@@ -123,17 +123,8 @@ export function TenantContextMenu({
   };
 
   const handleTemplates = () => {
-    try {
-      // Open tenant mail templates modal with tenant name and email
-      openTenantMailTemplatesModal(tenant.name, tenant.email);
-    } catch (error) {
-      console.error('Error opening mail templates modal:', error);
-      toast({
-        title: "Fehler",
-        description: "Fehler beim Öffnen der Mail-Vorlagen. Bitte versuchen Sie es erneut.",
-        variant: "destructive",
-      });
-    }
+    // Open tenant mail templates modal with tenant name and email
+    openTenantMailTemplatesModal(tenant.name, tenant.email);
   };
 
   return (

--- a/components/tenant-context-menu.tsx
+++ b/components/tenant-context-menu.tsx
@@ -8,7 +8,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu"
-import { Edit, User, Trash2, Euro } from "lucide-react"
+import { Edit, User, Trash2, Euro, FileText } from "lucide-react"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -22,6 +22,7 @@ import {
 import { toast } from "@/hooks/use-toast"
 import { deleteTenantAction } from "@/app/mieter-actions"; // Added import
 import { useModalStore } from "@/hooks/use-modal-store";
+import { useFeatureFlagEnabled } from "posthog-js/react"
 
 import { Tenant } from "@/types/Tenant";
 
@@ -41,6 +42,7 @@ export function TenantContextMenu({
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false)
   const [isDeleting, setIsDeleting] = React.useState(false)
   const { openKautionModal } = useModalStore()
+  const templatesEnabled = useFeatureFlagEnabled('template-modal-enabled')
 
   const handleKaution = () => {
     try {
@@ -120,6 +122,15 @@ export function TenantContextMenu({
     }
   };
 
+  const handleTemplates = () => {
+    // TODO: Implement template functionality
+    toast({
+      title: "Vorlagen",
+      description: "Vorlagen-Funktionalität wird bald verfügbar sein.",
+      variant: "default",
+    });
+  };
+
   return (
     <>
       <ContextMenu>
@@ -133,6 +144,12 @@ export function TenantContextMenu({
             <Euro className="h-4 w-4" />
             <span>Kaution</span>
           </ContextMenuItem>
+          {templatesEnabled && (
+            <ContextMenuItem onClick={handleTemplates} className="flex items-center gap-2 cursor-pointer">
+              <FileText className="h-4 w-4" />
+              <span>Vorlagen</span>
+            </ContextMenuItem>
+          )}
           <ContextMenuSeparator />
           <ContextMenuItem 
             onClick={() => setDeleteDialogOpen(true)}

--- a/components/tenant-context-menu.tsx
+++ b/components/tenant-context-menu.tsx
@@ -41,7 +41,7 @@ export function TenantContextMenu({
 }: TenantContextMenuProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false)
   const [isDeleting, setIsDeleting] = React.useState(false)
-  const { openKautionModal } = useModalStore()
+  const { openKautionModal, openTemplatesModal } = useModalStore()
   const templatesEnabled = useFeatureFlagEnabled('template-modal-enabled')
 
   const handleKaution = () => {
@@ -123,12 +123,17 @@ export function TenantContextMenu({
   };
 
   const handleTemplates = () => {
-    // TODO: Implement template functionality
-    toast({
-      title: "Vorlagen",
-      description: "Vorlagen-Funktionalität wird bald verfügbar sein.",
-      variant: "default",
-    });
+    try {
+      // Open templates modal with "Mail" category filter
+      openTemplatesModal('Mail');
+    } catch (error) {
+      console.error('Error opening templates modal:', error);
+      toast({
+        title: "Fehler",
+        description: "Fehler beim Öffnen der Vorlagen. Bitte versuchen Sie es erneut.",
+        variant: "destructive",
+      });
+    }
   };
 
   return (

--- a/components/tenant-context-menu.tsx
+++ b/components/tenant-context-menu.tsx
@@ -41,7 +41,7 @@ export function TenantContextMenu({
 }: TenantContextMenuProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false)
   const [isDeleting, setIsDeleting] = React.useState(false)
-  const { openKautionModal, openTemplatesModal } = useModalStore()
+  const { openKautionModal, openTenantMailTemplatesModal } = useModalStore()
   const templatesEnabled = useFeatureFlagEnabled('template-modal-enabled')
 
   const handleKaution = () => {
@@ -124,13 +124,13 @@ export function TenantContextMenu({
 
   const handleTemplates = () => {
     try {
-      // Open templates modal with "Mail" category filter
-      openTemplatesModal('Mail');
+      // Open tenant mail templates modal with tenant name
+      openTenantMailTemplatesModal(tenant.name);
     } catch (error) {
-      console.error('Error opening templates modal:', error);
+      console.error('Error opening mail templates modal:', error);
       toast({
         title: "Fehler",
-        description: "Fehler beim Öffnen der Vorlagen. Bitte versuchen Sie es erneut.",
+        description: "Fehler beim Öffnen der Mail-Vorlagen. Bitte versuchen Sie es erneut.",
         variant: "destructive",
       });
     }

--- a/components/tenant-mail-templates-modal.tsx
+++ b/components/tenant-mail-templates-modal.tsx
@@ -204,9 +204,6 @@ function TemplateCard({ template, tenantName, tenantEmail }: TemplateCardProps) 
       encodingStrategy = 'crlf';
     }
     
-    console.log(`Using encoding strategy: ${encodingStrategy}`);
-    console.log('Formatted content:', JSON.stringify(formattedContent));
-    
     // Encode the content
     const encodedContent = encodeURIComponent(formattedContent);
     
@@ -217,12 +214,9 @@ function TemplateCard({ template, tenantName, tenantEmail }: TemplateCardProps) 
       // Safari sometimes has issues with standard encoding, try simpler approach
       const simpleContent = emailContent.replace(/\n/g, '%0A');
       mailtoUrl = `mailto:${encodeURIComponent(recipient)}?subject=${encodeURIComponent(subject)}&body=${simpleContent}`;
-      console.log('Using Safari-specific encoding');
     } else {
       mailtoUrl = `mailto:${encodeURIComponent(recipient)}?subject=${encodeURIComponent(subject)}&body=${encodedContent}`;
     }
-    
-    console.log('Final mailto URL:', mailtoUrl);
     
     // Open mail app
     window.location.href = mailtoUrl;

--- a/components/tenant-mail-templates-modal.tsx
+++ b/components/tenant-mail-templates-modal.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useState, useMemo, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useTemplates } from '@/hooks/use-templates';
+import { Template } from '@/types/template';
+import { 
+  FileText, 
+  Search, 
+  AlertCircle,
+  Mail
+} from 'lucide-react';
+
+interface TenantMailTemplatesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  tenantName?: string;
+}
+
+interface TemplateCardProps {
+  template: Template;
+}
+
+function TemplateCard({ template }: TemplateCardProps) {
+  // Extract plain text from TipTap JSON content for preview
+  const getTextPreview = (content: any): string => {
+    if (!content || !content.content) return '';
+    
+    const extractText = (node: any): string => {
+      if (node.type === 'text') {
+        return node.text || '';
+      }
+      if (node.content && Array.isArray(node.content)) {
+        return node.content.map(extractText).join('');
+      }
+      return '';
+    };
+    
+    const text = content.content.map(extractText).join(' ');
+    return text.length > 150 ? text.substring(0, 150) + '...' : text;
+  };
+
+  const preview = getTextPreview(template.inhalt);
+
+  return (
+    <div className="border rounded-lg p-4 hover:bg-gray-50 transition-colors">
+      <div className="flex items-start justify-between mb-2">
+        <h3 className="font-medium text-sm line-clamp-2">{template.titel}</h3>
+        <Badge variant="secondary" className="ml-2 text-xs">
+          {template.kategorie}
+        </Badge>
+      </div>
+      
+      {preview && (
+        <p className="text-sm text-muted-foreground line-clamp-3 mb-3">
+          {preview}
+        </p>
+      )}
+      
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>
+          {new Date(template.erstellungsdatum).toLocaleDateString('de-DE')}
+        </span>
+        {template.kontext_anforderungen && template.kontext_anforderungen.length > 0 && (
+          <span className="text-xs">
+            {template.kontext_anforderungen.length} Variable{template.kontext_anforderungen.length !== 1 ? 'n' : ''}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function TenantMailTemplatesModal({ 
+  isOpen, 
+  onClose, 
+  tenantName 
+}: TenantMailTemplatesModalProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  
+  const {
+    templates,
+    loading,
+    error,
+  } = useTemplates();
+
+  // Filter templates to only show Mail category
+  const mailTemplates = useMemo(() => {
+    return templates.filter(template => template.kategorie === 'Mail');
+  }, [templates]);
+
+  // Apply search filter
+  const filteredTemplates = useMemo(() => {
+    if (!searchQuery.trim()) return mailTemplates;
+    
+    const query = searchQuery.toLowerCase();
+    return mailTemplates.filter(template =>
+      template.titel.toLowerCase().includes(query)
+    );
+  }, [mailTemplates, searchQuery]);
+
+  // Reset search when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setSearchQuery('');
+    }
+  }, [isOpen]);
+
+  // Render loading skeleton
+  const renderLoadingSkeleton = () => (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {Array.from({ length: 6 }).map((_, index) => (
+        <div key={index} className="space-y-3 p-4 border rounded-lg">
+          <Skeleton className="h-4 w-3/4" />
+          <Skeleton className="h-16 w-full" />
+          <div className="flex justify-between items-center">
+            <Skeleton className="h-3 w-1/3" />
+            <Skeleton className="h-4 w-12" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+
+  // Render error state
+  const renderError = () => (
+    <div className="flex flex-col items-center justify-center py-12 text-center">
+      <AlertCircle className="h-12 w-12 text-muted-foreground mb-4" />
+      <h3 className="text-lg font-medium mb-2">
+        Fehler beim Laden der Vorlagen
+      </h3>
+      <p className="text-muted-foreground">
+        {error}
+      </p>
+    </div>
+  );
+
+  // Render empty state
+  const renderEmptyState = () => (
+    <div className="flex flex-col items-center justify-center py-12 text-center">
+      <Mail className="h-12 w-12 text-muted-foreground mb-4" />
+      <h3 className="text-lg font-medium mb-2">
+        {searchQuery ? 'Keine Vorlagen gefunden' : 'Keine Mail-Vorlagen verfügbar'}
+      </h3>
+      <p className="text-muted-foreground">
+        {searchQuery 
+          ? 'Versuchen Sie andere Suchbegriffe.' 
+          : 'Es wurden noch keine Mail-Vorlagen erstellt.'
+        }
+      </p>
+    </div>
+  );
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-4xl h-[80vh] overflow-hidden flex flex-col">
+        <DialogHeader className="flex-shrink-0">
+          <DialogTitle className="flex items-center gap-2">
+            <Mail className="h-5 w-5" />
+            Mail-Vorlagen
+            {tenantName && (
+              <span className="text-muted-foreground font-normal">
+                für {tenantName}
+              </span>
+            )}
+          </DialogTitle>
+          <DialogDescription>
+            Verfügbare Mail-Vorlagen für die Kommunikation mit Mietern
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-hidden flex flex-col">
+          {/* Search Bar */}
+          <div className="flex-shrink-0 pb-4 border-b">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Vorlagen durchsuchen..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-10"
+              />
+            </div>
+            
+            {/* Results Count */}
+            {!loading && !error && (
+              <div className="flex items-center justify-between mt-2 text-sm text-muted-foreground">
+                <span>
+                  {filteredTemplates.length} von {mailTemplates.length} Mail-Vorlagen
+                </span>
+                {searchQuery && (
+                  <Badge variant="outline" className="text-xs">
+                    Suche: "{searchQuery}"
+                  </Badge>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Content */}
+          <div className="flex-1 overflow-y-auto py-4">
+            {loading && renderLoadingSkeleton()}
+            {error && renderError()}
+            {!loading && !error && filteredTemplates.length === 0 && renderEmptyState()}
+            {!loading && !error && filteredTemplates.length > 0 && (
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {filteredTemplates.map((template) => (
+                  <TemplateCard
+                    key={template.id}
+                    template={template}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/tenant-mail-templates-modal.tsx
+++ b/components/tenant-mail-templates-modal.tsx
@@ -189,12 +189,6 @@ function TemplateCard({ template, tenantName, tenantEmail }: TemplateCardProps) 
     // Detect platform and client
     const clientInfo = detectPlatformAndClient();
     
-    // Debug logging
-    console.log('Template content structure:', JSON.stringify(template.inhalt, null, 2));
-    console.log('Extracted email content:', emailContent);
-    console.log('Email content with visible line breaks:', JSON.stringify(emailContent));
-    console.log('Detected client info:', clientInfo);
-    
     let formattedContent: string;
     let encodingStrategy: string;
     

--- a/components/tenant-mail-templates-modal.tsx
+++ b/components/tenant-mail-templates-modal.tsx
@@ -221,7 +221,7 @@ export function TenantMailTemplatesModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-4xl h-[80vh] overflow-hidden flex flex-col">
+      <DialogContent className="max-w-4xl h-[80vh] flex flex-col">
         <DialogHeader className="flex-shrink-0">
           <DialogTitle className="flex items-center gap-2 text-foreground">
             <div className="rounded-md bg-primary/10 p-1.5">
@@ -239,16 +239,16 @@ export function TenantMailTemplatesModal({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex-1 overflow-hidden flex flex-col relative">
+        <div className="flex-1 flex flex-col relative min-h-0">
           {/* Search Bar */}
           <div className="flex-shrink-0 pb-4 border-b border-border relative z-10">
-            <div className="relative z-20">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground z-30 pointer-events-none" />
+            <div className="relative w-full">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
               <Input
                 placeholder="Vorlagen durchsuchen..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="pl-10 bg-background border-input focus:border-ring focus:ring-ring focus:ring-2 focus:ring-offset-0 focus:z-40 relative focus:shadow-lg transition-all duration-200 focus:bg-background"
+                className="w-full pl-10 bg-background border-input focus:border-primary focus:ring-0 focus:outline-none transition-colors duration-200"
               />
             </div>
             
@@ -278,7 +278,7 @@ export function TenantMailTemplatesModal({
           </div>
 
           {/* Content */}
-          <div className="flex-1 overflow-y-auto py-4 relative z-0">
+          <div className="flex-1 overflow-y-auto overflow-x-hidden py-4 relative z-0">
             {loading && renderLoadingSkeleton()}
             {error && renderError()}
             {!loading && !error && filteredTemplates.length === 0 && renderEmptyState()}

--- a/components/tenant-mail-templates-modal.tsx
+++ b/components/tenant-mail-templates-modal.tsx
@@ -26,14 +26,16 @@ interface TenantMailTemplatesModalProps {
   isOpen: boolean;
   onClose: () => void;
   tenantName?: string;
+  tenantEmail?: string;
 }
 
 interface TemplateCardProps {
   template: Template;
   tenantName?: string;
+  tenantEmail?: string;
 }
 
-function TemplateCard({ template, tenantName }: TemplateCardProps) {
+function TemplateCard({ template, tenantName, tenantEmail }: TemplateCardProps) {
   // Extract text with mention/variable highlighting from TipTap JSON content
   const getPreviewWithHighlights = (content: any): { text: string; hasVariables: boolean } => {
     if (!content || !content.content) return { text: '', hasVariables: false };
@@ -106,8 +108,9 @@ function TemplateCard({ template, tenantName }: TemplateCardProps) {
     const emailContent = getFullEmailContent(template.inhalt);
     const subject = template.titel;
     
-    // Create mailto URL
-    const mailtoUrl = `mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(emailContent)}`;
+    // Create mailto URL with tenant email as recipient
+    const recipient = tenantEmail || '';
+    const mailtoUrl = `mailto:${encodeURIComponent(recipient)}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(emailContent)}`;
     
     // Open mail app
     window.location.href = mailtoUrl;
@@ -189,7 +192,8 @@ function TemplateCard({ template, tenantName }: TemplateCardProps) {
 export function TenantMailTemplatesModal({ 
   isOpen, 
   onClose, 
-  tenantName 
+  tenantName,
+  tenantEmail 
 }: TenantMailTemplatesModalProps) {
   const [searchQuery, setSearchQuery] = useState('');
   
@@ -288,11 +292,21 @@ export function TenantMailTemplatesModal({
             {tenantName && (
               <span className="text-muted-foreground font-normal">
                 für {tenantName}
+                {tenantEmail && (
+                  <span className="text-xs text-green-600 dark:text-green-400 ml-2">
+                    ({tenantEmail})
+                  </span>
+                )}
               </span>
             )}
           </DialogTitle>
           <DialogDescription className="text-muted-foreground">
-            Verfügbare Mail-Vorlagen für die Kommunikation mit Mietern. Klicken Sie auf eine Vorlage für weitere Details.
+            Verfügbare Mail-Vorlagen für die Kommunikation mit Mietern. Klicken Sie auf eine Vorlage, um Ihre Mail-App zu öffnen.
+            {tenantEmail && (
+              <span className="block text-xs text-green-600 dark:text-green-400 mt-1">
+                E-Mails werden automatisch an {tenantEmail} adressiert.
+              </span>
+            )}
           </DialogDescription>
         </DialogHeader>
 
@@ -346,6 +360,7 @@ export function TenantMailTemplatesModal({
                     key={template.id}
                     template={template}
                     tenantName={tenantName}
+                    tenantEmail={tenantEmail}
                   />
                 ))}
               </div>

--- a/components/tenant-mail-templates-modal.tsx
+++ b/components/tenant-mail-templates-modal.tsx
@@ -239,22 +239,22 @@ export function TenantMailTemplatesModal({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex-1 overflow-hidden flex flex-col">
+        <div className="flex-1 overflow-hidden flex flex-col relative">
           {/* Search Bar */}
-          <div className="flex-shrink-0 pb-4 border-b border-border">
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <div className="flex-shrink-0 pb-4 border-b border-border relative z-10">
+            <div className="relative z-20">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground z-30 pointer-events-none" />
               <Input
                 placeholder="Vorlagen durchsuchen..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="pl-10 bg-background border-input focus:border-ring focus:ring-ring"
+                className="pl-10 bg-background border-input focus:border-ring focus:ring-ring focus:ring-2 focus:ring-offset-0 focus:z-40 relative focus:shadow-lg transition-all duration-200 focus:bg-background"
               />
             </div>
             
             {/* Results Count */}
             {!loading && !error && (
-              <div className="flex items-center justify-between mt-3 text-sm text-muted-foreground">
+              <div className="flex items-center justify-between mt-3 text-sm text-muted-foreground relative z-10">
                 <div className="flex items-center gap-2">
                   <span>
                     {filteredTemplates.length} von {mailTemplates.length} Mail-Vorlagen
@@ -278,7 +278,7 @@ export function TenantMailTemplatesModal({
           </div>
 
           {/* Content */}
-          <div className="flex-1 overflow-y-auto py-4">
+          <div className="flex-1 overflow-y-auto py-4 relative z-0">
             {loading && renderLoadingSkeleton()}
             {error && renderError()}
             {!loading && !error && filteredTemplates.length === 0 && renderEmptyState()}

--- a/components/tenant-mail-templates-modal.tsx
+++ b/components/tenant-mail-templates-modal.tsx
@@ -121,7 +121,7 @@ function TemplateCard({ template, tenantName, tenantEmail }: TemplateCardProps) 
       return '';
     };
     
-    // Process the document content - each paragraph should be separated by double line breaks
+    // Process the document content - each paragraph should be separated by single line breaks
     if (!content.content || !Array.isArray(content.content)) {
       return '';
     }
@@ -144,8 +144,8 @@ function TemplateCard({ template, tenantName, tenantEmail }: TemplateCardProps) 
       }
     });
     
-    // Join all paragraphs with double line breaks
-    return paragraphs.join('\n\n');
+    // Join all paragraphs with single line breaks
+    return paragraphs.join('\n');
   };
 
   // Handle template click to open mail app
@@ -167,8 +167,7 @@ function TemplateCard({ template, tenantName, tenantEmail }: TemplateCardProps) 
     
     // Replace encoded newlines with proper mailto line breaks
     encodedContent = encodedContent
-      .replace(/%0A%0A/g, '%0D%0A%0D%0A')  // Double newlines (paragraphs)
-      .replace(/%0A/g, '%0D%0A');          // Single newlines
+      .replace(/%0A/g, '%0D%0A');          // Single newlines to proper line breaks
     
     const mailtoUrl = `mailto:${encodeURIComponent(recipient)}?subject=${encodeURIComponent(subject)}&body=${encodedContent}`;
     

--- a/components/tenant-mail-templates-modal.tsx
+++ b/components/tenant-mail-templates-modal.tsx
@@ -242,13 +242,13 @@ export function TenantMailTemplatesModal({
         <div className="flex-1 flex flex-col relative min-h-0">
           {/* Search Bar */}
           <div className="flex-shrink-0 pb-4 border-b border-border relative z-10">
-            <div className="relative w-full">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+            <div className="relative w-full group">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none transition-all duration-300 ease-in-out peer-focus:text-primary peer-focus:scale-110 group-hover:text-foreground" />
               <Input
                 placeholder="Vorlagen durchsuchen..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full pl-10 bg-background border-input focus:border-primary focus:ring-0 focus:outline-none transition-colors duration-200"
+                className="peer w-full pl-10 bg-background border-input focus:border-primary focus:bg-background/80 hover:border-border/80 focus:ring-0 focus:outline-none transition-all duration-300 ease-in-out"
               />
             </div>
             

--- a/components/tenant-mail-templates-modal.tsx
+++ b/components/tenant-mail-templates-modal.tsx
@@ -121,7 +121,7 @@ function TemplateCard({ template, tenantName, tenantEmail }: TemplateCardProps) 
       return '';
     };
     
-    // Process the document content - each paragraph should be separated by single line breaks
+    // Process the document content - each paragraph should be separated by double line breaks
     if (!content.content || !Array.isArray(content.content)) {
       return '';
     }
@@ -144,8 +144,8 @@ function TemplateCard({ template, tenantName, tenantEmail }: TemplateCardProps) 
       }
     });
     
-    // Join all paragraphs with single line breaks
-    return paragraphs.join('\n');
+    // Join all paragraphs with double line breaks
+    return paragraphs.join('\n\n');
   };
 
   // Handle template click to open mail app
@@ -167,7 +167,8 @@ function TemplateCard({ template, tenantName, tenantEmail }: TemplateCardProps) 
     
     // Replace encoded newlines with proper mailto line breaks
     encodedContent = encodedContent
-      .replace(/%0A/g, '%0D%0A');          // Single newlines to proper line breaks
+      .replace(/%0A%0A/g, '%0D%0A%0D%0A')  // Double newlines (paragraphs)
+      .replace(/%0A/g, '%0D%0A');          // Single newlines
     
     const mailtoUrl = `mailto:${encodeURIComponent(recipient)}?subject=${encodeURIComponent(subject)}&body=${encodedContent}`;
     

--- a/components/tenant-mail-templates-modal.tsx
+++ b/components/tenant-mail-templates-modal.tsx
@@ -161,14 +161,15 @@ function TemplateCard({ template, tenantName, tenantEmail }: TemplateCardProps) 
     // Create mailto URL with tenant email as recipient
     const recipient = tenantEmail || '';
     
-    // Encode the content properly for mailto URLs
-    // Use encodeURIComponent but then replace encoded newlines with proper mailto line breaks
-    let encodedContent = encodeURIComponent(emailContent);
+    // Convert line breaks to proper format before encoding
+    const formattedContent = emailContent
+      .replace(/\n\n/g, '\r\n\r\n')  // Double newlines to CRLF
+      .replace(/\n/g, '\r\n');       // Single newlines to CRLF
     
-    // Replace encoded newlines with proper mailto line breaks
-    encodedContent = encodedContent
-      .replace(/%0A%0A/g, '%0D%0A%0D%0A')  // Double newlines (paragraphs)
-      .replace(/%0A/g, '%0D%0A');          // Single newlines
+    console.log('Formatted content with CRLF:', JSON.stringify(formattedContent));
+    
+    // Now encode the properly formatted content
+    const encodedContent = encodeURIComponent(formattedContent);
     
     const mailtoUrl = `mailto:${encodeURIComponent(recipient)}?subject=${encodeURIComponent(subject)}&body=${encodedContent}`;
     

--- a/components/tenant-mail-templates-modal.tsx
+++ b/components/tenant-mail-templates-modal.tsx
@@ -194,22 +194,14 @@ function TemplateCard({ template, tenantName, tenantEmail }: TemplateCardProps) 
     let encodingStrategy: string;
     
     // Choose encoding strategy based on platform and client
-    if (clientInfo.isMac) {
-      // macOS Mail.app typically works better with LF only
-      formattedContent = emailContent.replace(/\n\n/g, '\n\n').replace(/\n/g, '\n');
-      encodingStrategy = 'mac-lf';
-    } else if (clientInfo.isWindows || clientInfo.hasOutlook) {
-      // Windows and Outlook prefer CRLF
-      formattedContent = emailContent.replace(/\n\n/g, '\r\n\r\n').replace(/\n/g, '\r\n');
-      encodingStrategy = 'windows-crlf';
-    } else if (clientInfo.hasThunderbird || clientInfo.isFirefox) {
-      // Thunderbird and Firefox handle standard line breaks well
-      formattedContent = emailContent.replace(/\n\n/g, '\n\n').replace(/\n/g, '\n');
-      encodingStrategy = 'thunderbird-lf';
+    if (clientInfo.isMac || clientInfo.hasThunderbird || clientInfo.isFirefox) {
+      // These clients handle LF well, no conversion needed
+      formattedContent = emailContent;
+      encodingStrategy = 'lf';
     } else {
-      // Default: try CRLF for better compatibility
-      formattedContent = emailContent.replace(/\n\n/g, '\r\n\r\n').replace(/\n/g, '\r\n');
-      encodingStrategy = 'default-crlf';
+      // Default to CRLF for better compatibility (Windows, Outlook, etc.)
+      formattedContent = emailContent.replace(/\n/g, '\r\n');
+      encodingStrategy = 'crlf';
     }
     
     console.log(`Using encoding strategy: ${encodingStrategy}`);

--- a/components/tenant-mail-templates-modal.tsx
+++ b/components/tenant-mail-templates-modal.tsx
@@ -11,6 +11,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useAuth } from '@/components/auth-provider';
 import { useTemplates } from '@/hooks/use-templates';
 import { Template } from '@/types/template';
 import { 
@@ -36,6 +37,7 @@ interface TemplateCardProps {
 }
 
 function TemplateCard({ template, tenantName, tenantEmail }: TemplateCardProps) {
+  const { user } = useAuth();
   // Extract text with mention/variable highlighting from TipTap JSON content
   const getPreviewWithHighlights = (content: any): { text: string; hasVariables: boolean } => {
     if (!content || !content.content) return { text: '', hasVariables: false };
@@ -92,7 +94,7 @@ function TemplateCard({ template, tenantName, tenantEmail }: TemplateCardProps) 
           case 'datum.heute':
             return new Date().toLocaleDateString('de-DE');
           case 'vermieter.name':
-            return '[Vermieter Name]';
+            return (user?.user_metadata?.first_name && user?.user_metadata?.last_name ? `${user.user_metadata.first_name} ${user.user_metadata.last_name}` : user?.email) || '[Vermieter Name]';
           default:
             return `[${label}]`;
         }

--- a/components/tenant-mail-templates-modal.tsx
+++ b/components/tenant-mail-templates-modal.tsx
@@ -126,10 +126,26 @@ function TemplateCard({ template, tenantName, tenantEmail }: TemplateCardProps) 
       return '';
     }
     
-    const paragraphs = content.content.map(processNode).filter(p => p.trim() !== '');
+    // Process each paragraph and collect them
+    const paragraphs: string[] = [];
     
-    // Join paragraphs with double line breaks
-    return paragraphs.join('\n\n').trim();
+    content.content.forEach((node: any) => {
+      if (node.type === 'paragraph') {
+        const paragraphText = processNode(node);
+        if (paragraphText.trim()) {
+          paragraphs.push(paragraphText.trim());
+        }
+      } else {
+        // Handle other node types at document level
+        const nodeText = processNode(node);
+        if (nodeText.trim()) {
+          paragraphs.push(nodeText.trim());
+        }
+      }
+    });
+    
+    // Join all paragraphs with double line breaks
+    return paragraphs.join('\n\n');
   };
 
   // Handle template click to open mail app

--- a/components/user-settings.tsx
+++ b/components/user-settings.tsx
@@ -114,7 +114,7 @@ export function UserSettings() {
         <CustomDropdownSeparator />
         {templateModalEnabled && (
           <CustomDropdownItem 
-            onClick={openTemplatesModal}
+            onClick={() => openTemplatesModal()}
             aria-label={ARIA_LABELS.templatesModal}
           >
             <FileText className="mr-2 h-4 w-4" aria-hidden="true" />

--- a/hooks/use-modal-store.tsx
+++ b/hooks/use-modal-store.tsx
@@ -389,8 +389,9 @@ export interface ModalState {
   isTenantMailTemplatesModalOpen: boolean;
   tenantMailTemplatesModalData?: {
     tenantName?: string;
+    tenantEmail?: string;
   };
-  openTenantMailTemplatesModal: (tenantName?: string) => void;
+  openTenantMailTemplatesModal: (tenantName?: string, tenantEmail?: string) => void;
   closeTenantMailTemplatesModal: () => void;
 }
 
@@ -1052,10 +1053,11 @@ export const useModalStore = create<ModalState>((set, get) => {
     setTemplateEditorModalDirty: (isDirty) => set({ isTemplateEditorModalDirty: isDirty }),
 
     // Tenant Mail Templates Modal
-    openTenantMailTemplatesModal: (tenantName) => set({
+    openTenantMailTemplatesModal: (tenantName, tenantEmail) => set({
       isTenantMailTemplatesModalOpen: true,
       tenantMailTemplatesModalData: {
         tenantName,
+        tenantEmail,
       },
     }),
     closeTenantMailTemplatesModal: () => set(initialTenantMailTemplatesModalState),

--- a/hooks/use-modal-store.tsx
+++ b/hooks/use-modal-store.tsx
@@ -384,6 +384,14 @@ export interface ModalState {
   closeTemplateEditorModal: (options?: CloseModalOptions) => void;
   setTemplatesModalDirty: (isDirty: boolean) => void;
   setTemplateEditorModalDirty: (isDirty: boolean) => void;
+
+  // Tenant Mail Templates Modal State
+  isTenantMailTemplatesModalOpen: boolean;
+  tenantMailTemplatesModalData?: {
+    tenantName?: string;
+  };
+  openTenantMailTemplatesModal: (tenantName?: string) => void;
+  closeTenantMailTemplatesModal: () => void;
 }
 
 const CONFIRMATION_MODAL_DEFAULTS = {
@@ -539,6 +547,11 @@ const initialTemplatesModalState = {
   isTemplateEditorModalDirty: false,
 };
 
+const initialTenantMailTemplatesModalState = {
+  isTenantMailTemplatesModalOpen: false,
+  tenantMailTemplatesModalData: undefined,
+};
+
 const createInitialModalState = () => ({
   ...initialTenantModalState,
   ...initialHouseModalState,
@@ -562,6 +575,7 @@ const createInitialModalState = () => ({
   ...initialShareDocumentModalState,
   ...initialMarkdownEditorModalState,
   ...initialTemplatesModalState,
+  ...initialTenantMailTemplatesModalState,
   isConfirmationModalOpen: false,
   confirmationModalConfig: null,
 });
@@ -1036,5 +1050,14 @@ export const useModalStore = create<ModalState>((set, get) => {
       isTemplateEditorModalDirty: false,
     }),
     setTemplateEditorModalDirty: (isDirty) => set({ isTemplateEditorModalDirty: isDirty }),
+
+    // Tenant Mail Templates Modal
+    openTenantMailTemplatesModal: (tenantName) => set({
+      isTenantMailTemplatesModalOpen: true,
+      tenantMailTemplatesModalData: {
+        tenantName,
+      },
+    }),
+    closeTenantMailTemplatesModal: () => set(initialTenantMailTemplatesModalState),
   };
 });

--- a/hooks/use-modal-store.tsx
+++ b/hooks/use-modal-store.tsx
@@ -370,6 +370,7 @@ export interface ModalState {
 
   // Templates Modal State
   isTemplatesModalOpen: boolean;
+  templatesModalInitialCategory?: string;
   isTemplateEditorModalOpen: boolean;
   templateEditorData?: {
     template?: Template;
@@ -377,7 +378,7 @@ export interface ModalState {
   };
   isTemplatesModalDirty: boolean;
   isTemplateEditorModalDirty: boolean;
-  openTemplatesModal: () => void;
+  openTemplatesModal: (initialCategory?: string) => void;
   closeTemplatesModal: (options?: CloseModalOptions) => void;
   openTemplateEditorModal: (template?: Template, onSave?: (templateData: Partial<Template>) => void) => void;
   closeTemplateEditorModal: (options?: CloseModalOptions) => void;
@@ -531,6 +532,7 @@ const initialMarkdownEditorModalState = {
 
 const initialTemplatesModalState = {
   isTemplatesModalOpen: false,
+  templatesModalInitialCategory: undefined,
   isTemplateEditorModalOpen: false,
   templateEditorData: undefined,
   isTemplatesModalDirty: false,
@@ -1011,8 +1013,9 @@ export const useModalStore = create<ModalState>((set, get) => {
     closeMarkdownEditorModal: () => set(initialMarkdownEditorModalState),
 
     // Templates Modal
-    openTemplatesModal: () => set({
+    openTemplatesModal: (initialCategory) => set({
       isTemplatesModalOpen: true,
+      templatesModalInitialCategory: initialCategory,
       isTemplatesModalDirty: false,
     }),
     closeTemplatesModal: createCloseHandler('isTemplatesModalDirty', initialTemplatesModalState),


### PR DESCRIPTION
## Description

Adds a tenant mail-templates modal: pick a Mail template for a tenant and it opens pre-filled in the local mail app.

## Summary of Changes

- New `tenant-mail-templates-modal.tsx` (479 lines): searchable grid of Mail-category templates with variable highlighting; clicking a card builds a `mailto:` link to the tenant's address with the template title as subject and the content with variables resolved (mieter.name, datum.heute, vermieter.name); line-ending encoding adapted per platform/client (LF on Mac/Thunderbird/Firefox, CRLF elsewhere, special handling for Safari)
- Tenant context menu gets a "Vorlagen" entry (behind the `template-modal-enabled` feature flag) opening the modal with the tenant's name/email
- Modal store: state for the new modal plus an `initialCategory` for the regular templates modal; dashboard layout wires both