### PR TITLE
fix: resolve Lighthouse CI 'decamelize' module not found error

### DIFF
--- a/.github/workflows/lighthouse-report.yaml
+++ b/.github/workflows/lighthouse-report.yaml
@@ -152,32 +152,16 @@ jobs:
             build-
           fail-on-cache-miss: true
 
-      - name: Cache Lighthouse CI tools
-        id: cache-lighthouse-tools
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.npm
-            node_modules/@lhci
-            node_modules/wait-on
-            node_modules/which-module
-            node_modules/.bin/lhci
-            node_modules/.bin/wait-on
-          key: ${{ runner.os }}-lighthouse-tools-${{ hashFiles('**/package-lock.json') }}-v2
-          restore-keys: |
-            ${{ runner.os }}-lighthouse-tools-v2-
+      - name: Install dependencies (if not cached)
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline
 
       - name: Install Lighthouse CI tools
-        if: steps.cache-lighthouse-tools.outputs.cache-hit != 'true'
-        run: npm install --no-save @lhci/cli wait-on which-module
+        run: npm install --no-save @lhci/cli@0.12.x wait-on
 
       - name: Verify Lighthouse CI tools
         run: |
-          if [ "${{ steps.cache-lighthouse-tools.outputs.cache-hit }}" == "true" ]; then
-            echo "✓ Lighthouse CI tools restored from cache"
-          else
-            echo "✓ Lighthouse CI tools installed"
-          fi
+          echo "✓ Lighthouse CI tools installed"
           npx lhci --version
           npx wait-on --version
 


### PR DESCRIPTION
- Remove problematic caching of partial node_modules for @lhci tools
- Install @lhci/cli and wait-on fresh in each run to ensure complete dependency tree
- Pin @lhci/cli to 0.12.x for compatibility
- Remove unnecessary which-module dependency

This fixes the MODULE_NOT_FOUND error for 'decamelize' that was occurring due to incomplete caching of transitive dependencies.

fix #834 