### PR TITLE
Configure API routes for edge runtime to fix Cloudflare Pages build error. Added 'export const runtime = 'edge';' to all failing routes.

### DIFF
--- a/app/api/auth/outlook/callback/route.ts
+++ b/app/api/auth/outlook/callback/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
 
+export const runtime = 'edge';
+
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams
   const code = searchParams.get("code")

--- a/app/api/auth/outlook/disconnect/route.ts
+++ b/app/api/auth/outlook/disconnect/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
 
+export const runtime = 'edge';
+
 export async function POST() {
   try {
     const supabase = await createClient()

--- a/app/api/auth/outlook/route.ts
+++ b/app/api/auth/outlook/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
 
+export const runtime = 'edge';
+
 export async function GET(request: NextRequest) {
   const supabase = await createClient()
   

--- a/app/api/auth/outlook/status/route.ts
+++ b/app/api/auth/outlook/status/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
 
+export const runtime = 'edge';
+
 export async function GET() {
   try {
     const supabase = await createClient()

--- a/app/api/mail/outlook/sync/route.ts
+++ b/app/api/mail/outlook/sync/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
 
+export const runtime = 'edge';
+
 export async function POST() {
   try {
     const supabase = await createClient()


### PR DESCRIPTION
## Description

Adds the edge runtime declaration to the Outlook auth and sync routes.

## Summary of Changes

- `/api/auth/outlook` (start, callback, disconnect, status) and `/api/mail/outlook/sync` now export `runtime = 'edge'`