### PR TITLE
fix: add which-module dependency for Lighthouse CI

### DIFF
--- a/.github/workflows/lighthouse-report.yaml
+++ b/.github/workflows/lighthouse-report.yaml
@@ -160,11 +160,12 @@ jobs:
             ~/.npm
             node_modules/@lhci
             node_modules/wait-on
+            node_modules/which-module
             node_modules/.bin/lhci
             node_modules/.bin/wait-on
-          key: ${{ runner.os }}-lighthouse-tools-${{ hashFiles('**/package-lock.json') }}-v1
+          key: ${{ runner.os }}-lighthouse-tools-${{ hashFiles('**/package-lock.json') }}-v2
           restore-keys: |
-            ${{ runner.os }}-lighthouse-tools-
+            ${{ runner.os }}-lighthouse-tools-v2-
 
       - name: Install Lighthouse CI tools
         if: steps.cache-lighthouse-tools.outputs.cache-hit != 'true'


### PR DESCRIPTION
The @lhci/cli package depends on an older version of yargs that requires which-module. This dependency is not automatically installed, causing the Lighthouse CI workflow to fail with MODULE_NOT_FOUND error.

This fix explicitly installs which-module alongside @lhci/cli and wait-on to resolve the dependency issue.