### PR TITLE
feautre/update branch

### DIFF
--- a/__tests__/abrechnung-modal-optimization.test.tsx
+++ b/__tests__/abrechnung-modal-optimization.test.tsx
@@ -217,8 +217,8 @@ describe('AbrechnungModal Optimization', () => {
     expect(combobox).toBeInTheDocument();
     
     // Verify tenants are available in the combobox
-    expect(screen.getByText('John Doe')).toBeInTheDocument();
-    expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'John Doe' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Jane Smith' })).toBeInTheDocument();
   });
 
   it('should show performance indicator for pre-loaded data', () => {

--- a/__tests__/recommended-prepayment-rounding.test.ts
+++ b/__tests__/recommended-prepayment-rounding.test.ts
@@ -5,11 +5,9 @@
  * the monthly amount to the nearest 5 euros as requested.
  */
 
+import { roundToNearest5 } from "@/lib/utils";
+
 describe('Recommended Prepayment Rounding', () => {
-  // Helper function to round to nearest 5 euros (same as in the implementation)
-  const roundToNearest5 = (value: number): number => {
-    return Math.round(value / 5) * 5;
-  };
 
   // Function to calculate recommended prepayment (same logic as in the implementation)
   const calculateRecommendedPrepayment = (totalAnnualCosts: number): number => {

--- a/__tests__/recommended-prepayment-rounding.test.ts
+++ b/__tests__/recommended-prepayment-rounding.test.ts
@@ -6,21 +6,44 @@
  */
 
 import { roundToNearest5 } from "@/lib/utils";
+import { calculateRecommendedPrepayment as calculateRecommendedPrepaymentFromUtils } from "@/utils/abrechnung-calculations";
+import type { TenantCalculationResult } from "@/types/optimized-betriebskosten";
 
 describe('Recommended Prepayment Rounding', () => {
 
-  // Function to calculate recommended prepayment (same logic as in the implementation)
+  // Helper function to create a mock TenantCalculationResult for testing
+  const createMockTenantCalculation = (totalCosts: number): TenantCalculationResult => ({
+    tenantId: 'test-tenant-id',
+    tenantName: 'Test Tenant',
+    apartmentName: 'Test Apartment',
+    apartmentSize: 50,
+    occupancyPercentage: 100,
+    daysOccupied: 365,
+    daysInPeriod: 365,
+    operatingCosts: {
+      costItems: [],
+      totalCost: totalCosts
+    },
+    waterCosts: {
+      totalBuildingWaterCost: 0,
+      totalBuildingConsumption: 0,
+      pricePerCubicMeter: 0,
+      tenantConsumption: 0,
+      totalCost: 0
+    },
+    totalCosts,
+    prepayments: {
+      monthlyPayments: [],
+      totalPrepayments: 0,
+      averageMonthlyPayment: 0
+    },
+    finalSettlement: totalCosts
+  });
+
+  // Wrapper function to test the actual production code
   const calculateRecommendedPrepayment = (totalAnnualCosts: number): number => {
-    if (totalAnnualCosts <= 0) return 0;
-    
-    // Add 10% buffer and calculate monthly amount
-    const monthlyWithBuffer = (totalAnnualCosts * 1.1) / 12;
-    
-    // Round to nearest 5 euros for the monthly amount
-    const roundedMonthly = roundToNearest5(monthlyWithBuffer);
-    
-    // Return the annual amount (monthly * 12)
-    return roundedMonthly * 12;
+    const mockTenantCalculation = createMockTenantCalculation(totalAnnualCosts);
+    return calculateRecommendedPrepaymentFromUtils(mockTenantCalculation);
   };
 
   describe('roundToNearest5 function', () => {

--- a/__tests__/recommended-prepayment-rounding.test.ts
+++ b/__tests__/recommended-prepayment-rounding.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Test suite for recommended prepayment calculation with rounding to nearest 5 euros
+ * 
+ * This test verifies that the recommended prepayment calculation correctly rounds
+ * the monthly amount to the nearest 5 euros as requested.
+ */
+
+describe('Recommended Prepayment Rounding', () => {
+  // Helper function to round to nearest 5 euros (same as in the implementation)
+  const roundToNearest5 = (value: number): number => {
+    return Math.round(value / 5) * 5;
+  };
+
+  // Function to calculate recommended prepayment (same logic as in the implementation)
+  const calculateRecommendedPrepayment = (totalAnnualCosts: number): number => {
+    if (totalAnnualCosts <= 0) return 0;
+    
+    // Add 10% buffer and calculate monthly amount
+    const monthlyWithBuffer = (totalAnnualCosts * 1.1) / 12;
+    
+    // Round to nearest 5 euros for the monthly amount
+    const roundedMonthly = roundToNearest5(monthlyWithBuffer);
+    
+    // Return the annual amount (monthly * 12)
+    return roundedMonthly * 12;
+  };
+
+  describe('roundToNearest5 function', () => {
+    it('should round 74.35 to 75', () => {
+      expect(roundToNearest5(74.35)).toBe(75);
+    });
+
+    it('should round 72.48 to 70', () => {
+      expect(roundToNearest5(72.48)).toBe(70);
+    });
+
+    it('should round 73.00 to 75', () => {
+      expect(roundToNearest5(73.00)).toBe(75);
+    });
+
+    it('should round 72.50 to 75 (rounds up when exactly between)', () => {
+      expect(roundToNearest5(72.50)).toBe(75);
+    });
+
+    it('should round 77.50 to 80', () => {
+      expect(roundToNearest5(77.50)).toBe(80);
+    });
+
+    it('should round 80.00 to 80 (no change needed)', () => {
+      expect(roundToNearest5(80.00)).toBe(80);
+    });
+
+    it('should round 82.49 to 80', () => {
+      expect(roundToNearest5(82.49)).toBe(80);
+    });
+
+    it('should round 82.51 to 85', () => {
+      expect(roundToNearest5(82.51)).toBe(85);
+    });
+  });
+
+  describe('calculateRecommendedPrepayment function', () => {
+    it('should return 0 for zero or negative costs', () => {
+      expect(calculateRecommendedPrepayment(0)).toBe(0);
+      expect(calculateRecommendedPrepayment(-100)).toBe(0);
+    });
+
+    it('should calculate and round prepayment correctly for example case 1', () => {
+      // Example: Total annual costs = 892.20 EUR
+      // With 10% buffer: 892.20 * 1.1 = 981.42 EUR
+      // Monthly: 981.42 / 12 = 81.785 EUR
+      // Rounded to nearest 5: 80 EUR
+      // Annual recommendation: 80 * 12 = 960 EUR
+      const totalCosts = 892.20;
+      const result = calculateRecommendedPrepayment(totalCosts);
+      expect(result).toBe(960);
+    });
+
+    it('should calculate and round prepayment correctly for example case 2', () => {
+      // Example: Total annual costs = 869.76 EUR  
+      // With 10% buffer: 869.76 * 1.1 = 956.736 EUR
+      // Monthly: 956.736 / 12 = 79.728 EUR
+      // Rounded to nearest 5: 80 EUR
+      // Annual recommendation: 80 * 12 = 960 EUR
+      const totalCosts = 869.76;
+      const result = calculateRecommendedPrepayment(totalCosts);
+      expect(result).toBe(960);
+    });
+
+    it('should calculate and round prepayment correctly for case that rounds down', () => {
+      // Example: Total annual costs = 800 EUR
+      // With 10% buffer: 800 * 1.1 = 880 EUR
+      // Monthly: 880 / 12 = 73.333... EUR
+      // Rounded to nearest 5: 75 EUR
+      // Annual recommendation: 75 * 12 = 900 EUR
+      const totalCosts = 800;
+      const result = calculateRecommendedPrepayment(totalCosts);
+      expect(result).toBe(900);
+    });
+
+    it('should calculate and round prepayment correctly for case that rounds down significantly', () => {
+      // Example: Total annual costs = 780 EUR
+      // With 10% buffer: 780 * 1.1 = 858 EUR
+      // Monthly: 858 / 12 = 71.5 EUR
+      // Rounded to nearest 5: 70 EUR
+      // Annual recommendation: 70 * 12 = 840 EUR
+      const totalCosts = 780;
+      const result = calculateRecommendedPrepayment(totalCosts);
+      expect(result).toBe(840);
+    });
+
+    it('should handle edge case where monthly amount is exactly divisible by 5', () => {
+      // Example: Total annual costs = 1090.91 EUR
+      // With 10% buffer: 1090.91 * 1.1 = 1200.001 EUR
+      // Monthly: 1200.001 / 12 = 100.00008... EUR
+      // Rounded to nearest 5: 100 EUR (no change)
+      // Annual recommendation: 100 * 12 = 1200 EUR
+      const totalCosts = 1090.91;
+      const result = calculateRecommendedPrepayment(totalCosts);
+      expect(result).toBe(1200);
+    });
+
+    it('should handle small amounts correctly', () => {
+      // Example: Total annual costs = 120 EUR
+      // With 10% buffer: 120 * 1.1 = 132 EUR
+      // Monthly: 132 / 12 = 11 EUR
+      // Rounded to nearest 5: 10 EUR
+      // Annual recommendation: 10 * 12 = 120 EUR
+      const totalCosts = 120;
+      const result = calculateRecommendedPrepayment(totalCosts);
+      expect(result).toBe(120);
+    });
+
+    it('should handle very small amounts that round to 0', () => {
+      // Example: Total annual costs = 20 EUR
+      // With 10% buffer: 20 * 1.1 = 22 EUR
+      // Monthly: 22 / 12 = 1.833... EUR
+      // Rounded to nearest 5: 0 EUR (since 1.833 is closer to 0 than to 5)
+      // Annual recommendation: 0 * 12 = 0 EUR
+      const totalCosts = 20;
+      const result = calculateRecommendedPrepayment(totalCosts);
+      expect(result).toBe(0);
+    });
+
+    it('should handle amounts that round to 5', () => {
+      // Example: Total annual costs = 50 EUR
+      // With 10% buffer: 50 * 1.1 = 55 EUR
+      // Monthly: 55 / 12 = 4.583... EUR
+      // Rounded to nearest 5: 5 EUR
+      // Annual recommendation: 5 * 12 = 60 EUR
+      const totalCosts = 50;
+      const result = calculateRecommendedPrepayment(totalCosts);
+      expect(result).toBe(60);
+    });
+  });
+
+  describe('Real-world scenarios', () => {
+    it('should match user example: 74.35 monthly should become 75', () => {
+      // If monthly amount (with buffer) is 74.35, it should round to 75
+      // Working backwards: if monthly with buffer = 74.35, then annual with buffer = 892.20
+      // So annual costs = 892.20 / 1.1 = 811.09
+      const totalCosts = 811.09;
+      const result = calculateRecommendedPrepayment(totalCosts);
+      // Monthly with buffer: 811.09 * 1.1 / 12 = 74.35
+      // Rounded: 75
+      // Annual: 75 * 12 = 900
+      expect(result).toBe(900);
+    });
+
+    it('should match user example: 72.48 monthly should become 70', () => {
+      // If monthly amount (with buffer) is 72.48, it should round to 70
+      // Working backwards: if monthly with buffer = 72.48, then annual with buffer = 869.76
+      // So annual costs = 869.76 / 1.1 = 790.69
+      const totalCosts = 790.69;
+      const result = calculateRecommendedPrepayment(totalCosts);
+      // Monthly with buffer: 790.69 * 1.1 / 12 = 72.48
+      // Rounded: 70
+      // Annual: 70 * 12 = 840
+      expect(result).toBe(840);
+    });
+  });
+});

--- a/app/betriebskosten-actions.ts
+++ b/app/betriebskosten-actions.ts
@@ -3,6 +3,7 @@
 import { createClient } from "@/utils/supabase/server"; // Adjusted based on common project structure
 import { revalidatePath } from "next/cache";
 import { Nebenkosten, WasserzaehlerFormData, Mieter, Wasserzaehler, Rechnung, fetchWasserzaehlerByHausAndYear } from "../lib/data-fetching"; // Adjusted path, Added Rechnung
+import { roundToNearest5 } from "@/lib/utils";
 
 // Import optimized types from centralized location
 import { 
@@ -1597,11 +1598,6 @@ export async function createAbrechnungCalculationAction(
         // Calculate recommended prepayment for next period if requested
         let recommendedPrepayment = 0;
         if (options.includeRecommendations && totalCosts > 0) {
-          // Helper function to round to nearest 5 euros
-          const roundToNearest5 = (value: number): number => {
-            return Math.round(value / 5) * 5;
-          };
-          
           const monthlyWithBuffer = (totalCosts * 1.1) / 12;
           const roundedMonthly = roundToNearest5(monthlyWithBuffer);
           recommendedPrepayment = roundedMonthly * 12;

--- a/app/betriebskosten-actions.ts
+++ b/app/betriebskosten-actions.ts
@@ -1595,13 +1595,7 @@ export async function createAbrechnungCalculationAction(
         const totalCosts = operatingCosts.totalCost + waterCosts.totalCost;
         const finalSettlement = totalCosts - prepayments.totalPrepayments;
 
-        // Calculate recommended prepayment for next period if requested
-        let recommendedPrepayment = 0;
-        if (options.includeRecommendations && totalCosts > 0) {
-          const monthlyWithBuffer = (totalCosts * 1.1) / 12;
-          const roundedMonthly = roundToNearest5(monthlyWithBuffer);
-          recommendedPrepayment = roundedMonthly * 12;
-        }
+
 
         const tenantCalculation: TenantCalculationResult = {
           tenantId: tenant.id,

--- a/app/betriebskosten-actions.ts
+++ b/app/betriebskosten-actions.ts
@@ -1597,7 +1597,14 @@ export async function createAbrechnungCalculationAction(
         // Calculate recommended prepayment for next period if requested
         let recommendedPrepayment = 0;
         if (options.includeRecommendations && totalCosts > 0) {
-          recommendedPrepayment = Math.round((totalCosts * 1.1) / 12 * 100) / 100; // 10% buffer, monthly
+          // Helper function to round to nearest 5 euros
+          const roundToNearest5 = (value: number): number => {
+            return Math.round(value / 5) * 5;
+          };
+          
+          const monthlyWithBuffer = (totalCosts * 1.1) / 12;
+          const roundedMonthly = roundToNearest5(monthlyWithBuffer);
+          recommendedPrepayment = roundedMonthly * 12;
         }
 
         const tenantCalculation: TenantCalculationResult = {

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -33,6 +33,7 @@ import type { jsPDF } from 'jspdf'; // Type import for better type safety
 import type { CellHookData } from 'jspdf-autotable'; // Type import for autoTable hook data
 import { computeWgFactorsByTenant, getApartmentOccupants } from "@/utils/wg-cost-calculations";
 import { formatNumber } from "@/utils/format"; // New import for number formatting
+import { roundToNearest5 } from "@/lib/utils";
 // import jsPDF from 'jspdf'; // Removed for dynamic import
 // import autoTable from 'jspdf-autotable'; // Removed for dynamic import
 // import JSZip from 'jszip'; // Removed for dynamic import
@@ -57,11 +58,6 @@ const GERMAN_MONTHS = [
 
 // Financial calculation constants
 const PREPAYMENT_BUFFER_MULTIPLIER = 1.1; // 10% buffer for prepayment calculation
-
-// Helper function to round to nearest 5 euros
-const roundToNearest5 = (value: number): number => {
-  return Math.round(value / 5) * 5;
-};
 
 const calculateOccupancy = (
   einzug: string | null | undefined, 

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -273,7 +273,7 @@ export function AbrechnungModal({
   }, [tenants, nebenkostenItem?.startdatum, nebenkostenItem?.enddatum]);
 
   const [selectedTenantId, setSelectedTenantId] = useState<string | null>(null);
-  const [loadAllRelevantTenants, setLoadAllRelevantTenants] = useState<boolean>(false); // New state variable
+  const [loadAllRelevantTenants, setLoadAllRelevantTenants] = useState<boolean>(true); // New state variable
 
   // Memoize the price per cubic meter calculation
   const pricePerCubicMeter = useMemo(() => {

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -58,6 +58,11 @@ const GERMAN_MONTHS = [
 // Financial calculation constants
 const PREPAYMENT_BUFFER_MULTIPLIER = 1.1; // 10% buffer for prepayment calculation
 
+// Helper function to round to nearest 5 euros
+const roundToNearest5 = (value: number): number => {
+  return Math.round(value / 5) * 5;
+};
+
 const calculateOccupancy = (
   einzug: string | null | undefined, 
   auszug: string | null | undefined, 
@@ -512,9 +517,12 @@ export function AbrechnungModal({
       const finalSettlement = totalTenantCost - totalVorauszahlungen;
 
       // Calculate recommended prepayment for next year based on current year's settlement
-      const recommendedPrepayment = totalTenantCost > 0 
-        ? totalTenantCost * PREPAYMENT_BUFFER_MULTIPLIER 
-        : 0;
+      let recommendedPrepayment = 0;
+      if (totalTenantCost > 0) {
+        const monthlyAmount = (totalTenantCost * PREPAYMENT_BUFFER_MULTIPLIER) / 12;
+        const roundedMonthlyAmount = roundToNearest5(monthlyAmount);
+        recommendedPrepayment = roundedMonthlyAmount * 12;
+      }
 
       return {
         tenantId: tenant.id,

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -273,7 +273,14 @@ export function AbrechnungModal({
   }, [tenants, nebenkostenItem?.startdatum, nebenkostenItem?.enddatum]);
 
   const [selectedTenantId, setSelectedTenantId] = useState<string | null>(null);
-  const [loadAllRelevantTenants, setLoadAllRelevantTenants] = useState<boolean>(true); // New state variable
+  const [loadAllRelevantTenants, setLoadAllRelevantTenants] = useState<boolean>(false); // New state variable
+
+  // Auto-select first tenant when modal opens
+  useEffect(() => {
+    if (isOpen && safeTenants.length > 0 && !selectedTenantId) {
+      setSelectedTenantId(safeTenants[0].id);
+    }
+  }, [isOpen, safeTenants, selectedTenantId]);
 
   // Memoize the price per cubic meter calculation
   const pricePerCubicMeter = useMemo(() => {

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -34,6 +34,8 @@ import type { CellHookData } from 'jspdf-autotable'; // Type import for autoTabl
 import { computeWgFactorsByTenant, getApartmentOccupants } from "@/utils/wg-cost-calculations";
 import { formatNumber } from "@/utils/format"; // New import for number formatting
 import { roundToNearest5 } from "@/lib/utils";
+import { calculateRecommendedPrepayment } from "@/utils/abrechnung-calculations";
+import type { TenantCalculationResult } from "@/types/optimized-betriebskosten";
 // import jsPDF from 'jspdf'; // Removed for dynamic import
 // import autoTable from 'jspdf-autotable'; // Removed for dynamic import
 // import JSZip from 'jszip'; // Removed for dynamic import
@@ -515,9 +517,9 @@ export function AbrechnungModal({
       // Calculate recommended prepayment for next year based on current year's settlement
       let recommendedPrepayment = 0;
       if (totalTenantCost > 0) {
-        const monthlyAmount = (totalTenantCost * PREPAYMENT_BUFFER_MULTIPLIER) / 12;
-        const roundedMonthlyAmount = roundToNearest5(monthlyAmount);
-        recommendedPrepayment = roundedMonthlyAmount * 12;
+        // Use the centralized function to ensure consistency
+        const mockTenantCalculation = { totalCosts: totalTenantCost } as TenantCalculationResult;
+        recommendedPrepayment = calculateRecommendedPrepayment(mockTenantCalculation);
       }
 
       return {

--- a/components/template-editor-modal.tsx
+++ b/components/template-editor-modal.tsx
@@ -120,7 +120,7 @@ export function TemplateEditorModal({
           }
           break;
         case KEYBOARD_SHORTCUTS.closeModal:
-          handleClose();
+          handleAttemptClose();
           break;
       }
     },

--- a/components/template-editor-modal.tsx
+++ b/components/template-editor-modal.tsx
@@ -339,7 +339,7 @@ export function TemplateEditorModal({
   }, [isOpen, handleModalOpen, handleModalClose]);
 
   return (
-    <Dialog open={isOpen}>
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleAttemptClose()}>
       <DialogContent
         id={editorId}
         className="max-w-[95vw] sm:max-w-5xl lg:max-w-6xl h-[83vh] min-h-[83vh] max-h-[83vh] overflow-hidden flex flex-col"

--- a/components/template-editor-modal.tsx
+++ b/components/template-editor-modal.tsx
@@ -349,7 +349,7 @@ export function TemplateEditorModal({
     <Dialog open={isOpen} onOpenChange={handleClose}>
       <DialogContent
         id={editorId}
-        className="max-w-[98vw] sm:max-w-6xl lg:max-w-7xl h-[95vh] min-h-[95vh] max-h-[95vh] overflow-hidden flex flex-col"
+        className="max-w-[95vw] sm:max-w-5xl lg:max-w-6xl h-[83vh] min-h-[83vh] max-h-[83vh] overflow-hidden flex flex-col"
         isDirty={isTemplateEditorModalDirty}
         onAttemptClose={handleAttemptClose}
         role="dialog"

--- a/components/template-editor-modal.tsx
+++ b/components/template-editor-modal.tsx
@@ -99,7 +99,11 @@ export function TemplateEditorModal({
   const [isLoading, setIsLoading] = useState(false);
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
 
-  const { setTemplateEditorModalDirty, isTemplateEditorModalDirty } = useModalStore();
+  const { 
+    setTemplateEditorModalDirty, 
+    isTemplateEditorModalDirty,
+    closeTemplateEditorModal 
+  } = useModalStore();
 
   // Accessibility hook
   const {
@@ -306,31 +310,20 @@ export function TemplateEditorModal({
     setStep('category');
   };
 
-  // Handle modal close with dirty check
-  const handleClose = () => {
-    if (isTemplateEditorModalDirty) {
-      // This will be handled by the Dialog component's isDirty prop
-      return;
-    }
-    onClose();
+  // Handle attempt to close (called by Dialog component when dirty)
+  const handleAttemptClose = () => {
+    closeTemplateEditorModal(); // Store handles confirmation and cleanup
   };
 
-  // Handle attempt to close when dirty
-  const handleAttemptClose = () => {
-    // Reset forms and state
-    setStep('category');
-    setSelectedCategory(null);
-    setEditorContent(undefined);
-    setTemplateEditorModalDirty(false);
-    categoryForm.reset();
-    templateForm.reset();
-    onClose();
+  // Handle cancel button click (force close)
+  const handleCancelClick = () => {
+    closeTemplateEditorModal({ force: true }); // Force close without confirmation
   };
 
   // Set up keyboard navigation
   useModalKeyboardNavigation({
     isOpen,
-    onClose: handleClose,
+    onClose: handleAttemptClose,
     isDirty: isTemplateEditorModalDirty,
     onAttemptClose: handleAttemptClose,
     enableArrowNavigation: true,
@@ -346,7 +339,7 @@ export function TemplateEditorModal({
   }, [isOpen, handleModalOpen, handleModalClose]);
 
   return (
-    <Dialog open={isOpen} onOpenChange={handleClose}>
+    <Dialog open={isOpen}>
       <DialogContent
         id={editorId}
         className="max-w-[95vw] sm:max-w-5xl lg:max-w-6xl h-[83vh] min-h-[83vh] max-h-[83vh] overflow-hidden flex flex-col"
@@ -452,7 +445,7 @@ export function TemplateEditorModal({
                     <Button 
                       type="button" 
                       variant="outline" 
-                      onClick={onClose} 
+                      onClick={handleCancelClick} 
                       className="w-full sm:w-auto"
                       aria-label={ARIA_LABELS.cancelButton}
                     >
@@ -596,7 +589,7 @@ export function TemplateEditorModal({
                     <Button 
                       type="button" 
                       variant="outline" 
-                      onClick={handleClose}
+                      onClick={handleCancelClick}
                       disabled={isLoading}
                       className="w-full sm:w-auto"
                     >

--- a/components/template-editor-modal.tsx
+++ b/components/template-editor-modal.tsx
@@ -349,7 +349,7 @@ export function TemplateEditorModal({
     <Dialog open={isOpen} onOpenChange={handleClose}>
       <DialogContent
         id={editorId}
-        className="max-w-[95vw] sm:max-w-4xl h-[90vh] min-h-[90vh] max-h-[90vh] overflow-hidden flex flex-col"
+        className="max-w-[98vw] sm:max-w-6xl lg:max-w-7xl h-[95vh] min-h-[95vh] max-h-[95vh] overflow-hidden flex flex-col"
         isDirty={isTemplateEditorModalDirty}
         onAttemptClose={handleAttemptClose}
         role="dialog"

--- a/components/templates-modal.tsx
+++ b/components/templates-modal.tsx
@@ -294,7 +294,7 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
   const renderLoadingSkeleton = () => (
     <div className="px-1">
       <div 
-        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6"
+        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6"
         role="status"
         aria-label={ARIA_LABELS.loadingTemplates}
       >
@@ -409,7 +409,7 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
               </Badge>
             </div>
             <div 
-              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6"
+              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6"
               role="grid"
               aria-labelledby={`${modalId}-category-${category}`}
             >

--- a/components/templates-modal.tsx
+++ b/components/templates-modal.tsx
@@ -535,7 +535,7 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
                     <>
                       <Loader2 className="h-4 w-4 mr-1 sm:mr-2 animate-spin" aria-hidden="true" />
                       <span className="hidden sm:inline">Erstellt...</span>
-                      <span className="sm:hidden">Neu...</span>
+                      <span className="sm:hidden">Erstelle...</span>
                     </>
                   ) : (
                     <>

--- a/components/templates-modal.tsx
+++ b/components/templates-modal.tsx
@@ -472,9 +472,9 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
 
           <div className="flex-1 overflow-hidden flex flex-col p-1" ref={containerRef}>
             {/* Search, Filter and Actions Section */}
-            <div className="flex-shrink-0 pb-4 sm:pb-6 border-b space-y-4 px-2 pt-1">
-              {/* Top Row: Search and Create Button */}
-              <div className="flex items-center gap-3 sm:gap-4">
+            <div className="flex-shrink-0 pb-4 sm:pb-6 border-b space-y-3 px-2 pt-1">
+              {/* Single Row: Search, Filter, and Create Button */}
+              <div className="flex items-center gap-2 sm:gap-3">
                 {/* Search Bar - Takes most space */}
                 <div className="relative flex-1 min-w-0">
                   <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none z-10" aria-hidden="true" />
@@ -492,24 +492,54 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
                   </div>
                 </div>
 
+                {/* Category Filter - Medium width */}
+                <div className="flex items-center gap-1 min-w-0">
+                  <Filter className="h-4 w-4 text-muted-foreground flex-shrink-0 hidden sm:block" aria-hidden="true" />
+                  <div className="relative w-[140px] sm:w-[180px] min-w-0">
+                    <Select 
+                      value={selectedCategory || 'all'} 
+                      onValueChange={(value) => {
+                        setSelectedCategory(value);
+                        announceFilterApplied(value === 'all' ? templates.length : filteredTemplates.length);
+                      }}
+                    >
+                      <SelectTrigger 
+                        className="w-full focus-visible:scale-100 focus:ring-2 focus:ring-offset-1 focus:ring-offset-background text-sm"
+                        aria-label={ARIA_LABELS.categoryFilter}
+                        aria-expanded={false}
+                      >
+                        <SelectValue placeholder="Alle Kategorien" />
+                      </SelectTrigger>
+                      <SelectContent className="z-50 min-w-[200px]">
+                        <SelectItem value="all">Alle Kategorien</SelectItem>
+                        {availableCategories.map((category) => (
+                          <SelectItem key={category} value={category}>
+                            {category}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+
                 {/* Create Button - Fixed width */}
                 <Button 
                   data-create-template-button
                   onClick={handleCreateTemplate} 
-                  className="flex-shrink-0 min-w-[120px] sm:min-w-[140px]"
+                  className="flex-shrink-0 min-w-[100px] sm:min-w-[120px]"
                   disabled={isCreating || loading}
                   aria-label={ARIA_LABELS.createTemplateButton}
                   aria-describedby={`${modalId}-create-help`}
                 >
                   {isCreating ? (
                     <>
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden="true" />
+                      <Loader2 className="h-4 w-4 mr-1 sm:mr-2 animate-spin" aria-hidden="true" />
                       <span className="hidden sm:inline">Erstellt...</span>
-                      <span className="sm:hidden">Erstellt...</span>
+                      <span className="sm:hidden">Neu...</span>
                     </>
                   ) : (
                     <>
-                      <Plus className="h-4 w-4 mr-2" aria-hidden="true" />
+                      <Plus className="h-4 w-4 mr-1 sm:mr-2" aria-hidden="true" />
                       <span className="hidden sm:inline">Neue Vorlage</span>
                       <span className="sm:hidden">Neu</span>
                     </>
@@ -517,36 +547,6 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
                 </Button>
                 <div id={`${modalId}-create-help`} className="sr-only">
                   Erstellt eine neue Dokumentvorlage mit dem Rich-Text-Editor
-                </div>
-              </div>
-
-              {/* Second Row: Category Filter */}
-              <div className="flex items-center gap-2">
-                <Filter className="h-4 w-4 text-muted-foreground flex-shrink-0" aria-hidden="true" />
-                <div className="relative w-full sm:w-64 min-w-0">
-                  <Select 
-                    value={selectedCategory || 'all'} 
-                    onValueChange={(value) => {
-                      setSelectedCategory(value);
-                      announceFilterApplied(value === 'all' ? templates.length : filteredTemplates.length);
-                    }}
-                  >
-                    <SelectTrigger 
-                      className="w-full focus-visible:scale-100 focus:ring-2 focus:ring-offset-1 focus:ring-offset-background"
-                      aria-label={ARIA_LABELS.categoryFilter}
-                      aria-expanded={false}
-                    >
-                      <SelectValue placeholder="Alle Kategorien" />
-                    </SelectTrigger>
-                    <SelectContent className="z-50 min-w-[200px]">
-                      <SelectItem value="all">Alle Kategorien</SelectItem>
-                      {availableCategories.map((category) => (
-                        <SelectItem key={category} value={category}>
-                          {category}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
                 </div>
               </div>
 

--- a/components/templates-modal.tsx
+++ b/components/templates-modal.tsx
@@ -450,7 +450,7 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
       <Dialog open={isOpen} onOpenChange={handleClose}>
         <DialogContent 
           id={modalId}
-          className="max-w-[95vw] sm:max-w-4xl h-[90vh] min-h-[90vh] max-h-[90vh] overflow-hidden flex flex-col"
+          className="max-w-[98vw] sm:max-w-6xl lg:max-w-7xl h-[95vh] min-h-[95vh] max-h-[95vh] overflow-hidden flex flex-col"
           isDirty={isTemplatesModalDirty}
           onAttemptClose={handleAttemptClose}
           role="dialog"

--- a/components/templates-modal.tsx
+++ b/components/templates-modal.tsx
@@ -292,25 +292,27 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
 
   // Render loading skeleton
   const renderLoadingSkeleton = () => (
-    <div 
-      className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 sm:gap-4"
-      role="status"
-      aria-label={ARIA_LABELS.loadingTemplates}
-    >
-      {Array.from({ length: 8 }).map((_, index) => (
-        <div key={index} className="space-y-3 p-4 border rounded-lg" aria-hidden="true">
-          <Skeleton className="h-4 w-3/4" />
-          <Skeleton className="h-16 sm:h-20 w-full" />
-          <div className="flex justify-between items-center">
-            <Skeleton className="h-3 w-1/3" />
-            <div className="flex gap-1">
-              <Skeleton className="h-6 w-6" />
-              <Skeleton className="h-6 w-6" />
+    <div className="px-1">
+      <div 
+        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6"
+        role="status"
+        aria-label={ARIA_LABELS.loadingTemplates}
+      >
+        {Array.from({ length: 8 }).map((_, index) => (
+          <div key={index} className="space-y-3 p-4 border rounded-lg" aria-hidden="true">
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-16 sm:h-20 w-full" />
+            <div className="flex justify-between items-center">
+              <Skeleton className="h-3 w-1/3" />
+              <div className="flex gap-1">
+                <Skeleton className="h-6 w-6" />
+                <Skeleton className="h-6 w-6" />
+              </div>
             </div>
           </div>
-        </div>
-      ))}
-      <div className="sr-only">Vorlagen werden geladen...</div>
+        ))}
+        <div className="sr-only">Vorlagen werden geladen...</div>
+      </div>
     </div>
   );
 
@@ -388,10 +390,10 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
     }
 
     return (
-      <div className="space-y-8">
+      <div className="space-y-8 px-1">
         {categories.map((category) => (
           <div key={category} className="space-y-4">
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 sticky top-0 bg-background/95 backdrop-blur-sm py-2 -mx-1 px-1 z-10">
               <h3 
                 className="text-lg font-medium"
                 id={`${modalId}-category-${category}`}
@@ -407,14 +409,14 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
               </Badge>
             </div>
             <div 
-              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 sm:gap-4"
+              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6"
               role="grid"
               aria-labelledby={`${modalId}-category-${category}`}
             >
               {groupedTemplates[category].map((template, index) => (
                 <div 
                   key={template.id} 
-                  className="relative"
+                  className="relative min-h-0"
                   role="gridcell"
                   aria-rowindex={Math.floor(index / 4) + 1}
                   aria-colindex={(index % 4) + 1}
@@ -426,7 +428,7 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
                   />
                   {isDeleting === template.id && (
                     <div 
-                      className="absolute inset-0 bg-background/80 backdrop-blur-sm flex items-center justify-center rounded-lg"
+                      className="absolute inset-0 bg-background/80 backdrop-blur-sm flex items-center justify-center rounded-lg z-20"
                       role="status"
                       aria-label={ARIA_LABELS.deletingTemplate}
                     >
@@ -468,19 +470,20 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
             </DialogDescription>
           </DialogHeader>
 
-          <div className="flex-1 overflow-hidden flex flex-col" ref={containerRef}>
-            {/* Search, Filter and Actions Row */}
-            <div className="flex-shrink-0 pb-4 sm:pb-6 border-b">
-              <div className="flex items-center gap-3 sm:gap-4 p-1">
-                {/* Search Bar - Left */}
-                <div className="relative flex-1 z-10">
-                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          <div className="flex-1 overflow-hidden flex flex-col p-1" ref={containerRef}>
+            {/* Search, Filter and Actions Section */}
+            <div className="flex-shrink-0 pb-4 sm:pb-6 border-b space-y-4 px-2 pt-1">
+              {/* Top Row: Search and Create Button */}
+              <div className="flex items-center gap-3 sm:gap-4">
+                {/* Search Bar - Takes most space */}
+                <div className="relative flex-1 min-w-0">
+                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none z-10" aria-hidden="true" />
                   <Input
                     data-search-input
                     placeholder="Vorlagen durchsuchen..."
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
-                    className="pl-10"
+                    className="pl-10 w-full focus-visible:scale-100 focus:ring-2 focus:ring-offset-1 focus:ring-offset-background"
                     aria-label={ARIA_LABELS.templatesSearch}
                     aria-describedby={`${modalId}-search-help`}
                   />
@@ -489,39 +492,11 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
                   </div>
                 </div>
 
-                {/* Category Filter - Center */}
-                <div className="flex items-center gap-2 min-w-[200px] sm:min-w-[250px] z-10">
-                  <Filter className="h-4 w-4 text-muted-foreground flex-shrink-0" aria-hidden="true" />
-                  <Select 
-                    value={selectedCategory || 'all'} 
-                    onValueChange={(value) => {
-                      setSelectedCategory(value);
-                      announceFilterApplied(value === 'all' ? templates.length : filteredTemplates.length);
-                    }}
-                  >
-                    <SelectTrigger 
-                      className="w-full"
-                      aria-label={ARIA_LABELS.categoryFilter}
-                      aria-expanded={false}
-                    >
-                      <SelectValue placeholder="Alle Kategorien" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">Alle Kategorien</SelectItem>
-                      {availableCategories.map((category) => (
-                        <SelectItem key={category} value={category}>
-                          {category}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                {/* Create Button - Right */}
+                {/* Create Button - Fixed width */}
                 <Button 
                   data-create-template-button
                   onClick={handleCreateTemplate} 
-                  className="flex-shrink-0 min-w-[140px]"
+                  className="flex-shrink-0 min-w-[120px] sm:min-w-[140px]"
                   disabled={isCreating || loading}
                   aria-label={ARIA_LABELS.createTemplateButton}
                   aria-describedby={`${modalId}-create-help`}
@@ -530,7 +505,7 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
                     <>
                       <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden="true" />
                       <span className="hidden sm:inline">Erstellt...</span>
-                      <span className="sm:hidden">Wird erstellt...</span>
+                      <span className="sm:hidden">Erstellt...</span>
                     </>
                   ) : (
                     <>
@@ -545,11 +520,43 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
                 </div>
               </div>
 
-              {/* Active Filters */}
+              {/* Second Row: Category Filter */}
+              <div className="flex items-center gap-2">
+                <Filter className="h-4 w-4 text-muted-foreground flex-shrink-0" aria-hidden="true" />
+                <div className="relative w-full sm:w-64 min-w-0">
+                  <Select 
+                    value={selectedCategory || 'all'} 
+                    onValueChange={(value) => {
+                      setSelectedCategory(value);
+                      announceFilterApplied(value === 'all' ? templates.length : filteredTemplates.length);
+                    }}
+                  >
+                    <SelectTrigger 
+                      className="w-full focus-visible:scale-100 focus:ring-2 focus:ring-offset-1 focus:ring-offset-background"
+                      aria-label={ARIA_LABELS.categoryFilter}
+                      aria-expanded={false}
+                    >
+                      <SelectValue placeholder="Alle Kategorien" />
+                    </SelectTrigger>
+                    <SelectContent className="z-50 min-w-[200px]">
+                      <SelectItem value="all">Alle Kategorien</SelectItem>
+                      {availableCategories.map((category) => (
+                        <SelectItem key={category} value={category}>
+                          {category}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              {/* Third Row: Active Filters */}
               {(searchQuery || (selectedCategory && selectedCategory !== 'all')) && (
-                <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-                  <span className="hidden sm:inline">Aktive Filter:</span>
-                  <span className="sm:hidden">Filter:</span>
+                <div className="flex flex-wrap items-center gap-2 pt-2 border-t">
+                  <span className="text-sm text-muted-foreground">
+                    <span className="hidden sm:inline">Aktive Filter:</span>
+                    <span className="sm:hidden">Filter:</span>
+                  </span>
                   {searchQuery && (
                     <Badge variant="outline" className="text-xs">
                       <span className="hidden sm:inline">Suche: "</span>
@@ -567,7 +574,7 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
                     variant="ghost"
                     size="sm"
                     onClick={handleClearFilters}
-                    className="h-6 px-2 text-xs"
+                    className="h-6 px-2 text-xs ml-auto"
                     aria-label={ARIA_LABELS.clearFiltersButton}
                   >
                     <span className="hidden sm:inline">Zurücksetzen</span>
@@ -579,7 +586,7 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
               {/* Results Count */}
               {!loading && !error && (
                 <div 
-                  className="text-sm text-muted-foreground"
+                  className="text-sm text-muted-foreground pt-2"
                   role="status"
                   aria-live="polite"
                   aria-label={`${filteredTemplates.length} von ${templates.length} Vorlagen werden angezeigt`}
@@ -591,14 +598,16 @@ export function TemplatesModal({ isOpen, onClose }: TemplatesModalProps) {
 
             {/* Content */}
             <div 
-              className="flex-1 overflow-y-auto py-6"
+              className="flex-1 overflow-y-auto pt-6 pb-4"
               role="region"
               aria-label={ARIA_LABELS.templatesList}
               data-templates-grid
             >
-              {loading && renderLoadingSkeleton()}
-              {error && renderError()}
-              {!loading && !error && renderTemplateGroups()}
+              <div className="min-h-0">
+                {loading && renderLoadingSkeleton()}
+                {error && renderError()}
+                {!loading && !error && renderTemplateGroups()}
+              </div>
             </div>
           </div>
         </DialogContent>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -71,3 +71,13 @@ export function naturalSort(a: string, b: string): number {
   // If neither has numeric prefix, use regular string comparison
   return a.localeCompare(b);
 }
+
+/**
+ * Rounds a number to the nearest 5 euros.
+ * Used for calculating recommended prepayment amounts.
+ * @param value - The value to round
+ * @returns number - The value rounded to the nearest 5
+ */
+export function roundToNearest5(value: number): number {
+  return Math.round(value / 5) * 5;
+}

--- a/utils/abrechnung-calculations.ts
+++ b/utils/abrechnung-calculations.ts
@@ -257,6 +257,11 @@ export function calculatePrepayments(
   };
 }
 
+// Helper function to round to nearest 5 euros
+const roundToNearest5 = (value: number): number => {
+  return Math.round(value / 5) * 5;
+};
+
 /**
  * Calculate recommended prepayment for next period
  */
@@ -264,10 +269,17 @@ export function calculateRecommendedPrepayment(
   tenantCalculation: TenantCalculationResult
 ): number {
   const totalAnnualCosts = tenantCalculation.totalCosts;
-  const monthlyRecommendation = totalAnnualCosts / 12;
   
-  // Add 10% buffer to avoid underpayment
-  return Math.ceil(monthlyRecommendation * 1.1);
+  if (totalAnnualCosts <= 0) return 0;
+  
+  // Add 10% buffer and calculate monthly amount
+  const monthlyWithBuffer = (totalAnnualCosts * 1.1) / 12;
+  
+  // Round to nearest 5 euros for the monthly amount
+  const roundedMonthly = roundToNearest5(monthlyWithBuffer);
+  
+  // Return the annual amount (monthly * 12)
+  return roundedMonthly * 12;
 }
 
 /**

--- a/utils/abrechnung-calculations.ts
+++ b/utils/abrechnung-calculations.ts
@@ -8,6 +8,7 @@
 
 import { Mieter, Nebenkosten, Wasserzaehler } from "@/lib/data-fetching";
 import { calculateTenantOccupancy, TenantOccupancy } from "./date-calculations";
+import { roundToNearest5 } from "@/lib/utils";
 import { 
   calculateProFlächeDistribution,
   calculateProMieterDistribution,
@@ -257,10 +258,7 @@ export function calculatePrepayments(
   };
 }
 
-// Helper function to round to nearest 5 euros
-const roundToNearest5 = (value: number): number => {
-  return Math.round(value / 5) * 5;
-};
+
 
 /**
  * Calculate recommended prepayment for next period


### PR DESCRIPTION
## Description

Rounds the recommended prepayment to the nearest €5 and polishes the template modals.

## Summary of Changes

- New `roundToNearest5` helper in `lib/utils.ts`; `calculateRecommendedPrepayment` now computes the monthly amount (annual costs + 10% buffer), rounds it to the nearest €5 and returns the annual total
- Abrechnung modal uses the centralized calculation; the first tenant is auto-selected when the modal opens; the duplicated inline calculation removed from the server action
- New test suite `recommended-prepayment-rounding.test.ts` (203 lines) covering the rounding helper, the calculation and real-world examples
- Template editor modal: close flow routed through the modal store (confirm on dirty, force-close on cancel), wider/taller dialog; templates modal layout tightened — three-column grid, sticky category headers, compact responsive search/filter/create row