### PR TITLE
Optimize bundle size by lazy loading modals and heavy libraries

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -4,46 +4,47 @@ import { AuthProvider } from "@/components/auth-provider"
 import { CommandMenu } from "@/components/command-menu"
 import { DashboardLayout } from "@/components/dashboard-layout"
 import { useModalStore } from "@/hooks/use-modal-store" // Added
-import { TenantEditModal } from "@/components/tenant-edit-modal" // Added
+import dynamic from 'next/dynamic'
+
 // Importing server action from its new location
 import { handleSubmit as tenantServerAction } from "@/app/mieter-actions" // Adjusted import path
-import { HouseEditModal } from "@/components/house-edit-modal" // Added
 import { handleSubmit as houseServerAction } from "@/app/(dashboard)/haeuser/actions" // Added
-import { FinanceEditModal } from "@/components/finance-edit-modal" // Added
 import { financeServerAction } from "@/app/finanzen-actions" // Added - Adjusted path due to tool limitation
-import { WohnungEditModal } from "@/components/wohnung-edit-modal" // Added
 import { wohnungServerAction } from "@/app/wohnungen-actions" // Added - Adjusted path
-import { AufgabeEditModal } from "@/components/aufgabe-edit-modal" // Added
 import { aufgabeServerAction } from "@/app/todos-actions" // Added
-import { BetriebskostenEditModal } from "@/components/betriebskosten-edit-modal"; // Added
-// Old WasserzaehlerModal removed - now using new Wasser_Zaehler structure
-import { WasserZaehlerModal } from "@/components/wasser-zaehler-modal"; // Added for Wasser_Zaehler table
-import { WasserAblesenModal } from "@/components/wasser-ablesungen-modal"; // Added for Wasser_Ablesungen table
-import { KautionModal } from "@/components/kaution-modal"; // Added
 import { updateKautionAction } from "@/app/mieter-actions"; // Added
-// Assuming betriebskosten-actions.ts exports server actions, adjust if needed
-// For now, let's assume no specific serverAction prop is needed for BetriebskostenEditModal
-// as it seemed to handle its actions internally or via imported functions.
-// We will check this during integration.
+
+// Lazy load modals
+const TenantEditModal = dynamic(() => import('@/components/tenant-edit-modal').then(mod => mod.TenantEditModal), { ssr: false })
+const HouseEditModal = dynamic(() => import('@/components/house-edit-modal').then(mod => mod.HouseEditModal), { ssr: false })
+const FinanceEditModal = dynamic(() => import('@/components/finance-edit-modal').then(mod => mod.FinanceEditModal), { ssr: false })
+const WohnungEditModal = dynamic(() => import('@/components/wohnung-edit-modal').then(mod => mod.WohnungEditModal), { ssr: false })
+const AufgabeEditModal = dynamic(() => import('@/components/aufgabe-edit-modal').then(mod => mod.AufgabeEditModal), { ssr: false })
+const BetriebskostenEditModal = dynamic(() => import('@/components/betriebskosten-edit-modal').then(mod => mod.BetriebskostenEditModal), { ssr: false })
+const WasserZaehlerModal = dynamic(() => import('@/components/wasser-zaehler-modal').then(mod => mod.WasserZaehlerModal), { ssr: false })
+const WasserAblesenModal = dynamic(() => import('@/components/wasser-ablesungen-modal').then(mod => mod.WasserAblesenModal), { ssr: false })
+const KautionModal = dynamic(() => import('@/components/kaution-modal').then(mod => mod.KautionModal), { ssr: false })
+const HausOverviewModal = dynamic(() => import('@/components/haus-overview-modal').then(mod => mod.HausOverviewModal), { ssr: false })
+const WohnungOverviewModal = dynamic(() => import('@/components/wohnung-overview-modal').then(mod => mod.WohnungOverviewModal), { ssr: false })
+const ApartmentTenantDetailsModal = dynamic(() => import('@/components/apartment-tenant-details-modal').then(mod => mod.ApartmentTenantDetailsModal), { ssr: false })
+const FileUploadModal = dynamic(() => import('@/components/file-upload-modal').then(mod => mod.FileUploadModal), { ssr: false })
+const FileRenameModal = dynamic(() => import('@/components/file-rename-modal').then(mod => mod.FileRenameModal), { ssr: false })
+const CreateFolderModal = dynamic(() => import('@/components/create-folder-modal').then(mod => mod.CreateFolderModal), { ssr: false })
+const CreateFileModal = dynamic(() => import('@/components/create-file-modal').then(mod => mod.CreateFileModal), { ssr: false })
+const FolderDeleteConfirmationModal = dynamic(() => import('@/components/folder-delete-confirmation-modal').then(mod => mod.FolderDeleteConfirmationModal), { ssr: false })
+const FileMoveModal = dynamic(() => import('@/components/file-move-modal').then(mod => mod.FileMoveModal), { ssr: false })
+const ShareDocumentModal = dynamic(() => import('@/components/share-document-modal').then(mod => mod.ShareDocumentModal), { ssr: false })
+const MarkdownEditorModal = dynamic(() => import('@/components/markdown-editor-modal').then(mod => mod.MarkdownEditorModal), { ssr: false })
+const TemplatesModal = dynamic(() => import('@/components/templates-modal').then(mod => mod.TemplatesModal), { ssr: false })
+const TenantMailTemplatesModal = dynamic(() => import('@/components/tenant-mail-templates-modal').then(mod => mod.TenantMailTemplatesModal), { ssr: false })
+const AIAssistantModal = dynamic(() => import('@/components/ai-assistant-modal').then(mod => mod.AIAssistantModal), { ssr: false })
+// Default exports
+const TenantPaymentEditModal = dynamic(() => import('@/components/tenant-payment-edit-modal'), { ssr: false })
+const TenantPaymentOverviewModal = dynamic(() => import('@/components/tenant-payment-overview-modal'), { ssr: false })
+
 import { ConfirmationDialog } from "@/components/ui/confirmation-dialog"; // Added
-import { HausOverviewModal } from "@/components/haus-overview-modal"; // Added
-import { WohnungOverviewModal } from "@/components/wohnung-overview-modal"; // Added
-import { ApartmentTenantDetailsModal } from "@/components/apartment-tenant-details-modal"; // Added
-import { FileUploadModal } from "@/components/file-upload-modal" // Removed FilePreviewModal import
-import { FileRenameModal } from "@/components/file-rename-modal"; // Added
-import { CreateFolderModal } from "@/components/create-folder-modal"; // Added
-import { CreateFileModal } from "@/components/create-file-modal"; // Added
-import { FolderDeleteConfirmationModal } from "@/components/folder-delete-confirmation-modal"; // Added
-import { FileMoveModal } from "@/components/file-move-modal"; // Added
-import { ShareDocumentModal } from "@/components/share-document-modal"; // Added
-import { MarkdownEditorModal } from "@/components/markdown-editor-modal"; // Added
-import { TemplatesModal } from "@/components/templates-modal"; // Added
-import { TenantMailTemplatesModal } from "@/components/tenant-mail-templates-modal"; // Added
 import { GlobalDragDropProvider } from "@/components/global-drag-drop-provider"; // Added
 import { NestedDialogProvider } from "@/components/ui/nested-dialog"; // Added
-import { AIAssistantModal } from "@/components/ai-assistant-modal"; // Added
-import TenantPaymentEditModal from "@/components/tenant-payment-edit-modal"; // Added
-import TenantPaymentOverviewModal from "@/components/tenant-payment-overview-modal"; // Added
 
 export default function DashboardRootLayout({
   children,

--- a/components/operating-costs-table.tsx
+++ b/components/operating-costs-table.tsx
@@ -1,8 +1,8 @@
 "use client"
 
 import React, { useState, useMemo } from "react"
+import dynamic from 'next/dynamic'
 import { CheckedState } from "@radix-ui/react-checkbox"
-import { AbrechnungModal } from "./abrechnung-modal";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Button } from "@/components/ui/button"
@@ -28,10 +28,13 @@ import { Nebenkosten, Mieter, Wasserzaehler, Rechnung, Haus } from "../lib/data-
 import { OptimizedNebenkosten, AbrechnungModalData } from "@/types/optimized-betriebskosten"; // Removed WasserzaehlerModalData
 import { isoToGermanDate } from "@/utils/date-calculations"
 import { Edit, Trash2, FileText, Droplets, ChevronsUpDown, ArrowUp, ArrowDown, Calendar, Building2, Euro, Calculator, MoreVertical, X, Download, Pencil, Loader2 } from "lucide-react"
-import { OperatingCostsOverviewModal } from "./operating-costs-overview-modal"
-// Old WasserzaehlerModal removed - now using optimized modal store approach
-import { WasserZaehlerVerwaltungModal } from "./wasser-zaehler-verwaltung-modal" // Added
-import { WasserZaehlerAblesenModal } from "./wasser-zaehler-ablesungen-modal" // Added
+
+// Lazy load modals to reduce bundle size
+const AbrechnungModal = dynamic(() => import('./abrechnung-modal').then(mod => mod.AbrechnungModal), { ssr: false })
+const OperatingCostsOverviewModal = dynamic(() => import('./operating-costs-overview-modal').then(mod => mod.OperatingCostsOverviewModal), { ssr: false })
+const WasserZaehlerVerwaltungModal = dynamic(() => import('./wasser-zaehler-verwaltung-modal').then(mod => mod.WasserZaehlerVerwaltungModal), { ssr: false })
+const WasserZaehlerAblesenModal = dynamic(() => import('./wasser-zaehler-ablesungen-modal').then(mod => mod.WasserZaehlerAblesenModal), { ssr: false })
+
 import { 
   getAbrechnungModalDataAction, 
   deleteNebenkosten as deleteNebenkostenServerAction,

--- a/components/wasser-zaehler-import-modal.tsx
+++ b/components/wasser-zaehler-import-modal.tsx
@@ -10,8 +10,6 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useToast } from "@/hooks/use-toast";
 import { Upload, Check, AlertTriangle, X, FileSpreadsheet, Loader2, Hash, Calendar, Gauge, Droplets } from "lucide-react";
-import * as XLSX from "xlsx";
-import Papa from "papaparse";
 import { WasserZaehler, WasserAblesung } from "@/lib/data-fetching";
 import { bulkCreateWasserAblesungen } from "@/app/wasser-zaehler-actions";
 import { isoToGermanDate } from "@/utils/date-calculations";
@@ -77,6 +75,7 @@ export function WasserZaehlerImportModal({
     const fileExtension = file.name.split(".").pop()?.toLowerCase();
 
     if (fileExtension === "csv") {
+      const Papa = (await import("papaparse")).default;
       Papa.parse(file, {
         header: true,
         skipEmptyLines: true,
@@ -89,11 +88,12 @@ export function WasserZaehlerImportModal({
             toast({ title: "Fehler", description: "Die CSV-Datei ist leer oder ungültig.", variant: "destructive" });
           }
         },
-        error: (error) => {
+        error: (error: any) => {
           toast({ title: "Fehler", description: `Fehler beim Parsen der CSV: ${error.message}`, variant: "destructive" });
         },
       });
     } else if (fileExtension === "xlsx" || fileExtension === "xls") {
+      const XLSX = await import("xlsx");
       const reader = new FileReader();
       reader.onload = (e) => {
         try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -200,6 +200,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -786,6 +787,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -809,6 +811,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -828,6 +831,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1058,6 +1062,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.2.tgz",
       "integrity": "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.2",
         "@floating-ui/utils": "^0.2.10"
@@ -5142,6 +5147,7 @@
       "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-8.3.0.tgz",
       "integrity": "sha512-hmC3u0anySPI+As+wFGrKG38pXnXAUqyiitnYeYknEOslcDM96AkBdMNxKYOopecuP/v1HMbclUEq8/DKKn+6w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.16"
       }
@@ -5226,6 +5232,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.79.0.tgz",
       "integrity": "sha512-x9ndEaBSwoRnFOOZGhh2CeV69Uz4B/EOSGCbKysDhTiYakiCAdDXaNuLPluviKU/Aot+F7BglXZDZ0YJ3GpGrw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.79.0",
         "@supabase/functions-js": "2.79.0",
@@ -5356,6 +5363,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.10.2.tgz",
       "integrity": "sha512-rWgo/9g5lSWT3/00wPvG+3EEuPqDxegYMp0v7YkSuURi43Btf+SG4yGtQ5Si9ICF0NJjeZoHLusrjeVltcrsSw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5578,6 +5586,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.10.2.tgz",
       "integrity": "sha512-4IGOQRcy/REuaskha5z29Vb5Hn3l5jTgfT7+aUO5cwAGZFOlEzSgOGBCq2sH4gVSfBqzdG5mGSH4+LEdwfpW8g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5698,6 +5707,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.10.2.tgz",
       "integrity": "sha512-XyvMn6B6PCPsgV6VMLiS1QXI1OKarBAYwXmqsE+gCzzYyXxYX4sLUlQ8JKysREyIGMHxSg5vgOajsgXgFMrvyA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5712,6 +5722,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.10.2.tgz",
       "integrity": "sha512-qXsp7guPLoir49Fh6IOzg6IAJA3tYYy/1316vv7DhJwmdF9GebkwgFcei2XGk6vKlwv18jWV+BlqDv9iwQ5Alg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -5805,6 +5816,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.10.2.tgz",
       "integrity": "sha512-mgai1SV7a95UudYmKNovgr5blL2Nw876hQ96S2x2uRbWnSo4gE3rTwWk1PIMWn8ov7ULsA36WAyhnK2kXxAWKA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -5858,8 +5870,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6105,6 +6116,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.2.tgz",
       "integrity": "sha512-Cdqa/eJTvt4fC4wmq1Mcc0CPUjp/Qy2FGqLza3z3pKymsI969TcZ54diNJv8UYUgeWxyb8FSbCkhdR6WqmUFhA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -6143,6 +6155,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -6152,6 +6165,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
       "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -6251,6 +6265,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.38.0.tgz",
       "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.38.0",
         "@typescript-eslint/types": "8.38.0",
@@ -6747,6 +6762,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7374,6 +7390,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -8169,6 +8186,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -8369,8 +8387,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -8508,7 +8525,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -8778,6 +8796,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8945,6 +8964,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -10960,6 +10980,7 @@
       "integrity": "sha512-9QE0RS4WwTj/TtTC4h/eFVmFAhGNVerSB9XpJh8sqaXlP73ILcPcZ7JWjjEtJJe2m8QyBLKKfPQuK+3F+Xij/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.0.4",
         "@jest/types": "30.0.1",
@@ -12018,6 +12039,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -12062,6 +12084,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -12188,6 +12211,7 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.3.tgz",
       "integrity": "sha512-eURjAyz5iX1H8BOYAfzvdPfIKK53V7mCpBTe7Kb16PaM8JSXEcUQNBQaiWMI8wY5RvNOPj4GccMjTlfwRBd+oQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.9",
         "fast-png": "^6.2.0",
@@ -12418,7 +12442,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -12723,6 +12746,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.6.tgz",
       "integrity": "sha512-zTxsnI3LQo3c9HSdSf91O1jMNsEzIXDShXd4wVdg9y5shwLqBXi4ZtUUJyB86KGVSJLZx0PFONvO54aheGX8QQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.5.6",
         "@swc/helpers": "0.5.15",
@@ -13337,6 +13361,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13524,7 +13549,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -13540,7 +13564,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -13672,6 +13695,7 @@
       "version": "1.25.3",
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.3.tgz",
       "integrity": "sha512-dY2HdaNXlARknJbrManZ1WyUtos+AP97AmvqdOQtWtrrC5g4mohVX5DTi9rXNFSk09eczLq9GuNTtq3EfMeMGA==",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -13698,6 +13722,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
       "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -13753,6 +13778,7 @@
       "version": "1.41.0",
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.0.tgz",
       "integrity": "sha512-FatMIIl0vRHMcNc3sPy3cMw5MMyWuO1nWQxqvYpJvXAruucGvmQ2tyyjT2/Lbok77T9a/qZqBVCq4sj43V2ihw==",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -13851,6 +13877,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -13877,6 +13904,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -13890,6 +13918,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.66.0.tgz",
       "integrity": "sha512-xXBqsWGKrY46ZqaHDo+ZUYiMUgi8suYu5kdrS20EG8KiL7VRQitEbNjm+UcrDYrNi1YLyfpmAeGjCZYXLT9YBw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -13913,6 +13942,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -14091,7 +14121,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -15085,6 +15116,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -15239,6 +15271,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15409,6 +15442,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15608,6 +15642,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
- Lazy loaded all global modals in `app/(dashboard)/layout.tsx` using `next/dynamic` with `{ ssr: false }` to significantly reduce the initial bundle size for all dashboard pages.
- Lazy loaded modals in `components/operating-costs-table.tsx` to reduce the bundle size of the `/betriebskosten` page.
- Refactored `components/wasser-zaehler-import-modal.tsx` to use dynamic imports for `xlsx` and `papaparse`, ensuring these heavy libraries are only loaded when needed.
- Verified optimization by confirming a reduction in the `/betriebskosten` page size from 149 kB to ~20 kB and First Load JS from 357 kB to ~177 kB.