### PR TITLE
feat: add mail tab navigation with feature flag support

### DIFF
--- a/components/dashboard-sidebar.tsx
+++ b/components/dashboard-sidebar.tsx
@@ -11,7 +11,6 @@ import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { SimpleScrollArea } from "@/components/ui/simple-scroll-area"
 import { UserSettings } from "@/components/user-settings"
-import { createClient } from "@/utils/supabase/client"
 import { useSidebarActiveState } from "@/hooks/use-active-state-manager"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 
@@ -68,7 +67,7 @@ export function DashboardSidebar() {
   const pathname = usePathname()
   const [isOpen, setIsOpen] = useState(false)
   const { isRouteActive, getActiveStateClasses } = useSidebarActiveState()
-  // Removed supabase client and useEffect for userEmail as it's handled by UserSettings
+  // User email handling is managed by the UserSettings component
   const documentsEnabled = useFeatureFlagEnabled('documents_tab_access')
   const mailsEnabled = useFeatureFlagEnabled('mails-tab')
   


### PR DESCRIPTION
* **New Navigation Tab**: A new 'E-Mails' navigation item has been added to the dashboard sidebar, providing a dedicated link to mail-related functionalities.
* **Feature Flag Integration**: The visibility of the new 'E-Mails' tab is controlled by a feature flag named 'mails-tab', allowing for controlled rollout and A/B testing.
* **Icon Update**: The 'Mail' icon from `lucide-react` has been imported and assigned to the new 'E-Mails' sidebar entry.

preparement for the new mails tab feature