### PR TITLE
Feature/wasserzaehler modal

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -17,6 +17,7 @@ import { AufgabeEditModal } from "@/components/aufgabe-edit-modal" // Added
 import { aufgabeServerAction } from "@/app/todos-actions" // Added
 import { BetriebskostenEditModal } from "@/components/betriebskosten-edit-modal"; // Added
 import { WasserzaehlerModal } from "@/components/wasserzaehler-modal"; // Added
+import { WasserZaehlerModal } from "@/components/wasser-zaehler-modal"; // Added for Wasser_Zaehler table
 import { KautionModal } from "@/components/kaution-modal"; // Added
 import { updateKautionAction } from "@/app/mieter-actions"; // Added
 // Assuming betriebskosten-actions.ts exports server actions, adjust if needed
@@ -156,6 +157,8 @@ export default function DashboardRootLayout({
       <BetriebskostenEditModal />
       {/* WasserzaehlerModal - Handles its own state via modal store */}
       <WasserzaehlerModal />
+      {/* WasserZaehlerModal - Manages Wasser_Zaehler entries for apartments */}
+      <WasserZaehlerModal />
       {/* KautionModal - Handles kaution management */}
       <KautionModal serverAction={updateKautionAction} />
       {/* HausOverviewModal - Displays Haus overview with all Wohnungen */}

--- a/app/api/wasser-zaehler/[id]/route.ts
+++ b/app/api/wasser-zaehler/[id]/route.ts
@@ -1,0 +1,100 @@
+import { createClient } from '@/utils/supabase/server'
+import { NextRequest, NextResponse } from 'next/server'
+
+export const runtime = 'edge'
+
+// PATCH - Update a Wasserzähler
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const supabase = await createClient()
+    const { data: { user }, error: authError } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { id } = await params
+    const body = await request.json()
+    const { custom_id } = body
+
+    // Verify the Wasserzähler belongs to the user
+    const { data: existing, error: fetchError } = await supabase
+      .from('Wasser_Zaehler')
+      .select('id')
+      .eq('id', id)
+      .eq('user_id', user.id)
+      .single()
+
+    if (fetchError || !existing) {
+      return NextResponse.json({ error: 'Wasserzähler not found or access denied' }, { status: 404 })
+    }
+
+    // Update Wasserzähler
+    const { data, error } = await supabase
+      .from('Wasser_Zaehler')
+      .update({ custom_id: custom_id || null })
+      .eq('id', id)
+      .eq('user_id', user.id)
+      .select()
+      .single()
+
+    if (error) {
+      console.error('Error updating Wasserzähler:', error)
+      return NextResponse.json({ error: 'Failed to update Wasserzähler' }, { status: 500 })
+    }
+
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error('Unexpected error in PATCH /api/wasser-zaehler/[id]:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+// DELETE - Delete a Wasserzähler
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const supabase = await createClient()
+    const { data: { user }, error: authError } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { id } = await params
+
+    // Verify the Wasserzähler belongs to the user
+    const { data: existing, error: fetchError } = await supabase
+      .from('Wasser_Zaehler')
+      .select('id')
+      .eq('id', id)
+      .eq('user_id', user.id)
+      .single()
+
+    if (fetchError || !existing) {
+      return NextResponse.json({ error: 'Wasserzähler not found or access denied' }, { status: 404 })
+    }
+
+    // Delete Wasserzähler
+    const { error } = await supabase
+      .from('Wasser_Zaehler')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', user.id)
+
+    if (error) {
+      console.error('Error deleting Wasserzähler:', error)
+      return NextResponse.json({ error: 'Failed to delete Wasserzähler' }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Unexpected error in DELETE /api/wasser-zaehler/[id]:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/wasser-zaehler/[id]/route.ts
+++ b/app/api/wasser-zaehler/[id]/route.ts
@@ -18,7 +18,7 @@ export async function PATCH(
 
     const { id } = await params
     const body = await request.json()
-    const { custom_id } = body
+    const { custom_id, eichungsdatum } = body
 
     // Verify the Wasserzähler belongs to the user
     const { data: existing, error: fetchError } = await supabase
@@ -35,7 +35,10 @@ export async function PATCH(
     // Update Wasserzähler
     const { data, error } = await supabase
       .from('Wasser_Zaehler')
-      .update({ custom_id: custom_id || null })
+      .update({ 
+        custom_id: custom_id || null,
+        eichungsdatum: eichungsdatum || null,
+      })
       .eq('id', id)
       .eq('user_id', user.id)
       .select()

--- a/app/api/wasser-zaehler/route.ts
+++ b/app/api/wasser-zaehler/route.ts
@@ -63,7 +63,7 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json()
-    const { custom_id, wohnung_id } = body
+    const { custom_id, wohnung_id, eichungsdatum } = body
 
     if (!wohnung_id) {
       return NextResponse.json({ error: 'wohnung_id is required' }, { status: 400 })
@@ -87,6 +87,7 @@ export async function POST(request: NextRequest) {
       .insert({
         custom_id: custom_id || null,
         wohnung_id,
+        eichungsdatum: eichungsdatum || null,
         user_id: user.id,
       })
       .select()

--- a/app/api/wasser-zaehler/route.ts
+++ b/app/api/wasser-zaehler/route.ts
@@ -1,0 +1,105 @@
+import { createClient } from '@/utils/supabase/server'
+import { NextRequest, NextResponse } from 'next/server'
+
+export const runtime = 'edge'
+
+// GET - Fetch all Wasserzähler for a specific Wohnung
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient()
+    const { data: { user }, error: authError } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const searchParams = request.nextUrl.searchParams
+    const wohnungId = searchParams.get('wohnung_id')
+
+    if (!wohnungId) {
+      return NextResponse.json({ error: 'wohnung_id is required' }, { status: 400 })
+    }
+
+    // Verify the Wohnung belongs to the user
+    const { data: wohnung, error: wohnungError } = await supabase
+      .from('Wohnungen')
+      .select('id')
+      .eq('id', wohnungId)
+      .eq('user_id', user.id)
+      .single()
+
+    if (wohnungError || !wohnung) {
+      return NextResponse.json({ error: 'Wohnung not found or access denied' }, { status: 404 })
+    }
+
+    // Fetch Wasserzähler
+    const { data, error } = await supabase
+      .from('Wasser_Zaehler')
+      .select('*')
+      .eq('wohnung_id', wohnungId)
+      .eq('user_id', user.id)
+      .order('erstellungsdatum', { ascending: true })
+
+    if (error) {
+      console.error('Error fetching Wasserzähler:', error)
+      return NextResponse.json({ error: 'Failed to fetch Wasserzähler' }, { status: 500 })
+    }
+
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error('Unexpected error in GET /api/wasser-zaehler:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+// POST - Create a new Wasserzähler
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient()
+    const { data: { user }, error: authError } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = await request.json()
+    const { custom_id, wohnung_id } = body
+
+    if (!wohnung_id) {
+      return NextResponse.json({ error: 'wohnung_id is required' }, { status: 400 })
+    }
+
+    // Verify the Wohnung belongs to the user
+    const { data: wohnung, error: wohnungError } = await supabase
+      .from('Wohnungen')
+      .select('id')
+      .eq('id', wohnung_id)
+      .eq('user_id', user.id)
+      .single()
+
+    if (wohnungError || !wohnung) {
+      return NextResponse.json({ error: 'Wohnung not found or access denied' }, { status: 404 })
+    }
+
+    // Create Wasserzähler
+    const { data, error } = await supabase
+      .from('Wasser_Zaehler')
+      .insert({
+        custom_id: custom_id || null,
+        wohnung_id,
+        user_id: user.id,
+      })
+      .select()
+      .single()
+
+    if (error) {
+      console.error('Error creating Wasserzähler:', error)
+      return NextResponse.json({ error: 'Failed to create Wasserzähler' }, { status: 500 })
+    }
+
+    return NextResponse.json(data, { status: 201 })
+  } catch (error) {
+    console.error('Unexpected error in POST /api/wasser-zaehler:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/components/apartment-context-menu.tsx
+++ b/components/apartment-context-menu.tsx
@@ -8,7 +8,8 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu"
-import { Edit, Trash2 } from "lucide-react"
+import { Edit, Trash2, Droplet } from "lucide-react"
+import { useModalStore } from "@/hooks/use-modal-store"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -39,6 +40,7 @@ export function ApartmentContextMenu({
 }: ApartmentContextMenuProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false)
   const [isDeleting, setIsDeleting] = React.useState(false)
+  const { openWasserZaehlerModal } = useModalStore()
 
   const handleDelete = async () => {
     try {
@@ -82,6 +84,13 @@ export function ApartmentContextMenu({
           <ContextMenuItem onClick={onEdit} className="flex items-center gap-2 cursor-pointer">
             <Edit className="h-4 w-4" />
             <span>Bearbeiten</span>
+          </ContextMenuItem>
+          <ContextMenuItem 
+            onClick={() => openWasserZaehlerModal(apartment.id, apartment.name)}
+            className="flex items-center gap-2 cursor-pointer"
+          >
+            <Droplet className="h-4 w-4" />
+            <span>Wasserzähler</span>
           </ContextMenuItem>
           <ContextMenuSeparator />
           <ContextMenuItem 

--- a/components/wasser-zaehler-modal.tsx
+++ b/components/wasser-zaehler-modal.tsx
@@ -14,11 +14,24 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { toast } from "@/hooks/use-toast"
-import { Loader2, Plus, Trash2, Edit2, X, Check, CircleGauge, Calendar as CalendarIcon } from "lucide-react"
+import { 
+  Loader2, 
+  Plus, 
+  Trash2, 
+  Edit2, 
+  X, 
+  Check, 
+  CircleGauge, 
+  Calendar as CalendarIcon,
+  Gauge,
+  Clock,
+  Hash
+} from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Calendar } from "@/components/ui/calendar"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Separator } from "@/components/ui/separator"
 import { format } from "date-fns"
 import { de } from "date-fns/locale"
 import { cn } from "@/lib/utils"
@@ -346,7 +359,7 @@ export function WasserZaehlerModal() {
                   <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
                 </div>
               ) : zaehlerList.length === 0 ? (
-                <Card className="border-dashed">
+                <Card className="bg-gray-50 dark:bg-[#22272e] border border-dashed border-gray-300 dark:border-gray-600 rounded-3xl">
                   <CardContent className="flex flex-col items-center justify-center p-8 text-center">
                     <CircleGauge className="h-12 w-12 text-muted-foreground/50 mb-3" />
                     <p className="text-sm text-muted-foreground">
@@ -360,136 +373,132 @@ export function WasserZaehlerModal() {
               ) : (
                 <div className="grid gap-3">
                   {zaehlerList.map((zaehler) => (
-                    <Card key={zaehler.id} className="overflow-hidden hover:shadow-md transition-shadow">
-                      <CardContent className="p-4">
+                    <Card key={zaehler.id} className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl overflow-hidden hover:shadow-md transition-shadow">
+                      <CardContent className="p-0">
                         {editingId === zaehler.id ? (
                           // Edit Mode
-                          <div className="space-y-3">
-                            <div className="flex items-start gap-3">
-                              <div className="flex-shrink-0 mt-1">
+                          <div className="p-4 space-y-4">
+                            <div className="flex items-center justify-between">
+                              <div className="flex items-center gap-2">
                                 <div className="h-10 w-10 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
                                   <CircleGauge className="h-5 w-5 text-blue-600 dark:text-blue-400" />
                                 </div>
+                                <span className="text-sm font-medium text-muted-foreground">Bearbeiten</span>
                               </div>
-                              <div className="flex-1 space-y-3">
-                                <div>
-                                  <Label htmlFor={`edit-custom-id-${zaehler.id}`} className="text-xs text-muted-foreground">
-                                    Zähler-ID
-                                  </Label>
-                                  <Input
-                                    id={`edit-custom-id-${zaehler.id}`}
-                                    value={editCustomId}
-                                    onChange={(e) => setEditCustomId(e.target.value)}
-                                    onKeyDown={(e) => {
-                                      if (e.key === "Enter") {
-                                        handleUpdateZaehler(zaehler.id)
-                                      } else if (e.key === "Escape") {
-                                        cancelEdit()
-                                      }
-                                    }}
-                                    disabled={isSaving}
-                                    placeholder="Zähler-ID"
-                                    autoFocus
-                                    className="mt-1"
-                                  />
-                                </div>
-                                <div>
-                                  <Label htmlFor={`edit-eichungsdatum-${zaehler.id}`} className="text-xs text-muted-foreground">
-                                    Eichungsdatum
-                                  </Label>
-                                  <Popover>
-                                    <PopoverTrigger asChild>
-                                      <Button
-                                        variant="outline"
-                                        className={cn(
-                                          "w-full justify-start text-left font-normal mt-1",
-                                          !editEichungsdatum && "text-muted-foreground"
-                                        )}
-                                        disabled={isSaving}
-                                      >
-                                        <CalendarIcon className="mr-2 h-4 w-4" />
-                                        {editEichungsdatum ? (
-                                          format(editEichungsdatum, "dd.MM.yyyy", { locale: de })
-                                        ) : (
-                                          <span>Datum wählen</span>
-                                        )}
-                                      </Button>
-                                    </PopoverTrigger>
-                                    <PopoverContent className="w-auto p-0" align="start">
-                                      <Calendar
-                                        mode="single"
-                                        selected={editEichungsdatum}
-                                        onSelect={setEditEichungsdatum}
-                                        locale={de}
-                                        captionLayout="dropdown"
-                                        fromYear={1990}
-                                        toYear={new Date().getFullYear() + 10}
-                                        initialFocus
-                                      />
-                                      {editEichungsdatum && (
-                                        <div className="p-3 border-t">
-                                          <Button
-                                            variant="ghost"
-                                            size="sm"
-                                            className="w-full"
-                                            onClick={() => setEditEichungsdatum(undefined)}
-                                          >
-                                            Datum löschen
-                                          </Button>
-                                        </div>
+                              <div className="flex gap-1">
+                                <Button
+                                  size="sm"
+                                  onClick={() => handleUpdateZaehler(zaehler.id)}
+                                  disabled={!editCustomId.trim() || isSaving}
+                                >
+                                  <Check className="h-4 w-4 mr-1" />
+                                  Speichern
+                                </Button>
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  onClick={cancelEdit}
+                                  disabled={isSaving}
+                                >
+                                  <X className="h-4 w-4" />
+                                </Button>
+                              </div>
+                            </div>
+                            
+                            <Separator />
+                            
+                            <div className="space-y-3">
+                              <div>
+                                <Label htmlFor={`edit-custom-id-${zaehler.id}`} className="text-xs text-muted-foreground flex items-center gap-1">
+                                  <Hash className="h-3 w-3" />
+                                  Zähler-ID
+                                </Label>
+                                <Input
+                                  id={`edit-custom-id-${zaehler.id}`}
+                                  value={editCustomId}
+                                  onChange={(e) => setEditCustomId(e.target.value)}
+                                  onKeyDown={(e) => {
+                                    if (e.key === "Enter") {
+                                      handleUpdateZaehler(zaehler.id)
+                                    } else if (e.key === "Escape") {
+                                      cancelEdit()
+                                    }
+                                  }}
+                                  disabled={isSaving}
+                                  placeholder="Zähler-ID"
+                                  autoFocus
+                                  className="mt-1.5"
+                                />
+                              </div>
+                              <div>
+                                <Label htmlFor={`edit-eichungsdatum-${zaehler.id}`} className="text-xs text-muted-foreground flex items-center gap-1">
+                                  <CalendarIcon className="h-3 w-3" />
+                                  Eichungsdatum
+                                </Label>
+                                <Popover>
+                                  <PopoverTrigger asChild>
+                                    <Button
+                                      variant="outline"
+                                      className={cn(
+                                        "w-full justify-start text-left font-normal mt-1.5",
+                                        !editEichungsdatum && "text-muted-foreground"
                                       )}
-                                    </PopoverContent>
-                                  </Popover>
-                                </div>
-                                <div className="flex gap-2 pt-2">
-                                  <Button
-                                    size="sm"
-                                    onClick={() => handleUpdateZaehler(zaehler.id)}
-                                    disabled={!editCustomId.trim() || isSaving}
-                                    className="flex-1"
-                                  >
-                                    <Check className="h-4 w-4 mr-2" />
-                                    Speichern
-                                  </Button>
-                                  <Button
-                                    size="sm"
-                                    variant="outline"
-                                    onClick={cancelEdit}
-                                    disabled={isSaving}
-                                  >
-                                    <X className="h-4 w-4" />
-                                  </Button>
-                                </div>
+                                      disabled={isSaving}
+                                    >
+                                      <CalendarIcon className="mr-2 h-4 w-4" />
+                                      {editEichungsdatum ? (
+                                        format(editEichungsdatum, "dd.MM.yyyy", { locale: de })
+                                      ) : (
+                                        <span>Datum wählen</span>
+                                      )}
+                                    </Button>
+                                  </PopoverTrigger>
+                                  <PopoverContent className="w-auto p-0" align="start">
+                                    <Calendar
+                                      mode="single"
+                                      selected={editEichungsdatum}
+                                      onSelect={setEditEichungsdatum}
+                                      locale={de}
+                                      captionLayout="dropdown"
+                                      fromYear={1990}
+                                      toYear={new Date().getFullYear() + 10}
+                                      initialFocus
+                                    />
+                                    {editEichungsdatum && (
+                                      <div className="p-3 border-t">
+                                        <Button
+                                          variant="ghost"
+                                          size="sm"
+                                          className="w-full"
+                                          onClick={() => setEditEichungsdatum(undefined)}
+                                        >
+                                          Datum löschen
+                                        </Button>
+                                      </div>
+                                    )}
+                                  </PopoverContent>
+                                </Popover>
                               </div>
                             </div>
                           </div>
                         ) : (
                           // View Mode
-                          <div className="flex items-start gap-3">
-                            <div className="flex-shrink-0">
-                              <div className="h-10 w-10 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
-                                <CircleGauge className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-                              </div>
-                            </div>
-                            <div className="flex-1 min-w-0">
-                              <div className="flex items-start justify-between gap-2">
-                                <div className="flex-1 min-w-0">
-                                  <h4 className="font-semibold text-base truncate">
-                                    {zaehler.custom_id || "Unbenannt"}
-                                  </h4>
-                                  <div className="flex flex-wrap gap-2 mt-2">
-                                    {zaehler.eichungsdatum && (
-                                      <Badge variant="secondary" className="text-xs font-normal">
-                                        <CalendarIcon className="h-3 w-3 mr-1" />
-                                        Eichung: {formatDate(zaehler.eichungsdatum)}
-                                      </Badge>
-                                    )}
-                                    <Badge variant="outline" className="text-xs font-normal">
-                                      Erstellt: {formatDate(zaehler.erstellungsdatum)}
-                                    </Badge>
+                          <div>
+                            {/* Header */}
+                            <div className="p-4">
+                              <div className="flex items-center justify-between">
+                                <div className="flex items-center gap-3">
+                                  <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center">
+                                    <CircleGauge className="h-5 w-5 text-primary" />
+                                  </div>
+                                  <div>
+                                    <h4 className="font-semibold text-base">
+                                      {zaehler.custom_id || "Unbenannt"}
+                                    </h4>
+                                    <p className="text-xs text-muted-foreground">Wasserzähler</p>
                                   </div>
                                 </div>
-                                <div className="flex gap-1 flex-shrink-0">
+                                <div className="flex gap-1">
                                   <Button
                                     size="sm"
                                     variant="ghost"
@@ -512,6 +521,60 @@ export function WasserZaehlerModal() {
                                     <Trash2 className="h-4 w-4" />
                                   </Button>
                                 </div>
+                              </div>
+                            </div>
+
+                            <Separator className="bg-gray-200 dark:bg-gray-700" />
+
+                            {/* Information Grid */}
+                            <div className="p-4 grid grid-cols-1 sm:grid-cols-3 gap-4">
+                              {/* Zählerstand (Placeholder) */}
+                              <div className="flex items-start gap-2">
+                                <div className="flex-shrink-0 mt-0.5">
+                                  <Gauge className="h-4 w-4 text-muted-foreground" />
+                                </div>
+                                <div className="flex-1 min-w-0">
+                                  <p className="text-xs text-muted-foreground mb-1">Zählerstand</p>
+                                  <p className="text-sm font-medium text-muted-foreground italic">
+                                    Noch nicht erfasst
+                                  </p>
+                                </div>
+                              </div>
+
+                              {/* Eichungsdatum */}
+                              <div className="flex items-start gap-2">
+                                <div className="flex-shrink-0 mt-0.5">
+                                  <CalendarIcon className="h-4 w-4 text-muted-foreground" />
+                                </div>
+                                <div className="flex-1 min-w-0">
+                                  <p className="text-xs text-muted-foreground mb-1">Eichungsdatum</p>
+                                  <p className="text-sm font-medium">
+                                    {zaehler.eichungsdatum ? formatDate(zaehler.eichungsdatum) : (
+                                      <span className="text-muted-foreground italic">Nicht gesetzt</span>
+                                    )}
+                                  </p>
+                                </div>
+                              </div>
+
+                              {/* Letzte Ablesung (Placeholder) */}
+                              <div className="flex items-start gap-2">
+                                <div className="flex-shrink-0 mt-0.5">
+                                  <Clock className="h-4 w-4 text-muted-foreground" />
+                                </div>
+                                <div className="flex-1 min-w-0">
+                                  <p className="text-xs text-muted-foreground mb-1">Letzte Ablesung</p>
+                                  <p className="text-sm font-medium text-muted-foreground italic">
+                                    Noch keine Ablesung
+                                  </p>
+                                </div>
+                              </div>
+                            </div>
+
+                            {/* Footer */}
+                            <div className="px-4 pb-4">
+                              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                                <Clock className="h-3 w-3" />
+                                <span>Erstellt am {formatDate(zaehler.erstellungsdatum)}</span>
                               </div>
                             </div>
                           </div>

--- a/components/wasser-zaehler-modal.tsx
+++ b/components/wasser-zaehler-modal.tsx
@@ -35,6 +35,7 @@ import { Separator } from "@/components/ui/separator"
 import { format } from "date-fns"
 import { de } from "date-fns/locale"
 import { cn } from "@/lib/utils"
+import { motion, AnimatePresence } from "framer-motion"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -373,11 +374,19 @@ export function WasserZaehlerModal() {
               ) : (
                 <div className="grid gap-3">
                   {zaehlerList.map((zaehler) => (
-                    <Card key={zaehler.id} className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl overflow-hidden hover:shadow-md transition-shadow">
+                    <Card key={zaehler.id} className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-sm rounded-3xl overflow-hidden hover:shadow-md transition-all duration-300">
                       <CardContent className="p-0">
-                        {editingId === zaehler.id ? (
-                          // Edit Mode
-                          <div className="p-4 space-y-4">
+                        <AnimatePresence mode="wait">
+                          {editingId === zaehler.id ? (
+                            // Edit Mode
+                            <motion.div
+                              key="edit"
+                              initial={{ opacity: 0, y: -10 }}
+                              animate={{ opacity: 1, y: 0 }}
+                              exit={{ opacity: 0, y: 10 }}
+                              transition={{ duration: 0.2, ease: "easeInOut" }}
+                              className="p-4 space-y-4"
+                            >
                             <div className="flex items-center justify-between">
                               <div className="flex items-center gap-2">
                                 <div className="h-10 w-10 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
@@ -408,7 +417,11 @@ export function WasserZaehlerModal() {
                             <Separator />
                             
                             <div className="space-y-3">
-                              <div>
+                              <motion.div
+                                initial={{ opacity: 0, y: 10 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                transition={{ duration: 0.2, delay: 0.1 }}
+                              >
                                 <Label htmlFor={`edit-custom-id-${zaehler.id}`} className="text-xs text-muted-foreground flex items-center gap-1">
                                   <Hash className="h-3 w-3" />
                                   Zähler-ID
@@ -429,8 +442,12 @@ export function WasserZaehlerModal() {
                                   autoFocus
                                   className="mt-1.5"
                                 />
-                              </div>
-                              <div>
+                              </motion.div>
+                              <motion.div
+                                initial={{ opacity: 0, y: 10 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                transition={{ duration: 0.2, delay: 0.2 }}
+                              >
                                 <Label htmlFor={`edit-eichungsdatum-${zaehler.id}`} className="text-xs text-muted-foreground flex items-center gap-1">
                                   <CalendarIcon className="h-3 w-3" />
                                   Eichungsdatum
@@ -478,12 +495,18 @@ export function WasserZaehlerModal() {
                                     )}
                                   </PopoverContent>
                                 </Popover>
-                              </div>
+                              </motion.div>
                             </div>
-                          </div>
-                        ) : (
-                          // View Mode
-                          <div>
+                            </motion.div>
+                          ) : (
+                            // View Mode
+                            <motion.div
+                              key="view"
+                              initial={{ opacity: 0, y: 10 }}
+                              animate={{ opacity: 1, y: 0 }}
+                              exit={{ opacity: 0, y: -10 }}
+                              transition={{ duration: 0.2, ease: "easeInOut" }}
+                            >
                             {/* Header */}
                             <div className="p-4">
                               <div className="flex items-center justify-between">
@@ -529,7 +552,12 @@ export function WasserZaehlerModal() {
                             {/* Information Grid */}
                             <div className="p-4 grid grid-cols-1 sm:grid-cols-3 gap-4">
                               {/* Zählerstand (Placeholder) */}
-                              <div className="flex items-start gap-2">
+                              <motion.div
+                                initial={{ opacity: 0, x: -20 }}
+                                animate={{ opacity: 1, x: 0 }}
+                                transition={{ duration: 0.3, delay: 0.1 }}
+                                className="flex items-start gap-2"
+                              >
                                 <div className="flex-shrink-0 mt-0.5">
                                   <Gauge className="h-4 w-4 text-muted-foreground" />
                                 </div>
@@ -539,10 +567,15 @@ export function WasserZaehlerModal() {
                                     Noch nicht erfasst
                                   </p>
                                 </div>
-                              </div>
+                              </motion.div>
 
                               {/* Eichungsdatum */}
-                              <div className="flex items-start gap-2">
+                              <motion.div
+                                initial={{ opacity: 0, x: -20 }}
+                                animate={{ opacity: 1, x: 0 }}
+                                transition={{ duration: 0.3, delay: 0.2 }}
+                                className="flex items-start gap-2"
+                              >
                                 <div className="flex-shrink-0 mt-0.5">
                                   <CalendarIcon className="h-4 w-4 text-muted-foreground" />
                                 </div>
@@ -554,10 +587,15 @@ export function WasserZaehlerModal() {
                                     )}
                                   </p>
                                 </div>
-                              </div>
+                              </motion.div>
 
                               {/* Letzte Ablesung (Placeholder) */}
-                              <div className="flex items-start gap-2">
+                              <motion.div
+                                initial={{ opacity: 0, x: -20 }}
+                                animate={{ opacity: 1, x: 0 }}
+                                transition={{ duration: 0.3, delay: 0.3 }}
+                                className="flex items-start gap-2"
+                              >
                                 <div className="flex-shrink-0 mt-0.5">
                                   <Clock className="h-4 w-4 text-muted-foreground" />
                                 </div>
@@ -567,7 +605,7 @@ export function WasserZaehlerModal() {
                                     Noch keine Ablesung
                                   </p>
                                 </div>
-                              </div>
+                              </motion.div>
                             </div>
 
                             {/* Footer */}
@@ -577,8 +615,9 @@ export function WasserZaehlerModal() {
                                 <span>Erstellt am {formatDate(zaehler.erstellungsdatum)}</span>
                               </div>
                             </div>
-                          </div>
-                        )}
+                            </motion.div>
+                          )}
+                        </AnimatePresence>
                       </CardContent>
                     </Card>
                   ))}

--- a/components/wasser-zaehler-modal.tsx
+++ b/components/wasser-zaehler-modal.tsx
@@ -1,0 +1,396 @@
+"use client"
+
+import * as React from "react"
+import { useModalStore } from "@/hooks/use-modal-store"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { toast } from "@/hooks/use-toast"
+import { Loader2, Plus, Trash2, Edit2, X, Check } from "lucide-react"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+
+interface WasserZaehler {
+  id: string
+  custom_id: string | null
+  wohnung_id: string
+}
+
+export function WasserZaehlerModal() {
+  const {
+    isWasserZaehlerModalOpen,
+    wasserZaehlerModalData,
+    closeWasserZaehlerModal,
+    setWasserZaehlerModalDirty,
+  } = useModalStore()
+
+  const [zaehlerList, setZaehlerList] = React.useState<WasserZaehler[]>([])
+  const [isLoading, setIsLoading] = React.useState(false)
+  const [isSaving, setIsSaving] = React.useState(false)
+  const [newCustomId, setNewCustomId] = React.useState("")
+  const [editingId, setEditingId] = React.useState<string | null>(null)
+  const [editValue, setEditValue] = React.useState("")
+  const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false)
+  const [zaehlerToDelete, setZaehlerToDelete] = React.useState<string | null>(null)
+
+  // Load existing Wasserzähler when modal opens
+  React.useEffect(() => {
+    if (isWasserZaehlerModalOpen && wasserZaehlerModalData?.wohnungId) {
+      loadZaehler()
+    }
+  }, [isWasserZaehlerModalOpen, wasserZaehlerModalData?.wohnungId])
+
+  const loadZaehler = async () => {
+    if (!wasserZaehlerModalData?.wohnungId) return
+
+    setIsLoading(true)
+    try {
+      const response = await fetch(`/api/wasser-zaehler?wohnung_id=${wasserZaehlerModalData.wohnungId}`)
+      if (response.ok) {
+        const data = await response.json()
+        setZaehlerList(data)
+      } else {
+        throw new Error("Fehler beim Laden der Wasserzähler")
+      }
+    } catch (error) {
+      console.error("Error loading Wasserzähler:", error)
+      toast({
+        title: "Fehler",
+        description: "Wasserzähler konnten nicht geladen werden.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleAddZaehler = async () => {
+    if (!newCustomId.trim() || !wasserZaehlerModalData?.wohnungId) return
+
+    setIsSaving(true)
+    try {
+      const response = await fetch("/api/wasser-zaehler", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          custom_id: newCustomId.trim(),
+          wohnung_id: wasserZaehlerModalData.wohnungId,
+        }),
+      })
+
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(error.error || "Fehler beim Hinzufügen")
+      }
+
+      const newZaehler = await response.json()
+      setZaehlerList((prev) => [...prev, newZaehler])
+      setNewCustomId("")
+      setWasserZaehlerModalDirty(true)
+      
+      toast({
+        title: "Erfolg",
+        description: "Wasserzähler erfolgreich hinzugefügt.",
+        variant: "success",
+      })
+    } catch (error) {
+      console.error("Error adding Wasserzähler:", error)
+      toast({
+        title: "Fehler",
+        description: error instanceof Error ? error.message : "Wasserzähler konnte nicht hinzugefügt werden.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleUpdateZaehler = async (id: string) => {
+    if (!editValue.trim()) return
+
+    setIsSaving(true)
+    try {
+      const response = await fetch(`/api/wasser-zaehler/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ custom_id: editValue.trim() }),
+      })
+
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(error.error || "Fehler beim Aktualisieren")
+      }
+
+      const updatedZaehler = await response.json()
+      setZaehlerList((prev) =>
+        prev.map((z) => (z.id === id ? updatedZaehler : z))
+      )
+      setEditingId(null)
+      setEditValue("")
+      setWasserZaehlerModalDirty(true)
+      
+      toast({
+        title: "Erfolg",
+        description: "Wasserzähler erfolgreich aktualisiert.",
+        variant: "success",
+      })
+    } catch (error) {
+      console.error("Error updating Wasserzähler:", error)
+      toast({
+        title: "Fehler",
+        description: error instanceof Error ? error.message : "Wasserzähler konnte nicht aktualisiert werden.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleDeleteZaehler = async () => {
+    if (!zaehlerToDelete) return
+
+    setIsSaving(true)
+    try {
+      const response = await fetch(`/api/wasser-zaehler/${zaehlerToDelete}`, {
+        method: "DELETE",
+      })
+
+      if (!response.ok) {
+        const error = await response.json()
+        throw new Error(error.error || "Fehler beim Löschen")
+      }
+
+      setZaehlerList((prev) => prev.filter((z) => z.id !== zaehlerToDelete))
+      setDeleteDialogOpen(false)
+      setZaehlerToDelete(null)
+      setWasserZaehlerModalDirty(true)
+      
+      toast({
+        title: "Erfolg",
+        description: "Wasserzähler erfolgreich gelöscht.",
+        variant: "success",
+      })
+    } catch (error) {
+      console.error("Error deleting Wasserzähler:", error)
+      toast({
+        title: "Fehler",
+        description: error instanceof Error ? error.message : "Wasserzähler konnte nicht gelöscht werden.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const startEdit = (zaehler: WasserZaehler) => {
+    setEditingId(zaehler.id)
+    setEditValue(zaehler.custom_id || "")
+  }
+
+  const cancelEdit = () => {
+    setEditingId(null)
+    setEditValue("")
+  }
+
+  const handleClose = () => {
+    setNewCustomId("")
+    setEditingId(null)
+    setEditValue("")
+    closeWasserZaehlerModal()
+  }
+
+  return (
+    <>
+      <Dialog open={isWasserZaehlerModalOpen} onOpenChange={handleClose}>
+        <DialogContent className="sm:max-w-[600px]">
+          <DialogHeader>
+            <DialogTitle>Wasserzähler verwalten</DialogTitle>
+            <DialogDescription>
+              Wasserzähler für Wohnung: {wasserZaehlerModalData?.wohnungName}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            {/* Add new Wasserzähler */}
+            <div className="flex gap-2">
+              <div className="flex-1">
+                <Label htmlFor="custom_id" className="sr-only">
+                  Zähler-ID
+                </Label>
+                <Input
+                  id="custom_id"
+                  placeholder="Zähler-ID eingeben..."
+                  value={newCustomId}
+                  onChange={(e) => setNewCustomId(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && newCustomId.trim()) {
+                      handleAddZaehler()
+                    }
+                  }}
+                  disabled={isSaving}
+                />
+              </div>
+              <Button
+                onClick={handleAddZaehler}
+                disabled={!newCustomId.trim() || isSaving}
+                size="default"
+              >
+                {isSaving ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <>
+                    <Plus className="h-4 w-4 mr-2" />
+                    Hinzufügen
+                  </>
+                )}
+              </Button>
+            </div>
+
+            {/* List of existing Wasserzähler */}
+            <div className="border rounded-lg">
+              {isLoading ? (
+                <div className="flex items-center justify-center p-8">
+                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                </div>
+              ) : zaehlerList.length === 0 ? (
+                <div className="text-center p-8 text-muted-foreground">
+                  Keine Wasserzähler vorhanden
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Zähler-ID</TableHead>
+                      <TableHead className="w-[100px] text-right">Aktionen</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {zaehlerList.map((zaehler) => (
+                      <TableRow key={zaehler.id}>
+                        <TableCell>
+                          {editingId === zaehler.id ? (
+                            <div className="flex gap-2">
+                              <Input
+                                value={editValue}
+                                onChange={(e) => setEditValue(e.target.value)}
+                                onKeyDown={(e) => {
+                                  if (e.key === "Enter") {
+                                    handleUpdateZaehler(zaehler.id)
+                                  } else if (e.key === "Escape") {
+                                    cancelEdit()
+                                  }
+                                }}
+                                disabled={isSaving}
+                                autoFocus
+                              />
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                onClick={() => handleUpdateZaehler(zaehler.id)}
+                                disabled={!editValue.trim() || isSaving}
+                              >
+                                <Check className="h-4 w-4" />
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                onClick={cancelEdit}
+                                disabled={isSaving}
+                              >
+                                <X className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          ) : (
+                            <span>{zaehler.custom_id || "-"}</span>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {editingId !== zaehler.id && (
+                            <div className="flex gap-1 justify-end">
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                onClick={() => startEdit(zaehler)}
+                                disabled={isSaving}
+                              >
+                                <Edit2 className="h-4 w-4" />
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                onClick={() => {
+                                  setZaehlerToDelete(zaehler.id)
+                                  setDeleteDialogOpen(true)
+                                }}
+                                disabled={isSaving}
+                                className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={handleClose}>
+              Schließen
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Wasserzähler löschen?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Möchten Sie diesen Wasserzähler wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isSaving}>Abbrechen</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteZaehler}
+              disabled={isSaving}
+              className="bg-red-600 hover:bg-red-700"
+            >
+              {isSaving ? "Löschen..." : "Löschen"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/components/wasser-zaehler-modal.tsx
+++ b/components/wasser-zaehler-modal.tsx
@@ -13,16 +13,10 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
 import { toast } from "@/hooks/use-toast"
-import { Loader2, Plus, Trash2, Edit2, X, Check } from "lucide-react"
+import { Loader2, Plus, Trash2, Edit2, X, Check, CircleGauge, Calendar } from "lucide-react"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -250,15 +244,15 @@ export function WasserZaehlerModal() {
   return (
     <>
       <Dialog open={isWasserZaehlerModalOpen} onOpenChange={handleClose}>
-        <DialogContent className="sm:max-w-[600px]">
+        <DialogContent className="sm:max-w-[700px] max-h-[85vh] flex flex-col">
           <DialogHeader>
             <DialogTitle>Wasserzähler verwalten</DialogTitle>
             <DialogDescription>
-              Wasserzähler für Wohnung: {wasserZaehlerModalData?.wohnungName}
+              Wasserzähler für Wohnung: <span className="font-medium">{wasserZaehlerModalData?.wohnungName}</span>
             </DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-4 py-4">
+          <div className="space-y-4 py-4 overflow-y-auto flex-1">
             {/* Add new Wasserzähler */}
             <div className="space-y-2">
               <Label className="text-sm font-medium">Neuen Wasserzähler hinzufügen</Label>
@@ -306,113 +300,151 @@ export function WasserZaehlerModal() {
             </div>
 
             {/* List of existing Wasserzähler */}
-            <div className="border rounded-lg">
+            <div className="space-y-3">
               {isLoading ? (
                 <div className="flex items-center justify-center p-8">
                   <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
                 </div>
               ) : zaehlerList.length === 0 ? (
-                <div className="text-center p-8 text-muted-foreground">
-                  Keine Wasserzähler vorhanden
-                </div>
+                <Card className="border-dashed">
+                  <CardContent className="flex flex-col items-center justify-center p-8 text-center">
+                    <CircleGauge className="h-12 w-12 text-muted-foreground/50 mb-3" />
+                    <p className="text-sm text-muted-foreground">
+                      Keine Wasserzähler vorhanden
+                    </p>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Fügen Sie oben einen neuen Wasserzähler hinzu
+                    </p>
+                  </CardContent>
+                </Card>
               ) : (
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Zähler-ID</TableHead>
-                      <TableHead>Eichungsdatum</TableHead>
-                      <TableHead>Erstellungsdatum</TableHead>
-                      <TableHead className="w-[100px] text-right">Aktionen</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {zaehlerList.map((zaehler) => (
-                      <TableRow key={zaehler.id}>
-                        <TableCell>
-                          {editingId === zaehler.id ? (
-                            <Input
-                              value={editCustomId}
-                              onChange={(e) => setEditCustomId(e.target.value)}
-                              onKeyDown={(e) => {
-                                if (e.key === "Enter") {
-                                  handleUpdateZaehler(zaehler.id)
-                                } else if (e.key === "Escape") {
-                                  cancelEdit()
-                                }
-                              }}
-                              disabled={isSaving}
-                              placeholder="Zähler-ID"
-                              autoFocus
-                            />
-                          ) : (
-                            <span>{zaehler.custom_id || "-"}</span>
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          {editingId === zaehler.id ? (
-                            <Input
-                              type="date"
-                              value={editEichungsdatum}
-                              onChange={(e) => setEditEichungsdatum(e.target.value)}
-                              disabled={isSaving}
-                              placeholder="Eichungsdatum"
-                            />
-                          ) : (
-                            <span className="text-muted-foreground">{formatDate(zaehler.eichungsdatum)}</span>
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          <span className="text-muted-foreground">{formatDate(zaehler.erstellungsdatum)}</span>
-                        </TableCell>
-                        <TableCell className="text-right">
-                          {editingId === zaehler.id ? (
-                            <div className="flex gap-1 justify-end">
-                              <Button
-                                size="sm"
-                                variant="ghost"
-                                onClick={() => handleUpdateZaehler(zaehler.id)}
-                                disabled={!editCustomId.trim() || isSaving}
-                              >
-                                <Check className="h-4 w-4" />
-                              </Button>
-                              <Button
-                                size="sm"
-                                variant="ghost"
-                                onClick={cancelEdit}
-                                disabled={isSaving}
-                              >
-                                <X className="h-4 w-4" />
-                              </Button>
+                <div className="grid gap-3">
+                  {zaehlerList.map((zaehler) => (
+                    <Card key={zaehler.id} className="overflow-hidden hover:shadow-md transition-shadow">
+                      <CardContent className="p-4">
+                        {editingId === zaehler.id ? (
+                          // Edit Mode
+                          <div className="space-y-3">
+                            <div className="flex items-start gap-3">
+                              <div className="flex-shrink-0 mt-1">
+                                <div className="h-10 w-10 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
+                                  <CircleGauge className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+                                </div>
+                              </div>
+                              <div className="flex-1 space-y-3">
+                                <div>
+                                  <Label htmlFor={`edit-custom-id-${zaehler.id}`} className="text-xs text-muted-foreground">
+                                    Zähler-ID
+                                  </Label>
+                                  <Input
+                                    id={`edit-custom-id-${zaehler.id}`}
+                                    value={editCustomId}
+                                    onChange={(e) => setEditCustomId(e.target.value)}
+                                    onKeyDown={(e) => {
+                                      if (e.key === "Enter") {
+                                        handleUpdateZaehler(zaehler.id)
+                                      } else if (e.key === "Escape") {
+                                        cancelEdit()
+                                      }
+                                    }}
+                                    disabled={isSaving}
+                                    placeholder="Zähler-ID"
+                                    autoFocus
+                                    className="mt-1"
+                                  />
+                                </div>
+                                <div>
+                                  <Label htmlFor={`edit-eichungsdatum-${zaehler.id}`} className="text-xs text-muted-foreground">
+                                    Eichungsdatum
+                                  </Label>
+                                  <Input
+                                    id={`edit-eichungsdatum-${zaehler.id}`}
+                                    type="date"
+                                    value={editEichungsdatum}
+                                    onChange={(e) => setEditEichungsdatum(e.target.value)}
+                                    disabled={isSaving}
+                                    className="mt-1"
+                                  />
+                                </div>
+                                <div className="flex gap-2 pt-2">
+                                  <Button
+                                    size="sm"
+                                    onClick={() => handleUpdateZaehler(zaehler.id)}
+                                    disabled={!editCustomId.trim() || isSaving}
+                                    className="flex-1"
+                                  >
+                                    <Check className="h-4 w-4 mr-2" />
+                                    Speichern
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={cancelEdit}
+                                    disabled={isSaving}
+                                  >
+                                    <X className="h-4 w-4" />
+                                  </Button>
+                                </div>
+                              </div>
                             </div>
-                          ) : (
-                            <div className="flex gap-1 justify-end">
-                              <Button
-                                size="sm"
-                                variant="ghost"
-                                onClick={() => startEdit(zaehler)}
-                                disabled={isSaving}
-                              >
-                                <Edit2 className="h-4 w-4" />
-                              </Button>
-                              <Button
-                                size="sm"
-                                variant="ghost"
-                                onClick={() => {
-                                  setZaehlerToDelete(zaehler.id)
-                                  setDeleteDialogOpen(true)
-                                }}
-                                disabled={isSaving}
-                                className="text-red-600 hover:text-red-700 hover:bg-red-50"
-                              >
-                                <Trash2 className="h-4 w-4" />
-                              </Button>
+                          </div>
+                        ) : (
+                          // View Mode
+                          <div className="flex items-start gap-3">
+                            <div className="flex-shrink-0">
+                              <div className="h-10 w-10 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
+                                <CircleGauge className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+                              </div>
                             </div>
-                          )}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
+                            <div className="flex-1 min-w-0">
+                              <div className="flex items-start justify-between gap-2">
+                                <div className="flex-1 min-w-0">
+                                  <h4 className="font-semibold text-base truncate">
+                                    {zaehler.custom_id || "Unbenannt"}
+                                  </h4>
+                                  <div className="flex flex-wrap gap-2 mt-2">
+                                    {zaehler.eichungsdatum && (
+                                      <Badge variant="secondary" className="text-xs font-normal">
+                                        <Calendar className="h-3 w-3 mr-1" />
+                                        Eichung: {formatDate(zaehler.eichungsdatum)}
+                                      </Badge>
+                                    )}
+                                    <Badge variant="outline" className="text-xs font-normal">
+                                      Erstellt: {formatDate(zaehler.erstellungsdatum)}
+                                    </Badge>
+                                  </div>
+                                </div>
+                                <div className="flex gap-1 flex-shrink-0">
+                                  <Button
+                                    size="sm"
+                                    variant="ghost"
+                                    onClick={() => startEdit(zaehler)}
+                                    disabled={isSaving}
+                                    className="h-8 w-8 p-0"
+                                  >
+                                    <Edit2 className="h-4 w-4" />
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="ghost"
+                                    onClick={() => {
+                                      setZaehlerToDelete(zaehler.id)
+                                      setDeleteDialogOpen(true)
+                                    }}
+                                    disabled={isSaving}
+                                    className="h-8 w-8 p-0 text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-950"
+                                  >
+                                    <Trash2 className="h-4 w-4" />
+                                  </Button>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        )}
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Description

Adds the water meter management modal with its own API.

## Summary of Changes

- New edge API routes `/api/wasser-zaehler` (GET list by `wohnung_id`, POST create) and `/api/wasser-zaehler/[id]` (PATCH, DELETE) — every operation verifies the apartment/meter belongs to the authenticated user
- New `wasser-zaehler-modal.tsx` (660 lines): add meters (custom id + optional calibration date), inline edit with animation, delete with confirmation dialog, empty state
- Apartment context menu gains a "Wasserzähler" entry; modal store gets the new modal state (including eager fetch of existing meters on open); modal registered in the dashboard layout