### PR TITLE
Feature/auto fill nebenkosten date

### DIFF
--- a/components/tenant-edit-modal.tsx
+++ b/components/tenant-edit-modal.tsx
@@ -192,10 +192,10 @@ export function TenantEditModal({ serverAction }: TenantEditModalProps) {
           // Update the first entry's date if it's empty or matches the previous move-in date
           const firstEntry = prevEntries[0];
           if (firstEntry && (!firstEntry.date || firstEntry.date === prevFormData.einzug)) {
-            return [
+            return getSortedNebenkostenEntries([
               { ...firstEntry, date: formattedDate },
               ...prevEntries.slice(1)
-            ];
+            ]);
           }
           
           return prevEntries;


### PR DESCRIPTION
* **Default Nebenkosten Entry**: When editing a tenant who does not have any existing utility cost (Nebenkosten) entries, the system will now automatically initialize the form with one empty entry, ready for user input.
* **Automatic Nebenkosten Date Population**: The date field of the first utility cost entry will now automatically be populated with the tenant's 'Einzug' (move-in) date. This occurs when the move-in date is set or changed, and the utility cost entry's date is either empty or matches the previous move-in date.

fix #854 