### PR TITLE
Feature/improve template modal

### DIFF
--- a/components/template-editor-modal.tsx
+++ b/components/template-editor-modal.tsx
@@ -120,7 +120,7 @@ export function TemplateEditorModal({
           }
           break;
         case KEYBOARD_SHORTCUTS.closeModal:
-          handleClose();
+          handleAttemptClose();
           break;
       }
     },

--- a/components/template-editor-modal.tsx
+++ b/components/template-editor-modal.tsx
@@ -339,7 +339,7 @@ export function TemplateEditorModal({
   }, [isOpen, handleModalOpen, handleModalClose]);
 
   return (
-    <Dialog open={isOpen}>
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleAttemptClose()}>
       <DialogContent
         id={editorId}
         className="max-w-[95vw] sm:max-w-5xl lg:max-w-6xl h-[83vh] min-h-[83vh] max-h-[83vh] overflow-hidden flex flex-col"

--- a/components/template-editor-modal.tsx
+++ b/components/template-editor-modal.tsx
@@ -349,7 +349,7 @@ export function TemplateEditorModal({
     <Dialog open={isOpen} onOpenChange={handleClose}>
       <DialogContent
         id={editorId}
-        className="max-w-[98vw] sm:max-w-6xl lg:max-w-7xl h-[95vh] min-h-[95vh] max-h-[95vh] overflow-hidden flex flex-col"
+        className="max-w-[95vw] sm:max-w-5xl lg:max-w-6xl h-[83vh] min-h-[83vh] max-h-[83vh] overflow-hidden flex flex-col"
         isDirty={isTemplateEditorModalDirty}
         onAttemptClose={handleAttemptClose}
         role="dialog"

--- a/components/template-editor-modal.tsx
+++ b/components/template-editor-modal.tsx
@@ -99,7 +99,11 @@ export function TemplateEditorModal({
   const [isLoading, setIsLoading] = useState(false);
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
 
-  const { setTemplateEditorModalDirty, isTemplateEditorModalDirty } = useModalStore();
+  const { 
+    setTemplateEditorModalDirty, 
+    isTemplateEditorModalDirty,
+    closeTemplateEditorModal 
+  } = useModalStore();
 
   // Accessibility hook
   const {
@@ -306,31 +310,20 @@ export function TemplateEditorModal({
     setStep('category');
   };
 
-  // Handle modal close with dirty check
-  const handleClose = () => {
-    if (isTemplateEditorModalDirty) {
-      // This will be handled by the Dialog component's isDirty prop
-      return;
-    }
-    onClose();
+  // Handle attempt to close (called by Dialog component when dirty)
+  const handleAttemptClose = () => {
+    closeTemplateEditorModal(); // Store handles confirmation and cleanup
   };
 
-  // Handle attempt to close when dirty
-  const handleAttemptClose = () => {
-    // Reset forms and state
-    setStep('category');
-    setSelectedCategory(null);
-    setEditorContent(undefined);
-    setTemplateEditorModalDirty(false);
-    categoryForm.reset();
-    templateForm.reset();
-    onClose();
+  // Handle cancel button click (force close)
+  const handleCancelClick = () => {
+    closeTemplateEditorModal({ force: true }); // Force close without confirmation
   };
 
   // Set up keyboard navigation
   useModalKeyboardNavigation({
     isOpen,
-    onClose: handleClose,
+    onClose: handleAttemptClose,
     isDirty: isTemplateEditorModalDirty,
     onAttemptClose: handleAttemptClose,
     enableArrowNavigation: true,
@@ -346,7 +339,7 @@ export function TemplateEditorModal({
   }, [isOpen, handleModalOpen, handleModalClose]);
 
   return (
-    <Dialog open={isOpen} onOpenChange={handleClose}>
+    <Dialog open={isOpen}>
       <DialogContent
         id={editorId}
         className="max-w-[95vw] sm:max-w-5xl lg:max-w-6xl h-[83vh] min-h-[83vh] max-h-[83vh] overflow-hidden flex flex-col"
@@ -452,7 +445,7 @@ export function TemplateEditorModal({
                     <Button 
                       type="button" 
                       variant="outline" 
-                      onClick={onClose} 
+                      onClick={handleCancelClick} 
                       className="w-full sm:w-auto"
                       aria-label={ARIA_LABELS.cancelButton}
                     >
@@ -596,7 +589,7 @@ export function TemplateEditorModal({
                     <Button 
                       type="button" 
                       variant="outline" 
-                      onClick={handleClose}
+                      onClick={handleCancelClick}
                       disabled={isLoading}
                       className="w-full sm:w-auto"
                     >

--- a/components/template-editor-modal.tsx
+++ b/components/template-editor-modal.tsx
@@ -349,7 +349,7 @@ export function TemplateEditorModal({
     <Dialog open={isOpen} onOpenChange={handleClose}>
       <DialogContent
         id={editorId}
-        className="max-w-[95vw] sm:max-w-4xl h-[90vh] min-h-[90vh] max-h-[90vh] overflow-hidden flex flex-col"
+        className="max-w-[98vw] sm:max-w-6xl lg:max-w-7xl h-[95vh] min-h-[95vh] max-h-[95vh] overflow-hidden flex flex-col"
         isDirty={isTemplateEditorModalDirty}
         onAttemptClose={handleAttemptClose}
         role="dialog"

--- a/components/templates-modal.tsx
+++ b/components/templates-modal.tsx
@@ -294,7 +294,7 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
   const renderLoadingSkeleton = () => (
     <div className="px-1">
       <div 
-        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6"
+        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6"
         role="status"
         aria-label={ARIA_LABELS.loadingTemplates}
       >
@@ -409,7 +409,7 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
               </Badge>
             </div>
             <div 
-              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6"
+              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6"
               role="grid"
               aria-labelledby={`${modalId}-category-${category}`}
             >

--- a/components/templates-modal.tsx
+++ b/components/templates-modal.tsx
@@ -450,7 +450,7 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
       <Dialog open={isOpen} onOpenChange={handleClose}>
         <DialogContent 
           id={modalId}
-          className="max-w-[95vw] sm:max-w-4xl h-[90vh] min-h-[90vh] max-h-[90vh] overflow-hidden flex flex-col"
+          className="max-w-[98vw] sm:max-w-6xl lg:max-w-7xl h-[95vh] min-h-[95vh] max-h-[95vh] overflow-hidden flex flex-col"
           isDirty={isTemplatesModalDirty}
           onAttemptClose={handleAttemptClose}
           role="dialog"


### PR DESCRIPTION
## Description

Improves the template modals: a robust close flow and roomier dialogs.

## Summary of Changes

- Template editor modal: closing is routed through the modal store — `handleAttemptClose` asks for confirmation when dirty, the cancel buttons force-close; Escape/keyboard navigation use the same flow
- Dialog sizes increased: editor to `max-w-5xl/lg:max-w-6xl` at 83vh, templates modal to `max-w-6xl/lg:max-w-7xl` at 95vh
- Templates grid reduced from four to three columns so cards have more breathing room