### PR TITLE
feat: configure mail queue routes for edge runtime

### DIFF
--- a/app/api/mail/queue/process/route.ts
+++ b/app/api/mail/queue/process/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
 
+export const runtime = 'edge';
+
 export async function POST() {
   try {
     const supabase = await createClient()

--- a/app/api/mail/queue/retry/route.ts
+++ b/app/api/mail/queue/retry/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
 
+export const runtime = 'edge';
+
 export async function POST() {
   try {
     const supabase = await createClient()

--- a/app/api/mail/queue/status/route.ts
+++ b/app/api/mail/queue/status/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
 
+export const runtime = 'edge';
+
 export async function GET() {
   try {
     const supabase = await createClient()


### PR DESCRIPTION
## Description

Adds the edge runtime declaration to the mail queue routes.

## Summary of Changes

- `/api/mail/queue/process`, `/retry` and `/status` now export `runtime = 'edge'`, matching the rest of the mail API