### PR TITLE
fix: remove nested container in login modal by making inner card transparent

### DIFF
--- a/components/auth-modal.tsx
+++ b/components/auth-modal.tsx
@@ -436,7 +436,7 @@ export default function AuthModal({
         <DialogHeader className="sr-only">
           <DialogTitle>Authentication</DialogTitle>
         </DialogHeader>
-        <Card className="mx-auto w-full max-w-md border-none">
+        <Card className="mx-auto w-full max-w-md border-none bg-transparent shadow-none">
           {renderContent()}
         </Card>
       </DialogContent>

--- a/components/auth-modal.tsx
+++ b/components/auth-modal.tsx
@@ -436,9 +436,7 @@ export default function AuthModal({
         <DialogHeader className="sr-only">
           <DialogTitle>Authentication</DialogTitle>
         </DialogHeader>
-        <Card className="mx-auto w-full max-w-md border-none bg-transparent shadow-none">
-          {renderContent()}
-        </Card>
+        {renderContent()}
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
## Description

Removes the redundant card wrapper inside the auth modal.

## Summary of Changes

- `auth-modal.tsx`: the extra `<Card>` container around the modal content removed — the dialog renders its content directly (fixes double borders/nested card styling)