### PR TITLE
Feature/nebenkosten chart

### DIFF
--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -9,6 +9,7 @@ import { getDashboardSummary } from "@/lib/data-fetching"
 import { RevenueExpensesChart } from "@/components/charts/revenue-expenses-chart"
 import { OccupancyChart } from "@/components/charts/occupancy-chart"
 import { MaintenanceDonutChart } from "@/components/charts/maintenance-donut-chart"
+import { NebenkostenChart } from "@/components/charts/nebenkosten-chart"
 import { LastTransactionsContainer } from "@/components/last-transactions-container"
 
 export default async function Dashboard() {
@@ -220,7 +221,7 @@ export default async function Dashboard() {
           </div>
         </div>
 
-        {/* Row 8: Last Transactions (left 50%) + Instandhaltung Chart (right 50%) */}
+        {/* Row 8: Last Transactions (left 50%) + Nebenkosten Chart (right 50%) */}
         <div className="col-span-1 row-span-1 md:col-span-3 md:row-span-3">
           <div className="h-[300px] md:h-full overflow-hidden">
             <LastTransactionsContainer />
@@ -228,7 +229,7 @@ export default async function Dashboard() {
         </div>
         <div className="col-span-1 row-span-1 md:col-span-3 md:row-span-3">
           <div className="h-[300px] md:h-full overflow-hidden">
-            <MaintenanceDonutChart />
+            <NebenkostenChart />
           </div>
         </div>
       </div>

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Building2, Home, Users, Wallet, FileSpreadsheet, CheckSquare } from "lucide-react"
 import { TenantPaymentBento } from "@/components/tenant-payment-bento"
-import { getDashboardSummary } from "@/lib/data-fetching"
+import { getDashboardSummary, getNebenkostenChartData } from "@/lib/data-fetching"
 import { RevenueExpensesChart } from "@/components/charts/revenue-expenses-chart"
 import { OccupancyChart } from "@/components/charts/occupancy-chart"
 import { MaintenanceDonutChart } from "@/components/charts/maintenance-donut-chart"
@@ -14,7 +14,10 @@ import { LastTransactionsContainer } from "@/components/last-transactions-contai
 
 export default async function Dashboard() {
   // Fetch real data from database
-  const summary = await getDashboardSummary();
+  const [summary, nebenkostenData] = await Promise.all([
+    getDashboardSummary(),
+    getNebenkostenChartData()
+  ]);
   
   return (
     <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
@@ -229,7 +232,7 @@ export default async function Dashboard() {
         </div>
         <div className="col-span-1 row-span-1 md:col-span-3 md:row-span-3">
           <div className="h-[300px] md:h-full overflow-hidden">
-            <NebenkostenChart />
+            <NebenkostenChart nebenkostenData={nebenkostenData} />
           </div>
         </div>
       </div>

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -19,6 +19,8 @@ export default async function Dashboard() {
     getNebenkostenChartData()
   ]);
   
+  const { data: nebenkostenChartData, year: nebenkostenYear } = nebenkostenData;
+  
   return (
     <div className="flex flex-col gap-8 p-8 bg-white dark:bg-[#181818]">
       <div>
@@ -232,7 +234,7 @@ export default async function Dashboard() {
         </div>
         <div className="col-span-1 row-span-1 md:col-span-3 md:row-span-3">
           <div className="h-[300px] md:h-full overflow-hidden">
-            <NebenkostenChart nebenkostenData={nebenkostenData} />
+            <NebenkostenChart nebenkostenData={nebenkostenChartData} year={nebenkostenYear} />
           </div>
         </div>
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -139,6 +139,17 @@
     /* Z-index management */
     --z-index-dropdown: 1000;
     --z-index-sticky: 1020;
+    
+    /* Chart colors */
+    --chart-color-1: #34d399;
+    --chart-color-2: #f59e42;
+    --chart-color-3: #818cf8;
+    --chart-color-4: #f87171;
+    --chart-color-5: #a78bfa;
+    --chart-color-6: #fb923c;
+    --chart-color-7: #4ade80;
+    --chart-color-8: #fbbf24;
+    --chart-color-empty: #94a3b8; /* For empty/placeholder data */
     --z-index-fixed: 1030;
     --z-index-modal-backdrop: 1040;
     --z-index-modal: 1050;

--- a/components/charts/nebenkosten-chart.tsx
+++ b/components/charts/nebenkosten-chart.tsx
@@ -4,7 +4,18 @@ import type { NebenkostenChartDatum } from "@/lib/data-fetching";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { PieChart, Pie, Cell, Legend, Tooltip, ResponsiveContainer } from "recharts";
 
-const COLORS = ["#34d399", "#f59e42", "#818cf8", "#f87171", "#a78bfa", "#fb923c", "#4ade80", "#fbbf24"];
+const COLORS = [
+  'var(--chart-color-1)',
+  'var(--chart-color-2)',
+  'var(--chart-color-3)',
+  'var(--chart-color-4)',
+  'var(--chart-color-5)',
+  'var(--chart-color-6)',
+  'var(--chart-color-7)',
+  'var(--chart-color-8)'
+];
+
+const EMPTY_COLOR = 'var(--chart-color-empty)';
 
 interface NebenkostenChartProps {
   nebenkostenData: NebenkostenChartDatum[];
@@ -43,6 +54,7 @@ const CustomTooltip = ({ active, payload }: TooltipProps) => {
 
 export function NebenkostenChart({ nebenkostenData }: NebenkostenChartProps) {
   const data = nebenkostenData.length > 0 ? nebenkostenData : EMPTY_STATE;
+  const colors = data === EMPTY_STATE ? [EMPTY_COLOR] : COLORS;
 
   return (
     <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
@@ -65,7 +77,10 @@ export function NebenkostenChart({ nebenkostenData }: NebenkostenChartProps) {
               paddingAngle={2}
             >
               {data.map((entry, idx) => (
-                <Cell key={`cell-${idx}`} fill={COLORS[idx % COLORS.length]} />
+                <Cell 
+                  key={`cell-${idx}`} 
+                  fill={colors[idx % colors.length]} 
+                />
               ))}
             </Pie>
             <Legend wrapperStyle={{ fontSize: 10 }} />

--- a/components/charts/nebenkosten-chart.tsx
+++ b/components/charts/nebenkosten-chart.tsx
@@ -1,108 +1,48 @@
 "use client";
-import { useEffect, useState } from "react";
+
+import type { NebenkostenChartDatum } from "@/lib/data-fetching";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { PieChart, Pie, Cell, Legend, Tooltip, ResponsiveContainer } from "recharts";
-import { createClient } from "@/utils/supabase/client";
 
 const COLORS = ["#34d399", "#f59e42", "#818cf8", "#f87171", "#a78bfa", "#fb923c", "#4ade80", "#fbbf24"];
 
-type NebenkostenData = {
-  name: string;
-  value: number;
+interface NebenkostenChartProps {
+  nebenkostenData: NebenkostenChartDatum[];
+}
+
+interface TooltipProps {
+  active?: boolean;
+  payload?: Array<{
+    name: string;
+    value: number;
+    payload: NebenkostenChartDatum;
+  }>;
+}
+
+const EMPTY_STATE: NebenkostenChartDatum[] = [
+  { name: "Keine Daten", value: 1 }
+];
+
+const CustomTooltip = ({ active, payload }: TooltipProps) => {
+  if (active && payload && payload.length) {
+    const data = payload[0];
+    return (
+      <div className="grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl">
+        <p className="font-medium text-foreground">{data.name}</p>
+        <p className="font-mono font-medium tabular-nums text-foreground">
+          {new Intl.NumberFormat('de-DE', {
+            style: 'currency',
+            currency: 'EUR'
+          }).format(data.value)}
+        </p>
+      </div>
+    );
+  }
+  return null;
 };
 
-export function NebenkostenChart() {
-  const [nebenkostenData, setNebenkostenData] = useState<NebenkostenData[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchNebenkostenData = async () => {
-      const supabase = createClient();
-      
-      try {
-        // Calculate date range for last year
-        const now = new Date();
-        const oneYearAgo = new Date(now);
-        oneYearAgo.setFullYear(now.getFullYear() - 1);
-        
-        const startDate = oneYearAgo.toISOString().split('T')[0];
-        const endDate = now.toISOString().split('T')[0];
-
-        // Fetch Nebenkosten data from the last year
-        const { data: nebenkostenRecords, error } = await supabase
-          .from("Nebenkosten")
-          .select("nebenkostenart, betrag, startdatum, enddatum")
-          .gte("enddatum", startDate)
-          .lte("startdatum", endDate)
-          .order("startdatum", { ascending: false });
-
-        if (error) {
-          console.error("Error fetching Nebenkosten data:", error);
-          setLoading(false);
-          return;
-        }
-
-        // Aggregate costs by category
-        const categoryTotals: Record<string, number> = {};
-
-        nebenkostenRecords?.forEach((record) => {
-          const arten = record.nebenkostenart || [];
-          const betraege = record.betrag || [];
-
-          arten.forEach((art: string, index: number) => {
-            if (art && betraege[index]) {
-              const betrag = Number(betraege[index]) || 0;
-              categoryTotals[art] = (categoryTotals[art] || 0) + betrag;
-            }
-          });
-        });
-
-        // Format data for the chart
-        const formattedData: NebenkostenData[] = Object.entries(categoryTotals)
-          .map(([name, value]) => ({ name, value }))
-          .sort((a, b) => b.value - a.value); // Sort by value descending
-
-        setNebenkostenData(formattedData.length > 0 ? formattedData : [
-          { name: "Keine Daten", value: 1 }
-        ]);
-      } catch (error) {
-        console.error("Error processing Nebenkosten data:", error);
-        setNebenkostenData([{ name: "Keine Daten", value: 1 }]);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchNebenkostenData();
-  }, []);
-
-  // Custom tooltip to format currency
-  interface TooltipProps {
-    active?: boolean;
-    payload?: Array<{
-      name: string;
-      value: number;
-      payload: NebenkostenData;
-    }>;
-  }
-
-  const CustomTooltip = ({ active, payload }: TooltipProps) => {
-    if (active && payload && payload.length) {
-      const data = payload[0];
-      return (
-        <div className="grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl">
-          <p className="font-medium text-foreground">{data.name}</p>
-          <p className="font-mono font-medium tabular-nums text-foreground">
-            {new Intl.NumberFormat('de-DE', { 
-              style: 'currency', 
-              currency: 'EUR' 
-            }).format(data.value)}
-          </p>
-        </div>
-      );
-    }
-    return null;
-  };
+export function NebenkostenChart({ nebenkostenData }: NebenkostenChartProps) {
+  const data = nebenkostenData.length > 0 ? nebenkostenData : EMPTY_STATE;
 
   return (
     <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
@@ -111,33 +51,27 @@ export function NebenkostenChart() {
         <CardDescription>Verteilung der Betriebskosten im letzten Jahr</CardDescription>
       </CardHeader>
       <CardContent className="flex-1 p-2 min-h-0">
-        {loading ? (
-          <div className="flex justify-center items-center h-full">
-            <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary" />
-          </div>
-        ) : (
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie
-                data={nebenkostenData}
-                dataKey="value"
-                nameKey="name"
-                cx="50%"
-                cy="50%"
-                innerRadius="40%"
-                outerRadius="70%"
-                fill="#8884d8"
-                paddingAngle={2}
-              >
-                {nebenkostenData.map((entry, idx) => (
-                  <Cell key={`cell-${idx}`} fill={COLORS[idx % COLORS.length]} />
-                ))}
-              </Pie>
-              <Legend wrapperStyle={{ fontSize: 10 }} />
-              <Tooltip content={<CustomTooltip />} />
-            </PieChart>
-          </ResponsiveContainer>
-        )}
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={data}
+              dataKey="value"
+              nameKey="name"
+              cx="50%"
+              cy="50%"
+              innerRadius="40%"
+              outerRadius="70%"
+              fill="#8884d8"
+              paddingAngle={2}
+            >
+              {data.map((entry, idx) => (
+                <Cell key={`cell-${idx}`} fill={COLORS[idx % COLORS.length]} />
+              ))}
+            </Pie>
+            <Legend wrapperStyle={{ fontSize: 10 }} />
+            <Tooltip content={<CustomTooltip />} />
+          </PieChart>
+        </ResponsiveContainer>
       </CardContent>
     </Card>
   );

--- a/components/charts/nebenkosten-chart.tsx
+++ b/components/charts/nebenkosten-chart.tsx
@@ -90,9 +90,9 @@ export function NebenkostenChart() {
     if (active && payload && payload.length) {
       const data = payload[0];
       return (
-        <div className="bg-white dark:bg-gray-800 p-2 border rounded shadow-lg">
-          <p className="text-sm font-medium">{data.name}</p>
-          <p className="text-sm text-blue-600 dark:text-blue-400">
+        <div className="grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl">
+          <p className="font-medium text-foreground">{data.name}</p>
+          <p className="font-mono font-medium tabular-nums text-foreground">
             {new Intl.NumberFormat('de-DE', { 
               style: 'currency', 
               currency: 'EUR' 

--- a/components/charts/nebenkosten-chart.tsx
+++ b/components/charts/nebenkosten-chart.tsx
@@ -19,6 +19,7 @@ const EMPTY_COLOR = 'var(--chart-color-empty)';
 
 interface NebenkostenChartProps {
   nebenkostenData: NebenkostenChartDatum[];
+  year: number;
 }
 
 interface TooltipProps {
@@ -52,15 +53,17 @@ const CustomTooltip = ({ active, payload }: TooltipProps) => {
   return null;
 };
 
-export function NebenkostenChart({ nebenkostenData }: NebenkostenChartProps) {
+export function NebenkostenChart({ nebenkostenData, year }: NebenkostenChartProps) {
   const data = nebenkostenData.length > 0 ? nebenkostenData : EMPTY_STATE;
   const colors = data === EMPTY_STATE ? [EMPTY_COLOR] : COLORS;
 
   return (
     <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
       <CardHeader className="flex-shrink-0 pb-2">
-        <CardTitle className="text-lg">Nebenkosten nach Kategorie</CardTitle>
-        <CardDescription>Verteilung der Betriebskosten im letzten Jahr</CardDescription>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-lg">Nebenkosten nach Kategorie</CardTitle>
+        </div>
+        <CardDescription>Verteilung der Betriebskosten (Jahr {year})</CardDescription>
       </CardHeader>
       <CardContent className="flex-1 p-2 min-h-0">
         <ResponsiveContainer width="100%" height="100%">

--- a/components/charts/nebenkosten-chart.tsx
+++ b/components/charts/nebenkosten-chart.tsx
@@ -54,8 +54,9 @@ const CustomTooltip = ({ active, payload }: TooltipProps) => {
 };
 
 export function NebenkostenChart({ nebenkostenData, year }: NebenkostenChartProps) {
-  const data = nebenkostenData.length > 0 ? nebenkostenData : EMPTY_STATE;
-  const colors = data === EMPTY_STATE ? [EMPTY_COLOR] : COLORS;
+  const hasData = nebenkostenData.length > 0;
+  const data = hasData ? nebenkostenData : EMPTY_STATE;
+  const colors = hasData ? COLORS : [EMPTY_COLOR];
 
   return (
     <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
@@ -87,7 +88,7 @@ export function NebenkostenChart({ nebenkostenData, year }: NebenkostenChartProp
               ))}
             </Pie>
             <Legend wrapperStyle={{ fontSize: 10 }} />
-            <Tooltip content={<CustomTooltip />} />
+            {hasData && <Tooltip content={<CustomTooltip />} />}
           </PieChart>
         </ResponsiveContainer>
       </CardContent>

--- a/components/charts/nebenkosten-chart.tsx
+++ b/components/charts/nebenkosten-chart.tsx
@@ -1,0 +1,144 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { PieChart, Pie, Cell, Legend, Tooltip, ResponsiveContainer } from "recharts";
+import { createClient } from "@/utils/supabase/client";
+
+const COLORS = ["#34d399", "#f59e42", "#818cf8", "#f87171", "#a78bfa", "#fb923c", "#4ade80", "#fbbf24"];
+
+type NebenkostenData = {
+  name: string;
+  value: number;
+};
+
+export function NebenkostenChart() {
+  const [nebenkostenData, setNebenkostenData] = useState<NebenkostenData[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchNebenkostenData = async () => {
+      const supabase = createClient();
+      
+      try {
+        // Calculate date range for last year
+        const now = new Date();
+        const oneYearAgo = new Date(now);
+        oneYearAgo.setFullYear(now.getFullYear() - 1);
+        
+        const startDate = oneYearAgo.toISOString().split('T')[0];
+        const endDate = now.toISOString().split('T')[0];
+
+        // Fetch Nebenkosten data from the last year
+        const { data: nebenkostenRecords, error } = await supabase
+          .from("Nebenkosten")
+          .select("nebenkostenart, betrag, startdatum, enddatum")
+          .gte("enddatum", startDate)
+          .lte("startdatum", endDate)
+          .order("startdatum", { ascending: false });
+
+        if (error) {
+          console.error("Error fetching Nebenkosten data:", error);
+          setLoading(false);
+          return;
+        }
+
+        // Aggregate costs by category
+        const categoryTotals: Record<string, number> = {};
+
+        nebenkostenRecords?.forEach((record) => {
+          const arten = record.nebenkostenart || [];
+          const betraege = record.betrag || [];
+
+          arten.forEach((art: string, index: number) => {
+            if (art && betraege[index]) {
+              const betrag = Number(betraege[index]) || 0;
+              categoryTotals[art] = (categoryTotals[art] || 0) + betrag;
+            }
+          });
+        });
+
+        // Format data for the chart
+        const formattedData: NebenkostenData[] = Object.entries(categoryTotals)
+          .map(([name, value]) => ({ name, value }))
+          .sort((a, b) => b.value - a.value); // Sort by value descending
+
+        setNebenkostenData(formattedData.length > 0 ? formattedData : [
+          { name: "Keine Daten", value: 1 }
+        ]);
+      } catch (error) {
+        console.error("Error processing Nebenkosten data:", error);
+        setNebenkostenData([{ name: "Keine Daten", value: 1 }]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchNebenkostenData();
+  }, []);
+
+  // Custom tooltip to format currency
+  interface TooltipProps {
+    active?: boolean;
+    payload?: Array<{
+      name: string;
+      value: number;
+      payload: NebenkostenData;
+    }>;
+  }
+
+  const CustomTooltip = ({ active, payload }: TooltipProps) => {
+    if (active && payload && payload.length) {
+      const data = payload[0];
+      return (
+        <div className="bg-white dark:bg-gray-800 p-2 border rounded shadow-lg">
+          <p className="text-sm font-medium">{data.name}</p>
+          <p className="text-sm text-blue-600 dark:text-blue-400">
+            {new Intl.NumberFormat('de-DE', { 
+              style: 'currency', 
+              currency: 'EUR' 
+            }).format(data.value)}
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <Card className="h-full flex flex-col bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-[2rem]">
+      <CardHeader className="flex-shrink-0 pb-2">
+        <CardTitle className="text-lg">Nebenkosten nach Kategorie</CardTitle>
+        <CardDescription>Verteilung der Betriebskosten im letzten Jahr</CardDescription>
+      </CardHeader>
+      <CardContent className="flex-1 p-2 min-h-0">
+        {loading ? (
+          <div className="flex justify-center items-center h-full">
+            <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary" />
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie
+                data={nebenkostenData}
+                dataKey="value"
+                nameKey="name"
+                cx="50%"
+                cy="50%"
+                innerRadius="40%"
+                outerRadius="70%"
+                fill="#8884d8"
+                paddingAngle={2}
+              >
+                {nebenkostenData.map((entry, idx) => (
+                  <Cell key={`cell-${idx}`} fill={COLORS[idx % COLORS.length]} />
+                ))}
+              </Pie>
+              <Legend wrapperStyle={{ fontSize: 10 }} />
+              <Tooltip content={<CustomTooltip />} />
+            </PieChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/lib/data-fetching.ts
+++ b/lib/data-fetching.ts
@@ -258,8 +258,7 @@ export async function getNebenkostenChartData(): Promise<NebenkostenChartData> {
         return;
       }
 
-      const rawAmount = betraege[index];
-      const amount = typeof rawAmount === "number" ? rawAmount : Number(rawAmount ?? 0);
+      const amount = Number(betraege[index]);
 
       if (!Number.isFinite(amount) || amount <= 0) {
         return;

--- a/lib/data-fetching.ts
+++ b/lib/data-fetching.ts
@@ -74,6 +74,14 @@ export type Nebenkosten = {
   anzahlMieter?: number; // Number of tenants (calculated field)
 };
 
+export type NebenkostenChartData = {
+  year: number;
+  data: {
+    name: string;
+    value: number;
+  }[];
+};
+
 export type NebenkostenChartDatum = {
   name: string;
   value: number;
@@ -205,7 +213,7 @@ export async function fetchNebenkosten(year?: string): Promise<Nebenkosten[]> {
   return data as Nebenkosten[];
 }
 
-export async function getNebenkostenChartData(): Promise<NebenkostenChartDatum[]> {
+export async function getNebenkostenChartData(): Promise<NebenkostenChartData> {
   const supabase = createSupabaseServerClient();
 
   // First, get the most recent year with data
@@ -218,7 +226,7 @@ export async function getNebenkostenChartData(): Promise<NebenkostenChartDatum[]
 
   if (!latestYearData?.startdatum) {
     console.log("No Nebenkosten data found");
-    return [];
+    return { year: new Date().getFullYear(), data: [] };
   }
 
   // Extract the year from the most recent entry
@@ -236,7 +244,7 @@ export async function getNebenkostenChartData(): Promise<NebenkostenChartDatum[]
 
   if (error) {
     console.error("Error fetching Nebenkosten chart data:", error);
-    return [];
+    return { year: latestYear, data: [] };
   }
 
   const categoryTotals: Record<string, number> = {};
@@ -261,9 +269,14 @@ export async function getNebenkostenChartData(): Promise<NebenkostenChartDatum[]
     });
   });
 
-  return Object.entries(categoryTotals)
+  const formattedData = Object.entries(categoryTotals)
     .map(([name, value]) => ({ name, value }))
     .sort((a, b) => b.value - a.value);
+
+  return {
+    year: latestYear,
+    data: formattedData
+  };
 }
 
 // getHausGesamtFlaeche function removed - replaced by get_nebenkosten_with_metrics database function


### PR DESCRIPTION
## Description

Adds a Nebenkosten donut chart to the dashboard, fed by real cost data.

## Summary of Changes

- New `NebenkostenChart` component: recharts donut with per-category colors (new `--chart-color-*` CSS variables), German EUR tooltip formatting and an empty-state placeholder
- `lib/data-fetching.ts`: new `getNebenkostenChartData()` — finds the most recent year with data and aggregates `betrag` per `nebenkostenart` (sorted descending)
- Dashboard: the static `MaintenanceDonutChart` is replaced by the live `NebenkostenChart`; chart data fetched in parallel with the summary