### PR TITLE
feat: automatically load all tenants in abrechnung modal by default

### DIFF
--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -273,7 +273,14 @@ export function AbrechnungModal({
   }, [tenants, nebenkostenItem?.startdatum, nebenkostenItem?.enddatum]);
 
   const [selectedTenantId, setSelectedTenantId] = useState<string | null>(null);
-  const [loadAllRelevantTenants, setLoadAllRelevantTenants] = useState<boolean>(true); // New state variable
+  const [loadAllRelevantTenants, setLoadAllRelevantTenants] = useState<boolean>(false); // New state variable
+
+  // Auto-select first tenant when modal opens
+  useEffect(() => {
+    if (isOpen && safeTenants.length > 0 && !selectedTenantId) {
+      setSelectedTenantId(safeTenants[0].id);
+    }
+  }, [isOpen, safeTenants, selectedTenantId]);
 
   // Memoize the price per cubic meter calculation
   const pricePerCubicMeter = useMemo(() => {


### PR DESCRIPTION
- Changed loadAllRelevantTenants default state from false to true
- Users now see all tenant data immediately when opening the modal
- Improves UX by eliminating the need to manually select 'Load all tenants'

fix #681 