### PR TITLE
Feature/improve documents page

### DIFF
--- a/app/(dashboard)/betriebskosten/client-wrapper.tsx
+++ b/app/(dashboard)/betriebskosten/client-wrapper.tsx
@@ -198,7 +198,7 @@ export default function BetriebskostenClientView({
   ];
 
   return (
-    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div
         className="absolute inset-0 z-[-1]"
         style={{

--- a/app/(dashboard)/betriebskosten/loading.tsx
+++ b/app/(dashboard)/betriebskosten/loading.tsx
@@ -10,20 +10,35 @@ export default function Loading() {
           backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
         }}
       />
-      {/* Instruction Cards Skeleton */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {[1, 2, 3, 4].map((idx) => (
-          <Card key={idx} className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-            <CardHeader className="pb-2">
-              <Skeleton className="h-5 w-48" />
-            </CardHeader>
-            <CardContent className="flex items-center justify-between gap-4">
-              <Skeleton className="h-4 w-2/3" />
-              <Skeleton className="h-9 w-28 rounded-full" />
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+      {/* Instruction Guide Skeleton */}
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+        <CardHeader className="pb-4">
+          <div className="flex items-start justify-between">
+            <div className="flex-1">
+              <Skeleton className="h-6 w-64 mb-2" />
+              <Skeleton className="h-4 w-96" />
+            </div>
+            <Skeleton className="h-8 w-24 rounded-lg" />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex gap-4">
+                <Skeleton className="flex-shrink-0 w-8 h-8 rounded-full" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-4 w-48" />
+                  <Skeleton className="h-3 w-full" />
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700 flex gap-3">
+            <Skeleton className="h-10 flex-1 rounded-full" />
+            <Skeleton className="h-10 w-40 rounded-full" />
+          </div>
+        </CardContent>
+      </Card>
 
       {/* Main Card Structure Skeleton */}
       <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">

--- a/app/(dashboard)/betriebskosten/loading.tsx
+++ b/app/(dashboard)/betriebskosten/loading.tsx
@@ -1,80 +1,10 @@
-import { Skeleton } from "@/components/ui/skeleton"
-import { Card, CardHeader, CardContent } from "@/components/ui/card"
+import { PageSkeleton } from "@/components/page-skeleton"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
-      <div
-        className="absolute inset-0 z-[-1]"
-        style={{
-          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
-        }}
-      />
-      {/* Instruction Guide Skeleton */}
-      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
-        <CardHeader className="pb-4">
-          <div className="flex items-start justify-between">
-            <div className="flex-1">
-              <Skeleton className="h-6 w-64 mb-2" />
-              <Skeleton className="h-4 w-96" />
-            </div>
-            <Skeleton className="h-8 w-24 rounded-lg" />
-          </div>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-4">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="flex gap-4">
-                <Skeleton className="flex-shrink-0 w-8 h-8 rounded-full" />
-                <div className="flex-1 space-y-2">
-                  <Skeleton className="h-4 w-48" />
-                  <Skeleton className="h-3 w-full" />
-                </div>
-              </div>
-            ))}
-          </div>
-          <div className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700 flex gap-3">
-            <Skeleton className="h-10 flex-1 rounded-full" />
-            <Skeleton className="h-10 w-40 rounded-full" />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Main Card Structure Skeleton */}
-      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
-        <CardHeader>
-          <div className="flex flex-row items-start justify-between">
-            <div>
-              <Skeleton className="h-6 w-48 mb-2" />
-              <Skeleton className="h-4 w-72" />
-            </div>
-            <Skeleton className="h-10 w-60 sm:w-[280px] rounded-full" />
-          </div>
-        </CardHeader>
-        <div className="px-6">
-          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
-        </div>
-        <CardContent className="flex flex-col gap-6">
-          {/* Filters Skeleton */}
-          <div className="flex flex-col gap-4 mt-6">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex flex-wrap gap-2">
-                {Array.from({ length: 3 }).map((_, i) => (
-                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
-                ))}
-              </div>
-              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
-            </div>
-          </div>
-
-          {/* Table Skeleton */}
-          <div className="space-y-3">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <Skeleton key={i} className="h-16 w-full rounded-lg" />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+    <PageSkeleton
+      buttonWidth="w-60 sm:w-[280px]"
+      showInstructionGuide={true}
+    />
   )
 }

--- a/app/(dashboard)/betriebskosten/loading.tsx
+++ b/app/(dashboard)/betriebskosten/loading.tsx
@@ -1,5 +1,5 @@
 import { Skeleton } from "@/components/ui/skeleton"
-import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card"
+import { Card, CardHeader, CardContent } from "@/components/ui/card"
 
 export default function Loading() {
   return (

--- a/app/(dashboard)/betriebskosten/loading.tsx
+++ b/app/(dashboard)/betriebskosten/loading.tsx
@@ -1,55 +1,65 @@
-import { Skeleton } from "@/components/ui/skeleton";
-import { Card, CardHeader, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton"
+import { Card, CardHeader, CardContent, CardTitle } from "@/components/ui/card"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
       {/* Instruction Cards Skeleton */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {[1,2,3,4].map((idx) => (
-          <Card key={idx} className="rounded-2xl">
+        {[1, 2, 3, 4].map((idx) => (
+          <Card key={idx} className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
             <CardHeader className="pb-2">
-              <Skeleton className="h-5 w-48" /> {/* Mimics CardTitle */}
+              <Skeleton className="h-5 w-48" />
             </CardHeader>
             <CardContent className="flex items-center justify-between gap-4">
-              <Skeleton className="h-4 w-2/3" /> {/* Mimics description */}
-              <Skeleton className="h-9 w-28" /> {/* Mimics action button */}
+              <Skeleton className="h-4 w-2/3" />
+              <Skeleton className="h-9 w-28 rounded-full" />
             </CardContent>
           </Card>
         ))}
       </div>
 
       {/* Main Card Structure Skeleton */}
-      <Card className="overflow-hidden rounded-2xl shadow-md">
-        <CardHeader className="flex flex-row items-center justify-between">
-          {/* Left side: Card Title Skeleton */}
-          <Skeleton className="h-6 w-48" /> {/* Mimics CardTitle */}
-          {/* Right side: Button Skeleton */}
-          <Skeleton className="h-10 w-60 sm:w-[280px]" /> {/* Mimics Button "Betriebskostenabrechnung erstellen" */}
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+        <CardHeader>
+          <div className="flex flex-row items-start justify-between">
+            <div>
+              <Skeleton className="h-6 w-48 mb-2" />
+              <Skeleton className="h-4 w-72" />
+            </div>
+            <Skeleton className="h-10 w-60 sm:w-[280px] rounded-full" />
+          </div>
         </CardHeader>
+        <div className="px-6">
+          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
+        </div>
         <CardContent className="flex flex-col gap-6">
           {/* Filters Skeleton */}
-          <div className="flex flex-col sm:flex-row gap-4 mb-2"> {/* Adjusted mb from 6 to 2 to match original page better */}
-            <Skeleton className="h-10 flex-grow" /> {/* Mimics search input */}
-            <Skeleton className="h-10 w-full sm:w-48" /> {/* Mimics a select filter */}
-            <Skeleton className="h-10 w-full sm:w-48" /> {/* Mimics another select filter */}
+          <div className="flex flex-col gap-4 mt-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-wrap gap-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
+                ))}
+              </div>
+              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
+            </div>
           </div>
 
           {/* Table Skeleton */}
-          <div className="rounded-md border">
-            {/* Table Header Skeleton */}
-            <Skeleton className="h-12 w-full" />
-            {/* Table Body Skeletons (Rows) */}
-            <div className="p-4 space-y-2"> {/* Added padding and spacing for rows if table rows have it */}
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-            </div>
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-lg" />
+            ))}
           </div>
         </CardContent>
       </Card>
     </div>
-  );
+  )
 }

--- a/app/(dashboard)/dateien/loading.tsx
+++ b/app/(dashboard)/dateien/loading.tsx
@@ -1,5 +1,4 @@
 import { Skeleton } from "@/components/ui/skeleton"
-import { Card } from "@/components/ui/card"
 
 export const runtime = 'edge'
 
@@ -13,17 +12,21 @@ export default function DateienLoading() {
         }}
       />
       
-      {/* Summary Cards Skeleton */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {/* Summary Cards Skeleton - 3 equal flex cards */}
+      <div className="flex flex-wrap gap-4">
         {Array.from({ length: 3 }).map((_, i) => (
-          <Card key={i} className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl p-6">
-            <div className="flex items-center justify-between mb-4">
-              <Skeleton className="h-10 w-10 rounded-lg" />
-              <Skeleton className="h-8 w-8 rounded-full" />
+          <div key={i} className="relative overflow-hidden rounded-3xl shadow-sm flex-1 bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251]">
+            <div className="p-6">
+              <div className="flex items-center justify-between space-y-0 pb-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-4 w-4" />
+              </div>
+              <div>
+                <Skeleton className="h-8 w-28 mb-1" />
+                <Skeleton className="h-3 w-40" />
+              </div>
             </div>
-            <Skeleton className="h-8 w-24 mb-2" />
-            <Skeleton className="h-4 w-32" />
-          </Card>
+          </div>
         ))}
       </div>
       
@@ -34,42 +37,39 @@ export default function DateienLoading() {
           <div className="p-6">
             <div className="flex flex-row items-start justify-between mb-6">
               <div>
-                <Skeleton className="h-8 w-32 mb-2" />
-                <Skeleton className="h-4 w-72" />
+                <Skeleton className="h-8 w-32 mb-1" />
+                <Skeleton className="h-4 w-80" />
               </div>
             </div>
             
             {/* Quick Actions Skeleton */}
             <div className="space-y-4">
+              {/* Search and sort row */}
               <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                {/* Left side: Search, Sort, Categories */}
                 <div className="flex flex-wrap gap-2">
-                  <Skeleton className="h-10 w-32 rounded-full" />
-                  <Skeleton className="h-10 w-36 rounded-full" />
-                  <Skeleton className="h-10 w-32 rounded-full" />
+                  <Skeleton className="h-9 w-full sm:w-[300px] rounded-full" />
+                  <Skeleton className="h-9 w-28 rounded-full" />
+                  <Skeleton className="h-9 w-32 rounded-full" />
                 </div>
-                <div className="flex gap-2">
-                  <Skeleton className="h-10 w-10 rounded-lg" />
-                  <Skeleton className="h-10 w-10 rounded-lg" />
-                  <Skeleton className="h-10 w-10 rounded-lg" />
-                </div>
-              </div>
-              
-              <div className="flex items-center justify-between">
-                <Skeleton className="h-10 flex-1 max-w-md rounded-full" />
-                <div className="flex gap-2 ml-4">
-                  <Skeleton className="h-10 w-24 rounded-lg" />
-                  <Skeleton className="h-10 w-20 rounded-lg" />
-                  <Skeleton className="h-10 w-20 rounded-lg" />
+                
+                {/* Right side: View mode toggle + Add button */}
+                <div className="flex items-center gap-2 mt-1">
+                  {/* View mode toggle */}
+                  <div className="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded-full p-1">
+                    <Skeleton className="h-8 w-10 rounded-full" />
+                    <Skeleton className="h-8 w-10 rounded-full" />
+                  </div>
+                  {/* Add button */}
+                  <Skeleton className="h-10 w-32 rounded-lg" />
                 </div>
               </div>
             </div>
             
             {/* Breadcrumb Skeleton */}
-            <div className="flex items-center space-x-2 mt-4">
-              <Skeleton className="h-8 w-24 rounded-md" />
-              <span className="text-muted-foreground/50">/</span>
-              <Skeleton className="h-8 w-32 rounded-md" />
-            </div>
+            <nav className="flex items-center space-x-1 text-base mt-4">
+              <Skeleton className="h-9 w-28 rounded-md" />
+            </nav>
           </div>
         </div>
         
@@ -80,7 +80,7 @@ export default function DateienLoading() {
               {Array.from({ length: 24 }).map((_, i) => (
                 <div key={i} className="animate-pulse" style={{ animationDelay: `${i * 20}ms` }}>
                   <Skeleton className="h-32 rounded-2xl mb-3 bg-gray-100 dark:bg-[#22272e]" />
-                  <Skeleton className="h-4 w-3/4 mb-2" />
+                  <Skeleton className="h-4 w-3/4 mb-1" />
                   <Skeleton className="h-3 w-1/2" />
                 </div>
               ))}

--- a/app/(dashboard)/dateien/loading.tsx
+++ b/app/(dashboard)/dateien/loading.tsx
@@ -1,64 +1,91 @@
 import { Skeleton } from "@/components/ui/skeleton"
+import { Card } from "@/components/ui/card"
 
 export const runtime = 'edge'
 
 export default function DateienLoading() {
   return (
-    <div className="h-full flex flex-col bg-white dark:bg-[#181818]">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div
         className="absolute inset-0 z-[-1]"
         style={{
           backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
         }}
       />
-      {/* Header skeleton */}
-      <div className="border-b border-gray-200 dark:border-gray-700 p-6 space-y-6">
-        <div className="flex items-center justify-between">
-          <div className="space-y-2">
-            <Skeleton className="h-9 w-64" />
-            <Skeleton className="h-4 w-80" />
-          </div>
-          <div className="flex space-x-3">
-            <Skeleton className="h-10 w-36 rounded-full" />
-            <Skeleton className="h-10 w-32 rounded-full" />
+      
+      {/* Summary Cards Skeleton */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Card key={i} className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl p-6">
+            <div className="flex items-center justify-between mb-4">
+              <Skeleton className="h-10 w-10 rounded-lg" />
+              <Skeleton className="h-8 w-8 rounded-full" />
+            </div>
+            <Skeleton className="h-8 w-24 mb-2" />
+            <Skeleton className="h-4 w-32" />
+          </Card>
+        ))}
+      </div>
+      
+      {/* Main File Container Skeleton */}
+      <div className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem] flex flex-col">
+        {/* Header */}
+        <div className="border-b border-gray-200 dark:border-gray-700">
+          <div className="p-6">
+            <div className="flex flex-row items-start justify-between mb-6">
+              <div>
+                <Skeleton className="h-8 w-32 mb-2" />
+                <Skeleton className="h-4 w-72" />
+              </div>
+            </div>
+            
+            {/* Quick Actions Skeleton */}
+            <div className="space-y-4">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-wrap gap-2">
+                  <Skeleton className="h-10 w-32 rounded-full" />
+                  <Skeleton className="h-10 w-36 rounded-full" />
+                  <Skeleton className="h-10 w-32 rounded-full" />
+                </div>
+                <div className="flex gap-2">
+                  <Skeleton className="h-10 w-10 rounded-lg" />
+                  <Skeleton className="h-10 w-10 rounded-lg" />
+                  <Skeleton className="h-10 w-10 rounded-lg" />
+                </div>
+              </div>
+              
+              <div className="flex items-center justify-between">
+                <Skeleton className="h-10 flex-1 max-w-md rounded-full" />
+                <div className="flex gap-2 ml-4">
+                  <Skeleton className="h-10 w-24 rounded-lg" />
+                  <Skeleton className="h-10 w-20 rounded-lg" />
+                  <Skeleton className="h-10 w-20 rounded-lg" />
+                </div>
+              </div>
+            </div>
+            
+            {/* Breadcrumb Skeleton */}
+            <div className="flex items-center space-x-2 mt-4">
+              <Skeleton className="h-8 w-24 rounded-md" />
+              <span className="text-muted-foreground/50">/</span>
+              <Skeleton className="h-8 w-32 rounded-md" />
+            </div>
           </div>
         </div>
         
-        <div className="space-y-4">
-          <div className="flex items-center justify-between">
-            <div className="flex space-x-2">
-              <Skeleton className="h-9 w-24 rounded-full" />
-              <Skeleton className="h-9 w-32 rounded-full" />
-            </div>
-            <div className="flex space-x-2">
-              <Skeleton className="h-8 w-20 rounded-lg" />
-              <Skeleton className="h-8 w-16 rounded-lg" />
-            </div>
-          </div>
-          
-          <div className="flex items-center justify-between">
-            <Skeleton className="h-10 w-96 rounded-full" />
-            <div className="flex space-x-2">
-              <Skeleton className="h-8 w-12 rounded-lg" />
-              <Skeleton className="h-8 w-16 rounded-lg" />
-              <Skeleton className="h-8 w-20 rounded-lg" />
-              <Skeleton className="h-8 w-16 rounded-lg" />
-              <Skeleton className="h-8 w-20 rounded-lg" />
+        {/* Content Area Skeleton */}
+        <div className="flex-1 overflow-auto">
+          <div className="p-6">
+            <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
+              {Array.from({ length: 24 }).map((_, i) => (
+                <div key={i} className="animate-pulse" style={{ animationDelay: `${i * 20}ms` }}>
+                  <Skeleton className="h-32 rounded-2xl mb-3 bg-gray-100 dark:bg-[#22272e]" />
+                  <Skeleton className="h-4 w-3/4 mb-2" />
+                  <Skeleton className="h-3 w-1/2" />
+                </div>
+              ))}
             </div>
           </div>
-        </div>
-      </div>
-      
-      {/* Content skeleton */}
-      <div className="flex-1 p-6">
-        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
-          {Array.from({ length: 24 }).map((_, i) => (
-            <div key={i} className="animate-pulse">
-              <Skeleton className="h-32 rounded-2xl mb-3 bg-gray-100 dark:bg-[#22272e]" />
-              <Skeleton className="h-4 w-3/4 mb-2" />
-              <Skeleton className="h-3 w-1/2" />
-            </div>
-          ))}
         </div>
       </div>
     </div>

--- a/app/(dashboard)/dateien/loading.tsx
+++ b/app/(dashboard)/dateien/loading.tsx
@@ -4,40 +4,46 @@ export const runtime = 'edge'
 
 export default function DateienLoading() {
   return (
-    <div className="h-full flex flex-col">
+    <div className="h-full flex flex-col bg-white dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
       {/* Header skeleton */}
-      <div className="border-b p-6 space-y-6">
+      <div className="border-b border-gray-200 dark:border-gray-700 p-6 space-y-6">
         <div className="flex items-center justify-between">
           <div className="space-y-2">
             <Skeleton className="h-9 w-64" />
             <Skeleton className="h-4 w-80" />
           </div>
           <div className="flex space-x-3">
-            <Skeleton className="h-9 w-32" />
-            <Skeleton className="h-9 w-28" />
+            <Skeleton className="h-10 w-36 rounded-full" />
+            <Skeleton className="h-10 w-32 rounded-full" />
           </div>
         </div>
         
         <div className="space-y-4">
           <div className="flex items-center justify-between">
             <div className="flex space-x-2">
-              <Skeleton className="h-9 w-24" />
-              <Skeleton className="h-9 w-32" />
+              <Skeleton className="h-9 w-24 rounded-full" />
+              <Skeleton className="h-9 w-32 rounded-full" />
             </div>
             <div className="flex space-x-2">
-              <Skeleton className="h-8 w-20" />
-              <Skeleton className="h-8 w-16" />
+              <Skeleton className="h-8 w-20 rounded-lg" />
+              <Skeleton className="h-8 w-16 rounded-lg" />
             </div>
           </div>
           
           <div className="flex items-center justify-between">
-            <Skeleton className="h-9 w-96" />
+            <Skeleton className="h-10 w-96 rounded-full" />
             <div className="flex space-x-2">
-              <Skeleton className="h-8 w-12" />
-              <Skeleton className="h-8 w-16" />
-              <Skeleton className="h-8 w-20" />
-              <Skeleton className="h-8 w-16" />
-              <Skeleton className="h-8 w-20" />
+              <Skeleton className="h-8 w-12 rounded-lg" />
+              <Skeleton className="h-8 w-16 rounded-lg" />
+              <Skeleton className="h-8 w-20 rounded-lg" />
+              <Skeleton className="h-8 w-16 rounded-lg" />
+              <Skeleton className="h-8 w-20 rounded-lg" />
             </div>
           </div>
         </div>
@@ -48,7 +54,7 @@ export default function DateienLoading() {
         <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
           {Array.from({ length: 24 }).map((_, i) => (
             <div key={i} className="animate-pulse">
-              <Skeleton className="h-32 rounded-lg mb-3" />
+              <Skeleton className="h-32 rounded-2xl mb-3 bg-gray-100 dark:bg-[#22272e]" />
               <Skeleton className="h-4 w-3/4 mb-2" />
               <Skeleton className="h-3 w-1/2" />
             </div>

--- a/app/(dashboard)/dateien/page.tsx
+++ b/app/(dashboard)/dateien/page.tsx
@@ -9,34 +9,87 @@ export const runtime = 'edge'
 
 function CloudStorageLoading() {
   return (
-    <div className="h-full flex flex-col">
-      {/* Header skeleton */}
-      <div className="border-b p-6 space-y-4">
-        <div className="flex items-center justify-between">
-          <div className="space-y-2">
-            <Skeleton className="h-8 w-48" />
-            <Skeleton className="h-4 w-64" />
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
+      
+      {/* Summary Cards Skeleton */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl p-6">
+            <div className="flex items-center justify-between mb-4">
+              <Skeleton className="h-10 w-10 rounded-lg" />
+              <Skeleton className="h-8 w-8 rounded-full" />
+            </div>
+            <Skeleton className="h-8 w-24 mb-2" />
+            <Skeleton className="h-4 w-32" />
           </div>
-          <Skeleton className="h-9 w-32" />
-        </div>
-        <div className="flex items-center justify-between">
-          <Skeleton className="h-9 w-80" />
-          <div className="flex space-x-2">
-            <Skeleton className="h-9 w-24" />
-            <Skeleton className="h-9 w-20" />
-          </div>
-        </div>
+        ))}
       </div>
       
-      {/* Content skeleton */}
-      <div className="flex-1 p-6">
-        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
-          {Array.from({ length: 16 }).map((_, i) => (
-            <div key={i} className="animate-pulse">
-              <Skeleton className="h-24 rounded-lg mb-2" />
-              <Skeleton className="h-4 w-3/4" />
+      {/* Main File Container Skeleton */}
+      <div className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem] flex flex-col">
+        {/* Header */}
+        <div className="border-b border-gray-200 dark:border-gray-700">
+          <div className="p-6">
+            <div className="flex flex-row items-start justify-between mb-6">
+              <div>
+                <Skeleton className="h-8 w-32 mb-2" />
+                <Skeleton className="h-4 w-72" />
+              </div>
             </div>
-          ))}
+            
+            {/* Quick Actions Skeleton */}
+            <div className="space-y-4">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-wrap gap-2">
+                  <Skeleton className="h-10 w-32 rounded-full" />
+                  <Skeleton className="h-10 w-36 rounded-full" />
+                  <Skeleton className="h-10 w-32 rounded-full" />
+                </div>
+                <div className="flex gap-2">
+                  <Skeleton className="h-10 w-10 rounded-lg" />
+                  <Skeleton className="h-10 w-10 rounded-lg" />
+                  <Skeleton className="h-10 w-10 rounded-lg" />
+                </div>
+              </div>
+              
+              <div className="flex items-center justify-between">
+                <Skeleton className="h-10 flex-1 max-w-md rounded-full" />
+                <div className="flex gap-2 ml-4">
+                  <Skeleton className="h-10 w-24 rounded-lg" />
+                  <Skeleton className="h-10 w-20 rounded-lg" />
+                  <Skeleton className="h-10 w-20 rounded-lg" />
+                </div>
+              </div>
+            </div>
+            
+            {/* Breadcrumb Skeleton */}
+            <div className="flex items-center space-x-2 mt-4">
+              <Skeleton className="h-8 w-24 rounded-md" />
+              <span className="text-muted-foreground/50">/</span>
+              <Skeleton className="h-8 w-32 rounded-md" />
+            </div>
+          </div>
+        </div>
+        
+        {/* Content Area Skeleton */}
+        <div className="flex-1 overflow-auto">
+          <div className="p-6">
+            <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
+              {Array.from({ length: 24 }).map((_, i) => (
+                <div key={i} className="animate-pulse" style={{ animationDelay: `${i * 20}ms` }}>
+                  <Skeleton className="h-32 rounded-2xl mb-3 bg-gray-100 dark:bg-[#22272e]" />
+                  <Skeleton className="h-4 w-3/4 mb-2" />
+                  <Skeleton className="h-3 w-1/2" />
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/app/(dashboard)/dateien/page.tsx
+++ b/app/(dashboard)/dateien/page.tsx
@@ -1,9 +1,31 @@
+import { Suspense } from 'react'
 import { CloudStorageSimple } from "@/components/cloud-storage-simple"
 import { createClient } from "@/utils/supabase/server"
 import { redirect } from "next/navigation"
 import { getPathContents } from "./actions"
+import DateienLoading from './loading'
 
 export const runtime = 'edge'
+
+async function CloudStorageContent({ userId }: { userId: string }) {
+  // Load initial files, folders and breadcrumbs on the server
+  const initialPath = `user_${userId}`
+  const { files, folders, breadcrumbs, error: loadError } = await getPathContents(userId, initialPath)
+
+  if (loadError) {
+    console.error('Error loading initial files:', loadError)
+  }
+
+  return (
+    <CloudStorageSimple
+      userId={userId}
+      initialPath={initialPath}
+      initialFiles={files}
+      initialFolders={folders}
+      initialBreadcrumbs={breadcrumbs}
+    />
+  )
+}
 
 export default async function DateienPage() {
   const supabase = await createClient()
@@ -15,21 +37,9 @@ export default async function DateienPage() {
     redirect('/auth/login')
   }
 
-  // Load initial files, folders and breadcrumbs on the server
-  const initialPath = `user_${user.id}`
-  const { files, folders, breadcrumbs, error: loadError } = await getPathContents(user.id, initialPath)
-
-  if (loadError) {
-    console.error('Error loading initial files:', loadError)
-  }
-
   return (
-    <CloudStorageSimple
-      userId={user.id}
-      initialPath={initialPath}
-      initialFiles={files}
-      initialFolders={folders}
-      initialBreadcrumbs={breadcrumbs}
-    />
+    <Suspense fallback={<DateienLoading />}>
+      <CloudStorageContent userId={user.id} />
+    </Suspense>
   )
 }

--- a/app/(dashboard)/dateien/page.tsx
+++ b/app/(dashboard)/dateien/page.tsx
@@ -17,16 +17,20 @@ function CloudStorageLoading() {
         }}
       />
       
-      {/* Summary Cards Skeleton */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {/* Summary Cards Skeleton - 3 equal flex cards */}
+      <div className="flex flex-wrap gap-4">
         {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl p-6">
-            <div className="flex items-center justify-between mb-4">
-              <Skeleton className="h-10 w-10 rounded-lg" />
-              <Skeleton className="h-8 w-8 rounded-full" />
+          <div key={i} className="relative overflow-hidden rounded-3xl shadow-sm flex-1 bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251]">
+            <div className="p-6">
+              <div className="flex items-center justify-between space-y-0 pb-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-4 w-4" />
+              </div>
+              <div>
+                <Skeleton className="h-8 w-28 mb-1" />
+                <Skeleton className="h-3 w-40" />
+              </div>
             </div>
-            <Skeleton className="h-8 w-24 mb-2" />
-            <Skeleton className="h-4 w-32" />
           </div>
         ))}
       </div>
@@ -38,42 +42,39 @@ function CloudStorageLoading() {
           <div className="p-6">
             <div className="flex flex-row items-start justify-between mb-6">
               <div>
-                <Skeleton className="h-8 w-32 mb-2" />
-                <Skeleton className="h-4 w-72" />
+                <Skeleton className="h-8 w-32 mb-1" />
+                <Skeleton className="h-4 w-80" />
               </div>
             </div>
             
             {/* Quick Actions Skeleton */}
             <div className="space-y-4">
+              {/* Search and sort row */}
               <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                {/* Left side: Search, Sort, Categories */}
                 <div className="flex flex-wrap gap-2">
-                  <Skeleton className="h-10 w-32 rounded-full" />
-                  <Skeleton className="h-10 w-36 rounded-full" />
-                  <Skeleton className="h-10 w-32 rounded-full" />
+                  <Skeleton className="h-9 w-full sm:w-[300px] rounded-full" />
+                  <Skeleton className="h-9 w-28 rounded-full" />
+                  <Skeleton className="h-9 w-32 rounded-full" />
                 </div>
-                <div className="flex gap-2">
-                  <Skeleton className="h-10 w-10 rounded-lg" />
-                  <Skeleton className="h-10 w-10 rounded-lg" />
-                  <Skeleton className="h-10 w-10 rounded-lg" />
-                </div>
-              </div>
-              
-              <div className="flex items-center justify-between">
-                <Skeleton className="h-10 flex-1 max-w-md rounded-full" />
-                <div className="flex gap-2 ml-4">
-                  <Skeleton className="h-10 w-24 rounded-lg" />
-                  <Skeleton className="h-10 w-20 rounded-lg" />
-                  <Skeleton className="h-10 w-20 rounded-lg" />
+                
+                {/* Right side: View mode toggle + Add button */}
+                <div className="flex items-center gap-2 mt-1">
+                  {/* View mode toggle */}
+                  <div className="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded-full p-1">
+                    <Skeleton className="h-8 w-10 rounded-full" />
+                    <Skeleton className="h-8 w-10 rounded-full" />
+                  </div>
+                  {/* Add button */}
+                  <Skeleton className="h-10 w-32 rounded-lg" />
                 </div>
               </div>
             </div>
             
             {/* Breadcrumb Skeleton */}
-            <div className="flex items-center space-x-2 mt-4">
-              <Skeleton className="h-8 w-24 rounded-md" />
-              <span className="text-muted-foreground/50">/</span>
-              <Skeleton className="h-8 w-32 rounded-md" />
-            </div>
+            <nav className="flex items-center space-x-1 text-base mt-4">
+              <Skeleton className="h-9 w-28 rounded-md" />
+            </nav>
           </div>
         </div>
         
@@ -84,7 +85,7 @@ function CloudStorageLoading() {
               {Array.from({ length: 24 }).map((_, i) => (
                 <div key={i} className="animate-pulse" style={{ animationDelay: `${i * 20}ms` }}>
                   <Skeleton className="h-32 rounded-2xl mb-3 bg-gray-100 dark:bg-[#22272e]" />
-                  <Skeleton className="h-4 w-3/4 mb-2" />
+                  <Skeleton className="h-4 w-3/4 mb-1" />
                   <Skeleton className="h-3 w-1/2" />
                 </div>
               ))}

--- a/app/(dashboard)/dateien/page.tsx
+++ b/app/(dashboard)/dateien/page.tsx
@@ -1,121 +1,9 @@
-import { Suspense } from "react"
 import { CloudStorageSimple } from "@/components/cloud-storage-simple"
 import { createClient } from "@/utils/supabase/server"
 import { redirect } from "next/navigation"
-import { Skeleton } from "@/components/ui/skeleton"
 import { getPathContents } from "./actions"
 
 export const runtime = 'edge'
-
-function CloudStorageLoading() {
-  return (
-    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
-      <div
-        className="absolute inset-0 z-[-1]"
-        style={{
-          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
-        }}
-      />
-      
-      {/* Summary Cards Skeleton - 3 equal flex cards */}
-      <div className="flex flex-wrap gap-4">
-        {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="relative overflow-hidden rounded-3xl shadow-sm flex-1 bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251]">
-            <div className="p-6">
-              <div className="flex items-center justify-between space-y-0 pb-2">
-                <Skeleton className="h-4 w-32" />
-                <Skeleton className="h-4 w-4" />
-              </div>
-              <div>
-                <Skeleton className="h-8 w-28 mb-1" />
-                <Skeleton className="h-3 w-40" />
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
-      
-      {/* Main File Container Skeleton */}
-      <div className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem] flex flex-col">
-        {/* Header */}
-        <div className="border-b border-gray-200 dark:border-gray-700">
-          <div className="p-6">
-            <div className="flex flex-row items-start justify-between mb-6">
-              <div>
-                <Skeleton className="h-8 w-32 mb-1" />
-                <Skeleton className="h-4 w-80" />
-              </div>
-            </div>
-            
-            {/* Quick Actions Skeleton */}
-            <div className="space-y-4">
-              {/* Search and sort row */}
-              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                {/* Left side: Search, Sort, Categories */}
-                <div className="flex flex-wrap gap-2">
-                  <Skeleton className="h-9 w-full sm:w-[300px] rounded-full" />
-                  <Skeleton className="h-9 w-28 rounded-full" />
-                  <Skeleton className="h-9 w-32 rounded-full" />
-                </div>
-                
-                {/* Right side: View mode toggle + Add button */}
-                <div className="flex items-center gap-2 mt-1">
-                  {/* View mode toggle */}
-                  <div className="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded-full p-1">
-                    <Skeleton className="h-8 w-10 rounded-full" />
-                    <Skeleton className="h-8 w-10 rounded-full" />
-                  </div>
-                  {/* Add button */}
-                  <Skeleton className="h-10 w-32 rounded-lg" />
-                </div>
-              </div>
-            </div>
-            
-            {/* Breadcrumb Skeleton */}
-            <nav className="flex items-center space-x-1 text-base mt-4">
-              <Skeleton className="h-9 w-28 rounded-md" />
-            </nav>
-          </div>
-        </div>
-        
-        {/* Content Area Skeleton */}
-        <div className="flex-1 overflow-auto">
-          <div className="p-6">
-            <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
-              {Array.from({ length: 24 }).map((_, i) => (
-                <div key={i} className="animate-pulse" style={{ animationDelay: `${i * 20}ms` }}>
-                  <Skeleton className="h-32 rounded-2xl mb-3 bg-gray-100 dark:bg-[#22272e]" />
-                  <Skeleton className="h-4 w-3/4 mb-1" />
-                  <Skeleton className="h-3 w-1/2" />
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-async function CloudStorageContent({ userId }: { userId: string }) {
-  // Load initial files, folders and breadcrumbs on the server
-  const initialPath = `user_${userId}`
-  const { files, folders, breadcrumbs, error } = await getPathContents(userId, initialPath)
-
-  if (error) {
-    console.error('Error loading initial files:', error)
-  }
-
-  return (
-    <CloudStorageSimple
-      userId={userId}
-      initialPath={initialPath}
-      initialFiles={files}
-      initialFolders={folders}
-      initialBreadcrumbs={breadcrumbs}
-    />
-  )
-}
 
 export default async function DateienPage() {
   const supabase = await createClient()
@@ -127,11 +15,21 @@ export default async function DateienPage() {
     redirect('/auth/login')
   }
 
+  // Load initial files, folders and breadcrumbs on the server
+  const initialPath = `user_${user.id}`
+  const { files, folders, breadcrumbs, error: loadError } = await getPathContents(user.id, initialPath)
+
+  if (loadError) {
+    console.error('Error loading initial files:', loadError)
+  }
+
   return (
-    <div className="h-full">
-      <Suspense fallback={<CloudStorageLoading />}>
-        <CloudStorageContent userId={user.id} />
-      </Suspense>
-    </div>
+    <CloudStorageSimple
+      userId={user.id}
+      initialPath={initialPath}
+      initialFiles={files}
+      initialFolders={folders}
+      initialBreadcrumbs={breadcrumbs}
+    />
   )
 }

--- a/app/(dashboard)/finanzen/client-wrapper.tsx
+++ b/app/(dashboard)/finanzen/client-wrapper.tsx
@@ -400,7 +400,7 @@ export default function FinanzenClientWrapper({ finances: initialFinances, wohnu
 
 
   return (
-    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div
         className="absolute inset-0 z-[-1]"
         style={{

--- a/app/(dashboard)/finanzen/loading.tsx
+++ b/app/(dashboard)/finanzen/loading.tsx
@@ -1,116 +1,132 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Button } from "@/components/ui/button"
-import { PlusCircle, ArrowUpCircle, ArrowDownCircle, BarChart3, Wallet } from "lucide-react"
-import { SummaryCardSkeleton } from "@/components/summary-card-skeleton"
-import { ChartSkeleton } from "@/components/chart-skeletons"
+import { ArrowUpCircle, ArrowDownCircle, BarChart3, Wallet } from "lucide-react"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8 animate-in fade-in-0 duration-300">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818] animate-in fade-in-0 duration-300">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
       {/* Summary Cards */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <div className="animate-pulse" style={{ animationDelay: '0ms' }}>
-          <SummaryCardSkeleton 
-            title="Ø Monatliche Einnahmen" 
-            icon={<ArrowUpCircle className="h-4 w-4 text-green-500" />} 
-          />
-        </div>
-        <div className="animate-pulse" style={{ animationDelay: '100ms' }}>
-          <SummaryCardSkeleton 
-            title="Ø Monatliche Ausgaben" 
-            icon={<ArrowDownCircle className="h-4 w-4 text-red-500" />} 
-          />
-        </div>
-        <div className="animate-pulse" style={{ animationDelay: '200ms' }}>
-          <SummaryCardSkeleton 
-            title="Ø Monatlicher Cashflow" 
-            icon={<Wallet className="h-4 w-4 text-muted-foreground" />} 
-          />
-        </div>
-        <div className="animate-pulse" style={{ animationDelay: '300ms' }}>
-          <SummaryCardSkeleton 
-            title="Jahresprognose" 
-            icon={<BarChart3 className="h-4 w-4 text-muted-foreground" />} 
-          />
-        </div>
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl animate-pulse" style={{ animationDelay: '0ms' }}>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Ø Monatliche Einnahmen</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <ArrowUpCircle className="h-4 w-4 text-green-500" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-24 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl animate-pulse" style={{ animationDelay: '100ms' }}>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Ø Monatliche Ausgaben</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <ArrowDownCircle className="h-4 w-4 text-red-500" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-24 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl animate-pulse" style={{ animationDelay: '200ms' }}>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Ø Monatlicher Cashflow</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Wallet className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-24 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl animate-pulse" style={{ animationDelay: '300ms' }}>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Jahresprognose</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <BarChart3 className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-24 mb-2" />
+          </CardContent>
+        </Card>
       </div>
 
       {/* Chart Skeleton */}
-      <Card className="p-4">
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem] p-6">
         <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-6">
           {/* Chart type selector skeleton */}
           <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
-            <Skeleton className="h-9 w-20" />
-            <Skeleton className="h-9 w-20" />
-            <Skeleton className="h-9 w-20" />
-            <Skeleton className="h-9 w-20" />
+            <Skeleton className="h-9 w-20 rounded-full" />
+            <Skeleton className="h-9 w-20 rounded-full" />
+            <Skeleton className="h-9 w-20 rounded-full" />
+            <Skeleton className="h-9 w-20 rounded-full" />
           </div>
           {/* Year selector skeleton */}
           <div className="mt-4 md:mt-0 flex items-center gap-2">
             <Skeleton className="h-4 w-8" />
-            <Skeleton className="h-9 w-16" />
+            <Skeleton className="h-9 w-16 rounded-lg" />
           </div>
         </div>
         
-        <ChartSkeleton 
-          title="Einnahmen nach Wohnung" 
-          description="Verteilung der Mieteinnahmen nach Wohnungen"
-          type="pie" 
-        />
+        <div className="space-y-4">
+          <div>
+            <Skeleton className="h-6 w-48 mb-2" />
+            <Skeleton className="h-4 w-64" />
+          </div>
+          <Skeleton className="h-64 w-full rounded-lg" />
+        </div>
       </Card>
 
       {/* Transactions Table Skeleton */}
-      <Card>
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
         <CardHeader>
           <div className="flex items-center justify-between">
-            <CardTitle>
-              <Skeleton className="h-6 w-32" />
-            </CardTitle>
+            <div>
+              <Skeleton className="h-6 w-32 mb-2" />
+              <Skeleton className="h-4 w-48" />
+            </div>
             <div className="flex items-center gap-2">
-              <Skeleton className="h-9 w-20" />
-              <Skeleton className="h-9 w-20" />
+              <Skeleton className="h-10 w-32 rounded-full" />
             </div>
           </div>
         </CardHeader>
-        <CardContent>
+        <div className="px-6">
+          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
+        </div>
+        <CardContent className="pt-6">
           <div className="space-y-4">
             {/* Search and filter bar */}
-            <div className="flex items-center gap-4">
-              <Skeleton className="h-9 flex-1" />
-              <Skeleton className="h-9 w-24" />
-              <Skeleton className="h-9 w-24" />
-            </div>
-            
-            {/* Table header */}
-            <div className="grid grid-cols-6 gap-4 pb-2 border-b">
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-4 w-12" />
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-wrap gap-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-9 w-24 rounded-full" />
+                ))}
+              </div>
+              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
             </div>
             
             {/* Table rows */}
-            {Array.from({ length: 10 }).map((_, i) => (
-              <div 
-                key={i} 
-                className="grid grid-cols-6 gap-4 py-3 border-b border-border/50 animate-pulse"
-                style={{ animationDelay: `${i * 50}ms` }}
-              >
-                <Skeleton className="h-4 w-20" />
-                <Skeleton className="h-4 w-32" />
-                <Skeleton className="h-4 w-28" />
-                <Skeleton className="h-4 w-20" />
-                <Skeleton className="h-4 w-24" />
-                <Skeleton className="h-4 w-8" />
-              </div>
-            ))}
+            <div className="space-y-3">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <Skeleton 
+                  key={i} 
+                  className="h-16 w-full rounded-lg animate-pulse"
+                  style={{ animationDelay: `${i * 50}ms` }}
+                />
+              ))}
+            </div>
             
             {/* Load more button */}
             <div className="flex justify-center pt-4">
-              <Skeleton className="h-9 w-32" />
+              <Skeleton className="h-10 w-40 rounded-full" />
             </div>
           </div>
         </CardContent>

--- a/app/(dashboard)/haeuser/client-wrapper.tsx
+++ b/app/(dashboard)/haeuser/client-wrapper.tsx
@@ -150,7 +150,7 @@ export default function HaeuserClientView({ enrichedHaeuser }: HaeuserClientView
   }, [selectedHouses, router, refreshTable]);
 
   return (
-    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div
         className="absolute inset-0 z-[-1]"
         style={{

--- a/app/(dashboard)/haeuser/loading.tsx
+++ b/app/(dashboard)/haeuser/loading.tsx
@@ -1,82 +1,50 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Building, Home, Key } from "lucide-react"
+import { PageSkeleton } from "@/components/page-skeleton"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
-      <div
-        className="absolute inset-0 z-[-1]"
-        style={{
-          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
-        }}
-      />
-      <div className="flex flex-wrap gap-4">
-        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Häuser gesamt</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <Building className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-16 mb-2" />
-          </CardContent>
-        </Card>
-        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Wohnungen gesamt</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <Home className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-16 mb-2" />
-          </CardContent>
-        </Card>
-        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Freie Wohnungen</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <Key className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-16 mb-2" />
-          </CardContent>
-        </Card>
-      </div>
-      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
-        <CardHeader>
-          <div className="flex flex-row items-start justify-between">
-            <div>
-              <Skeleton className="h-6 w-40 mb-2" />
-              <Skeleton className="h-4 w-64" />
-            </div>
-            <Skeleton className="h-10 w-40 rounded-full" />
-          </div>
-        </CardHeader>
-        <div className="px-6">
-          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
-        </div>
-        <CardContent className="flex flex-col gap-6">
-          <div className="flex flex-col gap-4 mt-6">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex flex-wrap gap-2">
-                {Array.from({ length: 3 }).map((_, i) => (
-                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
-                ))}
+    <PageSkeleton
+      headerTitleWidth="w-40"
+      headerDescriptionWidth="w-64"
+      statsCards={
+        <div className="flex flex-wrap gap-4">
+          <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Häuser gesamt</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <Building className="h-4 w-4 text-muted-foreground" />
               </div>
-              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
-            </div>
-          </div>
-          <div className="space-y-3">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <Skeleton key={i} className="h-16 w-full rounded-lg" />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-16 mb-2" />
+            </CardContent>
+          </Card>
+          <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Wohnungen gesamt</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <Home className="h-4 w-4 text-muted-foreground" />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-16 mb-2" />
+            </CardContent>
+          </Card>
+          <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Freie Wohnungen</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <Key className="h-4 w-4 text-muted-foreground" />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-16 mb-2" />
+            </CardContent>
+          </Card>
+        </div>
+      }
+    />
   )
 }

--- a/app/(dashboard)/haeuser/loading.tsx
+++ b/app/(dashboard)/haeuser/loading.tsx
@@ -1,24 +1,80 @@
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
-import { SummaryCardSkeleton } from "@/components/summary-card-skeleton";
-import { Building, Home, Key } from "lucide-react";
+import { Building, Home, Key } from "lucide-react"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8">
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <SummaryCardSkeleton title="Häuser" icon={<Building className="h-4 w-4 text-muted-foreground" />} />
-        <SummaryCardSkeleton title="Wohnungen" icon={<Home className="h-4 w-4 text-muted-foreground" />} />
-        <SummaryCardSkeleton title="Freie Wohnungen" icon={<Key className="h-4 w-4 text-muted-foreground" />} />
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
+      <div className="flex flex-wrap gap-4">
+        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Häuser gesamt</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Building className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-16 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Wohnungen gesamt</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Home className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-16 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Freie Wohnungen</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Key className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-16 mb-2" />
+          </CardContent>
+        </Card>
       </div>
-      <Card className="overflow-hidden rounded-2xl shadow-md">
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
         <CardHeader>
-          <Skeleton className="h-6 w-40 mb-2" />
+          <div className="flex flex-row items-start justify-between">
+            <div>
+              <Skeleton className="h-6 w-40 mb-2" />
+              <Skeleton className="h-4 w-64" />
+            </div>
+            <Skeleton className="h-10 w-40 rounded-full" />
+          </div>
         </CardHeader>
-        <CardContent className="flex flex-col gap-2">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <Skeleton key={i} className="h-4 w-full" />
-          ))}
+        <div className="px-6">
+          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
+        </div>
+        <CardContent className="flex flex-col gap-6">
+          <div className="flex flex-col gap-4 mt-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-wrap gap-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
+                ))}
+              </div>
+              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
+            </div>
+          </div>
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-lg" />
+            ))}
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -16,14 +16,20 @@ export default async function Dashboard() {
   const summary = await getDashboardSummary();
   
   return (
-    <div className="flex flex-col gap-4 p-4 md:gap-8 md:p-8">
+    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
       <div>
         <h1 className="text-2xl font-bold tracking-tight md:text-3xl">Dashboard</h1>
       </div>
       <div className="grid gap-4 grid-cols-1 auto-rows-auto md:grid-cols-6 md:auto-rows-[140px] md:h-[calc(100vh-200px)]">
         {/* Row 1: Three wider summary cards (2/3 width - 4 columns total) + Tenant Payment List (1/3 width - 2 columns) */}
         <Link href="/haeuser" className="col-span-1 row-span-1 md:col-span-1 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden rounded-xl md:rounded-2xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Häuser</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -39,7 +45,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/wohnungen" className="col-span-1 row-span-1 md:col-span-2 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden rounded-xl md:rounded-2xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Wohnungen</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -55,7 +61,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/mieter" className="col-span-1 row-span-1 md:col-span-1 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden rounded-xl md:rounded-2xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Mieter</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -92,7 +98,7 @@ export default async function Dashboard() {
         </div>
         {/* Mobile: Individual cards, Desktop: Stacked container */}
         <Link href="/todos" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -114,7 +120,7 @@ export default async function Dashboard() {
         </Link>
         
         <Link href="/finanzen" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -134,7 +140,7 @@ export default async function Dashboard() {
         </Link>
         
         <Link href="/betriebskosten" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden rounded-xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -157,7 +163,7 @@ export default async function Dashboard() {
         <div className="hidden md:block md:col-span-2 md:row-span-3">
           <div className="h-full flex flex-col gap-4">
             <Link href="/todos" className="flex-1">
-              <Card className="h-full overflow-hidden rounded-2xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
@@ -179,7 +185,7 @@ export default async function Dashboard() {
             </Link>
             
             <Link href="/finanzen" className="flex-1">
-              <Card className="h-full overflow-hidden rounded-2xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
@@ -199,7 +205,7 @@ export default async function Dashboard() {
             </Link>
             
             <Link href="/betriebskosten" className="flex-1">
-              <Card className="h-full overflow-hidden rounded-2xl shadow-md hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -237,6 +237,9 @@ export default async function Dashboard() {
             <MaintenanceDonutChart />
           </div>
         </div>
+        
+        {/* Empty row for bottom spacing */}
+        <div className="col-span-1 md:col-span-6 h-4 md:h-8"></div>
       </div>
     </div>
   )

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -29,7 +29,7 @@ export default async function Dashboard() {
       <div className="grid gap-4 grid-cols-1 auto-rows-auto md:grid-cols-6 md:auto-rows-[140px] md:h-[calc(100vh-200px)]">
         {/* Row 1: Three wider summary cards (2/3 width - 4 columns total) + Tenant Payment List (1/3 width - 2 columns) */}
         <Link href="/haeuser" className="col-span-1 row-span-1 md:col-span-1 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Häuser</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -45,7 +45,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/wohnungen" className="col-span-1 row-span-1 md:col-span-2 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Wohnungen</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -61,7 +61,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/mieter" className="col-span-1 row-span-1 md:col-span-1 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Mieter</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -98,7 +98,7 @@ export default async function Dashboard() {
         </div>
         {/* Mobile: Individual cards, Desktop: Stacked container */}
         <Link href="/todos" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -120,7 +120,7 @@ export default async function Dashboard() {
         </Link>
         
         <Link href="/finanzen" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -140,7 +140,7 @@ export default async function Dashboard() {
         </Link>
         
         <Link href="/betriebskosten" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -163,7 +163,7 @@ export default async function Dashboard() {
         <div className="hidden md:block md:col-span-2 md:row-span-3">
           <div className="h-full flex flex-col gap-4">
             <Link href="/todos" className="flex-1">
-              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
@@ -185,7 +185,7 @@ export default async function Dashboard() {
             </Link>
             
             <Link href="/finanzen" className="flex-1">
-              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
@@ -205,7 +205,7 @@ export default async function Dashboard() {
             </Link>
             
             <Link href="/betriebskosten" className="flex-1">
-              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -29,7 +29,7 @@ export default async function Dashboard() {
       <div className="grid gap-4 grid-cols-1 auto-rows-auto md:grid-cols-6 md:auto-rows-[140px] md:h-[calc(100vh-200px)]">
         {/* Row 1: Three wider summary cards (2/3 width - 4 columns total) + Tenant Payment List (1/3 width - 2 columns) */}
         <Link href="/haeuser" className="col-span-1 row-span-1 md:col-span-1 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Häuser</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -45,7 +45,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/wohnungen" className="col-span-1 row-span-1 md:col-span-2 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Wohnungen</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -61,7 +61,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/mieter" className="col-span-1 row-span-1 md:col-span-1 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Mieter</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -98,7 +98,7 @@ export default async function Dashboard() {
         </div>
         {/* Mobile: Individual cards, Desktop: Stacked container */}
         <Link href="/todos" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -120,7 +120,7 @@ export default async function Dashboard() {
         </Link>
         
         <Link href="/finanzen" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -140,7 +140,7 @@ export default async function Dashboard() {
         </Link>
         
         <Link href="/betriebskosten" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -163,7 +163,7 @@ export default async function Dashboard() {
         <div className="hidden md:block md:col-span-2 md:row-span-3">
           <div className="h-full flex flex-col gap-4">
             <Link href="/todos" className="flex-1">
-              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
@@ -185,7 +185,7 @@ export default async function Dashboard() {
             </Link>
             
             <Link href="/finanzen" className="flex-1">
-              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
@@ -205,7 +205,7 @@ export default async function Dashboard() {
             </Link>
             
             <Link href="/betriebskosten" className="flex-1">
-              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer summary-card flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -16,13 +16,7 @@ export default async function Dashboard() {
   const summary = await getDashboardSummary();
   
   return (
-    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
-      <div
-        className="absolute inset-0 z-[-1]"
-        style={{
-          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
-        }}
-      />
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div>
         <h1 className="text-2xl font-bold tracking-tight md:text-3xl">Dashboard</h1>
       </div>

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -20,7 +20,7 @@ export default async function Dashboard() {
       <div>
         <h1 className="text-2xl font-bold tracking-tight md:text-3xl">Dashboard</h1>
       </div>
-      <div className="grid gap-4 grid-cols-1 auto-rows-auto md:grid-cols-6 md:auto-rows-[140px] md:h-[calc(100vh-200px)]">
+      <div className="grid gap-4 grid-cols-1 auto-rows-auto md:grid-cols-6 md:auto-rows-[140px]">
         {/* Row 1: Three wider summary cards (2/3 width - 4 columns total) + Tenant Payment List (1/3 width - 2 columns) */}
         <Link href="/haeuser" className="col-span-1 row-span-1 md:col-span-1 md:row-span-1">
           <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -231,9 +231,6 @@ export default async function Dashboard() {
             <MaintenanceDonutChart />
           </div>
         </div>
-        
-        {/* Empty row for bottom spacing */}
-        <div className="col-span-1 md:col-span-6 h-4 md:h-8"></div>
       </div>
     </div>
   )

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -29,7 +29,7 @@ export default async function Dashboard() {
       <div className="grid gap-4 grid-cols-1 auto-rows-auto md:grid-cols-6 md:auto-rows-[140px] md:h-[calc(100vh-200px)]">
         {/* Row 1: Three wider summary cards (2/3 width - 4 columns total) + Tenant Payment List (1/3 width - 2 columns) */}
         <Link href="/haeuser" className="col-span-1 row-span-1 md:col-span-1 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Häuser</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -45,7 +45,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/wohnungen" className="col-span-1 row-span-1 md:col-span-2 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Wohnungen</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -61,7 +61,7 @@ export default async function Dashboard() {
           </Card>
         </Link>
         <Link href="/mieter" className="col-span-1 row-span-1 md:col-span-1 md:row-span-1">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Mieter</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -98,7 +98,7 @@ export default async function Dashboard() {
         </div>
         {/* Mobile: Individual cards, Desktop: Stacked container */}
         <Link href="/todos" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -120,7 +120,7 @@ export default async function Dashboard() {
         </Link>
         
         <Link href="/finanzen" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -140,7 +140,7 @@ export default async function Dashboard() {
         </Link>
         
         <Link href="/betriebskosten" className="col-span-1 row-span-1 md:hidden">
-          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
+          <Card className="min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
               <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
               <div className="p-2 bg-muted rounded-lg">
@@ -163,7 +163,7 @@ export default async function Dashboard() {
         <div className="hidden md:block md:col-span-2 md:row-span-3">
           <div className="h-full flex flex-col gap-4">
             <Link href="/todos" className="flex-1">
-              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
@@ -185,7 +185,7 @@ export default async function Dashboard() {
             </Link>
             
             <Link href="/finanzen" className="flex-1">
-              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">
@@ -205,7 +205,7 @@ export default async function Dashboard() {
             </Link>
             
             <Link href="/betriebskosten" className="flex-1">
-              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
+              <Card className="h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl hover:shadow-lg transition-all cursor-pointer flex flex-col">
                 <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2 flex-shrink-0">
                   <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
                   <div className="p-2 bg-muted rounded-lg">

--- a/app/(dashboard)/loading.tsx
+++ b/app/(dashboard)/loading.tsx
@@ -1,164 +1,207 @@
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
+import { Building2, Home, Users, Wallet, FileSpreadsheet, CheckSquare } from "lucide-react"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div>
-        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-9 w-48" />
       </div>
-      <div className="grid gap-4 grid-cols-6 auto-rows-[140px] h-[calc(100vh-200px)]">
-        {/* Row 1: Three summary cards (1+2+1 columns) + Tenant Payment List (2 columns) */}
-        <Card className="col-span-1 row-span-1 h-full overflow-hidden rounded-2xl shadow-md">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
-            <Skeleton className="h-4 w-16" />
-            <Skeleton className="h-8 w-8 rounded-lg" />
+      <div className="grid gap-4 grid-cols-1 auto-rows-auto md:grid-cols-6 md:auto-rows-[140px]">
+        {/* Row 1: Three summary cards + Tenant Payment List */}
+        <Card className="col-span-1 row-span-1 md:col-span-1 md:row-span-1 min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Häuser</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Building2 className="h-4 w-4 text-muted-foreground" />
+            </div>
           </CardHeader>
-          <CardContent className="pt-0">
-            <Skeleton className="h-8 w-8 mb-2" />
-            <Skeleton className="h-3 w-24" />
-          </CardContent>
-        </Card>
-        
-        <Card className="col-span-2 row-span-1 h-full overflow-hidden rounded-2xl shadow-md">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
-            <Skeleton className="h-4 w-20" />
-            <Skeleton className="h-8 w-8 rounded-lg" />
-          </CardHeader>
-          <CardContent className="pt-0">
-            <Skeleton className="h-8 w-8 mb-2" />
-            <Skeleton className="h-3 w-28" />
-          </CardContent>
-        </Card>
-        
-        <Card className="col-span-1 row-span-1 h-full overflow-hidden rounded-2xl shadow-md">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-3">
-            <Skeleton className="h-4 w-12" />
-            <Skeleton className="h-8 w-8 rounded-lg" />
-          </CardHeader>
-          <CardContent className="pt-0">
-            <Skeleton className="h-8 w-8 mb-2" />
+          <CardContent className="pt-0 pb-6">
+            <Skeleton className="h-8 w-16 mb-2" />
             <Skeleton className="h-3 w-32" />
           </CardContent>
         </Card>
-        
-        {/* Tenant Payment List */}
-        <Card className="col-span-2 row-span-4 h-full overflow-hidden rounded-2xl shadow-md">
-          <CardHeader className="pb-3">
-            <Skeleton className="h-5 w-32" />
-            <Skeleton className="h-3 w-48" />
+
+        <Card className="col-span-1 row-span-1 md:col-span-2 md:row-span-1 min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Wohnungen</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Home className="h-4 w-4 text-muted-foreground" />
+            </div>
           </CardHeader>
-          <CardContent className="space-y-3">
-            {Array.from({ length: 8 }).map((_, i) => (
-              <div key={i} className="flex items-center justify-between p-3 border rounded-lg">
-                <div className="flex items-center gap-3">
-                  <Skeleton className="h-8 w-8 rounded-full" />
-                  <div>
-                    <Skeleton className="h-4 w-24 mb-1" />
-                    <Skeleton className="h-3 w-16" />
-                  </div>
-                </div>
-                <Skeleton className="h-4 w-16" />
-              </div>
-            ))}
+          <CardContent className="pt-0 pb-6">
+            <Skeleton className="h-8 w-16 mb-2" />
+            <Skeleton className="h-3 w-32" />
           </CardContent>
         </Card>
 
-        {/* Row 2: Occupancy Chart (4 columns, 3 rows) */}
-        <Card className="col-span-4 row-span-3 h-full overflow-hidden rounded-2xl shadow-md">
-          <CardHeader className="pb-3">
-            <Skeleton className="h-5 w-24" />
-            <Skeleton className="h-3 w-40" />
+        <Card className="col-span-1 row-span-1 md:col-span-1 md:row-span-1 min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Mieter</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Users className="h-4 w-4 text-muted-foreground" />
+            </div>
           </CardHeader>
-          <CardContent className="h-full">
-            <Skeleton className="h-full w-full rounded" />
+          <CardContent className="pt-0 pb-6">
+            <Skeleton className="h-8 w-16 mb-2" />
+            <Skeleton className="h-3 w-32" />
           </CardContent>
         </Card>
 
-        {/* Row 5: Revenue Chart (4 columns, 3 rows) + Stacked summary cards (2 columns, 3 rows) */}
-        <Card className="col-span-4 row-span-3 h-full overflow-hidden rounded-2xl shadow-md">
+        {/* Tenant Payment List Skeleton */}
+        <Card className="col-span-1 row-span-1 md:col-span-2 md:row-span-4 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
           <CardHeader className="pb-3">
-            <Skeleton className="h-5 w-32" />
-            <Skeleton className="h-3 w-48" />
-          </CardHeader>
-          <CardContent className="h-full">
-            <Skeleton className="h-full w-full rounded" />
-          </CardContent>
-        </Card>
-        
-        {/* Vertically stacked summary cards */}
-        <div className="col-span-2 row-span-3 h-full flex flex-col gap-4">
-          <Card className="flex-1 overflow-hidden rounded-2xl shadow-md">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-8 w-8 rounded-lg" />
-            </CardHeader>
-            <CardContent className="pt-0">
-              <div className="flex items-center gap-2 mb-2">
-                <Skeleton className="h-8 w-8" />
-                <Skeleton className="h-5 w-12 rounded-full" />
-              </div>
-              <Skeleton className="h-3 w-24" />
-            </CardContent>
-          </Card>
-          
-          <Card className="flex-1 overflow-hidden rounded-2xl shadow-md">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-8 w-8 rounded-lg" />
-            </CardHeader>
-            <CardContent className="pt-0">
-              <div className="flex items-center gap-2 mb-2">
-                <Skeleton className="h-8 w-16" />
-                <Skeleton className="h-5 w-12 rounded-full" />
-              </div>
-              <Skeleton className="h-3 w-32" />
-            </CardContent>
-          </Card>
-          
-          <Card className="flex-1 overflow-hidden rounded-2xl shadow-md">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-8 w-8 rounded-lg" />
-            </CardHeader>
-            <CardContent className="pt-0">
-              <div className="flex items-center gap-2 mb-2">
-                <Skeleton className="h-8 w-16" />
-                <Skeleton className="h-5 w-12 rounded-full" />
-              </div>
-              <Skeleton className="h-3 w-28" />
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Row 8: Last Transactions (3 columns) + Maintenance Chart (3 columns) */}
-        <Card className="col-span-3 row-span-3 h-full overflow-hidden rounded-2xl shadow-md">
-          <CardHeader className="pb-3">
-            <Skeleton className="h-5 w-28" />
-            <Skeleton className="h-3 w-40" />
+            <Skeleton className="h-5 w-40 mb-2" />
+            <Skeleton className="h-4 w-56" />
           </CardHeader>
           <CardContent className="space-y-3">
             {Array.from({ length: 6 }).map((_, i) => (
-              <div key={i} className="flex items-center justify-between p-3 border rounded-lg">
+              <div key={i} className="flex items-center justify-between p-3 bg-background rounded-lg">
                 <div className="flex items-center gap-3">
-                  <Skeleton className="h-8 w-8 rounded" />
-                  <div>
-                    <Skeleton className="h-4 w-32 mb-1" />
-                    <Skeleton className="h-3 w-20" />
+                  <Skeleton className="h-10 w-10 rounded-full" />
+                  <div className="space-y-2">
+                    <Skeleton className="h-4 w-24" />
+                    <Skeleton className="h-3 w-32" />
                   </div>
                 </div>
-                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-6 w-16 rounded-full" />
               </div>
             ))}
           </CardContent>
         </Card>
-        
-        <Card className="col-span-3 row-span-3 h-full overflow-hidden rounded-2xl shadow-md">
-          <CardHeader className="pb-3">
-            <Skeleton className="h-5 w-28" />
-            <Skeleton className="h-3 w-36" />
+
+        {/* Row 2: Occupancy Chart */}
+        <Card className="col-span-1 row-span-1 md:col-span-4 md:row-span-3 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader>
+            <Skeleton className="h-5 w-32 mb-2" />
+            <Skeleton className="h-4 w-48" />
           </CardHeader>
-          <CardContent className="h-full flex items-center justify-center">
+          <CardContent>
+            <Skeleton className="h-full w-full rounded-lg" />
+          </CardContent>
+        </Card>
+
+        {/* Row 5: Revenue Chart + Stacked Cards */}
+        <Card className="col-span-1 row-span-1 md:col-span-4 md:row-span-3 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader>
+            <Skeleton className="h-5 w-40 mb-2" />
+            <Skeleton className="h-4 w-56" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-full w-full rounded-lg" />
+          </CardContent>
+        </Card>
+
+        {/* Mobile: Individual cards, Desktop: Stacked container */}
+        <Card className="col-span-1 row-span-1 md:hidden min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <CheckSquare className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent className="pt-0 pb-6">
+            <Skeleton className="h-6 w-12 mb-2" />
+            <Skeleton className="h-3 w-28" />
+          </CardContent>
+        </Card>
+
+        <Card className="col-span-1 row-span-1 md:hidden min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Wallet className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent className="pt-0 pb-6">
+            <Skeleton className="h-6 w-24 mb-2" />
+            <Skeleton className="h-3 w-36" />
+          </CardContent>
+        </Card>
+
+        <Card className="col-span-1 row-span-1 md:hidden min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <FileSpreadsheet className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent className="pt-0 pb-6">
+            <Skeleton className="h-6 w-24 mb-2" />
+            <Skeleton className="h-3 w-32" />
+          </CardContent>
+        </Card>
+
+        {/* Desktop: Stacked container */}
+        <div className="hidden md:block md:col-span-2 md:row-span-3">
+          <div className="h-full flex flex-col gap-4">
+            <Card className="flex-1 overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
+                <div className="p-2 bg-muted rounded-lg">
+                  <CheckSquare className="h-4 w-4 text-muted-foreground" />
+                </div>
+              </CardHeader>
+              <CardContent className="pt-0 pb-6">
+                <Skeleton className="h-8 w-16 mb-2" />
+                <Skeleton className="h-3 w-28" />
+              </CardContent>
+            </Card>
+
+            <Card className="flex-1 overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
+                <div className="p-2 bg-muted rounded-lg">
+                  <Wallet className="h-4 w-4 text-muted-foreground" />
+                </div>
+              </CardHeader>
+              <CardContent className="pt-0 pb-6">
+                <Skeleton className="h-8 w-24 mb-2" />
+                <Skeleton className="h-3 w-36" />
+              </CardContent>
+            </Card>
+
+            <Card className="flex-1 overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
+                <div className="p-2 bg-muted rounded-lg">
+                  <FileSpreadsheet className="h-4 w-4 text-muted-foreground" />
+                </div>
+              </CardHeader>
+              <CardContent className="pt-0 pb-6">
+                <Skeleton className="h-8 w-24 mb-2" />
+                <Skeleton className="h-3 w-32" />
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+
+        {/* Row 8: Last Transactions + Maintenance Chart */}
+        <Card className="col-span-1 row-span-1 md:col-span-3 md:row-span-3 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader>
+            <Skeleton className="h-5 w-36 mb-2" />
+            <Skeleton className="h-4 w-48" />
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="flex items-center justify-between p-3 bg-background rounded-lg">
+                <div className="space-y-2">
+                  <Skeleton className="h-4 w-32" />
+                  <Skeleton className="h-3 w-24" />
+                </div>
+                <Skeleton className="h-5 w-20" />
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card className="col-span-1 row-span-1 md:col-span-3 md:row-span-3 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader>
+            <Skeleton className="h-5 w-32 mb-2" />
+            <Skeleton className="h-4 w-48" />
+          </CardHeader>
+          <CardContent className="flex items-center justify-center">
             <Skeleton className="h-48 w-48 rounded-full" />
           </CardContent>
         </Card>

--- a/app/(dashboard)/mieter/client-wrapper.tsx
+++ b/app/(dashboard)/mieter/client-wrapper.tsx
@@ -208,13 +208,7 @@ export default function MieterClientView({
   }, [selectedTenants, router]);
 
   return (
-    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
-      <div
-        className="absolute inset-0 z-[-1]"
-        style={{
-          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
-        }}
-      />
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div className="flex flex-wrap gap-4">
         <StatCard
           title="Mieter gesamt"

--- a/app/(dashboard)/mieter/loading.tsx
+++ b/app/(dashboard)/mieter/loading.tsx
@@ -1,82 +1,51 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Users, BadgeCheck, Euro } from "lucide-react"
+import { PageSkeleton } from "@/components/page-skeleton"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
-      <div
-        className="absolute inset-0 z-[-1]"
-        style={{
-          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
-        }}
-      />
-      <div className="flex flex-wrap gap-4">
-        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Mieter gesamt</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <Users className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-16 mb-2" />
-          </CardContent>
-        </Card>
-        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Aktiv / Ehemalig</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <BadgeCheck className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-24 mb-2" />
-          </CardContent>
-        </Card>
-        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Ø Nebenkosten</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <Euro className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-20 mb-2" />
-          </CardContent>
-        </Card>
-      </div>
-      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
-        <CardHeader>
-          <div className="flex flex-row items-start justify-between">
-            <div>
-              <Skeleton className="h-6 w-40 mb-2" />
-              <Skeleton className="h-4 w-64" />
-            </div>
-            <Skeleton className="h-10 w-44 rounded-full" />
-          </div>
-        </CardHeader>
-        <div className="px-6">
-          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
-        </div>
-        <CardContent className="flex flex-col gap-6">
-          <div className="flex flex-col gap-4 mt-6">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex flex-wrap gap-2">
-                {Array.from({ length: 3 }).map((_, i) => (
-                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
-                ))}
+    <PageSkeleton
+      headerTitleWidth="w-40"
+      headerDescriptionWidth="w-64"
+      buttonWidth="w-44"
+      statsCards={
+        <div className="flex flex-wrap gap-4">
+          <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Mieter gesamt</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <Users className="h-4 w-4 text-muted-foreground" />
               </div>
-              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
-            </div>
-          </div>
-          <div className="space-y-3">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <Skeleton key={i} className="h-16 w-full rounded-lg" />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-16 mb-2" />
+            </CardContent>
+          </Card>
+          <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Aktiv / Ehemalig</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <BadgeCheck className="h-4 w-4 text-muted-foreground" />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-24 mb-2" />
+            </CardContent>
+          </Card>
+          <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Ø Nebenkosten</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <Euro className="h-4 w-4 text-muted-foreground" />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-20 mb-2" />
+            </CardContent>
+          </Card>
+        </div>
+      }
+    />
   )
 }

--- a/app/(dashboard)/mieter/loading.tsx
+++ b/app/(dashboard)/mieter/loading.tsx
@@ -1,27 +1,80 @@
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
-import { SummaryCardSkeleton } from "@/components/summary-card-skeleton";
-import { Users, BadgeCheck, Euro } from "lucide-react";
+import { Users, BadgeCheck, Euro } from "lucide-react"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8">
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <SummaryCardSkeleton title="Mieter gesamt" icon={<Users className="h-4 w-4 text-muted-foreground" />} />
-        <SummaryCardSkeleton title="Aktiv / Ehemalig" icon={<BadgeCheck className="h-4 w-4 text-muted-foreground" />} />
-        <SummaryCardSkeleton title="Ø Nebenkosten" icon={<Euro className="h-4 w-4 text-muted-foreground" />} />
-      </div>
-      <Card className="overflow-hidden rounded-2xl shadow-md">
-        <CardHeader>
-          <Skeleton className="h-6 w-40 mb-2" />
-        </CardHeader>
-        <CardContent className="flex flex-col gap-6">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="flex flex-col gap-2">
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-3/4" />
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
+      <div className="flex flex-wrap gap-4">
+        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Mieter gesamt</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Users className="h-4 w-4 text-muted-foreground" />
             </div>
-          ))}
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-16 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Aktiv / Ehemalig</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <BadgeCheck className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-24 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Ø Nebenkosten</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Euro className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-20 mb-2" />
+          </CardContent>
+        </Card>
+      </div>
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+        <CardHeader>
+          <div className="flex flex-row items-start justify-between">
+            <div>
+              <Skeleton className="h-6 w-40 mb-2" />
+              <Skeleton className="h-4 w-64" />
+            </div>
+            <Skeleton className="h-10 w-44 rounded-full" />
+          </div>
+        </CardHeader>
+        <div className="px-6">
+          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
+        </div>
+        <CardContent className="flex flex-col gap-6">
+          <div className="flex flex-col gap-4 mt-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-wrap gap-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
+                ))}
+              </div>
+              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
+            </div>
+          </div>
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-lg" />
+            ))}
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/app/(dashboard)/todos/client-wrapper.tsx
+++ b/app/(dashboard)/todos/client-wrapper.tsx
@@ -44,7 +44,7 @@ export default function TodosClientWrapper({ tasks: initialTasks }: TodosClientW
   }, [openAufgabeModal, handleTaskUpdated]);
 
   return (
-    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div
         className="absolute inset-0 z-[-1]"
         style={{

--- a/app/(dashboard)/todos/client-wrapper.tsx
+++ b/app/(dashboard)/todos/client-wrapper.tsx
@@ -51,7 +51,7 @@ export default function TodosClientWrapper({ tasks: initialTasks }: TodosClientW
           backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
         }}
       />
-      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2.5rem]">
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
         <CardHeader>
           <div className="flex flex-row items-start justify-between">
             <div>

--- a/app/(dashboard)/todos/loading.tsx
+++ b/app/(dashboard)/todos/loading.tsx
@@ -1,24 +1,44 @@
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <Skeleton className="h-8 w-48 mb-2" />
-        <Skeleton className="h-4 w-64" />
-      </div>
-      <Card className="overflow-hidden rounded-2xl shadow-md">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
         <CardHeader>
-          <Skeleton className="h-6 w-40 mb-2" />
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="flex items-center gap-2">
-              <Skeleton className="h-4 w-4 rounded-full" />
-              <Skeleton className="h-4 w-full" />
+          <div className="flex flex-row items-start justify-between">
+            <div>
+              <Skeleton className="h-6 w-40 mb-2" />
+              <Skeleton className="h-4 w-64" />
             </div>
-          ))}
+            <Skeleton className="h-10 w-44 rounded-full" />
+          </div>
+        </CardHeader>
+        <div className="px-6">
+          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
+        </div>
+        <CardContent className="flex flex-col gap-6">
+          <div className="flex flex-col gap-4 mt-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-wrap gap-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
+                ))}
+              </div>
+              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
+            </div>
+          </div>
+          <div className="space-y-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-lg" />
+            ))}
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/app/(dashboard)/todos/loading.tsx
+++ b/app/(dashboard)/todos/loading.tsx
@@ -1,46 +1,12 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Skeleton } from "@/components/ui/skeleton"
+import { PageSkeleton } from "@/components/page-skeleton"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
-      <div
-        className="absolute inset-0 z-[-1]"
-        style={{
-          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
-        }}
-      />
-      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
-        <CardHeader>
-          <div className="flex flex-row items-start justify-between">
-            <div>
-              <Skeleton className="h-6 w-40 mb-2" />
-              <Skeleton className="h-4 w-64" />
-            </div>
-            <Skeleton className="h-10 w-44 rounded-full" />
-          </div>
-        </CardHeader>
-        <div className="px-6">
-          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
-        </div>
-        <CardContent className="flex flex-col gap-6">
-          <div className="flex flex-col gap-4 mt-6">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex flex-wrap gap-2">
-                {Array.from({ length: 3 }).map((_, i) => (
-                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
-                ))}
-              </div>
-              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
-            </div>
-          </div>
-          <div className="space-y-3">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <Skeleton key={i} className="h-16 w-full rounded-lg" />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+    <PageSkeleton
+      headerTitleWidth="w-40"
+      headerDescriptionWidth="w-64"
+      buttonWidth="w-44"
+      tableRowCount={6}
+    />
   )
 }

--- a/app/(dashboard)/wohnungen/client.tsx
+++ b/app/(dashboard)/wohnungen/client.tsx
@@ -322,7 +322,7 @@ export default function WohnungenClientView({
   }, [handleEditWohnung]);
 
   return (
-    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div
         className="absolute inset-0 z-[-1]"
         style={{

--- a/app/(dashboard)/wohnungen/loading.tsx
+++ b/app/(dashboard)/wohnungen/loading.tsx
@@ -1,30 +1,91 @@
-import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
-import { SummaryCardSkeleton } from "@/components/summary-card-skeleton";
-import { Home, Key, Euro, Ruler } from "lucide-react";
+import { Home, Key, Euro, Ruler } from "lucide-react"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <SummaryCardSkeleton title="Wohnungen gesamt" icon={<Home className="h-4 w-4 text-muted-foreground" />} />
-        <SummaryCardSkeleton title="Frei / Vermietet" icon={<Key className="h-4 w-4 text-muted-foreground" />} />
-        <SummaryCardSkeleton title="Ø Miete" icon={<Euro className="h-4 w-4 text-muted-foreground" />} />
-        <SummaryCardSkeleton title="Ø Preis pro m²" icon={<Ruler className="h-4 w-4 text-muted-foreground" />} />
-      </div>
-      <Card className="overflow-hidden rounded-2xl shadow-md">
-        <CardHeader>
-          <Skeleton className="h-6 w-40 mb-2" />
-          <Skeleton className="h-4 w-56" />
-        </CardHeader>
-        <CardContent className="flex flex-col gap-6">
-          {/* Loading skeletons for list items */}
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="flex flex-col gap-2">
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-3/4" />
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Wohnungen gesamt</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Home className="h-4 w-4 text-muted-foreground" />
             </div>
-          ))}
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-16 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Frei / Vermietet</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Key className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-24 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Ø Miete</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Euro className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-20 mb-2" />
+          </CardContent>
+        </Card>
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Ø Preis pro m²</CardTitle>
+            <div className="p-2 bg-muted rounded-lg">
+              <Ruler className="h-4 w-4 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-20 mb-2" />
+          </CardContent>
+        </Card>
+      </div>
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+        <CardHeader>
+          <div className="flex flex-row items-start justify-between">
+            <div>
+              <Skeleton className="h-6 w-48 mb-2" />
+              <Skeleton className="h-4 w-72" />
+            </div>
+            <Skeleton className="h-10 w-48 rounded-full" />
+          </div>
+        </CardHeader>
+        <div className="px-6">
+          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
+        </div>
+        <CardContent className="flex flex-col gap-6">
+          <div className="flex flex-col gap-4 mt-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-wrap gap-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
+                ))}
+              </div>
+              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
+            </div>
+          </div>
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-lg" />
+            ))}
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/app/(dashboard)/wohnungen/loading.tsx
+++ b/app/(dashboard)/wohnungen/loading.tsx
@@ -1,93 +1,60 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Home, Key, Euro, Ruler } from "lucide-react"
+import { PageSkeleton } from "@/components/page-skeleton"
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
-      <div
-        className="absolute inset-0 z-[-1]"
-        style={{
-          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
-        }}
-      />
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Wohnungen gesamt</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <Home className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-16 mb-2" />
-          </CardContent>
-        </Card>
-        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Frei / Vermietet</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <Key className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-24 mb-2" />
-          </CardContent>
-        </Card>
-        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Ø Miete</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <Euro className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-20 mb-2" />
-          </CardContent>
-        </Card>
-        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Ø Preis pro m²</CardTitle>
-            <div className="p-2 bg-muted rounded-lg">
-              <Ruler className="h-4 w-4 text-muted-foreground" />
-            </div>
-          </CardHeader>
-          <CardContent>
-            <Skeleton className="h-8 w-20 mb-2" />
-          </CardContent>
-        </Card>
-      </div>
-      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
-        <CardHeader>
-          <div className="flex flex-row items-start justify-between">
-            <div>
-              <Skeleton className="h-6 w-48 mb-2" />
-              <Skeleton className="h-4 w-72" />
-            </div>
-            <Skeleton className="h-10 w-48 rounded-full" />
-          </div>
-        </CardHeader>
-        <div className="px-6">
-          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
-        </div>
-        <CardContent className="flex flex-col gap-6">
-          <div className="flex flex-col gap-4 mt-6">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex flex-wrap gap-2">
-                {Array.from({ length: 3 }).map((_, i) => (
-                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
-                ))}
+    <PageSkeleton
+      buttonWidth="w-48"
+      statsCards={
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Wohnungen gesamt</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <Home className="h-4 w-4 text-muted-foreground" />
               </div>
-              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
-            </div>
-          </div>
-          <div className="space-y-3">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <Skeleton key={i} className="h-16 w-full rounded-lg" />
-            ))}
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-16 mb-2" />
+            </CardContent>
+          </Card>
+          <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Frei / Vermietet</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <Key className="h-4 w-4 text-muted-foreground" />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-24 mb-2" />
+            </CardContent>
+          </Card>
+          <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Ø Miete</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <Euro className="h-4 w-4 text-muted-foreground" />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-20 mb-2" />
+            </CardContent>
+          </Card>
+          <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Ø Preis pro m²</CardTitle>
+              <div className="p-2 bg-muted rounded-lg">
+                <Ruler className="h-4 w-4 text-muted-foreground" />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-20 mb-2" />
+            </CardContent>
+          </Card>
+        </div>
+      }
+    />
   )
 }

--- a/components/charts/maintenance-donut-chart.tsx
+++ b/components/charts/maintenance-donut-chart.tsx
@@ -147,7 +147,7 @@ export function MaintenanceDonutChart() {
   };
 
   return (
-    <Card className="h-full flex flex-col rounded-xl">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Ausgaben nach Kategorie</CardTitle>
         <CardDescription>Verteilung der Betriebskosten</CardDescription>

--- a/components/charts/maintenance-donut-chart.tsx
+++ b/components/charts/maintenance-donut-chart.tsx
@@ -147,7 +147,7 @@ export function MaintenanceDonutChart() {
   };
 
   return (
-    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Ausgaben nach Kategorie</CardTitle>
         <CardDescription>Verteilung der Betriebskosten</CardDescription>

--- a/components/charts/maintenance-donut-chart.tsx
+++ b/components/charts/maintenance-donut-chart.tsx
@@ -147,7 +147,7 @@ export function MaintenanceDonutChart() {
   };
 
   return (
-    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Ausgaben nach Kategorie</CardTitle>
         <CardDescription>Verteilung der Betriebskosten</CardDescription>

--- a/components/charts/occupancy-chart.tsx
+++ b/components/charts/occupancy-chart.tsx
@@ -114,7 +114,7 @@ export function OccupancyChart() {
   }, []);
 
   return (
-    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Belegung</CardTitle>
         <CardDescription>Wohnungsbelegung nach Monat</CardDescription>

--- a/components/charts/occupancy-chart.tsx
+++ b/components/charts/occupancy-chart.tsx
@@ -114,7 +114,7 @@ export function OccupancyChart() {
   }, []);
 
   return (
-    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Belegung</CardTitle>
         <CardDescription>Wohnungsbelegung nach Monat</CardDescription>

--- a/components/charts/occupancy-chart.tsx
+++ b/components/charts/occupancy-chart.tsx
@@ -114,7 +114,7 @@ export function OccupancyChart() {
   }, []);
 
   return (
-    <Card className="h-full flex flex-col rounded-xl">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Belegung</CardTitle>
         <CardDescription>Wohnungsbelegung nach Monat</CardDescription>

--- a/components/charts/revenue-expenses-chart.tsx
+++ b/components/charts/revenue-expenses-chart.tsx
@@ -102,7 +102,7 @@ export function RevenueExpensesChart() {
   }, []);
 
   return (
-    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Einnahmen & Ausgaben</CardTitle>
         <CardDescription>Monatliche Übersicht der Finanzen</CardDescription>

--- a/components/charts/revenue-expenses-chart.tsx
+++ b/components/charts/revenue-expenses-chart.tsx
@@ -102,7 +102,7 @@ export function RevenueExpensesChart() {
   }, []);
 
   return (
-    <Card className="h-full flex flex-col rounded-xl">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Einnahmen & Ausgaben</CardTitle>
         <CardDescription>Monatliche Übersicht der Finanzen</CardDescription>

--- a/components/charts/revenue-expenses-chart.tsx
+++ b/components/charts/revenue-expenses-chart.tsx
@@ -102,7 +102,7 @@ export function RevenueExpensesChart() {
   }, []);
 
   return (
-    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Einnahmen & Ausgaben</CardTitle>
         <CardDescription>Monatliche Übersicht der Finanzen</CardDescription>

--- a/components/cloud-storage-quick-actions.tsx
+++ b/components/cloud-storage-quick-actions.tsx
@@ -74,23 +74,23 @@ export function CloudStorageQuickActions({
   return (
     <div className="space-y-4">
       {/* Search and primary actions row */}
-      <div className="flex items-center justify-between gap-4">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         {/* Search input and sort button on the left */}
-        <div className="flex items-center space-x-2">
-          <div className="relative flex-shrink-0">
+        <div className="flex flex-wrap gap-2">
+          <div className="relative w-full sm:w-auto sm:min-w-[300px]">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
             <Input
               placeholder="Dateien und Ordner durchsuchen..."
               value={searchQuery}
               onChange={(e) => onSearch(e.target.value)}
-              className="pl-10 h-9 w-80"
+              className="pl-10 rounded-full"
             />
           </div>
           
           {/* Sort dropdown next to search */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm" className="h-9">
+              <Button variant="ghost" className="h-9 rounded-full">
                 <SortAsc className="h-4 w-4 mr-2" />
                 Sortieren
               </Button>
@@ -114,7 +114,7 @@ export function CloudStorageQuickActions({
           {/* Categories dropdown next to sort */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm" className="h-9">
+              <Button variant="ghost" className="h-9 rounded-full">
                 <Filter className="h-4 w-4 mr-2" />
                 Kategorien
               </Button>
@@ -160,14 +160,14 @@ export function CloudStorageQuickActions({
         </div>
 
         {/* Primary action buttons and view controls on the right */}
-        <div className="flex items-center space-x-2">
+        <div className="flex items-center gap-2 mt-1">
           {/* View mode toggle */}
-          <div className="flex border rounded-md">
+          <div className="flex items-center gap-1 bg-gray-100 dark:bg-gray-800 rounded-full p-1">
             <Button
               variant={viewMode === 'grid' ? 'default' : 'ghost'}
               size="sm"
               onClick={() => onViewMode('grid')}
-              className="rounded-r-none h-9 px-3"
+              className="h-8 px-3 rounded-full"
             >
               <Grid3X3 className="h-4 w-4" />
             </Button>
@@ -175,7 +175,7 @@ export function CloudStorageQuickActions({
               variant={viewMode === 'list' ? 'default' : 'ghost'}
               size="sm"
               onClick={() => onViewMode('list')}
-              className="rounded-l-none h-9 px-3"
+              className="h-8 px-3 rounded-full"
             >
               <List className="h-4 w-4" />
             </Button>
@@ -184,7 +184,7 @@ export function CloudStorageQuickActions({
           {/* Unified add/upload dropdown */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button className="h-9">
+              <Button className="sm:w-auto">
                 <Plus className="h-4 w-4 mr-2" />
                 Hinzufügen
               </Button>
@@ -211,29 +211,31 @@ export function CloudStorageQuickActions({
 
       {/* Bulk actions when items are selected */}
       {selectedCount > 0 && (
-        <div className="flex items-center space-x-2">
-          <Badge variant="secondary" className="px-3 py-1">
-            {selectedCount} ausgewählt
-          </Badge>
+        <div className="p-4 bg-primary/10 dark:bg-primary/20 border border-primary/20 rounded-lg flex items-center justify-between animate-in slide-in-from-top-2 duration-200">
+          <div className="flex items-center gap-3">
+            <Badge variant="secondary" className="px-3 py-1">
+              {selectedCount} ausgewählt
+            </Badge>
+          </div>
           
-          <div className="flex items-center space-x-1">
+          <div className="flex items-center gap-2">
             {onBulkDownload && (
-              <Button variant="outline" size="sm" onClick={onBulkDownload}>
-                <Download className="h-4 w-4 mr-1" />
+              <Button variant="outline" size="sm" onClick={onBulkDownload} className="h-8 gap-2">
+                <Download className="h-4 w-4" />
                 Herunterladen
               </Button>
             )}
             
             {onBulkArchive && (
-              <Button variant="outline" size="sm" onClick={onBulkArchive}>
-                <Archive className="h-4 w-4 mr-1" />
+              <Button variant="outline" size="sm" onClick={onBulkArchive} className="h-8 gap-2">
+                <Archive className="h-4 w-4" />
                 Archivieren
               </Button>
             )}
             
             {onBulkDelete && (
-              <Button variant="outline" size="sm" onClick={onBulkDelete} className="text-destructive hover:text-destructive">
-                <Trash2 className="h-4 w-4 mr-1" />
+              <Button variant="outline" size="sm" onClick={onBulkDelete} className="h-8 gap-2 text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950">
+                <Trash2 className="h-4 w-4" />
                 Löschen
               </Button>
             )}

--- a/components/cloud-storage-quick-actions.tsx
+++ b/components/cloud-storage-quick-actions.tsx
@@ -234,7 +234,7 @@ export function CloudStorageQuickActions({
             )}
             
             {onBulkDelete && (
-              <Button variant="outline" size="sm" onClick={onBulkDelete} className="h-8 gap-2 text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950">
+              <Button variant="outline" size="sm" onClick={onBulkDelete} className="h-8 gap-2 text-destructive border-destructive/50 hover:bg-destructive/10 hover:text-destructive">
                 <Trash2 className="h-4 w-4" />
                 Löschen
               </Button>

--- a/components/cloud-storage-quick-actions.tsx
+++ b/components/cloud-storage-quick-actions.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
+import { DeleteConfirmationDialog } from "./delete-confirmation-dialog"
 
 interface QuickActionsProps {
   onUpload: () => void
@@ -64,6 +65,7 @@ export function CloudStorageQuickActions({
   onBulkArchive
 }: QuickActionsProps) {
   const [activeFilter, setActiveFilter] = useState<string>('all')
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
   const createFileEnabled = useFeatureFlagEnabled('create-file-option')
 
   const handleFilterChange = (filter: string) => {
@@ -234,10 +236,23 @@ export function CloudStorageQuickActions({
             )}
             
             {onBulkDelete && (
-              <Button variant="outline" size="sm" onClick={onBulkDelete} className="h-8 gap-2 text-destructive border-destructive/50 hover:bg-destructive/10 hover:text-destructive">
-                <Trash2 className="h-4 w-4" />
-                Löschen
-              </Button>
+              <>
+                <Button 
+                  variant="outline" 
+                  size="sm" 
+                  onClick={() => setIsDeleteDialogOpen(true)} 
+                  className="h-8 gap-2 text-destructive border-destructive/50 hover:bg-destructive/10 hover:text-destructive"
+                >
+                  <Trash2 className="h-4 w-4" />
+                  Löschen
+                </Button>
+                <DeleteConfirmationDialog
+                  isOpen={isDeleteDialogOpen}
+                  onOpenChange={setIsDeleteDialogOpen}
+                  onConfirm={onBulkDelete}
+                  itemCount={selectedCount}
+                />
+              </>
             )}
           </div>
         </div>

--- a/components/cloud-storage-simple.tsx
+++ b/components/cloud-storage-simple.tsx
@@ -480,12 +480,25 @@ export function CloudStorageSimple({
   const displayError = storeError || navigationError
   
   return (
-    <div className="h-full flex flex-col">
-      {/* Header */}
-      <div className="border-b bg-card/50 backdrop-blur-sm sticky top-0 z-10">
-        <div className="p-6">
-          {/* Quick Actions */}
-          <CloudStorageQuickActions
+    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
+      <div className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2.5rem] h-full flex flex-col">
+        {/* Header */}
+        <div className="border-b border-gray-200 dark:border-gray-700">
+          <div className="p-6">
+            <div className="flex flex-row items-start justify-between mb-6">
+              <div>
+                <h1 className="text-2xl font-semibold">Dateien</h1>
+                <p className="text-sm text-muted-foreground mt-1">Verwalten Sie hier alle Ihre Dateien und Ordner</p>
+              </div>
+            </div>
+            {/* Quick Actions */}
+            <CloudStorageQuickActions
             onUpload={handleUpload}
             onCreateFolder={handleCreateFolder}
             onCreateFile={handleCreateFile}
@@ -500,8 +513,8 @@ export function CloudStorageSimple({
             onBulkDelete={selectedItems.size > 0 ? handleBulkDelete : undefined}
           />
 
-{/* Breadcrumb Navigation */}
-          <nav className="flex items-center space-x-1 text-base mt-4" aria-label="Breadcrumb">
+            {/* Breadcrumb Navigation */}
+            <nav className="flex items-center space-x-1 text-base mt-4" aria-label="Breadcrumb">
             <ol className="flex items-center space-x-1">
               {breadcrumbs.map((breadcrumb, index) => {
                 const isLast = index === breadcrumbs.length - 1
@@ -564,13 +577,13 @@ export function CloudStorageSimple({
                 </li>
               )}
             </ol>
-          </nav>
+            </nav>
+          </div>
         </div>
-      </div>
 
-      {/* Content Area */}
-      <div className="flex-1 overflow-auto">
-        <div className="p-6">
+        {/* Content Area */}
+        <div className="flex-1 overflow-auto">
+          <div className="p-6">
           {/* Loading State */}
           {showLoading && (
             <div className="text-center py-16">
@@ -744,6 +757,7 @@ export function CloudStorageSimple({
               ))}
             </div>
           )}
+          </div>
         </div>
       </div>
     </div>

--- a/components/cloud-storage-simple.tsx
+++ b/components/cloud-storage-simple.tsx
@@ -510,6 +510,15 @@ export function CloudStorageSimple({
           backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
         }}
       />
+      
+      {/* Summary Cards Container */}
+      <DocumentsSummaryCards
+        totalSize={totalFileSize}
+        onUpload={handleUploadWithFiles}
+        onCreateFolder={handleCreateFolder}
+      />
+      
+      {/* Main File Container */}
       <div className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem] h-full flex flex-col">
         {/* Header */}
         <div className="border-b border-gray-200 dark:border-gray-700">
@@ -520,13 +529,6 @@ export function CloudStorageSimple({
                 <p className="text-sm text-muted-foreground mt-1">Verwalten Sie hier alle Ihre Dateien und Ordner</p>
               </div>
             </div>
-            
-            {/* Summary Cards */}
-            <DocumentsSummaryCards
-              totalSize={totalFileSize}
-              onUpload={handleUploadWithFiles}
-              onCreateFolder={handleCreateFolder}
-            />
             
             {/* Quick Actions */}
             <CloudStorageQuickActions

--- a/components/cloud-storage-simple.tsx
+++ b/components/cloud-storage-simple.tsx
@@ -487,7 +487,7 @@ export function CloudStorageSimple({
           backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
         }}
       />
-      <div className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2.5rem] h-full flex flex-col">
+      <div className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem] h-full flex flex-col">
         {/* Header */}
         <div className="border-b border-gray-200 dark:border-gray-700">
           <div className="p-6">

--- a/components/cloud-storage-simple.tsx
+++ b/components/cloud-storage-simple.tsx
@@ -16,6 +16,7 @@ import { useModalStore } from "@/hooks/use-modal-store"
 import { useToast } from "@/hooks/use-toast"
 import { CloudStorageQuickActions } from "@/components/cloud-storage-quick-actions"
 import { CloudStorageItemCard } from "@/components/cloud-storage-item-card"
+import { DocumentsSummaryCards } from "@/components/documents-summary-cards"
 import { cn } from "@/lib/utils"
 
 interface CloudStorageSimpleProps {
@@ -301,6 +302,13 @@ export function CloudStorageSimple({
   )
   
   /**
+   * Calculate total file size
+   */
+  const totalFileSize = useMemo(() => {
+    return files.reduce((total, file) => total + (file.size || 0), 0)
+  }, [files])
+  
+  /**
    * Handle item selection
    */
   const handleItemSelect = useCallback((itemId: string, selected: boolean) => {
@@ -428,6 +436,21 @@ export function CloudStorageSimple({
   }, [currentNavPath, initialPath, openUploadModal, handleRefresh, toast])
 
   /**
+   * Handle upload with files (for drag & drop)
+   */
+  const handleUploadWithFiles = useCallback((files: File[]) => {
+    const targetPath = currentNavPath || initialPath
+    if (targetPath) {
+      openUploadModal(targetPath, () => {
+        handleRefresh()
+        toast({
+          description: "Dateien wurden erfolgreich hochgeladen."
+        })
+      }, files)
+    }
+  }, [currentNavPath, initialPath, openUploadModal, handleRefresh, toast])
+
+  /**
    * Handle create folder
    */
   const handleCreateFolder = useCallback(() => {
@@ -497,6 +520,14 @@ export function CloudStorageSimple({
                 <p className="text-sm text-muted-foreground mt-1">Verwalten Sie hier alle Ihre Dateien und Ordner</p>
               </div>
             </div>
+            
+            {/* Summary Cards */}
+            <DocumentsSummaryCards
+              totalSize={totalFileSize}
+              onUpload={handleUploadWithFiles}
+              onCreateFolder={handleCreateFolder}
+            />
+            
             {/* Quick Actions */}
             <CloudStorageQuickActions
             onUpload={handleUpload}

--- a/components/cloud-storage-simple.tsx
+++ b/components/cloud-storage-simple.tsx
@@ -503,7 +503,7 @@ export function CloudStorageSimple({
   const displayError = storeError || navigationError
   
   return (
-    <div className="flex flex-col gap-8 p-8 bg-gray-50/50 dark:bg-[#181818]">
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div
         className="absolute inset-0 z-[-1]"
         style={{

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -137,7 +137,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
           isMobile ? "pb-20 pt-6" : "pb-6 pt-6"
         )}>
           <div className={cn(
-            "flex-1 overflow-y-auto border shadow-sm",
+            "flex-1 overflow-y-auto overflow-x-hidden border shadow-sm",
             "rounded-[2rem] md:rounded-[2.5rem]",
             // Enhanced CSS-only fallback for mobile bottom margin
             "mb-4 md:mb-0",

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -71,7 +71,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
             </div>
           </header>
           <main className="flex flex-1 flex-col min-h-0 p-6 pt-6 md:pt-6 main-content-responsive responsive-transition prevent-layout-shift">
-            <div className="flex-1 overflow-y-auto rounded-2xl border border-gray-200 dark:border-gray-800 shadow-sm mb-4 md:mb-0">
+            <div className="flex-1 overflow-y-auto rounded-2xl border shadow-sm mb-4 md:mb-0">
               <div className="p-6">
                 <div className="space-y-4">
                   <div className="h-8 bg-muted rounded animate-pulse" />
@@ -137,7 +137,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
           isMobile ? "pb-20 pt-6" : "pb-6 pt-6"
         )}>
           <div className={cn(
-            "flex-1 overflow-y-auto border border-gray-200 dark:border-gray-800 shadow-sm",
+            "flex-1 overflow-y-auto border shadow-sm",
             "rounded-[2rem] md:rounded-[2.5rem]",
             // Enhanced CSS-only fallback for mobile bottom margin
             "mb-4 md:mb-0",

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -71,7 +71,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
             </div>
           </header>
           <main className="flex flex-1 flex-col min-h-0 p-6 pt-6 md:pt-6 main-content-responsive responsive-transition prevent-layout-shift">
-            <div className="flex-1 overflow-y-auto rounded-2xl bg-white dark:bg-[#0d1117] shadow-sm mb-4 md:mb-0">
+            <div className="flex-1 overflow-y-auto rounded-2xl border border-gray-200 dark:border-gray-800 shadow-sm mb-4 md:mb-0">
               <div className="p-6">
                 <div className="space-y-4">
                   <div className="h-8 bg-muted rounded animate-pulse" />
@@ -137,7 +137,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
           isMobile ? "pb-20 pt-6" : "pb-6 pt-6"
         )}>
           <div className={cn(
-            "flex-1 overflow-y-auto bg-white dark:bg-[#0d1117] shadow-sm",
+            "flex-1 overflow-y-auto border border-gray-200 dark:border-gray-800 shadow-sm",
             "rounded-[2rem] md:rounded-[2.5rem]",
             // Enhanced CSS-only fallback for mobile bottom margin
             "mb-4 md:mb-0",

--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -71,7 +71,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
             </div>
           </header>
           <main className="flex flex-1 flex-col min-h-0 p-6 pt-6 md:pt-6 main-content-responsive responsive-transition prevent-layout-shift">
-            <div className="flex-1 overflow-y-auto rounded-2xl bg-white border shadow-sm mb-4 md:mb-0">
+            <div className="flex-1 overflow-y-auto rounded-2xl bg-white dark:bg-[#0d1117] shadow-sm mb-4 md:mb-0">
               <div className="p-6">
                 <div className="space-y-4">
                   <div className="h-8 bg-muted rounded animate-pulse" />
@@ -137,7 +137,7 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
           isMobile ? "pb-20 pt-6" : "pb-6 pt-6"
         )}>
           <div className={cn(
-            "flex-1 overflow-y-auto bg-white dark:main-container border shadow-sm",
+            "flex-1 overflow-y-auto bg-white dark:bg-[#0d1117] shadow-sm",
             "rounded-[2rem] md:rounded-[2.5rem]",
             // Enhanced CSS-only fallback for mobile bottom margin
             "mb-4 md:mb-0",

--- a/components/delete-confirmation-dialog.tsx
+++ b/components/delete-confirmation-dialog.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { AlertCircle, Trash2 } from "lucide-react"
+
+export function DeleteConfirmationDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  itemCount = 0,
+  isFolder = false,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => void
+  itemCount?: number
+  isFolder?: boolean
+}) {
+  const itemText = itemCount > 1 ? `${itemCount} ${isFolder ? 'Ordner' : 'Dateien'}` : isFolder ? 'diesen Ordner' : 'diese Datei'
+  
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <div className="flex items-center gap-2">
+            <AlertCircle className="h-5 w-5 text-destructive" />
+            <DialogTitle>Löschen bestätigen</DialogTitle>
+          </div>
+          <DialogDescription className="pt-2">
+            Möchten Sie wirklich {itemText} unwiderruflich löschen? Diese Aktion kann nicht rückgängig gemacht werden.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="sm:justify-between">
+          <Button 
+            variant="outline" 
+            onClick={() => onOpenChange(false)}
+            className="mt-2 sm:mt-0"
+          >
+            Abbrechen
+          </Button>
+          <Button 
+            variant="destructive" 
+            onClick={() => {
+              onConfirm()
+              onOpenChange(false)
+            }}
+            className="gap-2"
+          >
+            <Trash2 className="h-4 w-4" />
+            Endgültig löschen
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/delete-confirmation-dialog.tsx
+++ b/components/delete-confirmation-dialog.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Button } from "@/components/ui/button"
+import { Button } from "./ui/button"
 import {
   Dialog,
   DialogContent,
@@ -8,43 +8,44 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog"
-import { AlertCircle, Trash2 } from "lucide-react"
+} from "./ui/dialog"
 
-export function DeleteConfirmationDialog({
-  open,
-  onOpenChange,
-  onConfirm,
-  itemCount = 0,
-  isFolder = false,
-}: {
-  open: boolean
+type DeleteConfirmationDialogProps = {
+  isOpen: boolean
   onOpenChange: (open: boolean) => void
   onConfirm: () => void
+  title?: string
+  description?: string
+  confirmText?: string
+  cancelText?: string
   itemCount?: number
-  isFolder?: boolean
-}) {
-  const itemText = itemCount > 1 ? `${itemCount} ${isFolder ? 'Ordner' : 'Dateien'}` : isFolder ? 'diesen Ordner' : 'diese Datei'
-  
+}
+
+export function DeleteConfirmationDialog({
+  isOpen,
+  onOpenChange,
+  onConfirm,
+  title = "Löschen bestätigen",
+  description = "Sind Sie sicher, dass Sie die ausgewählten Elemente löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
+  confirmText = "Löschen",
+  cancelText = "Abbrechen",
+  itemCount
+}: DeleteConfirmationDialogProps) {
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px]">
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent>
         <DialogHeader>
-          <div className="flex items-center gap-2">
-            <AlertCircle className="h-5 w-5 text-destructive" />
-            <DialogTitle>Löschen bestätigen</DialogTitle>
-          </div>
-          <DialogDescription className="pt-2">
-            Möchten Sie wirklich {itemText} unwiderruflich löschen? Diese Aktion kann nicht rückgängig gemacht werden.
+          <DialogTitle>
+            {title}
+          </DialogTitle>
+          <DialogDescription>
+            {itemCount ? `Sie haben ${itemCount} Element${itemCount > 1 ? 'e' : ''} zum Löschen ausgewählt. ` : ''}
+            {description}
           </DialogDescription>
         </DialogHeader>
-        <DialogFooter className="sm:justify-between">
-          <Button 
-            variant="outline" 
-            onClick={() => onOpenChange(false)}
-            className="mt-2 sm:mt-0"
-          >
-            Abbrechen
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {cancelText}
           </Button>
           <Button 
             variant="destructive" 
@@ -52,10 +53,8 @@ export function DeleteConfirmationDialog({
               onConfirm()
               onOpenChange(false)
             }}
-            className="gap-2"
           >
-            <Trash2 className="h-4 w-4" />
-            Endgültig löschen
+            {confirmText}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/components/documents-summary-cards.tsx
+++ b/components/documents-summary-cards.tsx
@@ -110,10 +110,13 @@ export function DocumentsSummaryCards({
             <Upload className="h-4 w-4 text-muted-foreground" />
           </div>
           <div>
+            <div className="text-2xl font-bold mb-1">
+              {isDragging ? "Ablegen" : "Hochladen"}
+            </div>
             <p className="text-xs text-muted-foreground">
               {isDragging 
                 ? "Dateien hier ablegen..." 
-                : "Klicken oder Dateien hierher ziehen"
+                : "Klicken oder hierher ziehen"
               }
             </p>
           </div>
@@ -144,8 +147,11 @@ export function DocumentsSummaryCards({
             <FolderPlus className="h-4 w-4 text-muted-foreground" />
           </div>
           <div>
+            <div className="text-2xl font-bold mb-1">
+              Neuer Ordner
+            </div>
             <p className="text-xs text-muted-foreground">
-              Neuen Ordner anlegen
+              Klicken zum Erstellen
             </p>
           </div>
         </div>

--- a/components/documents-summary-cards.tsx
+++ b/components/documents-summary-cards.tsx
@@ -87,11 +87,12 @@ export function DocumentsSummaryCards({
   }, [])
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+    <div className="flex flex-wrap gap-4">
       {/* Drag & Drop Upload Card */}
       <Card
         className={cn(
-          "relative overflow-hidden transition-all duration-200 cursor-pointer group",
+          "relative overflow-hidden rounded-3xl shadow-sm transition-all duration-200 cursor-pointer group flex-1",
+          "bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251]",
           "hover:shadow-md hover:scale-[1.02]",
           isDragging && "ring-2 ring-primary ring-offset-2 scale-[1.02]"
         )}
@@ -102,28 +103,20 @@ export function DocumentsSummaryCards({
         onClick={handleUploadClick}
       >
         <div className="p-6">
-          <div className="flex items-center justify-between mb-2">
-            <div className={cn(
-              "p-2 rounded-lg transition-colors",
-              isDragging 
-                ? "bg-primary/20" 
-                : "bg-blue-500/10 group-hover:bg-blue-500/20"
-            )}>
-              <Upload className={cn(
-                "h-5 w-5 transition-colors",
-                isDragging ? "text-primary" : "text-blue-500"
-              )} />
-            </div>
+          <div className="flex items-center justify-between space-y-0 pb-2">
+            <h3 className="text-sm font-medium">
+              Dateien hochladen
+            </h3>
+            <Upload className="h-4 w-4 text-muted-foreground" />
           </div>
-          <h3 className="text-sm font-medium text-muted-foreground mb-1">
-            Dateien hochladen
-          </h3>
-          <p className="text-xs text-muted-foreground/70">
-            {isDragging 
-              ? "Dateien hier ablegen..." 
-              : "Klicken oder Dateien hierher ziehen"
-            }
-          </p>
+          <div>
+            <p className="text-xs text-muted-foreground">
+              {isDragging 
+                ? "Dateien hier ablegen..." 
+                : "Klicken oder Dateien hierher ziehen"
+              }
+            </p>
+          </div>
         </div>
         <input
           ref={fileInputRef}
@@ -136,38 +129,45 @@ export function DocumentsSummaryCards({
 
       {/* Create Folder Card */}
       <Card
-        className="relative overflow-hidden transition-all duration-200 cursor-pointer group hover:shadow-md hover:scale-[1.02]"
+        className={cn(
+          "relative overflow-hidden rounded-3xl shadow-sm transition-all duration-200 cursor-pointer group flex-1",
+          "bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251]",
+          "hover:shadow-md hover:scale-[1.02]"
+        )}
         onClick={onCreateFolder}
       >
         <div className="p-6">
-          <div className="flex items-center justify-between mb-2">
-            <div className="p-2 rounded-lg bg-green-500/10 group-hover:bg-green-500/20 transition-colors">
-              <FolderPlus className="h-5 w-5 text-green-500" />
-            </div>
+          <div className="flex items-center justify-between space-y-0 pb-2">
+            <h3 className="text-sm font-medium">
+              Ordner erstellen
+            </h3>
+            <FolderPlus className="h-4 w-4 text-muted-foreground" />
           </div>
-          <h3 className="text-sm font-medium text-muted-foreground mb-1">
-            Ordner erstellen
-          </h3>
-          <p className="text-xs text-muted-foreground/70">
-            Neuen Ordner anlegen
-          </p>
+          <div>
+            <p className="text-xs text-muted-foreground">
+              Neuen Ordner anlegen
+            </p>
+          </div>
         </div>
       </Card>
 
       {/* Total Size Card */}
-      <Card className="relative overflow-hidden">
+      <Card className={cn(
+        "relative overflow-hidden rounded-3xl shadow-sm transition-opacity duration-200 flex-1",
+        "bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251]"
+      )}>
         <div className="p-6">
-          <div className="flex items-center justify-between mb-2">
-            <div className="p-2 rounded-lg bg-purple-500/10">
-              <HardDrive className="h-5 w-5 text-purple-500" />
+          <div className="flex items-center justify-between space-y-0 pb-2">
+            <h3 className="text-sm font-medium">
+              Gesamtgröße
+            </h3>
+            <HardDrive className="h-4 w-4 text-muted-foreground" />
+          </div>
+          <div>
+            <div className="text-2xl font-bold">
+              {formatFileSize(totalSize)}
             </div>
           </div>
-          <h3 className="text-sm font-medium text-muted-foreground mb-1">
-            Gesamtgröße
-          </h3>
-          <p className="text-2xl font-semibold">
-            {formatFileSize(totalSize)}
-          </p>
         </div>
       </Card>
     </div>

--- a/components/documents-summary-cards.tsx
+++ b/components/documents-summary-cards.tsx
@@ -1,0 +1,175 @@
+"use client"
+
+import { useCallback, useState, useRef } from "react"
+import { Upload, FolderPlus, HardDrive } from "lucide-react"
+import { Card } from "@/components/ui/card"
+import { cn } from "@/lib/utils"
+import { useToast } from "@/hooks/use-toast"
+
+interface DocumentsSummaryCardsProps {
+  totalSize: number
+  onUpload: (files: File[]) => void
+  onCreateFolder: () => void
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes === 0) return '0 B'
+  const k = 1024
+  const sizes = ['B', 'KB', 'MB', 'GB', 'TB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return `${(bytes / Math.pow(k, i)).toFixed(2)} ${sizes[i]}`
+}
+
+export function DocumentsSummaryCards({
+  totalSize,
+  onUpload,
+  onCreateFolder
+}: DocumentsSummaryCardsProps) {
+  const { toast } = useToast()
+  const [isDragging, setIsDragging] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const dragCounter = useRef(0)
+
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    dragCounter.current++
+    if (e.dataTransfer.items && e.dataTransfer.items.length > 0) {
+      setIsDragging(true)
+    }
+  }, [])
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    dragCounter.current--
+    if (dragCounter.current === 0) {
+      setIsDragging(false)
+    }
+  }, [])
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+  }, [])
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragging(false)
+    dragCounter.current = 0
+
+    const files = Array.from(e.dataTransfer.files)
+    if (files.length > 0) {
+      onUpload(files)
+      toast({
+        description: `${files.length} Datei${files.length > 1 ? 'en' : ''} wird hochgeladen...`
+      })
+    }
+  }, [onUpload, toast])
+
+  const handleFileInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || [])
+    if (files.length > 0) {
+      onUpload(files)
+      toast({
+        description: `${files.length} Datei${files.length > 1 ? 'en' : ''} wird hochgeladen...`
+      })
+    }
+    // Reset input
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ''
+    }
+  }, [onUpload, toast])
+
+  const handleUploadClick = useCallback(() => {
+    fileInputRef.current?.click()
+  }, [])
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+      {/* Drag & Drop Upload Card */}
+      <Card
+        className={cn(
+          "relative overflow-hidden transition-all duration-200 cursor-pointer group",
+          "hover:shadow-md hover:scale-[1.02]",
+          isDragging && "ring-2 ring-primary ring-offset-2 scale-[1.02]"
+        )}
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+        onClick={handleUploadClick}
+      >
+        <div className="p-6">
+          <div className="flex items-center justify-between mb-2">
+            <div className={cn(
+              "p-2 rounded-lg transition-colors",
+              isDragging 
+                ? "bg-primary/20" 
+                : "bg-blue-500/10 group-hover:bg-blue-500/20"
+            )}>
+              <Upload className={cn(
+                "h-5 w-5 transition-colors",
+                isDragging ? "text-primary" : "text-blue-500"
+              )} />
+            </div>
+          </div>
+          <h3 className="text-sm font-medium text-muted-foreground mb-1">
+            Dateien hochladen
+          </h3>
+          <p className="text-xs text-muted-foreground/70">
+            {isDragging 
+              ? "Dateien hier ablegen..." 
+              : "Klicken oder Dateien hierher ziehen"
+            }
+          </p>
+        </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={handleFileInputChange}
+        />
+      </Card>
+
+      {/* Create Folder Card */}
+      <Card
+        className="relative overflow-hidden transition-all duration-200 cursor-pointer group hover:shadow-md hover:scale-[1.02]"
+        onClick={onCreateFolder}
+      >
+        <div className="p-6">
+          <div className="flex items-center justify-between mb-2">
+            <div className="p-2 rounded-lg bg-green-500/10 group-hover:bg-green-500/20 transition-colors">
+              <FolderPlus className="h-5 w-5 text-green-500" />
+            </div>
+          </div>
+          <h3 className="text-sm font-medium text-muted-foreground mb-1">
+            Ordner erstellen
+          </h3>
+          <p className="text-xs text-muted-foreground/70">
+            Neuen Ordner anlegen
+          </p>
+        </div>
+      </Card>
+
+      {/* Total Size Card */}
+      <Card className="relative overflow-hidden">
+        <div className="p-6">
+          <div className="flex items-center justify-between mb-2">
+            <div className="p-2 rounded-lg bg-purple-500/10">
+              <HardDrive className="h-5 w-5 text-purple-500" />
+            </div>
+          </div>
+          <h3 className="text-sm font-medium text-muted-foreground mb-1">
+            Gesamtgröße
+          </h3>
+          <p className="text-2xl font-semibold">
+            {formatFileSize(totalSize)}
+          </p>
+        </div>
+      </Card>
+    </div>
+  )
+}

--- a/components/documents-summary-cards.tsx
+++ b/components/documents-summary-cards.tsx
@@ -87,7 +87,7 @@ export function DocumentsSummaryCards({
   }, [])
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
       {/* Drag & Drop Upload Card */}
       <Card
         className={cn(

--- a/components/file-preview-modal.tsx
+++ b/components/file-preview-modal.tsx
@@ -342,6 +342,7 @@ export function FilePreviewModal({ className }: FilePreviewModalProps) {
                 onDownload={handleDownload}
                 onError={(error) => setError(error)}
                 className="h-full"
+                forceCustomViewer={true}
               />
             ) : isLoading ? (
               <div className="flex items-center justify-center h-full bg-muted/10">

--- a/components/file-preview-modal.tsx
+++ b/components/file-preview-modal.tsx
@@ -329,150 +329,135 @@ export function FilePreviewModal({ className }: FilePreviewModalProps) {
         )}
 
         {/* Content */}
-        <div className={cn(
-          "flex-1 overflow-hidden rounded-b-lg",
-          isPdf ? "bg-transparent" : "bg-muted/10"
-        )}>
-          {isPdf ? (
-            // PDF viewer handles its own loading and error states
-            fileUrl && !isLoading && !error ? (
-              <PDFViewer
-                fileUrl={fileUrl}
-                fileName={filePreviewData.name}
-                onDownload={handleDownload}
-                onError={(error) => setError(error)}
-                className="h-full"
-                forceCustomViewer={true}
-              />
-            ) : isLoading ? (
-              <div className="flex items-center justify-center h-full bg-muted/10">
-                <div className="text-center">
-                  <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
-                  <p className="text-muted-foreground text-lg">Lade PDF...</p>
+        {isPdf ? (
+          // PDF viewer handles its own loading and error states
+          fileUrl && !isLoading && !error ? (
+            <PDFViewer
+              fileUrl={fileUrl}
+              fileName={filePreviewData.name}
+              onDownload={handleDownload}
+              onError={(error) => setError(error)}
+              className="flex-1 overflow-hidden rounded-b-lg"
+              forceCustomViewer={true}
+            />
+          ) : isLoading ? (
+            <div className="flex-1 flex items-center justify-center bg-muted/10 rounded-b-lg">
+              <div className="text-center">
+                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+                <p className="text-muted-foreground text-lg">Lade PDF...</p>
+              </div>
+            </div>
+          ) : error ? (
+            <div className="flex-1 flex items-center justify-center bg-muted/10 rounded-b-lg">
+              <div className="text-center max-w-md">
+                <div className="bg-destructive/10 rounded-full p-4 w-16 h-16 mx-auto mb-4 flex items-center justify-center">
+                  <ExternalLink className="h-8 w-8 text-destructive" />
+                </div>
+                <h3 className="text-lg font-semibold mb-2">Fehler beim Laden</h3>
+                <p className="text-destructive mb-6">{error}</p>
+                <Button onClick={loadFileUrl} variant="outline">
+                  Erneut versuchen
+                </Button>
+              </div>
+            </div>
+          ) : null
+        ) : (
+          // Non-PDF content
+          isLoading ? (
+            <div className="flex-1 flex items-center justify-center bg-muted/10 rounded-b-lg">
+              <div className="text-center">
+                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+                <p className="text-muted-foreground text-lg">Lade Datei...</p>
+              </div>
+            </div>
+          ) : error ? (
+            <div className="flex-1 flex items-center justify-center bg-muted/10 rounded-b-lg">
+              <div className="text-center max-w-md">
+                <div className="bg-destructive/10 rounded-full p-4 w-16 h-16 mx-auto mb-4 flex items-center justify-center">
+                  <ExternalLink className="h-8 w-8 text-destructive" />
+                </div>
+                <h3 className="text-lg font-semibold mb-2">Fehler beim Laden</h3>
+                <p className="text-destructive mb-6">{error}</p>
+                <Button onClick={loadFileUrl} variant="outline">
+                  Erneut versuchen
+                </Button>
+              </div>
+            </div>
+          ) : fileUrl ? (
+            isImage ? (
+              <div 
+                className="flex-1 flex items-center justify-center p-6 overflow-hidden bg-gradient-to-br from-muted/20 to-muted/5 rounded-b-lg"
+                onWheel={(e) => {
+                  if (e.ctrlKey || e.metaKey) {
+                    e.preventDefault()
+                    if (e.deltaY < 0) {
+                      handleZoomIn()
+                    } else {
+                      handleZoomOut()
+                    }
+                  }
+                }}
+              >
+                <div className="relative overflow-hidden rounded-lg">
+                  <img
+                    src={fileUrl}
+                    alt={filePreviewData.name}
+                    className="max-w-none transition-all duration-300 ease-in-out shadow-2xl rounded-lg border border-border/20"
+                    style={{
+                      transform: `scale(${zoom / 100}) rotate(${rotation}deg)`,
+                      transformOrigin: 'center',
+                      maxHeight: zoom <= 100 ? 'calc(98vh - 180px)' : 'none',
+                      maxWidth: zoom <= 100 ? 'calc(98vw - 80px)' : 'none'
+                    }}
+                    onError={() => setError('Bild konnte nicht geladen werden')}
+                    onLoad={() => {
+                      // Auto-fit large images to screen on initial load
+                      const img = document.querySelector('img[alt="' + filePreviewData.name + '"]') as HTMLImageElement
+                      if (img && zoom === 100) {
+                        const containerWidth = img.parentElement?.parentElement?.clientWidth || 0
+                        const containerHeight = img.parentElement?.parentElement?.clientHeight || 0
+                        const imgWidth = img.naturalWidth
+                        const imgHeight = img.naturalHeight
+                        
+                        if (imgWidth > containerWidth - 80 || imgHeight > containerHeight - 80) {
+                          const scaleX = (containerWidth - 80) / imgWidth
+                          const scaleY = (containerHeight - 80) / imgHeight
+                          const scale = Math.min(scaleX, scaleY, 1) * 100
+                          if (scale < 100) {
+                            setZoom(Math.round(scale))
+                          }
+                        }
+                      }
+                    }}
+                    draggable={false}
+                  />
                 </div>
               </div>
-            ) : error ? (
-              <div className="flex items-center justify-center h-full bg-muted/10">
+            ) : (
+              <div className="flex-1 flex items-center justify-center bg-muted/10 rounded-b-lg">
                 <div className="text-center max-w-md">
-                  <div className="bg-destructive/10 rounded-full p-4 w-16 h-16 mx-auto mb-4 flex items-center justify-center">
-                    <ExternalLink className="h-8 w-8 text-destructive" />
+                  <div className="bg-muted rounded-full p-6 w-20 h-20 mx-auto mb-6 flex items-center justify-center">
+                    <ExternalLink className="h-10 w-10 text-muted-foreground" />
                   </div>
-                  <h3 className="text-lg font-semibold mb-2">Fehler beim Laden</h3>
-                  <p className="text-destructive mb-6">{error}</p>
-                  <Button onClick={loadFileUrl} variant="outline">
-                    Erneut versuchen
-                  </Button>
-                </div>
-              </div>
-            ) : null
-          ) : (
-            // Non-PDF content
-            <>
-              {isLoading && (
-                <div className="flex items-center justify-center h-full">
-                  <div className="text-center">
-                    <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
-                    <p className="text-muted-foreground text-lg">Lade Datei...</p>
-                  </div>
-                </div>
-              )}
-
-              {error && (
-                <div className="flex items-center justify-center h-full">
-                  <div className="text-center max-w-md">
-                    <div className="bg-destructive/10 rounded-full p-4 w-16 h-16 mx-auto mb-4 flex items-center justify-center">
-                      <ExternalLink className="h-8 w-8 text-destructive" />
-                    </div>
-                    <h3 className="text-lg font-semibold mb-2">Fehler beim Laden</h3>
-                    <p className="text-destructive mb-6">{error}</p>
-                    <Button onClick={loadFileUrl} variant="outline">
-                      Erneut versuchen
+                  <h3 className="text-xl font-semibold mb-2">Vorschau nicht verfügbar</h3>
+                  <p className="text-muted-foreground mb-6">
+                    Für diesen Dateityp ist keine Vorschau verfügbar. Sie können die Datei herunterladen oder extern öffnen.
+                  </p>
+                  <div className="flex gap-3 justify-center">
+                    <Button onClick={handleDownload} variant="outline">
+                      <Download className="h-4 w-4 mr-2" />
+                      Herunterladen
+                    </Button>
+                    <Button onClick={handleOpenExternal} variant="outline">
+                      <ExternalLink className="h-4 w-4 mr-2" />
+                      Extern öffnen
                     </Button>
                   </div>
                 </div>
-              )}
-
-              {fileUrl && !isLoading && !error && (
-                <>
-                  {isImage && (
-                    <div 
-                      className="h-full flex items-center justify-center p-6 overflow-hidden bg-gradient-to-br from-muted/20 to-muted/5 rounded-b-lg"
-                      onWheel={(e) => {
-                        if (e.ctrlKey || e.metaKey) {
-                          e.preventDefault()
-                          if (e.deltaY < 0) {
-                            handleZoomIn()
-                          } else {
-                            handleZoomOut()
-                          }
-                        }
-                      }}
-                    >
-                      <div className="relative overflow-hidden rounded-lg">
-                        <img
-                          src={fileUrl}
-                          alt={filePreviewData.name}
-                          className="max-w-none transition-all duration-300 ease-in-out shadow-2xl rounded-lg border border-border/20"
-                          style={{
-                            transform: `scale(${zoom / 100}) rotate(${rotation}deg)`,
-                            transformOrigin: 'center',
-                            maxHeight: zoom <= 100 ? 'calc(98vh - 180px)' : 'none',
-                            maxWidth: zoom <= 100 ? 'calc(98vw - 80px)' : 'none'
-                          }}
-                          onError={() => setError('Bild konnte nicht geladen werden')}
-                          onLoad={() => {
-                            // Auto-fit large images to screen on initial load
-                            const img = document.querySelector('img[alt="' + filePreviewData.name + '"]') as HTMLImageElement
-                            if (img && zoom === 100) {
-                              const containerWidth = img.parentElement?.parentElement?.clientWidth || 0
-                              const containerHeight = img.parentElement?.parentElement?.clientHeight || 0
-                              const imgWidth = img.naturalWidth
-                              const imgHeight = img.naturalHeight
-                              
-                              if (imgWidth > containerWidth - 80 || imgHeight > containerHeight - 80) {
-                                const scaleX = (containerWidth - 80) / imgWidth
-                                const scaleY = (containerHeight - 80) / imgHeight
-                                const scale = Math.min(scaleX, scaleY, 1) * 100
-                                if (scale < 100) {
-                                  setZoom(Math.round(scale))
-                                }
-                              }
-                            }
-                          }}
-                          draggable={false}
-                        />
-                      </div>
-                    </div>
-                  )}
-
-                  {!isImage && (
-                    <div className="flex items-center justify-center h-full rounded-b-lg">
-                      <div className="text-center max-w-md">
-                        <div className="bg-muted rounded-full p-6 w-20 h-20 mx-auto mb-6 flex items-center justify-center">
-                          <ExternalLink className="h-10 w-10 text-muted-foreground" />
-                        </div>
-                        <h3 className="text-xl font-semibold mb-2">Vorschau nicht verfügbar</h3>
-                        <p className="text-muted-foreground mb-6">
-                          Für diesen Dateityp ist keine Vorschau verfügbar. Sie können die Datei herunterladen oder extern öffnen.
-                        </p>
-                        <div className="flex gap-3 justify-center">
-                          <Button onClick={handleDownload} variant="outline">
-                            <Download className="h-4 w-4 mr-2" />
-                            Herunterladen
-                          </Button>
-                          <Button onClick={handleOpenExternal} variant="outline">
-                            <ExternalLink className="h-4 w-4 mr-2" />
-                            Extern öffnen
-                          </Button>
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                </>
-              )}
-            </>
-          )}
-        </div>
+              </div>
+            )
+          ) : null
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/components/finance-visualization.tsx
+++ b/components/finance-visualization.tsx
@@ -176,7 +176,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
   }, [chartData])
 
   return (
-    <Card className="p-4 bg-white dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="p-4 bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl">
       <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-6">
         <ToggleGroup type="single" value={selectedChart} onValueChange={setSelectedChart} className="grid grid-cols-2 md:grid-cols-4 gap-2">
           <ToggleGroupItem value="apartment-income">Wohnung</ToggleGroupItem>

--- a/components/finance-visualization.tsx
+++ b/components/finance-visualization.tsx
@@ -84,7 +84,7 @@ const isChartDataEmpty = (data: ChartData): boolean => {
 
 // Empty state component
 const EmptyChartState = ({ title, description }: { title: string; description: string }) => (
-  <Card className="rounded-[1.5rem]">
+  <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
     <CardHeader>
       <CardTitle>{title}</CardTitle>
       <CardDescription>{description}</CardDescription>
@@ -176,7 +176,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
   }, [chartData])
 
   return (
-    <Card className="p-4 rounded-[2rem]">
+    <Card className="p-4 bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-6">
         <ToggleGroup type="single" value={selectedChart} onValueChange={setSelectedChart} className="grid grid-cols-2 md:grid-cols-4 gap-2">
           <ToggleGroupItem value="apartment-income">Wohnung</ToggleGroupItem>
@@ -247,7 +247,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
         <div className="animate-in fade-in-0 duration-500">
         {selectedChart === 'apartment-income' && (
           hasUserData ? (
-            <Card className="rounded-[1.5rem]">
+            <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
               <CardHeader>
                 <CardTitle>Einnahmen nach Wohnung</CardTitle>
                 <CardDescription>Verteilung der Mieteinnahmen nach Wohnungen in {selectedYear}</CardDescription>
@@ -285,7 +285,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
         )}
         {selectedChart === 'monthly-income' && (
           hasUserData ? (
-            <Card className="rounded-[1.5rem]">
+            <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
               <CardHeader>
                 <CardTitle>Monatliche Einnahmen</CardTitle>
                 <CardDescription>Monatliche Einnahmen für das Jahr {selectedYear}</CardDescription>
@@ -323,7 +323,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
         )}
         {selectedChart === 'income-expense' && (
           hasUserData ? (
-            <Card className="rounded-[1.5rem]">
+            <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
               <CardHeader>
                 <CardTitle>Einnahmen-Ausgaben-Verhältnis</CardTitle>
                 <CardDescription>Vergleich von Einnahmen und Ausgaben im Jahr {selectedYear}</CardDescription>
@@ -366,7 +366,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
         )}
         {selectedChart === 'expense-categories' && (
           hasUserData ? (
-            <Card className="rounded-[1.5rem]">
+            <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
               <CardHeader>
                 <CardTitle>Ausgabenkategorien</CardTitle>
                 <CardDescription>Verteilung der Ausgaben nach Kategorien in {selectedYear}</CardDescription>

--- a/components/finance-visualization.tsx
+++ b/components/finance-visualization.tsx
@@ -176,7 +176,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
   }, [chartData])
 
   return (
-    <Card className="p-4 bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="p-4 bg-white dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-6">
         <ToggleGroup type="single" value={selectedChart} onValueChange={setSelectedChart} className="grid grid-cols-2 md:grid-cols-4 gap-2">
           <ToggleGroupItem value="apartment-income">Wohnung</ToggleGroupItem>
@@ -247,7 +247,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
         <div className="animate-in fade-in-0 duration-500">
         {selectedChart === 'apartment-income' && (
           hasUserData ? (
-            <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+            <Card className="rounded-[1.5rem]">
               <CardHeader>
                 <CardTitle>Einnahmen nach Wohnung</CardTitle>
                 <CardDescription>Verteilung der Mieteinnahmen nach Wohnungen in {selectedYear}</CardDescription>
@@ -285,7 +285,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
         )}
         {selectedChart === 'monthly-income' && (
           hasUserData ? (
-            <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+            <Card className="bg-white dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
               <CardHeader>
                 <CardTitle>Monatliche Einnahmen</CardTitle>
                 <CardDescription>Monatliche Einnahmen für das Jahr {selectedYear}</CardDescription>

--- a/components/finance-visualization.tsx
+++ b/components/finance-visualization.tsx
@@ -285,7 +285,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
         )}
         {selectedChart === 'monthly-income' && (
           hasUserData ? (
-            <Card className="bg-white dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+            <Card className="rounded-[1.5rem]">
               <CardHeader>
                 <CardTitle>Monatliche Einnahmen</CardTitle>
                 <CardDescription>Monatliche Einnahmen für das Jahr {selectedYear}</CardDescription>
@@ -323,7 +323,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
         )}
         {selectedChart === 'income-expense' && (
           hasUserData ? (
-            <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+            <Card className="rounded-[1.5rem]">
               <CardHeader>
                 <CardTitle>Einnahmen-Ausgaben-Verhältnis</CardTitle>
                 <CardDescription>Vergleich von Einnahmen und Ausgaben im Jahr {selectedYear}</CardDescription>
@@ -366,7 +366,7 @@ export function FinanceVisualization({ finances, summaryData, availableYears }: 
         )}
         {selectedChart === 'expense-categories' && (
           hasUserData ? (
-            <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+            <Card className="rounded-[1.5rem]">
               <CardHeader>
                 <CardTitle>Ausgabenkategorien</CardTitle>
                 <CardDescription>Verteilung der Ausgaben nach Kategorien in {selectedYear}</CardDescription>

--- a/components/last-transactions-container.tsx
+++ b/components/last-transactions-container.tsx
@@ -113,7 +113,7 @@ export function LastTransactionsContainer() {
   };
 
   return (
-    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-3">
         <div className="flex items-center justify-between">
           <div>

--- a/components/last-transactions-container.tsx
+++ b/components/last-transactions-container.tsx
@@ -113,7 +113,7 @@ export function LastTransactionsContainer() {
   };
 
   return (
-    <Card className="h-full flex flex-col rounded-xl">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-3">
         <div className="flex items-center justify-between">
           <div>

--- a/components/last-transactions-container.tsx
+++ b/components/last-transactions-container.tsx
@@ -113,7 +113,7 @@ export function LastTransactionsContainer() {
   };
 
   return (
-    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-3">
         <div className="flex items-center justify-between">
           <div>

--- a/components/page-skeleton.tsx
+++ b/components/page-skeleton.tsx
@@ -1,0 +1,105 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card"
+import { Skeleton } from "@/components/ui/skeleton"
+import { ReactNode } from "react"
+
+interface PageSkeletonProps {
+  statsCards?: ReactNode
+  headerTitleWidth?: string
+  headerDescriptionWidth?: string
+  buttonWidth?: string
+  filterCount?: number
+  tableRowCount?: number
+  showInstructionGuide?: boolean
+}
+
+export function PageSkeleton({
+  statsCards,
+  headerTitleWidth = "w-48",
+  headerDescriptionWidth = "w-72",
+  buttonWidth = "w-40",
+  filterCount = 3,
+  tableRowCount = 5,
+  showInstructionGuide = false,
+}: PageSkeletonProps) {
+  return (
+    <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
+      <div
+        className="absolute inset-0 z-[-1]"
+        style={{
+          backgroundImage: `radial-gradient(circle at top left, rgba(121, 68, 255, 0.05), transparent 20%), radial-gradient(circle at bottom right, rgba(255, 121, 68, 0.05), transparent 20%)`,
+        }}
+      />
+
+      {/* Stats Cards (optional) */}
+      {statsCards}
+
+      {/* Instruction Guide Skeleton (optional) */}
+      {showInstructionGuide && (
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+          <CardHeader className="pb-4">
+            <div className="flex items-start justify-between">
+              <div className="flex-1">
+                <Skeleton className="h-6 w-64 mb-2" />
+                <Skeleton className="h-4 w-96" />
+              </div>
+              <Skeleton className="h-8 w-24 rounded-lg" />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className="flex gap-4">
+                  <Skeleton className="flex-shrink-0 w-8 h-8 rounded-full" />
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-4 w-48" />
+                    <Skeleton className="h-3 w-full" />
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700 flex gap-3">
+              <Skeleton className="h-10 flex-1 rounded-full" />
+              <Skeleton className="h-10 w-40 rounded-full" />
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Main Card Structure Skeleton */}
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+        <CardHeader>
+          <div className="flex flex-row items-start justify-between">
+            <div>
+              <Skeleton className={`h-6 ${headerTitleWidth} mb-2`} />
+              <Skeleton className={`h-4 ${headerDescriptionWidth}`} />
+            </div>
+            <Skeleton className={`h-10 ${buttonWidth} rounded-full`} />
+          </div>
+        </CardHeader>
+        <div className="px-6">
+          <div className="h-px bg-gray-200 dark:bg-gray-700 w-full"></div>
+        </div>
+        <CardContent className="flex flex-col gap-6">
+          {/* Filters Skeleton */}
+          <div className="flex flex-col gap-4 mt-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-wrap gap-2">
+                {Array.from({ length: filterCount }).map((_, i) => (
+                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
+                ))}
+              </div>
+              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
+            </div>
+          </div>
+
+          {/* Table Skeleton */}
+          <div className="space-y-3">
+            {Array.from({ length: tableRowCount }).map((_, i) => (
+              <Skeleton key={i} className="h-16 w-full rounded-lg" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/components/pdf-viewer.tsx
+++ b/components/pdf-viewer.tsx
@@ -277,7 +277,7 @@ export function PDFViewer({ fileUrl, fileName, className, onDownload, onError, f
     // If error is fallback-to-iframe and not forced to use custom viewer, show browser's built-in PDF viewer
     if (error === 'fallback-to-iframe' && !forceCustomViewer) {
       return (
-        <div className={cn("flex flex-col h-full bg-muted/10", className)}>
+        <div className={cn("flex flex-col h-full", className)}>
           {/* Simple header for fallback */}
           <div className="flex items-center justify-between p-4 border-b bg-background/95 backdrop-blur">
             <div className="flex-1 min-w-0 mr-4">
@@ -296,21 +296,19 @@ export function PDFViewer({ fileUrl, fileName, className, onDownload, onError, f
           </div>
           
           {/* Fallback iframe */}
-          <div className="flex-1 p-4">
-            <iframe
-              src={`${fileUrl}#toolbar=1&navpanes=1&scrollbar=1&view=FitH`}
-              className="w-full h-full border-0 rounded-lg shadow-lg"
-              title={fileName}
-              style={{ backgroundColor: 'white' }}
-            />
-          </div>
+          <iframe
+            src={`${fileUrl}#toolbar=1&navpanes=1&scrollbar=1&view=FitH`}
+            className="flex-1 w-full border-0 rounded-b-lg"
+            title={fileName}
+            style={{ backgroundColor: 'white' }}
+          />
         </div>
       )
     }
     
     // Regular error state
     return (
-      <div className={cn("flex items-center justify-center h-full bg-muted/10", className)}>
+      <div className={cn("flex items-center justify-center h-full", className)}>
         <div className="text-center max-w-md">
           <div className="bg-destructive/10 rounded-full p-4 w-16 h-16 mx-auto mb-4 flex items-center justify-center">
             <ChevronRight className="h-8 w-8 text-destructive" />
@@ -326,7 +324,7 @@ export function PDFViewer({ fileUrl, fileName, className, onDownload, onError, f
   }
 
   return (
-    <div className={cn("flex flex-col h-full bg-muted/10", className)}>
+    <div className={cn("flex flex-col h-full", className)}>
       {/* Toolbar */}
       <div className="flex items-center justify-between p-4 border-b bg-background/95 backdrop-blur">
         <div className="flex items-center gap-2">
@@ -427,23 +425,21 @@ export function PDFViewer({ fileUrl, fileName, className, onDownload, onError, f
       {/* PDF Canvas */}
       <div 
         ref={containerRef}
-        className="flex-1 overflow-auto bg-gradient-to-br from-muted/20 to-muted/5 p-4"
+        className="flex-1 overflow-auto bg-gradient-to-br from-muted/20 to-muted/5 flex justify-center items-start p-4"
       >
-        <div className="flex justify-center">
-          <div className="relative">
-            <canvas
-              ref={canvasRef}
-              className={cn(
-                "shadow-2xl rounded-lg border border-border/20 bg-white transition-opacity duration-200",
-                isRendering && "opacity-50"
-              )}
-            />
-            {isRendering && (
-              <div className="absolute inset-0 flex items-center justify-center bg-white/50 rounded-lg">
-                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
-              </div>
+        <div className="relative">
+          <canvas
+            ref={canvasRef}
+            className={cn(
+              "shadow-2xl rounded-lg border border-border/20 bg-white transition-opacity duration-200",
+              isRendering && "opacity-50"
             )}
-          </div>
+          />
+          {isRendering && (
+            <div className="absolute inset-0 flex items-center justify-center bg-white/50 rounded-lg">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+            </div>
+          )}
         </div>
       </div>
 

--- a/components/stat-card.tsx
+++ b/components/stat-card.tsx
@@ -33,7 +33,7 @@ export function StatCard({
   }
 
   return (
-    <Card className={`relative overflow-hidden rounded-2xl shadow-md transition-opacity duration-200 flex-1 summary-card ${className}`}>
+    <Card className={`relative overflow-hidden rounded-3xl shadow-sm transition-opacity duration-200 flex-1 ${className}`}>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <CardTitle className="text-sm font-medium">{title}</CardTitle>
         {icon}

--- a/components/summary-card.tsx
+++ b/components/summary-card.tsx
@@ -106,9 +106,9 @@ export function SummaryCard({
       <Card
         className={cn(
           // Main-Style-Äquivalent: abgeleitet von main, ohne Opacity-Loading (Skeleton übernimmt)
-          "relative overflow-hidden rounded-2xl shadow-md transition-opacity duration-200 summary-card",
+          "relative overflow-hidden rounded-3xl shadow-sm transition-opacity duration-200",
           // sichtbare Border wie im Main-Design
-          "border",
+          "border border-gray-200 dark:border-[#3C4251]",
           // Add cursor pointer and hover scale when onClick is provided
           onClick && "cursor-pointer hover:scale-[1.02] transition-transform duration-200",
           className
@@ -156,9 +156,9 @@ export function SummaryCardSkeleton({ className }: { className?: string }) {
   return (
     <Card
       className={cn(
-        "relative overflow-hidden rounded-2xl shadow-md transition-opacity duration-200 summary-card",
+        "relative overflow-hidden rounded-3xl shadow-sm transition-opacity duration-200",
         // konsistent zur Hauptkarte: sichtbare Border
-        "border",
+        "border border-gray-200 dark:border-[#3C4251]",
         className
       )}
     >

--- a/components/summary-card.tsx
+++ b/components/summary-card.tsx
@@ -107,6 +107,8 @@ export function SummaryCard({
         className={cn(
           // Main-Style-Äquivalent: abgeleitet von main, ohne Opacity-Loading (Skeleton übernimmt)
           "relative overflow-hidden rounded-3xl shadow-sm transition-opacity duration-200",
+          // Background color matching dashboard cards
+          "bg-gray-50 dark:bg-[#22272e]",
           // sichtbare Border wie im Main-Design
           "border border-gray-200 dark:border-[#3C4251]",
           // Add cursor pointer and hover scale when onClick is provided
@@ -157,6 +159,8 @@ export function SummaryCardSkeleton({ className }: { className?: string }) {
     <Card
       className={cn(
         "relative overflow-hidden rounded-3xl shadow-sm transition-opacity duration-200",
+        // Background color matching dashboard cards
+        "bg-gray-50 dark:bg-[#22272e]",
         // konsistent zur Hauptkarte: sichtbare Border
         "border border-gray-200 dark:border-[#3C4251]",
         className

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -168,7 +168,7 @@ export function TenantPaymentBento() {
   }
 
   return (
-    <Card className="h-full flex flex-col overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Mietzahlungen</CardTitle>
         <CardDescription>Bezahlt vs. offen</CardDescription>

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -168,7 +168,7 @@ export function TenantPaymentBento() {
   }
 
   return (
-    <Card className="h-full flex flex-col overflow-hidden rounded-xl shadow-md">
+    <Card className="h-full flex flex-col overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Mietzahlungen</CardTitle>
         <CardDescription>Bezahlt vs. offen</CardDescription>

--- a/components/tenant-payment-bento.tsx
+++ b/components/tenant-payment-bento.tsx
@@ -168,7 +168,7 @@ export function TenantPaymentBento() {
   }
 
   return (
-    <Card className="h-full flex flex-col overflow-hidden bg-gray-50 dark:bg-[#22272e] border-2 border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+    <Card className="h-full flex flex-col overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
         <CardTitle className="text-lg">Mietzahlungen</CardTitle>
         <CardDescription>Bezahlt vs. offen</CardDescription>


### PR DESCRIPTION
## Description

Polishes the card system and hardens the PDF viewer's error handling.

## Summary of Changes

- Page backgrounds unified to `bg-white`; stat/summary cards restyled (`rounded-3xl`, `shadow-sm`, themed backgrounds/borders, `summary-card` class cleanup)
- `pdf-viewer.tsx`: new `forceCustomViewer` prop (default true) — PDF.js load failures now surface a real error message (and call `onError`) instead of silently falling back to the browser iframe; the iframe fallback only triggers for invalid-PDF errors when not forced; worker source guaranteed; canvas centering fixed