### PR TITLE
feat: Increase test coverage for cost and finance calculations

### DIFF
--- a/__tests__/utils/cost-calculations.test.ts
+++ b/__tests__/utils/cost-calculations.test.ts
@@ -1,0 +1,138 @@
+
+import {
+  calculateProFlächeDistribution,
+  calculateProMieterDistribution,
+  calculateProWohnungDistribution,
+  calculateNachRechnungDistribution,
+  calculateWaterCostDistribution,
+} from '@/utils/cost-calculations';
+import { Mieter } from '@/lib/data-fetching';
+
+// Base mock tenants
+const mockTenants: Mieter[] = [
+  {
+    id: '1',
+    name: 'John Doe',
+    email: 'john.doe@example.com',
+    telefon: '123456789',
+    adresse: '123 Main St',
+    stadt: 'Anytown',
+    plz: '12345',
+    land: 'DE',
+    mietbeginn: '2023-01-01',
+    mietende: null,
+    einzug: '2023-01-01',
+    auszug: null,
+    kaution: 1000,
+    created_at: '2023-01-01T00:00:00.000Z',
+    user_id: 'user-1',
+    wohnung_id: 'wohnung-1',
+    Wohnungen: { groesse: 50 },
+  },
+  {
+    id: '2',
+    name: 'Jane Smith',
+    email: 'jane.smith@example.com',
+    telefon: '987654321',
+    adresse: '456 Oak Ave',
+    stadt: 'Anytown',
+    plz: '12345',
+    land: 'DE',
+    mietbeginn: '2023-07-01',
+    mietende: null,
+    einzug: '2023-07-01',
+    auszug: null,
+    kaution: 1200,
+    created_at: '2023-07-01T00:00:00.000Z',
+    user_id: 'user-1',
+    wohnung_id: 'wohnung-2',
+    Wohnungen: { groesse: 75 },
+  },
+];
+
+describe('Cost Calculation Functions', () => {
+  const startdatum = '2023-01-01';
+  const enddatum = '2023-12-31';
+  const totalCost = 1000;
+
+  describe('calculateProFlächeDistribution', () => {
+    it('should return zero distribution for empty tenant list', () => {
+      const distribution = calculateProFlächeDistribution([], totalCost, startdatum, enddatum);
+      expect(Object.keys(distribution).length).toBe(0);
+    });
+
+    it('should handle zero total cost', () => {
+      const distribution = calculateProFlächeDistribution(mockTenants, 0, startdatum, enddatum);
+      expect(distribution['1'].amount).toBe(0);
+      expect(distribution['2'].amount).toBe(0);
+    });
+
+    it('should distribute costs based on area and occupancy', () => {
+      const distribution = calculateProFlächeDistribution(mockTenants, totalCost, startdatum, enddatum);
+      expect(Object.keys(distribution).length).toBe(2);
+      expect(distribution['1'].amount).toBeCloseTo(569.42, 2);
+      expect(distribution['2'].amount).toBeCloseTo(430.58, 2);
+    });
+  });
+
+  describe('calculateProMieterDistribution', () => {
+    it('should return zero distribution for empty tenant list', () => {
+      const distribution = calculateProMieterDistribution([], totalCost, startdatum, enddatum);
+      expect(Object.keys(distribution).length).toBe(0);
+    });
+
+    it('should distribute costs per tenant based on occupancy', () => {
+      const distribution = calculateProMieterDistribution(mockTenants, totalCost, startdatum, enddatum);
+      expect(Object.keys(distribution).length).toBe(2);
+      expect(distribution['1'].amount).toBeCloseTo(664.85, 2);
+      expect(distribution['2'].amount).toBeCloseTo(335.15, 2);
+    });
+  });
+
+  describe('calculateProWohnungDistribution', () => {
+    it('should return zero distribution for empty tenant list', () => {
+      const distribution = calculateProWohnungDistribution([], totalCost, startdatum, enddatum);
+      expect(Object.keys(distribution).length).toBe(0);
+    });
+
+    it('should distribute costs equally among tenants in the same apartment', () => {
+        const sharedWohnungTenants = [
+            mockTenants[0],
+            { ...mockTenants[0], id: '3', einzug: '2023-01-01', auszug: '2023-06-30' }
+        ];
+        const distribution = calculateProWohnungDistribution(sharedWohnungTenants, totalCost, startdatum, enddatum);
+        expect(distribution['1'].amount).toBeCloseTo(500, 2);
+        expect(distribution['3'].amount).toBeCloseTo(500, 2);
+    });
+  });
+
+  describe('calculateNachRechnungDistribution', () => {
+    it('should return zero distribution for empty tenant list', () => {
+      const distribution = calculateNachRechnungDistribution({}, [], startdatum, enddatum);
+      expect(Object.keys(distribution).length).toBe(0);
+    });
+
+    it('should apply individual amounts with occupancy weighting', () => {
+      const individualAmounts = { '1': 500, '2': 500 };
+      const distribution = calculateNachRechnungDistribution(individualAmounts, mockTenants, startdatum, enddatum);
+      expect(Object.keys(distribution).length).toBe(2);
+      expect(distribution['1'].amount).toBeCloseTo(500, 2);
+      expect(distribution['2'].amount).toBeCloseTo(252.05, 2);
+    });
+  });
+
+  describe('calculateWaterCostDistribution', () => {
+    it('should return zero distribution for empty tenant list', () => {
+      const distribution = calculateWaterCostDistribution([], totalCost, {}, startdatum, enddatum);
+      expect(Object.keys(distribution).length).toBe(0);
+    });
+
+    it('should distribute water costs based on consumption and occupancy', () => {
+      const waterReadings = { '1': 100, '2': 150 };
+      const distribution = calculateWaterCostDistribution(mockTenants, totalCost, waterReadings, startdatum, enddatum);
+      expect(Object.keys(distribution).length).toBe(2);
+      expect(distribution['1'].amount).toBeCloseTo(569.42, 2);
+      expect(distribution['2'].amount).toBeCloseTo(430.58, 2);
+    });
+  });
+});

--- a/__tests__/utils/financeCalculations.test.ts
+++ b/__tests__/utils/financeCalculations.test.ts
@@ -1,0 +1,50 @@
+
+import { calculateFinancialSummary, FinanceTransaction } from '@/utils/financeCalculations';
+
+describe('calculateFinancialSummary', () => {
+  const year = 2023;
+
+  it('should return a zeroed summary for no transactions', () => {
+    const transactions: FinanceTransaction[] = [];
+    const summary = calculateFinancialSummary(transactions, year);
+    expect(summary.totalIncome).toBe(0);
+    expect(summary.totalExpenses).toBe(0);
+    expect(summary.totalCashflow).toBe(0);
+  });
+
+  it('should correctly calculate the summary for a single year', () => {
+    const transactions: FinanceTransaction[] = [
+      { betrag: 100, ist_einnahmen: true, datum: '2023-01-15' },
+      { betrag: 50, ist_einnahmen: false, datum: '2023-01-20' },
+      { betrag: 200, ist_einnahmen: true, datum: '2023-02-10' },
+    ];
+    const summary = calculateFinancialSummary(transactions, year);
+    expect(summary.totalIncome).toBe(300);
+    expect(summary.totalExpenses).toBe(50);
+    expect(summary.totalCashflow).toBe(250);
+  });
+
+  it('should only include transactions for the specified year', () => {
+    const transactions: FinanceTransaction[] = [
+      { betrag: 100, ist_einnahmen: true, datum: '2023-01-15' },
+      { betrag: 50, ist_einnahmen: false, datum: '2022-12-20' },
+      { betrag: 200, ist_einnahmen: true, datum: '2024-02-10' },
+    ];
+    const summary = calculateFinancialSummary(transactions, year);
+    expect(summary.totalIncome).toBe(100);
+    expect(summary.totalExpenses).toBe(0);
+    expect(summary.totalCashflow).toBe(100);
+  });
+
+  it('should handle various dates and calculate monthly data correctly', () => {
+    const transactions: FinanceTransaction[] = [
+      { betrag: 100, ist_einnahmen: true, datum: '2023-01-01' },
+      { betrag: 150, ist_einnahmen: true, datum: '2023-01-31' },
+      { betrag: 75, ist_einnahmen: false, datum: '2023-03-15' },
+    ];
+    const summary = calculateFinancialSummary(transactions, year);
+    expect(summary.monthlyData[0].income).toBe(250);
+    expect(summary.monthlyData[2].expenses).toBe(75);
+    expect(summary.monthlyData[1].income).toBe(0);
+  });
+});

--- a/utils/financeCalculations.ts
+++ b/utils/financeCalculations.ts
@@ -185,7 +185,13 @@ export function calculateFinancialSummary(
   }
   
   // Process each transaction
-  (transactions || []).forEach(item => {
+  (transactions || [])
+    .filter(item => {
+      if (!item.datum) return false;
+      const itemDate = new Date(item.datum);
+      return itemDate.getFullYear() === year;
+    })
+    .forEach(item => {
     if (!item.datum) return;
     
     const itemDate = new Date(item.datum);


### PR DESCRIPTION
## Description

Adds test suites for the cost and finance calculation utilities and fixes year filtering in the finance summary.

## Summary of Changes

- New `__tests__/utils/cost-calculations.test.ts` (138 lines): pro-Fläche, pro-Mieter, pro-Wohnung (shared apartment splitting), nach-Rechnung (occupancy weighting) and water cost distribution
- New `__tests__/utils/financeCalculations.test.ts` (50 lines): yearly summary totals, monthly bucketing and cross-year exclusion
- `utils/financeCalculations.ts`: transactions are now filtered to the requested year before aggregation (previously other years leaked into the summary)