### PR TITLE
Feature/enhance pdf next vorauszahlung betrag

### DIFF
--- a/app/api/stripe/customer/route.ts
+++ b/app/api/stripe/customer/route.ts
@@ -1,0 +1,92 @@
+export const runtime = 'edge';
+import { NextResponse } from 'next/server';
+import Stripe from 'stripe';
+import { createClient } from '@/utils/supabase/server';
+
+export async function GET() {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    return NextResponse.json({ error: 'Stripe secret key not configured.' }, { status: 500 });
+  }
+
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+    apiVersion: '2025-06-30.basil',
+  });
+
+  try {
+    const supabase = await createClient();
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+    }
+
+    // Get user profile to find customer ID
+    const { data: profile, error: profileError } = await supabase
+      .from('profiles')
+      .select('stripe_customer_id')
+      .eq('id', user.id)
+      .single();
+
+    if (profileError || !profile?.stripe_customer_id) {
+      return NextResponse.json({ error: 'Customer not found' }, { status: 404 });
+    }
+
+    // Fetch customer details from Stripe
+    const customer = await stripe.customers.retrieve(profile.stripe_customer_id, {
+      expand: ['invoice_settings.default_payment_method']
+    });
+
+    if (!customer || customer.deleted) {
+      return NextResponse.json({ error: 'Customer not found' }, { status: 404 });
+    }
+
+    // Extract billing address information
+    const billingAddress = customer.address;
+    const paymentMethod = customer.invoice_settings?.default_payment_method;
+
+    return NextResponse.json({
+      customer: {
+        id: customer.id,
+        name: customer.name,
+        email: customer.email,
+        phone: customer.phone,
+        address: billingAddress ? {
+          line1: billingAddress.line1,
+          line2: billingAddress.line2,
+          city: billingAddress.city,
+          state: billingAddress.state,
+          postal_code: billingAddress.postal_code,
+          country: billingAddress.country,
+        } : null,
+      },
+      payment_method: paymentMethod && typeof paymentMethod === 'object' ? {
+        id: paymentMethod.id,
+        type: paymentMethod.type,
+        card: paymentMethod.card ? {
+          brand: paymentMethod.card.brand,
+          last4: paymentMethod.card.last4,
+          exp_month: paymentMethod.card.exp_month,
+          exp_year: paymentMethod.card.exp_year,
+        } : null,
+        billing_details: paymentMethod.billing_details ? {
+          address: paymentMethod.billing_details.address ? {
+            line1: paymentMethod.billing_details.address.line1,
+            line2: paymentMethod.billing_details.address.line2,
+            city: paymentMethod.billing_details.address.city,
+            state: paymentMethod.billing_details.address.state,
+            postal_code: paymentMethod.billing_details.address.postal_code,
+            country: paymentMethod.billing_details.address.country,
+          } : null,
+        } : null,
+      } : null,
+    });
+
+  } catch (error) {
+    console.error('Error fetching customer data:', error);
+    const errorMessage = error instanceof Stripe.errors.StripeError 
+      ? error.message 
+      : 'Failed to fetch customer data';
+    
+    return NextResponse.json({ error: errorMessage }, { status: 500 });
+  }
+}

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -875,7 +875,6 @@ export function AbrechnungModal({
     let location = '';
     if (billingAddress) {
       const parts = [];
-      if (billingAddress.postal_code) parts.push(billingAddress.postal_code);
       if (billingAddress.city) parts.push(billingAddress.city);
       location = parts.join(' ');
     }

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -839,7 +839,7 @@ export function AbrechnungModal({
     const formattedDate = format(nextMonth, 'dd.MM.yy');
     
     doc.setFont("helvetica", "bold");
-    const label = `Vorauszahlung ab ${formattedDate} (nächster Monat; mind. 14 Tage)`;
+    const label = `Vorauszahlung ab ${formattedDate}`;
     doc.text(label, col1Start, startY, { align: 'left' });
     doc.text(formatCurrency(monthlyVorauszahlung), col5End, startY, { align: 'right' });
     

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -882,10 +882,10 @@ export function AbrechnungModal({
     
     if (location) {
       doc.setFont("helvetica", "normal");
-      doc.text(`${formattedToday}, ${location}`, col1Start, startY, { align: 'left' });
+      doc.text(`${location}, den ${formattedToday}`, col1Start, startY, { align: 'left' });
     } else {
       doc.setFont("helvetica", "normal");
-      doc.text(formattedToday, col1Start, startY, { align: 'left' });
+      doc.text(`den ${formattedToday}`, col1Start, startY, { align: 'left' });
     }
     
     return startY; // Return the final Y position

--- a/components/abrechnung-modal.tsx
+++ b/components/abrechnung-modal.tsx
@@ -827,6 +827,22 @@ export function AbrechnungModal({
     doc.text(settlementLabel, col1Start, startY, { align: 'left' });
     doc.text(formatCurrency(settlementAmount), col5End, startY, { align: 'right' });
     
+    startY += 8;
+    
+    // Suggested monthly Vorauszahlung line (rounded to nearest 5)
+    const suggestedVorauszahlung = tenantData.recommendedPrepayment ? roundToNearest5(tenantData.recommendedPrepayment) : 0;
+    const monthlyVorauszahlung = suggestedVorauszahlung / 12; // Convert annual to monthly
+    
+    // Calculate next month start date (at least 14 days from now)
+    const today = new Date();
+    const nextMonth = new Date(today.getFullYear(), today.getMonth() + 1, 1);
+    const formattedDate = format(nextMonth, 'dd.MM.yy');
+    
+    doc.setFont("helvetica", "bold");
+    const label = `Vorauszahlung ab ${formattedDate} (nächster Monat; mind. 14 Tage)`;
+    doc.text(label, col1Start, startY, { align: 'left' });
+    doc.text(formatCurrency(monthlyVorauszahlung), col5End, startY, { align: 'right' });
+    
     doc.setFont("helvetica", "normal");
     
     startY += 10;


### PR DESCRIPTION
## Description

Enriches the Abrechnung PDF with the landlord's billing address and a suggested new prepayment.

## Summary of Changes

- New edge route `GET /api/stripe/customer` (92 lines): returns the Stripe customer's billing address and default payment method (brand, last4, expiry)
- PDF generation fetches the billing address and prints a location + date line (e.g. "Berlin, den 12.08.2025") at the end of each tenant statement
- New bold line "Vorauszahlung ab {next month}" showing the suggested monthly prepayment (annual recommendation rounded to the nearest €5) right after the settlement amount — in both the combined and per-tenant PDF exports