### PR TITLE
Feature/improve dashboard page

### DIFF
--- a/app/(dashboard)/betriebskosten/client-wrapper.tsx
+++ b/app/(dashboard)/betriebskosten/client-wrapper.tsx
@@ -198,7 +198,7 @@ export default function BetriebskostenClientView({
   ];
 
   return (
-    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div
         className="absolute inset-0 z-[-1]"
         style={{

--- a/app/(dashboard)/betriebskosten/loading.tsx
+++ b/app/(dashboard)/betriebskosten/loading.tsx
@@ -10,20 +10,35 @@ export default function Loading() {
           backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
         }}
       />
-      {/* Instruction Cards Skeleton */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {[1, 2, 3, 4].map((idx) => (
-          <Card key={idx} className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-            <CardHeader className="pb-2">
-              <Skeleton className="h-5 w-48" />
-            </CardHeader>
-            <CardContent className="flex items-center justify-between gap-4">
-              <Skeleton className="h-4 w-2/3" />
-              <Skeleton className="h-9 w-28 rounded-full" />
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+      {/* Instruction Guide Skeleton */}
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+        <CardHeader className="pb-4">
+          <div className="flex items-start justify-between">
+            <div className="flex-1">
+              <Skeleton className="h-6 w-64 mb-2" />
+              <Skeleton className="h-4 w-96" />
+            </div>
+            <Skeleton className="h-8 w-24 rounded-lg" />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex gap-4">
+                <Skeleton className="flex-shrink-0 w-8 h-8 rounded-full" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-4 w-48" />
+                  <Skeleton className="h-3 w-full" />
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700 flex gap-3">
+            <Skeleton className="h-10 flex-1 rounded-full" />
+            <Skeleton className="h-10 w-40 rounded-full" />
+          </div>
+        </CardContent>
+      </Card>
 
       {/* Main Card Structure Skeleton */}
       <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">

--- a/app/(dashboard)/betriebskosten/loading.tsx
+++ b/app/(dashboard)/betriebskosten/loading.tsx
@@ -1,80 +1,10 @@
-import { Skeleton } from "@/components/ui/skeleton"
-import { Card, CardHeader, CardContent } from "@/components/ui/card"
+import { PageSkeleton } from "@/components/page-skeleton"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
-      <div
-        className="absolute inset-0 z-[-1]"
-        style={{
-          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
-        }}
-      />
-      {/* Instruction Guide Skeleton */}
-      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
-        <CardHeader className="pb-4">
-          <div className="flex items-start justify-between">
-            <div className="flex-1">
-              <Skeleton className="h-6 w-64 mb-2" />
-              <Skeleton className="h-4 w-96" />
-            </div>
-            <Skeleton className="h-8 w-24 rounded-lg" />
-          </div>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-4">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="flex gap-4">
-                <Skeleton className="flex-shrink-0 w-8 h-8 rounded-full" />
-                <div className="flex-1 space-y-2">
-                  <Skeleton className="h-4 w-48" />
-                  <Skeleton className="h-3 w-full" />
-                </div>
-              </div>
-            ))}
-          </div>
-          <div className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700 flex gap-3">
-            <Skeleton className="h-10 flex-1 rounded-full" />
-            <Skeleton className="h-10 w-40 rounded-full" />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Main Card Structure Skeleton */}
-      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
-        <CardHeader>
-          <div className="flex flex-row items-start justify-between">
-            <div>
-              <Skeleton className="h-6 w-48 mb-2" />
-              <Skeleton className="h-4 w-72" />
-            </div>
-            <Skeleton className="h-10 w-60 sm:w-[280px] rounded-full" />
-          </div>
-        </CardHeader>
-        <div className="px-6">
-          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
-        </div>
-        <CardContent className="flex flex-col gap-6">
-          {/* Filters Skeleton */}
-          <div className="flex flex-col gap-4 mt-6">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex flex-wrap gap-2">
-                {Array.from({ length: 3 }).map((_, i) => (
-                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
-                ))}
-              </div>
-              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
-            </div>
-          </div>
-
-          {/* Table Skeleton */}
-          <div className="space-y-3">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <Skeleton key={i} className="h-16 w-full rounded-lg" />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+    <PageSkeleton
+      buttonWidth="w-60 sm:w-[280px]"
+      showInstructionGuide={true}
+    />
   )
 }

--- a/app/(dashboard)/betriebskosten/loading.tsx
+++ b/app/(dashboard)/betriebskosten/loading.tsx
@@ -1,5 +1,5 @@
 import { Skeleton } from "@/components/ui/skeleton"
-import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card"
+import { Card, CardHeader, CardContent } from "@/components/ui/card"
 
 export default function Loading() {
   return (

--- a/app/(dashboard)/betriebskosten/loading.tsx
+++ b/app/(dashboard)/betriebskosten/loading.tsx
@@ -1,55 +1,65 @@
-import { Skeleton } from "@/components/ui/skeleton";
-import { Card, CardHeader, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton"
+import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
       {/* Instruction Cards Skeleton */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {[1,2,3,4].map((idx) => (
-          <Card key={idx} className="rounded-2xl">
+        {[1, 2, 3, 4].map((idx) => (
+          <Card key={idx} className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
             <CardHeader className="pb-2">
-              <Skeleton className="h-5 w-48" /> {/* Mimics CardTitle */}
+              <Skeleton className="h-5 w-48" />
             </CardHeader>
             <CardContent className="flex items-center justify-between gap-4">
-              <Skeleton className="h-4 w-2/3" /> {/* Mimics description */}
-              <Skeleton className="h-9 w-28" /> {/* Mimics action button */}
+              <Skeleton className="h-4 w-2/3" />
+              <Skeleton className="h-9 w-28 rounded-full" />
             </CardContent>
           </Card>
         ))}
       </div>
 
       {/* Main Card Structure Skeleton */}
-      <Card className="overflow-hidden rounded-2xl shadow-md">
-        <CardHeader className="flex flex-row items-center justify-between">
-          {/* Left side: Card Title Skeleton */}
-          <Skeleton className="h-6 w-48" /> {/* Mimics CardTitle */}
-          {/* Right side: Button Skeleton */}
-          <Skeleton className="h-10 w-60 sm:w-[280px]" /> {/* Mimics Button "Betriebskostenabrechnung erstellen" */}
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+        <CardHeader>
+          <div className="flex flex-row items-start justify-between">
+            <div>
+              <Skeleton className="h-6 w-48 mb-2" />
+              <Skeleton className="h-4 w-72" />
+            </div>
+            <Skeleton className="h-10 w-60 sm:w-[280px] rounded-full" />
+          </div>
         </CardHeader>
+        <div className="px-6">
+          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
+        </div>
         <CardContent className="flex flex-col gap-6">
           {/* Filters Skeleton */}
-          <div className="flex flex-col sm:flex-row gap-4 mb-2"> {/* Adjusted mb from 6 to 2 to match original page better */}
-            <Skeleton className="h-10 flex-grow" /> {/* Mimics search input */}
-            <Skeleton className="h-10 w-full sm:w-48" /> {/* Mimics a select filter */}
-            <Skeleton className="h-10 w-full sm:w-48" /> {/* Mimics another select filter */}
+          <div className="flex flex-col gap-4 mt-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-wrap gap-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
+                ))}
+              </div>
+              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
+            </div>
           </div>
 
           {/* Table Skeleton */}
-          <div className="rounded-md border">
-            {/* Table Header Skeleton */}
-            <Skeleton className="h-12 w-full" />
-            {/* Table Body Skeletons (Rows) */}
-            <div className="p-4 space-y-2"> {/* Added padding and spacing for rows if table rows have it */}
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-            </div>
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-lg" />
+            ))}
           </div>
         </CardContent>
       </Card>
     </div>
-  );
+  )
 }

--- a/app/(dashboard)/dateien/loading.tsx
+++ b/app/(dashboard)/dateien/loading.tsx
@@ -1,5 +1,4 @@
 import { Skeleton } from "@/components/ui/skeleton"
-import { Card } from "@/components/ui/card"
 
 export const runtime = 'edge'
 
@@ -13,17 +12,21 @@ export default function DateienLoading() {
         }}
       />
       
-      {/* Summary Cards Skeleton */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {/* Summary Cards Skeleton - 3 equal flex cards */}
+      <div className="flex flex-wrap gap-4">
         {Array.from({ length: 3 }).map((_, i) => (
-          <Card key={i} className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl p-6">
-            <div className="flex items-center justify-between mb-4">
-              <Skeleton className="h-10 w-10 rounded-lg" />
-              <Skeleton className="h-8 w-8 rounded-full" />
+          <div key={i} className="relative overflow-hidden rounded-3xl shadow-sm flex-1 bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251]">
+            <div className="p-6">
+              <div className="flex items-center justify-between space-y-0 pb-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-4 w-4" />
+              </div>
+              <div>
+                <Skeleton className="h-8 w-28 mb-1" />
+                <Skeleton className="h-3 w-40" />
+              </div>
             </div>
-            <Skeleton className="h-8 w-24 mb-2" />
-            <Skeleton className="h-4 w-32" />
-          </Card>
+          </div>
         ))}
       </div>
       
@@ -34,42 +37,39 @@ export default function DateienLoading() {
           <div className="p-6">
             <div className="flex flex-row items-start justify-between mb-6">
               <div>
-                <Skeleton className="h-8 w-32 mb-2" />
-                <Skeleton className="h-4 w-72" />
+                <Skeleton className="h-8 w-32 mb-1" />
+                <Skeleton className="h-4 w-80" />
               </div>
             </div>
             
             {/* Quick Actions Skeleton */}
             <div className="space-y-4">
+              {/* Search and sort row */}
               <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                {/* Left side: Search, Sort, Categories */}
                 <div className="flex flex-wrap gap-2">
-                  <Skeleton className="h-10 w-32 rounded-full" />
-                  <Skeleton className="h-10 w-36 rounded-full" />
-                  <Skeleton className="h-10 w-32 rounded-full" />
+                  <Skeleton className="h-9 w-full sm:w-[300px] rounded-full" />
+                  <Skeleton className="h-9 w-28 rounded-full" />
+                  <Skeleton className="h-9 w-32 rounded-full" />
                 </div>
-                <div className="flex gap-2">
-                  <Skeleton className="h-10 w-10 rounded-lg" />
-                  <Skeleton className="h-10 w-10 rounded-lg" />
-                  <Skeleton className="h-10 w-10 rounded-lg" />
-                </div>
-              </div>
-              
-              <div className="flex items-center justify-between">
-                <Skeleton className="h-10 flex-1 max-w-md rounded-full" />
-                <div className="flex gap-2 ml-4">
-                  <Skeleton className="h-10 w-24 rounded-lg" />
-                  <Skeleton className="h-10 w-20 rounded-lg" />
-                  <Skeleton className="h-10 w-20 rounded-lg" />
+                
+                {/* Right side: View mode toggle + Add button */}
+                <div className="flex items-center gap-2 mt-1">
+                  {/* View mode toggle */}
+                  <div className="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded-full p-1">
+                    <Skeleton className="h-8 w-10 rounded-full" />
+                    <Skeleton className="h-8 w-10 rounded-full" />
+                  </div>
+                  {/* Add button */}
+                  <Skeleton className="h-10 w-32 rounded-lg" />
                 </div>
               </div>
             </div>
             
             {/* Breadcrumb Skeleton */}
-            <div className="flex items-center space-x-2 mt-4">
-              <Skeleton className="h-8 w-24 rounded-md" />
-              <span className="text-muted-foreground/50">/</span>
-              <Skeleton className="h-8 w-32 rounded-md" />
-            </div>
+            <nav className="flex items-center space-x-1 text-base mt-4">
+              <Skeleton className="h-9 w-28 rounded-md" />
+            </nav>
           </div>
         </div>
         
@@ -80,7 +80,7 @@ export default function DateienLoading() {
               {Array.from({ length: 24 }).map((_, i) => (
                 <div key={i} className="animate-pulse" style={{ animationDelay: `${i * 20}ms` }}>
                   <Skeleton className="h-32 rounded-2xl mb-3 bg-gray-100 dark:bg-[#22272e]" />
-                  <Skeleton className="h-4 w-3/4 mb-2" />
+                  <Skeleton className="h-4 w-3/4 mb-1" />
                   <Skeleton className="h-3 w-1/2" />
                 </div>
               ))}

--- a/app/(dashboard)/dateien/loading.tsx
+++ b/app/(dashboard)/dateien/loading.tsx
@@ -1,64 +1,91 @@
 import { Skeleton } from "@/components/ui/skeleton"
+import { Card } from "@/components/ui/card"
 
 export const runtime = 'edge'
 
 export default function DateienLoading() {
   return (
-    <div className="h-full flex flex-col bg-white dark:bg-[#181818]">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div
         className="absolute inset-0 z-[-1]"
         style={{
           backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
         }}
       />
-      {/* Header skeleton */}
-      <div className="border-b border-gray-200 dark:border-gray-700 p-6 space-y-6">
-        <div className="flex items-center justify-between">
-          <div className="space-y-2">
-            <Skeleton className="h-9 w-64" />
-            <Skeleton className="h-4 w-80" />
-          </div>
-          <div className="flex space-x-3">
-            <Skeleton className="h-10 w-36 rounded-full" />
-            <Skeleton className="h-10 w-32 rounded-full" />
+      
+      {/* Summary Cards Skeleton */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Card key={i} className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl p-6">
+            <div className="flex items-center justify-between mb-4">
+              <Skeleton className="h-10 w-10 rounded-lg" />
+              <Skeleton className="h-8 w-8 rounded-full" />
+            </div>
+            <Skeleton className="h-8 w-24 mb-2" />
+            <Skeleton className="h-4 w-32" />
+          </Card>
+        ))}
+      </div>
+      
+      {/* Main File Container Skeleton */}
+      <div className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem] flex flex-col">
+        {/* Header */}
+        <div className="border-b border-gray-200 dark:border-gray-700">
+          <div className="p-6">
+            <div className="flex flex-row items-start justify-between mb-6">
+              <div>
+                <Skeleton className="h-8 w-32 mb-2" />
+                <Skeleton className="h-4 w-72" />
+              </div>
+            </div>
+            
+            {/* Quick Actions Skeleton */}
+            <div className="space-y-4">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-wrap gap-2">
+                  <Skeleton className="h-10 w-32 rounded-full" />
+                  <Skeleton className="h-10 w-36 rounded-full" />
+                  <Skeleton className="h-10 w-32 rounded-full" />
+                </div>
+                <div className="flex gap-2">
+                  <Skeleton className="h-10 w-10 rounded-lg" />
+                  <Skeleton className="h-10 w-10 rounded-lg" />
+                  <Skeleton className="h-10 w-10 rounded-lg" />
+                </div>
+              </div>
+              
+              <div className="flex items-center justify-between">
+                <Skeleton className="h-10 flex-1 max-w-md rounded-full" />
+                <div className="flex gap-2 ml-4">
+                  <Skeleton className="h-10 w-24 rounded-lg" />
+                  <Skeleton className="h-10 w-20 rounded-lg" />
+                  <Skeleton className="h-10 w-20 rounded-lg" />
+                </div>
+              </div>
+            </div>
+            
+            {/* Breadcrumb Skeleton */}
+            <div className="flex items-center space-x-2 mt-4">
+              <Skeleton className="h-8 w-24 rounded-md" />
+              <span className="text-muted-foreground/50">/</span>
+              <Skeleton className="h-8 w-32 rounded-md" />
+            </div>
           </div>
         </div>
         
-        <div className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div className="flex space-x-2">
-              <Skeleton className="h-9 w-24 rounded-full" />
-              <Skeleton className="h-9 w-32 rounded-full" />
-            </div>
-            <div className="flex space-x-2">
-              <Skeleton className="h-8 w-20 rounded-lg" />
-              <Skeleton className="h-8 w-16 rounded-lg" />
-            </div>
-          </div>
-          
-          <div className="flex items-center justify-between">
-            <Skeleton className="h-10 w-96 rounded-full" />
-            <div className="flex space-x-2">
-              <Skeleton className="h-8 w-12 rounded-lg" />
-              <Skeleton className="h-8 w-16 rounded-lg" />
-              <Skeleton className="h-8 w-20 rounded-lg" />
-              <Skeleton className="h-8 w-16 rounded-lg" />
-              <Skeleton className="h-8 w-20 rounded-lg" />
+        {/* Content Area Skeleton */}
+        <div className="flex-1 overflow-auto">
+          <div className="p-6">
+            <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
+              {Array.from({ length: 24 }).map((_, i) => (
+                <div key={i} className="animate-pulse" style={{ animationDelay: `${i * 20}ms` }}>
+                  <Skeleton className="h-32 rounded-2xl mb-3 bg-gray-100 dark:bg-[#22272e]" />
+                  <Skeleton className="h-4 w-3/4 mb-2" />
+                  <Skeleton className="h-3 w-1/2" />
+                </div>
+              ))}
             </div>
           </div>
-        </div>
-      </div>
-      
-      {/* Content skeleton */}
-      <div className="flex-1 p-6">
-        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
-          {Array.from({ length: 24 }).map((_, i) => (
-            <div key={i} className="animate-pulse">
-              <Skeleton className="h-32 rounded-2xl mb-3 bg-gray-100 dark:bg-[#22272e]" />
-              <Skeleton className="h-4 w-3/4 mb-2" />
-              <Skeleton className="h-3 w-1/2" />
-            </div>
-          ))}
         </div>
       </div>
     </div>

--- a/app/(dashboard)/dateien/loading.tsx
+++ b/app/(dashboard)/dateien/loading.tsx
@@ -4,40 +4,46 @@ export const runtime = 'edge'
 
 export default function DateienLoading() {
   return (
-    <div className="h-full flex flex-col">
+    <div className="h-full flex flex-col bg-white dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
       {/* Header skeleton */}
-      <div className="border-b p-6 space-y-6">
+      <div className="border-b border-gray-200 dark:border-gray-700 p-6 space-y-6">
         <div className="flex items-center justify-between">
           <div className="space-y-2">
             <Skeleton className="h-9 w-64" />
             <Skeleton className="h-4 w-80" />
           </div>
           <div className="flex space-x-3">
-            <Skeleton className="h-9 w-32" />
-            <Skeleton className="h-9 w-28" />
+            <Skeleton className="h-10 w-36 rounded-full" />
+            <Skeleton className="h-10 w-32 rounded-full" />
           </div>
         </div>
         
         <div className="space-y-4">
           <div className="flex items-center justify-between">
             <div className="flex space-x-2">
-              <Skeleton className="h-9 w-24" />
-              <Skeleton className="h-9 w-32" />
+              <Skeleton className="h-9 w-24 rounded-full" />
+              <Skeleton className="h-9 w-32 rounded-full" />
             </div>
             <div className="flex space-x-2">
-              <Skeleton className="h-8 w-20" />
-              <Skeleton className="h-8 w-16" />
+              <Skeleton className="h-8 w-20 rounded-lg" />
+              <Skeleton className="h-8 w-16 rounded-lg" />
             </div>
           </div>
           
           <div className="flex items-center justify-between">
-            <Skeleton className="h-9 w-96" />
+            <Skeleton className="h-10 w-96 rounded-full" />
             <div className="flex space-x-2">
-              <Skeleton className="h-8 w-12" />
-              <Skeleton className="h-8 w-16" />
-              <Skeleton className="h-8 w-20" />
-              <Skeleton className="h-8 w-16" />
-              <Skeleton className="h-8 w-20" />
+              <Skeleton className="h-8 w-12 rounded-lg" />
+              <Skeleton className="h-8 w-16 rounded-lg" />
+              <Skeleton className="h-8 w-20 rounded-lg" />
+              <Skeleton className="h-8 w-16 rounded-lg" />
+              <Skeleton className="h-8 w-20 rounded-lg" />
             </div>
           </div>
         </div>
@@ -48,7 +54,7 @@ export default function DateienLoading() {
         <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
           {Array.from({ length: 24 }).map((_, i) => (
             <div key={i} className="animate-pulse">
-              <Skeleton className="h-32 rounded-lg mb-3" />
+              <Skeleton className="h-32 rounded-2xl mb-3 bg-gray-100 dark:bg-[#22272e]" />
               <Skeleton className="h-4 w-3/4 mb-2" />
               <Skeleton className="h-3 w-1/2" />
             </div>

--- a/app/(dashboard)/dateien/page.tsx
+++ b/app/(dashboard)/dateien/page.tsx
@@ -9,34 +9,87 @@ export const runtime = 'edge'
 
 function CloudStorageLoading() {
   return (
-    <div className="h-full flex flex-col">
-      {/* Header skeleton */}
-      <div className="border-b p-6 space-y-4">
-        <div className="flex items-center justify-between">
-          <div className="space-y-2">
-            <Skeleton className="h-8 w-48" />
-            <Skeleton className="h-4 w-64" />
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
+      
+      {/* Summary Cards Skeleton */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl p-6">
+            <div className="flex items-center justify-between mb-4">
+              <Skeleton className="h-10 w-10 rounded-lg" />
+              <Skeleton className="h-8 w-8 rounded-full" />
+            </div>
+            <Skeleton className="h-8 w-24 mb-2" />
+            <Skeleton className="h-4 w-32" />
           </div>
-          <Skeleton className="h-9 w-32" />
-        </div>
-        <div className="flex items-center justify-between">
-          <Skeleton className="h-9 w-80" />
-          <div className="flex space-x-2">
-            <Skeleton className="h-9 w-24" />
-            <Skeleton className="h-9 w-20" />
-          </div>
-        </div>
+        ))}
       </div>
       
-      {/* Content skeleton */}
-      <div className="flex-1 p-6">
-        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
-          {Array.from({ length: 16 }).map((_, i) => (
-            <div key={i} className="animate-pulse">
-              <Skeleton className="h-24 rounded-lg mb-2" />
-              <Skeleton className="h-4 w-3/4" />
+      {/* Main File Container Skeleton */}
+      <div className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem] flex flex-col">
+        {/* Header */}
+        <div className="border-b border-gray-200 dark:border-gray-700">
+          <div className="p-6">
+            <div className="flex flex-row items-start justify-between mb-6">
+              <div>
+                <Skeleton className="h-8 w-32 mb-2" />
+                <Skeleton className="h-4 w-72" />
+              </div>
             </div>
-          ))}
+            
+            {/* Quick Actions Skeleton */}
+            <div className="space-y-4">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-wrap gap-2">
+                  <Skeleton className="h-10 w-32 rounded-full" />
+                  <Skeleton className="h-10 w-36 rounded-full" />
+                  <Skeleton className="h-10 w-32 rounded-full" />
+                </div>
+                <div className="flex gap-2">
+                  <Skeleton className="h-10 w-10 rounded-lg" />
+                  <Skeleton className="h-10 w-10 rounded-lg" />
+                  <Skeleton className="h-10 w-10 rounded-lg" />
+                </div>
+              </div>
+              
+              <div className="flex items-center justify-between">
+                <Skeleton className="h-10 flex-1 max-w-md rounded-full" />
+                <div className="flex gap-2 ml-4">
+                  <Skeleton className="h-10 w-24 rounded-lg" />
+                  <Skeleton className="h-10 w-20 rounded-lg" />
+                  <Skeleton className="h-10 w-20 rounded-lg" />
+                </div>
+              </div>
+            </div>
+            
+            {/* Breadcrumb Skeleton */}
+            <div className="flex items-center space-x-2 mt-4">
+              <Skeleton className="h-8 w-24 rounded-md" />
+              <span className="text-muted-foreground/50">/</span>
+              <Skeleton className="h-8 w-32 rounded-md" />
+            </div>
+          </div>
+        </div>
+        
+        {/* Content Area Skeleton */}
+        <div className="flex-1 overflow-auto">
+          <div className="p-6">
+            <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
+              {Array.from({ length: 24 }).map((_, i) => (
+                <div key={i} className="animate-pulse" style={{ animationDelay: `${i * 20}ms` }}>
+                  <Skeleton className="h-32 rounded-2xl mb-3 bg-gray-100 dark:bg-[#22272e]" />
+                  <Skeleton className="h-4 w-3/4 mb-2" />
+                  <Skeleton className="h-3 w-1/2" />
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/app/(dashboard)/dateien/page.tsx
+++ b/app/(dashboard)/dateien/page.tsx
@@ -17,16 +17,20 @@ function CloudStorageLoading() {
         }}
       />
       
-      {/* Summary Cards Skeleton */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {/* Summary Cards Skeleton - 3 equal flex cards */}
+      <div className="flex flex-wrap gap-4">
         {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl p-6">
-            <div className="flex items-center justify-between mb-4">
-              <Skeleton className="h-10 w-10 rounded-lg" />
-              <Skeleton className="h-8 w-8 rounded-full" />
+          <div key={i} className="relative overflow-hidden rounded-3xl shadow-sm flex-1 bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251]">
+            <div className="p-6">
+              <div className="flex items-center justify-between space-y-0 pb-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-4 w-4" />
+              </div>
+              <div>
+                <Skeleton className="h-8 w-28 mb-1" />
+                <Skeleton className="h-3 w-40" />
+              </div>
             </div>
-            <Skeleton className="h-8 w-24 mb-2" />
-            <Skeleton className="h-4 w-32" />
           </div>
         ))}
       </div>
@@ -38,42 +42,39 @@ function CloudStorageLoading() {
           <div className="p-6">
             <div className="flex flex-row items-start justify-between mb-6">
               <div>
-                <Skeleton className="h-8 w-32 mb-2" />
-                <Skeleton className="h-4 w-72" />
+                <Skeleton className="h-8 w-32 mb-1" />
+                <Skeleton className="h-4 w-80" />
               </div>
             </div>
             
             {/* Quick Actions Skeleton */}
             <div className="space-y-4">
+              {/* Search and sort row */}
               <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                {/* Left side: Search, Sort, Categories */}
                 <div className="flex flex-wrap gap-2">
-                  <Skeleton className="h-10 w-32 rounded-full" />
-                  <Skeleton className="h-10 w-36 rounded-full" />
-                  <Skeleton className="h-10 w-32 rounded-full" />
+                  <Skeleton className="h-9 w-full sm:w-[300px] rounded-full" />
+                  <Skeleton className="h-9 w-28 rounded-full" />
+                  <Skeleton className="h-9 w-32 rounded-full" />
                 </div>
-                <div className="flex gap-2">
-                  <Skeleton className="h-10 w-10 rounded-lg" />
-                  <Skeleton className="h-10 w-10 rounded-lg" />
-                  <Skeleton className="h-10 w-10 rounded-lg" />
-                </div>
-              </div>
-              
-              <div className="flex items-center justify-between">
-                <Skeleton className="h-10 flex-1 max-w-md rounded-full" />
-                <div className="flex gap-2 ml-4">
-                  <Skeleton className="h-10 w-24 rounded-lg" />
-                  <Skeleton className="h-10 w-20 rounded-lg" />
-                  <Skeleton className="h-10 w-20 rounded-lg" />
+                
+                {/* Right side: View mode toggle + Add button */}
+                <div className="flex items-center gap-2 mt-1">
+                  {/* View mode toggle */}
+                  <div className="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded-full p-1">
+                    <Skeleton className="h-8 w-10 rounded-full" />
+                    <Skeleton className="h-8 w-10 rounded-full" />
+                  </div>
+                  {/* Add button */}
+                  <Skeleton className="h-10 w-32 rounded-lg" />
                 </div>
               </div>
             </div>
             
             {/* Breadcrumb Skeleton */}
-            <div className="flex items-center space-x-2 mt-4">
-              <Skeleton className="h-8 w-24 rounded-md" />
-              <span className="text-muted-foreground/50">/</span>
-              <Skeleton className="h-8 w-32 rounded-md" />
-            </div>
+            <nav className="flex items-center space-x-1 text-base mt-4">
+              <Skeleton className="h-9 w-28 rounded-md" />
+            </nav>
           </div>
         </div>
         
@@ -84,7 +85,7 @@ function CloudStorageLoading() {
               {Array.from({ length: 24 }).map((_, i) => (
                 <div key={i} className="animate-pulse" style={{ animationDelay: `${i * 20}ms` }}>
                   <Skeleton className="h-32 rounded-2xl mb-3 bg-gray-100 dark:bg-[#22272e]" />
-                  <Skeleton className="h-4 w-3/4 mb-2" />
+                  <Skeleton className="h-4 w-3/4 mb-1" />
                   <Skeleton className="h-3 w-1/2" />
                 </div>
               ))}

--- a/app/(dashboard)/dateien/page.tsx
+++ b/app/(dashboard)/dateien/page.tsx
@@ -1,121 +1,9 @@
-import { Suspense } from "react"
 import { CloudStorageSimple } from "@/components/cloud-storage-simple"
 import { createClient } from "@/utils/supabase/server"
 import { redirect } from "next/navigation"
-import { Skeleton } from "@/components/ui/skeleton"
 import { getPathContents } from "./actions"
 
 export const runtime = 'edge'
-
-function CloudStorageLoading() {
-  return (
-    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
-      <div
-        className="absolute inset-0 z-[-1]"
-        style={{
-          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
-        }}
-      />
-      
-      {/* Summary Cards Skeleton - 3 equal flex cards */}
-      <div className="flex flex-wrap gap-4">
-        {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="relative overflow-hidden rounded-3xl shadow-sm flex-1 bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251]">
-            <div className="p-6">
-              <div className="flex items-center justify-between space-y-0 pb-2">
-                <Skeleton className="h-4 w-32" />
-                <Skeleton className="h-4 w-4" />
-              </div>
-              <div>
-                <Skeleton className="h-8 w-28 mb-1" />
-                <Skeleton className="h-3 w-40" />
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
-      
-      {/* Main File Container Skeleton */}
-      <div className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem] flex flex-col">
-        {/* Header */}
-        <div className="border-b border-gray-200 dark:border-gray-700">
-          <div className="p-6">
-            <div className="flex flex-row items-start justify-between mb-6">
-              <div>
-                <Skeleton className="h-8 w-32 mb-1" />
-                <Skeleton className="h-4 w-80" />
-              </div>
-            </div>
-            
-            {/* Quick Actions Skeleton */}
-            <div className="space-y-4">
-              {/* Search and sort row */}
-              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                {/* Left side: Search, Sort, Categories */}
-                <div className="flex flex-wrap gap-2">
-                  <Skeleton className="h-9 w-full sm:w-[300px] rounded-full" />
-                  <Skeleton className="h-9 w-28 rounded-full" />
-                  <Skeleton className="h-9 w-32 rounded-full" />
-                </div>
-                
-                {/* Right side: View mode toggle + Add button */}
-                <div className="flex items-center gap-2 mt-1">
-                  {/* View mode toggle */}
-                  <div className="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded-full p-1">
-                    <Skeleton className="h-8 w-10 rounded-full" />
-                    <Skeleton className="h-8 w-10 rounded-full" />
-                  </div>
-                  {/* Add button */}
-                  <Skeleton className="h-10 w-32 rounded-lg" />
-                </div>
-              </div>
-            </div>
-            
-            {/* Breadcrumb Skeleton */}
-            <nav className="flex items-center space-x-1 text-base mt-4">
-              <Skeleton className="h-9 w-28 rounded-md" />
-            </nav>
-          </div>
-        </div>
-        
-        {/* Content Area Skeleton */}
-        <div className="flex-1 overflow-auto">
-          <div className="p-6">
-            <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
-              {Array.from({ length: 24 }).map((_, i) => (
-                <div key={i} className="animate-pulse" style={{ animationDelay: `${i * 20}ms` }}>
-                  <Skeleton className="h-32 rounded-2xl mb-3 bg-gray-100 dark:bg-[#22272e]" />
-                  <Skeleton className="h-4 w-3/4 mb-1" />
-                  <Skeleton className="h-3 w-1/2" />
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-async function CloudStorageContent({ userId }: { userId: string }) {
-  // Load initial files, folders and breadcrumbs on the server
-  const initialPath = `user_${userId}`
-  const { files, folders, breadcrumbs, error } = await getPathContents(userId, initialPath)
-
-  if (error) {
-    console.error('Error loading initial files:', error)
-  }
-
-  return (
-    <CloudStorageSimple
-      userId={userId}
-      initialPath={initialPath}
-      initialFiles={files}
-      initialFolders={folders}
-      initialBreadcrumbs={breadcrumbs}
-    />
-  )
-}
 
 export default async function DateienPage() {
   const supabase = await createClient()
@@ -127,11 +15,21 @@ export default async function DateienPage() {
     redirect('/auth/login')
   }
 
+  // Load initial files, folders and breadcrumbs on the server
+  const initialPath = `user_${user.id}`
+  const { files, folders, breadcrumbs, error: loadError } = await getPathContents(user.id, initialPath)
+
+  if (loadError) {
+    console.error('Error loading initial files:', loadError)
+  }
+
   return (
-    <div className="h-full">
-      <Suspense fallback={<CloudStorageLoading />}>
-        <CloudStorageContent userId={user.id} />
-      </Suspense>
-    </div>
+    <CloudStorageSimple
+      userId={user.id}
+      initialPath={initialPath}
+      initialFiles={files}
+      initialFolders={folders}
+      initialBreadcrumbs={breadcrumbs}
+    />
   )
 }

--- a/app/(dashboard)/finanzen/client-wrapper.tsx
+++ b/app/(dashboard)/finanzen/client-wrapper.tsx
@@ -400,7 +400,7 @@ export default function FinanzenClientWrapper({ finances: initialFinances, wohnu
 
 
   return (
-    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div
         className="absolute inset-0 z-[-1]"
         style={{

--- a/app/(dashboard)/finanzen/loading.tsx
+++ b/app/(dashboard)/finanzen/loading.tsx
@@ -1,116 +1,132 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Button } from "@/components/ui/button"
-import { PlusCircle, ArrowUpCircle, ArrowDownCircle, BarChart3, Wallet } from "lucide-react"
-import { SummaryCardSkeleton } from "@/components/summary-card-skeleton"
-import { ChartSkeleton } from "@/components/chart-skeletons"
+import { ArrowUpCircle, ArrowDownCircle, BarChart3, Wallet } from "lucide-react"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8 animate-in fade-in-0 duration-300">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818] animate-in fade-in-0 duration-300">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
       {/* Summary Cards */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <div className="animate-pulse" style={{ animationDelay: '0ms' }}>
-          <SummaryCardSkeleton 
-            title="Ø Monatliche Einnahmen" 
-            icon={<ArrowUpCircle className="h-4 w-4 text-green-500" />} 
-          />
-        </div>
-        <div className="animate-pulse" style={{ animationDelay: '100ms' }}>
-          <SummaryCardSkeleton 
-            title="Ø Monatliche Ausgaben" 
-            icon={<ArrowDownCircle className="h-4 w-4 text-red-500" />} 
-          />
-        </div>
-        <div className="animate-pulse" style={{ animationDelay: '200ms' }}>
-          <SummaryCardSkeleton 
-            title="Ø Monatlicher Cashflow" 
-            icon={<Wallet className="h-4 w-4 text-muted-foreground" />} 
-          />
-        </div>
-        <div className="animate-pulse" style={{ animationDelay: '300ms' }}>
-          <SummaryCardSkeleton 
-            title="Jahresprognose" 
-            icon={<BarChart3 className="h-4 w-4 text-muted-foreground" />} 
-          />
-        </div>
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl animate-pulse" style={{ animationDelay: '0ms' }}>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Ø Monatliche Einnahmen</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <ArrowUpCircle className="h-4 w-4 text-green-500" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-24 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl animate-pulse" style={{ animationDelay: '100ms' }}>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Ø Monatliche Ausgaben</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <ArrowDownCircle className="h-4 w-4 text-red-500" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-24 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl animate-pulse" style={{ animationDelay: '200ms' }}>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Ø Monatlicher Cashflow</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Wallet className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-24 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl animate-pulse" style={{ animationDelay: '300ms' }}>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Jahresprognose</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <BarChart3 className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-24 mb-2" />
+          </CardContent>
+        </Card>
       </div>
 
       {/* Chart Skeleton */}
-      <Card className="p-4">
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem] p-6">
         <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-6">
           {/* Chart type selector skeleton */}
           <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
-            <Skeleton className="h-9 w-20" />
-            <Skeleton className="h-9 w-20" />
-            <Skeleton className="h-9 w-20" />
-            <Skeleton className="h-9 w-20" />
+            <Skeleton className="h-9 w-20 rounded-full" />
+            <Skeleton className="h-9 w-20 rounded-full" />
+            <Skeleton className="h-9 w-20 rounded-full" />
+            <Skeleton className="h-9 w-20 rounded-full" />
           </div>
           {/* Year selector skeleton */}
           <div className="mt-4 md:mt-0 flex items-center gap-2">
             <Skeleton className="h-4 w-8" />
-            <Skeleton className="h-9 w-16" />
+            <Skeleton className="h-9 w-16 rounded-lg" />
           </div>
         </div>
         
-        <ChartSkeleton 
-          title="Einnahmen nach Wohnung" 
-          description="Verteilung der Mieteinnahmen nach Wohnungen"
-          type="pie" 
-        />
+        <div className="space-y-4">
+          <div>
+            <Skeleton className="h-6 w-48 mb-2" />
+            <Skeleton className="h-4 w-64" />
+          </div>
+          <Skeleton className="h-64 w-full rounded-lg" />
+        </div>
       </Card>
 
       {/* Transactions Table Skeleton */}
-      <Card>
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
         <CardHeader>
           <div className="flex items-center justify-between">
-            <CardTitle>
-              <Skeleton className="h-6 w-32" />
-            </CardTitle>
+            <div>
+              <Skeleton className="h-6 w-32 mb-2" />
+              <Skeleton className="h-4 w-48" />
+            </div>
             <div className="flex items-center gap-2">
-              <Skeleton className="h-9 w-20" />
-              <Skeleton className="h-9 w-20" />
+              <Skeleton className="h-10 w-32 rounded-full" />
             </div>
           </div>
         </CardHeader>
-        <CardContent>
+        <div className="px-6">
+          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
+        </div>
+        <CardContent className="pt-6">
           <div className="space-y-4">
             {/* Search and filter bar */}
-            <div className="flex items-center gap-4">
-              <Skeleton className="h-9 flex-1" />
-              <Skeleton className="h-9 w-24" />
-              <Skeleton className="h-9 w-24" />
-            </div>
-            
-            {/* Table header */}
-            <div className="grid grid-cols-6 gap-4 pb-2 border-b">
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-4 w-12" />
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-wrap gap-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-9 w-24 rounded-full" />
+                ))}
+              </div>
+              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
             </div>
             
             {/* Table rows */}
-            {Array.from({ length: 10 }).map((_, i) => (
-              <div 
-                key={i} 
-                className="grid grid-cols-6 gap-4 py-3 border-b border-border/50 animate-pulse"
-                style={{ animationDelay: `${i * 50}ms` }}
-              >
-                <Skeleton className="h-4 w-20" />
-                <Skeleton className="h-4 w-32" />
-                <Skeleton className="h-4 w-28" />
-                <Skeleton className="h-4 w-20" />
-                <Skeleton className="h-4 w-24" />
-                <Skeleton className="h-4 w-8" />
-              </div>
-            ))}
+            <div className="space-y-3">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <Skeleton 
+                  key={i} 
+                  className="h-16 w-full rounded-lg animate-pulse"
+                  style={{ animationDelay: `${i * 50}ms` }}
+                />
+              ))}
+            </div>
             
             {/* Load more button */}
             <div className="flex justify-center pt-4">
-              <Skeleton className="h-9 w-32" />
+              <Skeleton className="h-10 w-40 rounded-full" />
             </div>
           </div>
         </CardContent>

--- a/app/(dashboard)/haeuser/client-wrapper.tsx
+++ b/app/(dashboard)/haeuser/client-wrapper.tsx
@@ -150,7 +150,7 @@ export default function HaeuserClientView({ enrichedHaeuser }: HaeuserClientView
   }, [selectedHouses, router, refreshTable]);
 
   return (
-    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div
         className="absolute inset-0 z-[-1]"
         style={{

--- a/app/(dashboard)/haeuser/loading.tsx
+++ b/app/(dashboard)/haeuser/loading.tsx
@@ -1,82 +1,50 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Building, Home, Key } from "lucide-react"
+import { PageSkeleton } from "@/components/page-skeleton"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
-      <div
-        className="absolute inset-0 z-[-1]"
-        style={{
-          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
-        }}
-      />
-      <div className="flex flex-wrap gap-4">
-        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Häuser gesamt</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <Building className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-16 mb-2" />
-          </CardContent>
-        </Card>
-        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Wohnungen gesamt</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <Home className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-16 mb-2" />
-          </CardContent>
-        </Card>
-        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Freie Wohnungen</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <Key className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-16 mb-2" />
-          </CardContent>
-        </Card>
-      </div>
-      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
-        <CardHeader>
-          <div className="flex flex-row items-start justify-between">
-            <div>
-              <Skeleton className="h-6 w-40 mb-2" />
-              <Skeleton className="h-4 w-64" />
-            </div>
-            <Skeleton className="h-10 w-40 rounded-full" />
-          </div>
-        </CardHeader>
-        <div className="px-6">
-          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
-        </div>
-        <CardContent className="flex flex-col gap-6">
-          <div className="flex flex-col gap-4 mt-6">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex flex-wrap gap-2">
-                {Array.from({ length: 3 }).map((_, i) => (
-                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
-                ))}
+    <PageSkeleton
+      headerTitleWidth="w-40"
+      headerDescriptionWidth="w-64"
+      statsCards={
+        <div className="flex flex-wrap gap-4">
+          <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Häuser gesamt</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <Building className="h-4 w-4 text-muted-foreground" />
               </div>
-              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
-            </div>
-          </div>
-          <div className="space-y-3">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <Skeleton key={i} className="h-16 w-full rounded-lg" />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-16 mb-2" />
+            </CardContent>
+          </Card>
+          <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Wohnungen gesamt</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <Home className="h-4 w-4 text-muted-foreground" />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-16 mb-2" />
+            </CardContent>
+          </Card>
+          <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Freie Wohnungen</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <Key className="h-4 w-4 text-muted-foreground" />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-16 mb-2" />
+            </CardContent>
+          </Card>
+        </div>
+      }
+    />
   )
 }

--- a/app/(dashboard)/haeuser/loading.tsx
+++ b/app/(dashboard)/haeuser/loading.tsx
@@ -1,24 +1,80 @@
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
-import { SummaryCardSkeleton } from "@/components/summary-card-skeleton";
-import { Building, Home, Key } from "lucide-react";
+import { Building, Home, Key } from "lucide-react"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8">
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <SummaryCardSkeleton title="Häuser" icon={<Building className="h-4 w-4 text-muted-foreground" />} />
-        <SummaryCardSkeleton title="Wohnungen" icon={<Home className="h-4 w-4 text-muted-foreground" />} />
-        <SummaryCardSkeleton title="Freie Wohnungen" icon={<Key className="h-4 w-4 text-muted-foreground" />} />
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
+      <div className="flex flex-wrap gap-4">
+        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Häuser gesamt</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Building className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-16 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Wohnungen gesamt</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Home className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-16 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Freie Wohnungen</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Key className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-16 mb-2" />
+          </CardContent>
+        </Card>
       </div>
-      <Card className="overflow-hidden rounded-2xl shadow-md">
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
         <CardHeader>
-          <Skeleton className="h-6 w-40 mb-2" />
+          <div className="flex flex-row items-start justify-between">
+            <div>
+              <Skeleton className="h-6 w-40 mb-2" />
+              <Skeleton className="h-4 w-64" />
+            </div>
+            <Skeleton className="h-10 w-40 rounded-full" />
+          </div>
         </CardHeader>
-        <CardContent className="flex flex-col gap-2">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <Skeleton key={i} className="h-4 w-full" />
-          ))}
+        <div className="px-6">
+          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
+        </div>
+        <CardContent className="flex flex-col gap-6">
+          <div className="flex flex-col gap-4 mt-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-wrap gap-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
+                ))}
+              </div>
+              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
+            </div>
+          </div>
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-lg" />
+            ))}
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -16,14 +16,20 @@ export default async function Dashboard() {
   const summary = await getDashboardSummary();
   
   return (
-    <div className="flex flex-col gap-4 p-4 md:gap-8 md:p-8">
+    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
       <div>
         <h1 className="text-2xl font-bold tracking-tight md:text-3xl">Dashboard</h1>
       </div>
       <div className="grid gap-4 grid-cols-1 auto-rows-auto md:grid-cols-6 md:auto-rows-[140px] md:h-[calc(100vh-200px)]">
         {/* Row 1: Three wider summary cards (2/3 width - 4 columns total) + Tenant Payment List (1/3 width - 2 columns) */}
         <Link href="/haeuser" className="col-span-1 row-span-1 md:col-span-1 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden rounded-xl md:rounded-2xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Häuser</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -39,7 +45,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/wohnungen" className="col-span-1 row-span-1 md:col-span-2 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden rounded-xl md:rounded-2xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Wohnungen</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -55,7 +61,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/mieter" className="col-span-1 row-span-1 md:col-span-1 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden rounded-xl md:rounded-2xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Mieter</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -92,7 +98,7 @@ export default async function Dashboard() {
         </div>
         {/* Mobile: Individual cards, Desktop: Stacked container */}
         <Link href="/todos" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -114,7 +120,7 @@ export default async function Dashboard() {
         </Link>
         
         <Link href="/finanzen" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -134,7 +140,7 @@ export default async function Dashboard() {
         </Link>
         
         <Link href="/betriebskosten" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -157,7 +163,7 @@ export default async function Dashboard() {
         <div className="hidden md:block md:col-span-2 md:row-span-3">
           <div className="h-full flex flex-col gap-4">
             <Link href="/todos" className="flex-1">
-              <Card className="h-full overflow-hidden rounded-2xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
@@ -179,7 +185,7 @@ export default async function Dashboard() {
             </Link>
             
             <Link href="/finanzen" className="flex-1">
-              <Card className="h-full overflow-hidden rounded-2xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
@@ -199,7 +205,7 @@ export default async function Dashboard() {
             </Link>
             
             <Link href="/betriebskosten" className="flex-1">
-              <Card className="h-full overflow-hidden rounded-2xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -237,6 +237,9 @@ export default async function Dashboard() {
             <MaintenanceDonutChart />
           </div>
         </div>
+        
+        {/* Empty row for bottom spacing */}
+        <div className="col-span-1 md:col-span-6 h-4 md:h-8"></div>
       </div>
     </div>
   )

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -29,7 +29,7 @@ export default async function Dashboard() {
       <div className="grid gap-4 grid-cols-1 auto-rows-auto md:grid-cols-6 md:auto-rows-[140px] md:h-[calc(100vh-200px)]">
         {/* Row 1: Three wider summary cards (2/3 width - 4 columns total) + Tenant Payment List (1/3 width - 2 columns) */}
         <Link href="/haeuser" className="col-span-1 row-span-1 md:col-span-1 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Häuser</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -45,7 +45,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/wohnungen" className="col-span-1 row-span-1 md:col-span-2 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Wohnungen</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -61,7 +61,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/mieter" className="col-span-1 row-span-1 md:col-span-1 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Mieter</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -98,7 +98,7 @@ export default async function Dashboard() {
         </div>
         {/* Mobile: Individual cards, Desktop: Stacked container */}
         <Link href="/todos" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -120,7 +120,7 @@ export default async function Dashboard() {
         </Link>
         
         <Link href="/finanzen" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -140,7 +140,7 @@ export default async function Dashboard() {
         </Link>
         
         <Link href="/betriebskosten" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -163,7 +163,7 @@ export default async function Dashboard() {
         <div className="hidden md:block md:col-span-2 md:row-span-3">
           <div className="h-full flex flex-col gap-4">
             <Link href="/todos" className="flex-1">
-              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
@@ -185,7 +185,7 @@ export default async function Dashboard() {
             </Link>
             
             <Link href="/finanzen" className="flex-1">
-              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
@@ -205,7 +205,7 @@ export default async function Dashboard() {
             </Link>
             
             <Link href="/betriebskosten" className="flex-1">
-              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -29,7 +29,7 @@ export default async function Dashboard() {
       <div className="grid gap-4 grid-cols-1 auto-rows-auto md:grid-cols-6 md:auto-rows-[140px] md:h-[calc(100vh-200px)]">
         {/* Row 1: Three wider summary cards (2/3 width - 4 columns total) + Tenant Payment List (1/3 width - 2 columns) */}
         <Link href="/haeuser" className="col-span-1 row-span-1 md:col-span-1 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Häuser</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -45,7 +45,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/wohnungen" className="col-span-1 row-span-1 md:col-span-2 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Wohnungen</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -61,7 +61,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/mieter" className="col-span-1 row-span-1 md:col-span-1 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Mieter</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -98,7 +98,7 @@ export default async function Dashboard() {
         </div>
         {/* Mobile: Individual cards, Desktop: Stacked container */}
         <Link href="/todos" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -120,7 +120,7 @@ export default async function Dashboard() {
         </Link>
         
         <Link href="/finanzen" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -140,7 +140,7 @@ export default async function Dashboard() {
         </Link>
         
         <Link href="/betriebskosten" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -163,7 +163,7 @@ export default async function Dashboard() {
         <div className="hidden md:block md:col-span-2 md:row-span-3">
           <div className="h-full flex flex-col gap-4">
             <Link href="/todos" className="flex-1">
-              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
@@ -185,7 +185,7 @@ export default async function Dashboard() {
             </Link>
             
             <Link href="/finanzen" className="flex-1">
-              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
@@ -205,7 +205,7 @@ export default async function Dashboard() {
             </Link>
             
             <Link href="/betriebskosten" className="flex-1">
-              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -16,13 +16,7 @@ export default async function Dashboard() {
   const summary = await getDashboardSummary();
   
   return (
-    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
-      <div
-        className="absolute inset-0 z-[-1]"
-        style={{
-          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
-        }}
-      />
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div>
         <h1 className="text-2xl font-bold tracking-tight md:text-3xl">Dashboard</h1>
       </div>

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -20,7 +20,7 @@ export default async function Dashboard() {
       <div>
         <h1 className="text-2xl font-bold tracking-tight md:text-3xl">Dashboard</h1>
       </div>
-      <div className="grid gap-4 grid-cols-1 auto-rows-auto md:grid-cols-6 md:auto-rows-[140px] md:h-[calc(100vh-200px)]">
+      <div className="grid gap-4 grid-cols-1 auto-rows-auto md:grid-cols-6 md:auto-rows-[140px]">
         {/* Row 1: Three wider summary cards (2/3 width - 4 columns total) + Tenant Payment List (1/3 width - 2 columns) */}
         <Link href="/haeuser" className="col-span-1 row-span-1 md:col-span-1 md:row-span-1">
           <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -231,9 +231,6 @@ export default async function Dashboard() {
             <MaintenanceDonutChart />
           </div>
         </div>
-        
-        {/* Empty row for bottom spacing */}
-        <div className="col-span-1 md:col-span-6 h-4 md:h-8"></div>
       </div>
     </div>
   )

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -29,7 +29,7 @@ export default async function Dashboard() {
       <div className="grid gap-4 grid-cols-1 auto-rows-auto md:grid-cols-6 md:auto-rows-[140px] md:h-[calc(100vh-200px)]">
         {/* Row 1: Three wider summary cards (2/3 width - 4 columns total) + Tenant Payment List (1/3 width - 2 columns) */}
         <Link href="/haeuser" className="col-span-1 row-span-1 md:col-span-1 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Häuser</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -45,7 +45,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/wohnungen" className="col-span-1 row-span-1 md:col-span-2 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Wohnungen</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -61,7 +61,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/mieter" className="col-span-1 row-span-1 md:col-span-1 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Mieter</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -98,7 +98,7 @@ export default async function Dashboard() {
         </div>
         {/* Mobile: Individual cards, Desktop: Stacked container */}
         <Link href="/todos" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -120,7 +120,7 @@ export default async function Dashboard() {
         </Link>
         
         <Link href="/finanzen" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -140,7 +140,7 @@ export default async function Dashboard() {
         </Link>
         
         <Link href="/betriebskosten" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -163,7 +163,7 @@ export default async function Dashboard() {
         <div className="hidden md:block md:col-span-2 md:row-span-3">
           <div className="h-full flex flex-col gap-4">
             <Link href="/todos" className="flex-1">
-              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
@@ -185,7 +185,7 @@ export default async function Dashboard() {
             </Link>
             
             <Link href="/finanzen" className="flex-1">
-              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
@@ -205,7 +205,7 @@ export default async function Dashboard() {
             </Link>
             
             <Link href="/betriebskosten" className="flex-1">
-              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">

--- a/app/(dashboard)/loading.tsx
+++ b/app/(dashboard)/loading.tsx
@@ -1,164 +1,207 @@
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
+import { Building2, Home, Users, Wallet, FileSpreadsheet, CheckSquare } from "lucide-react"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div>
-        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-9 w-48" />
       </div>
-      <div className="grid gap-4 grid-cols-6 auto-rows-[140px] h-[calc(100vh-200px)]">
-        {/* Row 1: Three summary cards (1+2+1 columns) + Tenant Payment List (2 columns) */}
-        <Card className="col-span-1 row-span-1 h-full overflow-hidden rounded-2xl shadow-md">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
-            <Skeleton className="h-4 w-16" />
-            <Skeleton className="h-8 w-8 rounded-lg" />
+      <div className="grid gap-4 grid-cols-1 auto-rows-auto md:grid-cols-6 md:auto-rows-[140px]">
+        {/* Row 1: Three summary cards + Tenant Payment List */}
+        <Card className="col-span-1 row-span-1 md:col-span-1 md:row-span-1 min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Häuser</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Building2 className="h-4 w-4 text-muted-foreground" />
+            </div>
           </CardHeader>
-          <CardContent className="pt-0">
-            <Skeleton className="h-8 w-8 mb-2" />
-            <Skeleton className="h-3 w-24" />
-          </CardContent>
-        </Card>
-        
-        <Card className="col-span-2 row-span-1 h-full overflow-hidden rounded-2xl shadow-md">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
-            <Skeleton className="h-4 w-20" />
-            <Skeleton className="h-8 w-8 rounded-lg" />
-          </CardHeader>
-          <CardContent className="pt-0">
-            <Skeleton className="h-8 w-8 mb-2" />
-            <Skeleton className="h-3 w-28" />
-          </CardContent>
-        </Card>
-        
-        <Card className="col-span-1 row-span-1 h-full overflow-hidden rounded-2xl shadow-md">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
-            <Skeleton className="h-4 w-12" />
-            <Skeleton className="h-8 w-8 rounded-lg" />
-          </CardHeader>
-          <CardContent className="pt-0">
-            <Skeleton className="h-8 w-8 mb-2" />
+          <CardContent className="pt-0 pb-6">
+            <Skeleton className="h-8 w-16 mb-2" />
             <Skeleton className="h-3 w-32" />
           </CardContent>
         </Card>
-        
-        {/* Tenant Payment List */}
-        <Card className="col-span-2 row-span-4 h-full overflow-hidden rounded-2xl shadow-md">
-          <CardHeader className="pb-3">
-            <Skeleton className="h-5 w-32" />
-            <Skeleton className="h-3 w-48" />
+
+        <Card className="col-span-1 row-span-1 md:col-span-2 md:row-span-1 min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Wohnungen</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Home className="h-4 w-4 text-muted-foreground" />
+            </div>
           </CardHeader>
-          <CardContent className="space-y-3">
-            {Array.from({ length: 8 }).map((_, i) => (
-              <div key={i} className="flex items-center justify-between p-3 border rounded-lg">
-                <div className="flex items-center gap-3">
-                  <Skeleton className="h-8 w-8 rounded-full" />
-                  <div>
-                    <Skeleton className="h-4 w-24 mb-1" />
-                    <Skeleton className="h-3 w-16" />
-                  </div>
-                </div>
-                <Skeleton className="h-4 w-16" />
-              </div>
-            ))}
+          <CardContent className="pt-0 pb-6">
+            <Skeleton className="h-8 w-16 mb-2" />
+            <Skeleton className="h-3 w-32" />
           </CardContent>
         </Card>
 
-        {/* Row 2: Occupancy Chart (4 columns, 3 rows) */}
-        <Card className="col-span-4 row-span-3 h-full overflow-hidden rounded-2xl shadow-md">
-          <CardHeader className="pb-3">
-            <Skeleton className="h-5 w-24" />
-            <Skeleton className="h-3 w-40" />
+        <Card className="col-span-1 row-span-1 md:col-span-1 md:row-span-1 min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Mieter</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Users className="h-4 w-4 text-muted-foreground" />
+            </div>
           </CardHeader>
-          <CardContent className="h-full">
-            <Skeleton className="h-full w-full rounded" />
+          <CardContent className="pt-0 pb-6">
+            <Skeleton className="h-8 w-16 mb-2" />
+            <Skeleton className="h-3 w-32" />
           </CardContent>
         </Card>
 
-        {/* Row 5: Revenue Chart (4 columns, 3 rows) + Stacked summary cards (2 columns, 3 rows) */}
-        <Card className="col-span-4 row-span-3 h-full overflow-hidden rounded-2xl shadow-md">
+        {/* Tenant Payment List Skeleton */}
+        <Card className="col-span-1 row-span-1 md:col-span-2 md:row-span-4 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
           <CardHeader className="pb-3">
-            <Skeleton className="h-5 w-32" />
-            <Skeleton className="h-3 w-48" />
-          </CardHeader>
-          <CardContent className="h-full">
-            <Skeleton className="h-full w-full rounded" />
-          </CardContent>
-        </Card>
-        
-        {/* Vertically stacked summary cards */}
-        <div className="col-span-2 row-span-3 h-full flex flex-col gap-4">
-          <Card className="flex-1 overflow-hidden rounded-2xl shadow-md">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-8 w-8 rounded-lg" />
-            </CardHeader>
-            <CardContent className="pt-0">
-              <div className="flex items-center gap-2 mb-2">
-                <Skeleton className="h-8 w-8" />
-                <Skeleton className="h-5 w-12 rounded-full" />
-              </div>
-              <Skeleton className="h-3 w-24" />
-            </CardContent>
-          </Card>
-          
-          <Card className="flex-1 overflow-hidden rounded-2xl shadow-md">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-8 w-8 rounded-lg" />
-            </CardHeader>
-            <CardContent className="pt-0">
-              <div className="flex items-center gap-2 mb-2">
-                <Skeleton className="h-8 w-16" />
-                <Skeleton className="h-5 w-12 rounded-full" />
-              </div>
-              <Skeleton className="h-3 w-32" />
-            </CardContent>
-          </Card>
-          
-          <Card className="flex-1 overflow-hidden rounded-2xl shadow-md">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-8 w-8 rounded-lg" />
-            </CardHeader>
-            <CardContent className="pt-0">
-              <div className="flex items-center gap-2 mb-2">
-                <Skeleton className="h-8 w-16" />
-                <Skeleton className="h-5 w-12 rounded-full" />
-              </div>
-              <Skeleton className="h-3 w-28" />
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Row 8: Last Transactions (3 columns) + Maintenance Chart (3 columns) */}
-        <Card className="col-span-3 row-span-3 h-full overflow-hidden rounded-2xl shadow-md">
-          <CardHeader className="pb-3">
-            <Skeleton className="h-5 w-28" />
-            <Skeleton className="h-3 w-40" />
+            <Skeleton className="h-5 w-40 mb-2" />
+            <Skeleton className="h-4 w-56" />
           </CardHeader>
           <CardContent className="space-y-3">
             {Array.from({ length: 6 }).map((_, i) => (
-              <div key={i} className="flex items-center justify-between p-3 border rounded-lg">
+              <div key={i} className="flex items-center justify-between p-3 bg-background rounded-lg">
                 <div className="flex items-center gap-3">
-                  <Skeleton className="h-8 w-8 rounded" />
-                  <div>
-                    <Skeleton className="h-4 w-32 mb-1" />
-                    <Skeleton className="h-3 w-20" />
+                  <Skeleton className="h-10 w-10 rounded-full" />
+                  <div className="space-y-2">
+                    <Skeleton className="h-4 w-24" />
+                    <Skeleton className="h-3 w-32" />
                   </div>
                 </div>
-                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-6 w-16 rounded-full" />
               </div>
             ))}
           </CardContent>
         </Card>
-        
-        <Card className="col-span-3 row-span-3 h-full overflow-hidden rounded-2xl shadow-md">
-          <CardHeader className="pb-3">
-            <Skeleton className="h-5 w-28" />
-            <Skeleton className="h-3 w-36" />
+
+        {/* Row 2: Occupancy Chart */}
+        <Card className="col-span-1 row-span-1 md:col-span-4 md:row-span-3 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader>
+            <Skeleton className="h-5 w-32 mb-2" />
+            <Skeleton className="h-4 w-48" />
           </CardHeader>
-          <CardContent className="h-full flex items-center justify-center">
+          <CardContent>
+            <Skeleton className="h-full w-full rounded-lg" />
+          </CardContent>
+        </Card>
+
+        {/* Row 5: Revenue Chart + Stacked Cards */}
+        <Card className="col-span-1 row-span-1 md:col-span-4 md:row-span-3 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader>
+            <Skeleton className="h-5 w-40 mb-2" />
+            <Skeleton className="h-4 w-56" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-full w-full rounded-lg" />
+          </CardContent>
+        </Card>
+
+        {/* Mobile: Individual cards, Desktop: Stacked container */}
+        <Card className="col-span-1 row-span-1 md:hidden min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <CheckSquare className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent className="pt-0 pb-6">
+            <Skeleton className="h-6 w-12 mb-2" />
+            <Skeleton className="h-3 w-28" />
+          </CardContent>
+        </Card>
+
+        <Card className="col-span-1 row-span-1 md:hidden min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Wallet className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent className="pt-0 pb-6">
+            <Skeleton className="h-6 w-24 mb-2" />
+            <Skeleton className="h-3 w-36" />
+          </CardContent>
+        </Card>
+
+        <Card className="col-span-1 row-span-1 md:hidden min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <FileSpreadsheet className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent className="pt-0 pb-6">
+            <Skeleton className="h-6 w-24 mb-2" />
+            <Skeleton className="h-3 w-32" />
+          </CardContent>
+        </Card>
+
+        {/* Desktop: Stacked container */}
+        <div className="hidden md:block md:col-span-2 md:row-span-3">
+          <div className="h-full flex flex-col gap-4">
+            <Card className="flex-1 overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
+                <div className="p-2 bg-muted rounded-lg">
+                  <CheckSquare className="h-4 w-4 text-muted-foreground" />
+                </div>
+              </CardHeader>
+              <CardContent className="pt-0 pb-6">
+                <Skeleton className="h-8 w-16 mb-2" />
+                <Skeleton className="h-3 w-28" />
+              </CardContent>
+            </Card>
+
+            <Card className="flex-1 overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
+                <div className="p-2 bg-muted rounded-lg">
+                  <Wallet className="h-4 w-4 text-muted-foreground" />
+                </div>
+              </CardHeader>
+              <CardContent className="pt-0 pb-6">
+                <Skeleton className="h-8 w-24 mb-2" />
+                <Skeleton className="h-3 w-36" />
+              </CardContent>
+            </Card>
+
+            <Card className="flex-1 overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
+                <div className="p-2 bg-muted rounded-lg">
+                  <FileSpreadsheet className="h-4 w-4 text-muted-foreground" />
+                </div>
+              </CardHeader>
+              <CardContent className="pt-0 pb-6">
+                <Skeleton className="h-8 w-24 mb-2" />
+                <Skeleton className="h-3 w-32" />
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+
+        {/* Row 8: Last Transactions + Maintenance Chart */}
+        <Card className="col-span-1 row-span-1 md:col-span-3 md:row-span-3 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader>
+            <Skeleton className="h-5 w-36 mb-2" />
+            <Skeleton className="h-4 w-48" />
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="flex items-center justify-between p-3 bg-background rounded-lg">
+                <div className="space-y-2">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-3 w-24" />
+                </div>
+                <Skeleton className="h-5 w-20" />
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card className="col-span-1 row-span-1 md:col-span-3 md:row-span-3 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader>
+            <Skeleton className="h-5 w-32 mb-2" />
+            <Skeleton className="h-4 w-48" />
+          </CardHeader>
+          <CardContent className="flex items-center justify-center">
             <Skeleton className="h-48 w-48 rounded-full" />
           </CardContent>
         </Card>

--- a/app/(dashboard)/mieter/client-wrapper.tsx
+++ b/app/(dashboard)/mieter/client-wrapper.tsx
@@ -208,13 +208,7 @@ export default function MieterClientView({
   }, [selectedTenants, router]);
 
   return (
-    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
-      <div
-        className="absolute inset-0 z-[-1]"
-        style={{
-          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
-        }}
-      />
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div className="flex flex-wrap gap-4">
         <StatCard
           title="Mieter gesamt"

--- a/app/(dashboard)/mieter/loading.tsx
+++ b/app/(dashboard)/mieter/loading.tsx
@@ -1,82 +1,51 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Users, BadgeCheck, Euro } from "lucide-react"
+import { PageSkeleton } from "@/components/page-skeleton"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
-      <div
-        className="absolute inset-0 z-[-1]"
-        style={{
-          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
-        }}
-      />
-      <div className="flex flex-wrap gap-4">
-        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Mieter gesamt</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <Users className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-16 mb-2" />
-          </CardContent>
-        </Card>
-        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Aktiv / Ehemalig</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <BadgeCheck className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-24 mb-2" />
-          </CardContent>
-        </Card>
-        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Ø Nebenkosten</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <Euro className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-20 mb-2" />
-          </CardContent>
-        </Card>
-      </div>
-      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
-        <CardHeader>
-          <div className="flex flex-row items-start justify-between">
-            <div>
-              <Skeleton className="h-6 w-40 mb-2" />
-              <Skeleton className="h-4 w-64" />
-            </div>
-            <Skeleton className="h-10 w-44 rounded-full" />
-          </div>
-        </CardHeader>
-        <div className="px-6">
-          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
-        </div>
-        <CardContent className="flex flex-col gap-6">
-          <div className="flex flex-col gap-4 mt-6">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex flex-wrap gap-2">
-                {Array.from({ length: 3 }).map((_, i) => (
-                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
-                ))}
+    <PageSkeleton
+      headerTitleWidth="w-40"
+      headerDescriptionWidth="w-64"
+      buttonWidth="w-44"
+      statsCards={
+        <div className="flex flex-wrap gap-4">
+          <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Mieter gesamt</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <Users className="h-4 w-4 text-muted-foreground" />
               </div>
-              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
-            </div>
-          </div>
-          <div className="space-y-3">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <Skeleton key={i} className="h-16 w-full rounded-lg" />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-16 mb-2" />
+            </CardContent>
+          </Card>
+          <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Aktiv / Ehemalig</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <BadgeCheck className="h-4 w-4 text-muted-foreground" />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-24 mb-2" />
+            </CardContent>
+          </Card>
+          <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Ø Nebenkosten</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <Euro className="h-4 w-4 text-muted-foreground" />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-20 mb-2" />
+            </CardContent>
+          </Card>
+        </div>
+      }
+    />
   )
 }

--- a/app/(dashboard)/mieter/loading.tsx
+++ b/app/(dashboard)/mieter/loading.tsx
@@ -1,27 +1,80 @@
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
-import { SummaryCardSkeleton } from "@/components/summary-card-skeleton";
-import { Users, BadgeCheck, Euro } from "lucide-react";
+import { Users, BadgeCheck, Euro } from "lucide-react"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8">
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <SummaryCardSkeleton title="Mieter gesamt" icon={<Users className="h-4 w-4 text-muted-foreground" />} />
-        <SummaryCardSkeleton title="Aktiv / Ehemalig" icon={<BadgeCheck className="h-4 w-4 text-muted-foreground" />} />
-        <SummaryCardSkeleton title="Ø Nebenkosten" icon={<Euro className="h-4 w-4 text-muted-foreground" />} />
-      </div>
-      <Card className="overflow-hidden rounded-2xl shadow-md">
-        <CardHeader>
-          <Skeleton className="h-6 w-40 mb-2" />
-        </CardHeader>
-        <CardContent className="flex flex-col gap-6">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="flex flex-col gap-2">
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-3/4" />
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
+      <div className="flex flex-wrap gap-4">
+        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Mieter gesamt</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Users className="h-4 w-4 text-muted-foreground" />
             </div>
-          ))}
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-16 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Aktiv / Ehemalig</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <BadgeCheck className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-24 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Ø Nebenkosten</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Euro className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-20 mb-2" />
+          </CardContent>
+        </Card>
+      </div>
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+        <CardHeader>
+          <div className="flex flex-row items-start justify-between">
+            <div>
+              <Skeleton className="h-6 w-40 mb-2" />
+              <Skeleton className="h-4 w-64" />
+            </div>
+            <Skeleton className="h-10 w-44 rounded-full" />
+          </div>
+        </CardHeader>
+        <div className="px-6">
+          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
+        </div>
+        <CardContent className="flex flex-col gap-6">
+          <div className="flex flex-col gap-4 mt-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-wrap gap-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
+                ))}
+              </div>
+              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
+            </div>
+          </div>
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-lg" />
+            ))}
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/app/(dashboard)/todos/client-wrapper.tsx
+++ b/app/(dashboard)/todos/client-wrapper.tsx
@@ -44,7 +44,7 @@ export default function TodosClientWrapper({ tasks: initialTasks }: TodosClientW
   }, [openAufgabeModal, handleTaskUpdated]);
 
   return (
-    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div
         className="absolute inset-0 z-[-1]"
         style={{

--- a/app/(dashboard)/todos/loading.tsx
+++ b/app/(dashboard)/todos/loading.tsx
@@ -1,24 +1,44 @@
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <Skeleton className="h-8 w-48 mb-2" />
-        <Skeleton className="h-4 w-64" />
-      </div>
-      <Card className="overflow-hidden rounded-2xl shadow-md">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
         <CardHeader>
-          <Skeleton className="h-6 w-40 mb-2" />
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="flex items-center gap-2">
-              <Skeleton className="h-4 w-4 rounded-full" />
-              <Skeleton className="h-4 w-full" />
+          <div className="flex flex-row items-start justify-between">
+            <div>
+              <Skeleton className="h-6 w-40 mb-2" />
+              <Skeleton className="h-4 w-64" />
             </div>
-          ))}
+            <Skeleton className="h-10 w-44 rounded-full" />
+          </div>
+        </CardHeader>
+        <div className="px-6">
+          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
+        </div>
+        <CardContent className="flex flex-col gap-6">
+          <div className="flex flex-col gap-4 mt-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-wrap gap-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
+                ))}
+              </div>
+              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
+            </div>
+          </div>
+          <div className="space-y-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-lg" />
+            ))}
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/app/(dashboard)/todos/loading.tsx
+++ b/app/(dashboard)/todos/loading.tsx
@@ -1,46 +1,12 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Skeleton } from "@/components/ui/skeleton"
+import { PageSkeleton } from "@/components/page-skeleton"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
-      <div
-        className="absolute inset-0 z-[-1]"
-        style={{
-          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
-        }}
-      />
-      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
-        <CardHeader>
-          <div className="flex flex-row items-start justify-between">
-            <div>
-              <Skeleton className="h-6 w-40 mb-2" />
-              <Skeleton className="h-4 w-64" />
-            </div>
-            <Skeleton className="h-10 w-44 rounded-full" />
-          </div>
-        </CardHeader>
-        <div className="px-6">
-          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
-        </div>
-        <CardContent className="flex flex-col gap-6">
-          <div className="flex flex-col gap-4 mt-6">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex flex-wrap gap-2">
-                {Array.from({ length: 3 }).map((_, i) => (
-                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
-                ))}
-              </div>
-              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
-            </div>
-          </div>
-          <div className="space-y-3">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <Skeleton key={i} className="h-16 w-full rounded-lg" />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+    <PageSkeleton
+      headerTitleWidth="w-40"
+      headerDescriptionWidth="w-64"
+      buttonWidth="w-44"
+      tableRowCount={6}
+    />
   )
 }

--- a/app/(dashboard)/wohnungen/client.tsx
+++ b/app/(dashboard)/wohnungen/client.tsx
@@ -322,7 +322,7 @@ export default function WohnungenClientView({
   }, [handleEditWohnung]);
 
   return (
-    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div
         className="absolute inset-0 z-[-1]"
         style={{

--- a/app/(dashboard)/wohnungen/loading.tsx
+++ b/app/(dashboard)/wohnungen/loading.tsx
@@ -1,30 +1,91 @@
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
-import { SummaryCardSkeleton } from "@/components/summary-card-skeleton";
-import { Home, Key, Euro, Ruler } from "lucide-react";
+import { Home, Key, Euro, Ruler } from "lucide-react"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <SummaryCardSkeleton title="Wohnungen gesamt" icon={<Home className="h-4 w-4 text-muted-foreground" />} />
-        <SummaryCardSkeleton title="Frei / Vermietet" icon={<Key className="h-4 w-4 text-muted-foreground" />} />
-        <SummaryCardSkeleton title="Ø Miete" icon={<Euro className="h-4 w-4 text-muted-foreground" />} />
-        <SummaryCardSkeleton title="Ø Preis pro m²" icon={<Ruler className="h-4 w-4 text-muted-foreground" />} />
-      </div>
-      <Card className="overflow-hidden rounded-2xl shadow-md">
-        <CardHeader>
-          <Skeleton className="h-6 w-40 mb-2" />
-          <Skeleton className="h-4 w-56" />
-        </CardHeader>
-        <CardContent className="flex flex-col gap-6">
-          {/* Loading skeletons for list items */}
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="flex flex-col gap-2">
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-3/4" />
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Wohnungen gesamt</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Home className="h-4 w-4 text-muted-foreground" />
             </div>
-          ))}
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-16 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Frei / Vermietet</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Key className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-24 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Ø Miete</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Euro className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-20 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Ø Preis pro m²</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Ruler className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-20 mb-2" />
+          </CardContent>
+        </Card>
+      </div>
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+        <CardHeader>
+          <div className="flex flex-row items-start justify-between">
+            <div>
+              <Skeleton className="h-6 w-48 mb-2" />
+              <Skeleton className="h-4 w-72" />
+            </div>
+            <Skeleton className="h-10 w-48 rounded-full" />
+          </div>
+        </CardHeader>
+        <div className="px-6">
+          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
+        </div>
+        <CardContent className="flex flex-col gap-6">
+          <div className="flex flex-col gap-4 mt-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-wrap gap-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
+                ))}
+              </div>
+              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
+            </div>
+          </div>
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-lg" />
+            ))}
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/app/(dashboard)/wohnungen/loading.tsx
+++ b/app/(dashboard)/wohnungen/loading.tsx
@@ -1,93 +1,60 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Home, Key, Euro, Ruler } from "lucide-react"
+import { PageSkeleton } from "@/components/page-skeleton"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
-      <div
-        className="absolute inset-0 z-[-1]"
-        style={{
-          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
-        }}
-      />
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Wohnungen gesamt</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <Home className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-16 mb-2" />
-          </CardContent>
-        </Card>
-        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Frei / Vermietet</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <Key className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-24 mb-2" />
-          </CardContent>
-        </Card>
-        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Ø Miete</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <Euro className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-20 mb-2" />
-          </CardContent>
-        </Card>
-        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Ø Preis pro m²</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <Ruler className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-20 mb-2" />
-          </CardContent>
-        </Card>
-      </div>
-      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
-        <CardHeader>
-          <div className="flex flex-row items-start justify-between">
-            <div>
-              <Skeleton className="h-6 w-48 mb-2" />
-              <Skeleton className="h-4 w-72" />
-            </div>
-            <Skeleton className="h-10 w-48 rounded-full" />
-          </div>
-        </CardHeader>
-        <div className="px-6">
-          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
-        </div>
-        <CardContent className="flex flex-col gap-6">
-          <div className="flex flex-col gap-4 mt-6">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex flex-wrap gap-2">
-                {Array.from({ length: 3 }).map((_, i) => (
-                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
-                ))}
+    <PageSkeleton
+      buttonWidth="w-48"
+      statsCards={
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Wohnungen gesamt</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <Home className="h-4 w-4 text-muted-foreground" />
               </div>
-              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
-            </div>
-          </div>
-          <div className="space-y-3">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <Skeleton key={i} className="h-16 w-full rounded-lg" />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-16 mb-2" />
+            </CardContent>
+          </Card>
+          <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Frei / Vermietet</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <Key className="h-4 w-4 text-muted-foreground" />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-24 mb-2" />
+            </CardContent>
+          </Card>
+          <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Ø Miete</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <Euro className="h-4 w-4 text-muted-foreground" />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-20 mb-2" />
+            </CardContent>
+          </Card>
+          <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Ø Preis pro m²</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <Ruler className="h-4 w-4 text-muted-foreground" />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-20 mb-2" />
+            </CardContent>
+          </Card>
+        </div>
+      }
+    />
   )
 }

--- a/components/charts/maintenance-donut-chart.tsx
+++ b/components/charts/maintenance-donut-chart.tsx
@@ -147,7 +147,7 @@ export function MaintenanceDonutChart() {
   };
 
   return (
-    <Card className="h-full flex flex-col rounded-xl">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Ausgaben nach Kategorie</CardTitle>
         <CardDescription>Verteilung der Betriebskosten</CardDescription>

--- a/components/charts/maintenance-donut-chart.tsx
+++ b/components/charts/maintenance-donut-chart.tsx
@@ -147,7 +147,7 @@ export function MaintenanceDonutChart() {
   };
 
   return (
-    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Ausgaben nach Kategorie</CardTitle>
         <CardDescription>Verteilung der Betriebskosten</CardDescription>

--- a/components/charts/maintenance-donut-chart.tsx
+++ b/components/charts/maintenance-donut-chart.tsx
@@ -147,7 +147,7 @@ export function MaintenanceDonutChart() {
   };
 
   return (
-    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Ausgaben nach Kategorie</CardTitle>
         <CardDescription>Verteilung der Betriebskosten</CardDescription>

--- a/components/charts/occupancy-chart.tsx
+++ b/components/charts/occupancy-chart.tsx
@@ -114,7 +114,7 @@ export function OccupancyChart() {
   }, []);
 
   return (
-    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Belegung</CardTitle>
         <CardDescription>Wohnungsbelegung nach Monat</CardDescription>

--- a/components/charts/occupancy-chart.tsx
+++ b/components/charts/occupancy-chart.tsx
@@ -114,7 +114,7 @@ export function OccupancyChart() {
   }, []);
 
   return (
-    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Belegung</CardTitle>
         <CardDescription>Wohnungsbelegung nach Monat</CardDescription>

--- a/components/charts/occupancy-chart.tsx
+++ b/components/charts/occupancy-chart.tsx
@@ -114,7 +114,7 @@ export function OccupancyChart() {
   }, []);
 
   return (
-    <Card className="h-full flex flex-col rounded-xl">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Belegung</CardTitle>
         <CardDescription>Wohnungsbelegung nach Monat</CardDescription>

--- a/components/charts/revenue-expenses-chart.tsx
+++ b/components/charts/revenue-expenses-chart.tsx
@@ -102,7 +102,7 @@ export function RevenueExpensesChart() {
   }, []);
 
   return (
-    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Einnahmen & Ausgaben</CardTitle>
         <CardDescription>Monatliche Übersicht der Finanzen</CardDescription>

--- a/components/charts/revenue-expenses-chart.tsx
+++ b/components/charts/revenue-expenses-chart.tsx
@@ -102,7 +102,7 @@ export function RevenueExpensesChart() {
   }, []);
 
   return (
-    <Card className="h-full flex flex-col rounded-xl">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Einnahmen & Ausgaben</CardTitle>
         <CardDescription>Monatliche Übersicht der Finanzen</CardDescription>

--- a/components/charts/revenue-expenses-chart.tsx
+++ b/components/charts/revenue-expenses-chart.tsx
@@ -102,7 +102,7 @@ export function RevenueExpensesChart() {
   }, []);
 
   return (
-    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Einnahmen & Ausgaben</CardTitle>
         <CardDescription>Monatliche Übersicht der Finanzen</CardDescription>

--- a/components/cloud-storage-simple.tsx
+++ b/components/cloud-storage-simple.tsx
@@ -503,7 +503,7 @@ export function CloudStorageSimple({
   const displayError = storeError || navigationError
   
   return (
-    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div
         className="absolute inset-0 z-[-1]"
         style={{

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -137,7 +137,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
           isMobile ? "pb-20 pt-6" : "pb-6 pt-6"
         )}>
           <div className={cn(
-            "flex-1 overflow-y-auto border shadow-sm",
+            "flex-1 overflow-y-auto overflow-x-hidden border shadow-sm",
             "rounded-[2rem] md:rounded-[2.5rem]",
             // Enhanced CSS-only fallback for mobile bottom margin
             "mb-4 md:mb-0",

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -71,7 +71,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
             </div>
           </header>
           <main className="flex flex-1 flex-col min-h-0 p-6 pt-6 md:pt-6 main-content-responsive responsive-transition prevent-layout-shift">
-            <div className="flex-1 overflow-y-auto rounded-2xl border border-gray-200 dark:border-gray-800 shadow-sm mb-4 md:mb-0">
+            <div className="flex-1 overflow-y-auto rounded-2xl border shadow-sm mb-4 md:mb-0">
               <div className="p-6">
                 <div className="space-y-4">
                   <div className="h-8 bg-muted rounded animate-pulse" />
@@ -137,7 +137,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
           isMobile ? "pb-20 pt-6" : "pb-6 pt-6"
         )}>
           <div className={cn(
-            "flex-1 overflow-y-auto border border-gray-200 dark:border-gray-800 shadow-sm",
+            "flex-1 overflow-y-auto border shadow-sm",
             "rounded-[2rem] md:rounded-[2.5rem]",
             // Enhanced CSS-only fallback for mobile bottom margin
             "mb-4 md:mb-0",

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -71,7 +71,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
             </div>
           </header>
           <main className="flex flex-1 flex-col min-h-0 p-6 pt-6 md:pt-6 main-content-responsive responsive-transition prevent-layout-shift">
-            <div className="flex-1 overflow-y-auto rounded-2xl bg-white dark:bg-[#0d1117] shadow-sm mb-4 md:mb-0">
+            <div className="flex-1 overflow-y-auto rounded-2xl border border-gray-200 dark:border-gray-800 shadow-sm mb-4 md:mb-0">
               <div className="p-6">
                 <div className="space-y-4">
                   <div className="h-8 bg-muted rounded animate-pulse" />
@@ -137,7 +137,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
           isMobile ? "pb-20 pt-6" : "pb-6 pt-6"
         )}>
           <div className={cn(
-            "flex-1 overflow-y-auto bg-white dark:bg-[#0d1117] shadow-sm",
+            "flex-1 overflow-y-auto border border-gray-200 dark:border-gray-800 shadow-sm",
             "rounded-[2rem] md:rounded-[2.5rem]",
             // Enhanced CSS-only fallback for mobile bottom margin
             "mb-4 md:mb-0",

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -71,7 +71,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
             </div>
           </header>
           <main className="flex flex-1 flex-col min-h-0 p-6 pt-6 md:pt-6 main-content-responsive responsive-transition prevent-layout-shift">
-            <div className="flex-1 overflow-y-auto rounded-2xl bg-white border shadow-sm mb-4 md:mb-0">
+            <div className="flex-1 overflow-y-auto rounded-2xl bg-white dark:bg-[#0d1117] shadow-sm mb-4 md:mb-0">
               <div className="p-6">
                 <div className="space-y-4">
                   <div className="h-8 bg-muted rounded animate-pulse" />
@@ -137,7 +137,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
           isMobile ? "pb-20 pt-6" : "pb-6 pt-6"
         )}>
           <div className={cn(
-            "flex-1 overflow-y-auto bg-white dark:main-container border shadow-sm",
+            "flex-1 overflow-y-auto bg-white dark:bg-[#0d1117] shadow-sm",
             "rounded-[2rem] md:rounded-[2.5rem]",
             // Enhanced CSS-only fallback for mobile bottom margin
             "mb-4 md:mb-0",

--- a/components/finance-visualization.tsx
+++ b/components/finance-visualization.tsx
@@ -176,7 +176,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
   }, [chartData])
 
   return (
-    <Card className="p-4 bg-white dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="p-4 bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
       <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-6">
         <ToggleGroup type="single" value={selectedChart} onValueChange={setSelectedChart} className="grid grid-cols-2 md:grid-cols-4 gap-2">
           <ToggleGroupItem value="apartment-income">Wohnung</ToggleGroupItem>

--- a/components/finance-visualization.tsx
+++ b/components/finance-visualization.tsx
@@ -84,7 +84,7 @@ const isChartDataEmpty = (data: ChartData): boolean => {
 
 // Empty state component
 const EmptyChartState = ({ title, description }: { title: string; description: string }) => (
-  <Card className="rounded-[1.5rem]">
+  <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
     <CardHeader>
       <CardTitle>{title}</CardTitle>
       <CardDescription>{description}</CardDescription>
@@ -176,7 +176,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
   }, [chartData])
 
   return (
-    <Card className="p-4 rounded-[2rem]">
+    <Card className="p-4 bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-6">
         <ToggleGroup type="single" value={selectedChart} onValueChange={setSelectedChart} className="grid grid-cols-2 md:grid-cols-4 gap-2">
           <ToggleGroupItem value="apartment-income">Wohnung</ToggleGroupItem>
@@ -247,7 +247,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
         <div className="animate-in fade-in-0 duration-500">
         {selectedChart === 'apartment-income' && (
           hasUserData ? (
-            <Card className="rounded-[1.5rem]">
+            <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
               <CardHeader>
                 <CardTitle>Einnahmen nach Wohnung</CardTitle>
                 <CardDescription>Verteilung der Mieteinnahmen nach Wohnungen in {selectedYear}</CardDescription>
@@ -285,7 +285,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
         )}
         {selectedChart === 'monthly-income' && (
           hasUserData ? (
-            <Card className="rounded-[1.5rem]">
+            <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
               <CardHeader>
                 <CardTitle>Monatliche Einnahmen</CardTitle>
                 <CardDescription>Monatliche Einnahmen für das Jahr {selectedYear}</CardDescription>
@@ -323,7 +323,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
         )}
         {selectedChart === 'income-expense' && (
           hasUserData ? (
-            <Card className="rounded-[1.5rem]">
+            <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
               <CardHeader>
                 <CardTitle>Einnahmen-Ausgaben-Verhältnis</CardTitle>
                 <CardDescription>Vergleich von Einnahmen und Ausgaben im Jahr {selectedYear}</CardDescription>
@@ -366,7 +366,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
         )}
         {selectedChart === 'expense-categories' && (
           hasUserData ? (
-            <Card className="rounded-[1.5rem]">
+            <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
               <CardHeader>
                 <CardTitle>Ausgabenkategorien</CardTitle>
                 <CardDescription>Verteilung der Ausgaben nach Kategorien in {selectedYear}</CardDescription>

--- a/components/finance-visualization.tsx
+++ b/components/finance-visualization.tsx
@@ -176,7 +176,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
   }, [chartData])
 
   return (
-    <Card className="p-4 bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="p-4 bg-white dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-6">
         <ToggleGroup type="single" value={selectedChart} onValueChange={setSelectedChart} className="grid grid-cols-2 md:grid-cols-4 gap-2">
           <ToggleGroupItem value="apartment-income">Wohnung</ToggleGroupItem>
@@ -247,7 +247,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
         <div className="animate-in fade-in-0 duration-500">
         {selectedChart === 'apartment-income' && (
           hasUserData ? (
-            <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+            <Card className="rounded-[1.5rem]">
               <CardHeader>
                 <CardTitle>Einnahmen nach Wohnung</CardTitle>
                 <CardDescription>Verteilung der Mieteinnahmen nach Wohnungen in {selectedYear}</CardDescription>
@@ -285,7 +285,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
         )}
         {selectedChart === 'monthly-income' && (
           hasUserData ? (
-            <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+            <Card className="bg-white dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
               <CardHeader>
                 <CardTitle>Monatliche Einnahmen</CardTitle>
                 <CardDescription>Monatliche Einnahmen für das Jahr {selectedYear}</CardDescription>

--- a/components/finance-visualization.tsx
+++ b/components/finance-visualization.tsx
@@ -285,7 +285,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
         )}
         {selectedChart === 'monthly-income' && (
           hasUserData ? (
-            <Card className="bg-white dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+            <Card className="rounded-[1.5rem]">
               <CardHeader>
                 <CardTitle>Monatliche Einnahmen</CardTitle>
                 <CardDescription>Monatliche Einnahmen für das Jahr {selectedYear}</CardDescription>
@@ -323,7 +323,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
         )}
         {selectedChart === 'income-expense' && (
           hasUserData ? (
-            <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+            <Card className="rounded-[1.5rem]">
               <CardHeader>
                 <CardTitle>Einnahmen-Ausgaben-Verhältnis</CardTitle>
                 <CardDescription>Vergleich von Einnahmen und Ausgaben im Jahr {selectedYear}</CardDescription>
@@ -366,7 +366,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
         )}
         {selectedChart === 'expense-categories' && (
           hasUserData ? (
-            <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+            <Card className="rounded-[1.5rem]">
               <CardHeader>
                 <CardTitle>Ausgabenkategorien</CardTitle>
                 <CardDescription>Verteilung der Ausgaben nach Kategorien in {selectedYear}</CardDescription>

--- a/components/last-transactions-container.tsx
+++ b/components/last-transactions-container.tsx
@@ -113,7 +113,7 @@ export function LastTransactionsContainer() {
   };
 
   return (
-    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-3">
         <div className="flex items-center justify-between">
           <div>

--- a/components/last-transactions-container.tsx
+++ b/components/last-transactions-container.tsx
@@ -113,7 +113,7 @@ export function LastTransactionsContainer() {
   };
 
   return (
-    <Card className="h-full flex flex-col rounded-xl">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-3">
         <div className="flex items-center justify-between">
           <div>

--- a/components/last-transactions-container.tsx
+++ b/components/last-transactions-container.tsx
@@ -113,7 +113,7 @@ export function LastTransactionsContainer() {
   };
 
   return (
-    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-3">
         <div className="flex items-center justify-between">
           <div>

--- a/components/page-skeleton.tsx
+++ b/components/page-skeleton.tsx
@@ -1,0 +1,105 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { ReactNode } from "react"
+
+interface PageSkeletonProps {
+  statsCards?: ReactNode
+  headerTitleWidth?: string
+  headerDescriptionWidth?: string
+  buttonWidth?: string
+  filterCount?: number
+  tableRowCount?: number
+  showInstructionGuide?: boolean
+}
+
+export function PageSkeleton({
+  statsCards,
+  headerTitleWidth = "w-48",
+  headerDescriptionWidth = "w-72",
+  buttonWidth = "w-40",
+  filterCount = 3,
+  tableRowCount = 5,
+  showInstructionGuide = false,
+}: PageSkeletonProps) {
+  return (
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
+
+      {/* Stats Cards (optional) */}
+      {statsCards}
+
+      {/* Instruction Guide Skeleton (optional) */}
+      {showInstructionGuide && (
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+          <CardHeader className="pb-4">
+            <div className="flex items-start justify-between">
+              <div className="flex-1">
+                <Skeleton className="h-6 w-64 mb-2" />
+                <Skeleton className="h-4 w-96" />
+              </div>
+              <Skeleton className="h-8 w-24 rounded-lg" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className="flex gap-4">
+                  <Skeleton className="flex-shrink-0 w-8 h-8 rounded-full" />
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-4 w-48" />
+                    <Skeleton className="h-3 w-full" />
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700 flex gap-3">
+              <Skeleton className="h-10 flex-1 rounded-full" />
+              <Skeleton className="h-10 w-40 rounded-full" />
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Main Card Structure Skeleton */}
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+        <CardHeader>
+          <div className="flex flex-row items-start justify-between">
+            <div>
+              <Skeleton className={`h-6 ${headerTitleWidth} mb-2`} />
+              <Skeleton className={`h-4 ${headerDescriptionWidth}`} />
+            </div>
+            <Skeleton className={`h-10 ${buttonWidth} rounded-full`} />
+          </div>
+        </CardHeader>
+        <div className="px-6">
+          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
+        </div>
+        <CardContent className="flex flex-col gap-6">
+          {/* Filters Skeleton */}
+          <div className="flex flex-col gap-4 mt-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-wrap gap-2">
+                {Array.from({ length: filterCount }).map((_, i) => (
+                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
+                ))}
+              </div>
+              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
+            </div>
+          </div>
+
+          {/* Table Skeleton */}
+          <div className="space-y-3">
+            {Array.from({ length: tableRowCount }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-lg" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/stat-card.tsx
+++ b/components/stat-card.tsx
@@ -33,7 +33,7 @@ export function StatCard({
   }
 
   return (
-    <Card className={`relative overflow-hidden rounded-2xl shadow-md transition-opacity duration-200 flex-1 summary-card ${className}`}>
+    <Card className={`relative overflow-hidden rounded-3xl shadow-sm transition-opacity duration-200 flex-1 ${className}`}>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-sm font-medium">{title}</CardTitle>
         {icon}

--- a/components/summary-card.tsx
+++ b/components/summary-card.tsx
@@ -106,9 +106,9 @@ export function SummaryCard({
       <Card
         className={cn(
           // Main-Style-Äquivalent: abgeleitet von main, ohne Opacity-Loading (Skeleton übernimmt)
-          "relative overflow-hidden rounded-2xl shadow-md transition-opacity duration-200 summary-card",
+          "relative overflow-hidden rounded-3xl shadow-sm transition-opacity duration-200",
           // sichtbare Border wie im Main-Design
-          "border",
+          "border border-gray-200 dark:border-[#3C4251]",
           // Add cursor pointer and hover scale when onClick is provided
           onClick && "cursor-pointer hover:scale-[1.02] transition-transform duration-200",
           className
@@ -156,9 +156,9 @@ export function SummaryCardSkeleton({ className }: { className?: string }) {
   return (
     <Card
       className={cn(
-        "relative overflow-hidden rounded-2xl shadow-md transition-opacity duration-200 summary-card",
+        "relative overflow-hidden rounded-3xl shadow-sm transition-opacity duration-200",
         // konsistent zur Hauptkarte: sichtbare Border
-        "border",
+        "border border-gray-200 dark:border-[#3C4251]",
         className
       )}
     >

--- a/components/summary-card.tsx
+++ b/components/summary-card.tsx
@@ -107,6 +107,8 @@ export function SummaryCard({
         className={cn(
           // Main-Style-Äquivalent: abgeleitet von main, ohne Opacity-Loading (Skeleton übernimmt)
           "relative overflow-hidden rounded-3xl shadow-sm transition-opacity duration-200",
+          // Background color matching dashboard cards
+          "bg-gray-50 dark:bg-[#22272e]",
           // sichtbare Border wie im Main-Design
           "border border-gray-200 dark:border-[#3C4251]",
           // Add cursor pointer and hover scale when onClick is provided
@@ -157,6 +159,8 @@ export function SummaryCardSkeleton({ className }: { className?: string }) {
     <Card
       className={cn(
         "relative overflow-hidden rounded-3xl shadow-sm transition-opacity duration-200",
+        // Background color matching dashboard cards
+        "bg-gray-50 dark:bg-[#22272e]",
         // konsistent zur Hauptkarte: sichtbare Border
         "border border-gray-200 dark:border-[#3C4251]",
         className

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -168,7 +168,7 @@ export function TenantPaymentBento() {
   }
 
   return (
-    <Card className="h-full flex flex-col overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Mietzahlungen</CardTitle>
         <CardDescription>Bezahlt vs. offen</CardDescription>

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -168,7 +168,7 @@ export function TenantPaymentBento() {
   }
 
   return (
-    <Card className="h-full flex flex-col overflow-hidden rounded-xl shadow-md">
+    <Card className="h-full flex flex-col overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Mietzahlungen</CardTitle>
         <CardDescription>Bezahlt vs. offen</CardDescription>

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -168,7 +168,7 @@ export function TenantPaymentBento() {
   }
 
   return (
-    <Card className="h-full flex flex-col overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Mietzahlungen</CardTitle>
         <CardDescription>Bezahlt vs. offen</CardDescription>


### PR DESCRIPTION
## Description

Unifies page backgrounds, introduces a shared page skeleton and polishes the card surfaces.

## Summary of Changes

- New `components/page-skeleton.tsx` (105 lines): configurable skeleton with optional stat cards, instruction-guide, filters and table rows — replacing the hand-rolled per-page loading screens
- Page backgrounds standardized to `bg-white`; dateien page drops the redundant Suspense wrapper (server-rendered directly)
- `dashboard-layout`: horizontal overflow clipped; finance visualization, last-transactions, stat/summary and tenant-payment cards aligned to the themed `bg-gray-50 dark:bg-[#22272e]` surface