### PR TITLE
style: enhance cookie consent banner dark mode styles

### DIFF
--- a/components/cookie-consent-banner.tsx
+++ b/components/cookie-consent-banner.tsx
@@ -42,7 +42,7 @@ export function CookieConsentBanner() {
 
   return (
     <div 
-      className="fixed inset-x-4 bottom-4 sm:inset-x-auto sm:right-4 sm:max-w-md p-6 bg-white dark:bg-gray-800 rounded-2xl shadow-lg border border-gray-200 dark:border-gray-700 z-50"
+      className="fixed inset-x-4 bottom-4 sm:inset-x-auto sm:right-4 sm:max-w-md p-6 bg-card text-card-foreground rounded-2xl shadow-lg border border-border z-50"
       role="dialog"
       aria-modal="true"
       aria-labelledby="cookie-consent-title"
@@ -50,10 +50,10 @@ export function CookieConsentBanner() {
     >
       <div className="space-y-4">
         <h3 id="cookie-consent-title" className="text-lg font-medium">Cookie-Einstellungen</h3>
-        <p id="cookie-consent-description" className="text-sm text-gray-600 dark:text-gray-300">
+        <p id="cookie-consent-description" className="text-sm text-muted-foreground">
           Wir verwenden Cookies, um Ihnen die beste Erfahrung auf unserer Website zu bieten. 
           Sie können Ihre Einstellungen jederzeit ändern. Weitere Informationen finden Sie in unserer{' '}
-          <Link href="/datenschutz" className="text-primary underline hover:underline">
+          <Link href="/datenschutz" className="text-primary underline-offset-4 hover:underline">
             Datenschutzerklärung
           </Link>.
         </p>

--- a/components/cookie-consent-banner.tsx
+++ b/components/cookie-consent-banner.tsx
@@ -53,7 +53,7 @@ export function CookieConsentBanner() {
         <p id="cookie-consent-description" className="text-sm text-muted-foreground">
           Wir verwenden Cookies, um Ihnen die beste Erfahrung auf unserer Website zu bieten. 
           Sie können Ihre Einstellungen jederzeit ändern. Weitere Informationen finden Sie in unserer{' '}
-          <Link href="/datenschutz" className="text-primary-foreground font-medium underline-offset-4 hover:underline">
+          <Link href="/datenschutz" className="text-foreground dark:text-white font-medium underline-offset-4 hover:underline hover:text-primary dark:hover:text-primary">
             Datenschutzerklärung
           </Link>.
         </p>

--- a/components/cookie-consent-banner.tsx
+++ b/components/cookie-consent-banner.tsx
@@ -53,7 +53,10 @@ export function CookieConsentBanner() {
         <p id="cookie-consent-description" className="text-sm text-muted-foreground">
           Wir verwenden Cookies, um Ihnen die beste Erfahrung auf unserer Website zu bieten. 
           Sie können Ihre Einstellungen jederzeit ändern. Weitere Informationen finden Sie in unserer{' '}
-          <Link href="/datenschutz" className="text-foreground dark:text-white font-medium underline-offset-4 hover:underline hover:text-primary dark:hover:text-primary">
+          <Link 
+            href="/datenschutz" 
+            className="font-medium underline-offset-4 hover:underline text-primary hover:text-primary/90 dark:text-white dark:hover:text-white/90"
+          >
             Datenschutzerklärung
           </Link>.
         </p>

--- a/components/cookie-consent-banner.tsx
+++ b/components/cookie-consent-banner.tsx
@@ -53,7 +53,7 @@ export function CookieConsentBanner() {
         <p id="cookie-consent-description" className="text-sm text-muted-foreground">
           Wir verwenden Cookies, um Ihnen die beste Erfahrung auf unserer Website zu bieten. 
           Sie können Ihre Einstellungen jederzeit ändern. Weitere Informationen finden Sie in unserer{' '}
-          <Link href="/datenschutz" className="text-primary underline-offset-4 hover:underline">
+          <Link href="/datenschutz" className="text-primary-foreground font-medium underline-offset-4 hover:underline">
             Datenschutzerklärung
           </Link>.
         </p>


### PR DESCRIPTION
## Description

Switches the cookie consent banner to theme tokens for proper dark-mode support.

## Summary of Changes

- `cookie-consent-banner.tsx`: hardcoded `bg-white dark:bg-gray-800` replaced by `bg-card text-card-foreground` and `text-muted-foreground`; the Datenschutz link gets consistent primary/white styling with `underline-offset-4`