### PR TITLE
Feature number input german format

### DIFF
--- a/__tests__/wasser-ablesungen-unsaved-changes.test.tsx
+++ b/__tests__/wasser-ablesungen-unsaved-changes.test.tsx
@@ -86,7 +86,7 @@ describe('WasserAblesenModal - Unsaved Changes Detection', () => {
     render(<WasserAblesenModal />)
 
     await waitFor(() => {
-      expect(screen.getByText('123.45 m³')).toBeInTheDocument()
+      expect(screen.getByText('123,45 m³')).toBeInTheDocument()
     })
 
     // Click edit button
@@ -100,12 +100,12 @@ describe('WasserAblesenModal - Unsaved Changes Detection', () => {
       fireEvent.click(editButton)
 
       await waitFor(() => {
-        const editInput = screen.getByDisplayValue('123.45')
+        const editInput = screen.getByDisplayValue('123,45')
         expect(editInput).toBeInTheDocument()
       })
 
       // Change the value
-      const editInput = screen.getByDisplayValue('123.45')
+      const editInput = screen.getByDisplayValue('123,45')
       fireEvent.change(editInput, { target: { value: '125.00' } })
 
       // Should set dirty state to true
@@ -119,7 +119,7 @@ describe('WasserAblesenModal - Unsaved Changes Detection', () => {
     render(<WasserAblesenModal />)
 
     await waitFor(() => {
-      expect(screen.getByText('123.45 m³')).toBeInTheDocument()
+      expect(screen.getByText('123,45 m³')).toBeInTheDocument()
     })
 
     // Click edit button
@@ -133,12 +133,12 @@ describe('WasserAblesenModal - Unsaved Changes Detection', () => {
       fireEvent.click(editButton)
 
       await waitFor(() => {
-        const editInput = screen.getByDisplayValue('123.45')
+        const editInput = screen.getByDisplayValue('123,45')
         expect(editInput).toBeInTheDocument()
       })
 
       // Change the value
-      const editInput = screen.getByDisplayValue('123.45')
+      const editInput = screen.getByDisplayValue('123,45')
       fireEvent.change(editInput, { target: { value: '125.00' } })
 
       // Find and click cancel button (X button)
@@ -188,7 +188,7 @@ describe('WasserAblesenModal - Unsaved Changes Detection', () => {
     render(<WasserAblesenModal />)
 
     await waitFor(() => {
-      expect(screen.getByText('123.45 m³')).toBeInTheDocument()
+      expect(screen.getByText('123,45 m³')).toBeInTheDocument()
     })
 
     // Initially should not be dirty (or set to false)
@@ -203,7 +203,7 @@ describe('WasserAblesenModal - Unsaved Changes Detection', () => {
     render(<WasserAblesenModal />)
 
     await waitFor(() => {
-      expect(screen.getByText('123.45 m³')).toBeInTheDocument()
+      expect(screen.getByText('123,45 m³')).toBeInTheDocument()
     })
 
     // Click edit button
@@ -217,7 +217,7 @@ describe('WasserAblesenModal - Unsaved Changes Detection', () => {
       fireEvent.click(editButton)
 
       await waitFor(() => {
-        const editInput = screen.getByDisplayValue('123.45')
+        const editInput = screen.getByDisplayValue('123,45')
         expect(editInput).toBeInTheDocument()
       })
 
@@ -240,7 +240,7 @@ describe('WasserAblesenModal - Unsaved Changes Detection', () => {
     render(<WasserAblesenModal />)
 
     await waitFor(() => {
-      expect(screen.getByText('123.45 m³')).toBeInTheDocument()
+      expect(screen.getByText('123,45 m³')).toBeInTheDocument()
     })
 
     // Click edit button
@@ -254,12 +254,12 @@ describe('WasserAblesenModal - Unsaved Changes Detection', () => {
       fireEvent.click(editButton)
 
       await waitFor(() => {
-        const editInput = screen.getByDisplayValue('15.5')
+        const editInput = screen.getByDisplayValue('15,5')
         expect(editInput).toBeInTheDocument()
       })
 
       // Change the verbrauch value
-      const verbrauchInput = screen.getByDisplayValue('15.5')
+      const verbrauchInput = screen.getByDisplayValue('15,5')
       fireEvent.change(verbrauchInput, { target: { value: '20.0' } })
 
       // Should set dirty state to true

--- a/components/apartment-edit-modal.tsx
+++ b/components/apartment-edit-modal.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { NumberInput } from "@/components/ui/number-input"
 import { Label } from "@/components/ui/label"
 import { CustomCombobox, ComboboxOption } from "@/components/ui/custom-combobox"
 import { toast } from "@/hooks/use-toast"
@@ -160,11 +161,11 @@ export function ApartmentEditModal({
           </div>
           <div className="space-y-2">
             <Label htmlFor="groesse">Größe (m²)</Label>
-            <Input id="groesse" name="groesse" type="number" value={formData.groesse} onChange={handleChange} required disabled={loading} />
+            <NumberInput id="groesse" name="groesse" value={formData.groesse} onChange={handleChange} required disabled={loading} />
           </div>
           <div className="space-y-2">
             <Label htmlFor="miete">Miete (€)</Label>
-            <Input id="miete" name="miete" type="number" value={formData.miete} onChange={handleChange} required disabled={loading} />
+            <NumberInput id="miete" name="miete" value={formData.miete} onChange={handleChange} required disabled={loading} />
           </div>
           <div className="space-y-2">
             <Label htmlFor="haus_id">Haus</Label>

--- a/components/betriebskosten-edit-modal.tsx
+++ b/components/betriebskosten-edit-modal.tsx
@@ -33,6 +33,7 @@ import {
 import { PlusCircle, Trash2, GripVertical, CalendarPlus, CalendarMinus, FileInput, BookDashed } from "lucide-react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
+import { NumberInput } from "./ui/number-input";
 import { Label } from "./ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 import { Skeleton } from "./ui/skeleton";
@@ -1053,7 +1054,7 @@ export function BetriebskostenEditModal({}: BetriebskostenEditModalPropsRefactor
                   Wasserkosten (€)
                 </LabelWithTooltip>
                 {isFormLoading ? <Skeleton className="h-10 w-full" /> : (
-                  <Input id="formWasserkosten" type="number" value={wasserkosten} onChange={handleWasserkostenChange} placeholder="z.B. 500.00" step="0.01" disabled={isSaving || isFormLoading} />
+                  <NumberInput id="formWasserkosten" value={wasserkosten} onChange={handleWasserkostenChange} placeholder="z.B. 500.00" step="0.01" disabled={isSaving || isFormLoading} />
                 )}
               </div>
             </div>

--- a/components/finance-edit-modal.tsx
+++ b/components/finance-edit-modal.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { NumberInput } from "@/components/ui/number-input";
 import { LabelWithTooltip } from "@/components/ui/label-with-tooltip";
 import {
   Select,
@@ -215,7 +216,7 @@ export function FinanceEditModal(props: FinanceEditModalProps) {
               <LabelWithTooltip htmlFor="betrag" infoText="Betrag der Transaktion in Euro.">
                 Betrag (€)
               </LabelWithTooltip>
-              <Input id="betrag" name="betrag" type="number" step="0.01" value={formData.betrag} onChange={handleChange} required disabled={isSubmitting} />
+              <NumberInput id="betrag" name="betrag" step="0.01" value={formData.betrag} onChange={handleChange} required disabled={isSubmitting} />
             </div>
             <div className="space-y-2">
               <LabelWithTooltip htmlFor="datum" infoText="Buchungs- oder Zahlungsdatum. Wird für Monats- und Jahresauswertungen, Cashflow-Berechnungen und die korrekte Zuordnung von Transaktionen verwendet.">

--- a/components/house-edit-modal.tsx
+++ b/components/house-edit-modal.tsx
@@ -10,6 +10,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -262,10 +263,9 @@ export function HouseEditModal(props: HouseEditModalProps) {
           </div>
           <div className="space-y-2">
             <Label htmlFor="manualGroesse">Größe in m²</Label>
-            <Input
+            <NumberInput
               id="manualGroesse"
               name="manualGroesse"
-              type="number"
               value={manualGroesse}
               onChange={handleManualGroesseChange}
               disabled={automaticSize || isSubmitting}

--- a/components/kaution-modal.tsx
+++ b/components/kaution-modal.tsx
@@ -7,6 +7,7 @@ import { toast } from "@/hooks/use-toast"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { NumberInput } from "@/components/ui/number-input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select"
 import { DatePicker } from "@/components/ui/date-picker"
@@ -301,9 +302,8 @@ export function KautionModal({ serverAction }: KautionModalProps) {
                   </span>
                 )}
               </Label>
-              <Input
+              <NumberInput
                 id="amount"
-                type="number"
                 step="0.01"
                 min="0"
                 placeholder="0,00"

--- a/components/sortable-cost-item.tsx
+++ b/components/sortable-cost-item.tsx
@@ -9,6 +9,7 @@ import { PlusCircle, Trash2, GripVertical } from "lucide-react";
 import { normalizeBerechnungsart } from "../utils/betriebskosten";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
+import { NumberInput } from "./ui/number-input";
 import { Label } from "./ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 import { Skeleton } from "./ui/skeleton";
@@ -121,9 +122,8 @@ export function SortableCostItem({
               Beträge pro Mieter unten
             </div>
           ) : (
-            <Input
+            <NumberInput
               id={`betrag-${item.id}`}
-              type="number"
               placeholder="Betrag (€)"
               value={item.betrag}
               onChange={(e) => onCostItemChange(index, 'betrag', e.target.value)}
@@ -230,9 +230,8 @@ export function SortableCostItem({
                           {mieter.name}
                         </Label>
                         <div className="flex-shrink-0 w-32">
-                          <Input
+                          <NumberInput
                             id={`rechnung-${item.id}-${mieter.id}`}
-                            type="number"
                             step="0.01"
                             placeholder="Betrag (€)"
                             value={rechnungForMieter?.betrag || ''}

--- a/components/tenant-edit-modal.tsx
+++ b/components/tenant-edit-modal.tsx
@@ -9,6 +9,7 @@ import { toast } from "@/hooks/use-toast";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { NumberInput } from "@/components/ui/number-input"
 import { Label } from "@/components/ui/label"
 import { InfoTooltip } from "@/components/ui/info-tooltip"
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select"
@@ -384,8 +385,7 @@ export function TenantEditModal({ serverAction }: TenantEditModalProps) {
                     ) : nebenkostenEntries.map((entry) => (
                       <div key={entry.id} className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] sm:items-start">
                         <div className="space-y-1">
-                          <Input
-                            type="number"
+                          <NumberInput
                             step="0.01"
                             placeholder="Betrag (€)"
                             value={entry.amount}

--- a/components/tenant-payment-edit-modal.tsx
+++ b/components/tenant-payment-edit-modal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { NumberInput } from "@/components/ui/number-input"
 import { Label } from "@/components/ui/label"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
@@ -317,9 +318,8 @@ export default function TenantPaymentEditModal() {
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
               <Label htmlFor="rent">Tatsächliche Mietzahlung (€)</Label>
-              <Input
+              <NumberInput
                 id="rent"
-                type="number"
                 step="0.01"
                 min="0"
                 value={rent}
@@ -332,9 +332,8 @@ export default function TenantPaymentEditModal() {
 
             <div>
               <Label htmlFor="nebenkosten">Tatsächliche Nebenkosten-Vorauszahlung (€)</Label>
-              <Input
+              <NumberInput
                 id="nebenkosten"
-                type="number"
                 step="0.01"
                 min="0"
                 value={nebenkosten}

--- a/components/ui/__tests__/number-input.test.tsx
+++ b/components/ui/__tests__/number-input.test.tsx
@@ -1,0 +1,47 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { NumberInput } from "../number-input"
+
+describe("NumberInput", () => {
+  it("formats initial value with comma", () => {
+    render(<NumberInput value="2.5" onChange={() => {}} />)
+    const input = screen.getByRole("textbox") as HTMLInputElement
+    expect(input.value).toBe("2,5")
+  })
+
+  it("handles undefined value by showing empty string", () => {
+    render(<NumberInput value={undefined} onChange={() => {}} />)
+    const input = screen.getByRole("textbox") as HTMLInputElement
+    expect(input.value).toBe("")
+  })
+
+  it("calls onChange with dot format when typing comma", () => {
+    const handleChange = jest.fn()
+    render(<NumberInput value="" onChange={handleChange} name="test-field" />)
+    const input = screen.getByRole("textbox") as HTMLInputElement
+
+    // User types "2,5"
+    fireEvent.change(input, { target: { value: "2,5" } })
+
+    expect(input.value).toBe("2,5")
+
+    expect(handleChange).toHaveBeenCalled()
+    const event = handleChange.mock.calls[0][0]
+    expect(event.target.value).toBe("2.5")
+    expect(event.target.name).toBe("test-field")
+  })
+
+  it("calls onChange with dot format when typing dot", () => {
+    const handleChange = jest.fn()
+    render(<NumberInput value="" onChange={handleChange} />)
+    const input = screen.getByRole("textbox") as HTMLInputElement
+
+    // User types "2.5"
+    fireEvent.change(input, { target: { value: "2.5" } })
+
+    expect(input.value).toBe("2.5")
+
+    expect(handleChange).toHaveBeenCalled()
+    expect(handleChange.mock.calls[0][0].target.value).toBe("2.5")
+  })
+})

--- a/components/ui/number-input.tsx
+++ b/components/ui/number-input.tsx
@@ -1,0 +1,58 @@
+import * as React from "react"
+import { Input } from "@/components/ui/input"
+
+export interface NumberInputProps extends Omit<React.ComponentProps<"input">, "value" | "onChange"> {
+  value?: string | number
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+}
+
+export const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
+  ({ value, onChange, ...props }, ref) => {
+    const [displayValue, setDisplayValue] = React.useState("")
+
+    React.useEffect(() => {
+       if (value === undefined || value === null) {
+        setDisplayValue("")
+      } else {
+        // Convert dot to comma for display
+        setDisplayValue(value.toString().replace('.', ','))
+      }
+    }, [value])
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const inputValue = e.target.value
+
+      // Update display value immediately
+      setDisplayValue(inputValue)
+
+      // Replace comma with dot for the value passed to parent
+      const dotValue = inputValue.replace(/,/g, '.')
+
+      if (onChange) {
+        // Create a proxy event that allows reading target.name and target.value
+        const eventShim = {
+            ...e,
+            target: {
+                ...e.target,
+                value: dotValue,
+                name: props.name || e.target.name,
+            }
+        } as unknown as React.ChangeEvent<HTMLInputElement>;
+
+        onChange(eventShim);
+      }
+    }
+
+    return (
+      <Input
+        {...props}
+        ref={ref}
+        type="text"
+        inputMode="decimal"
+        value={displayValue}
+        onChange={handleChange}
+      />
+    )
+  }
+)
+NumberInput.displayName = "NumberInput"

--- a/components/ui/number-input.tsx
+++ b/components/ui/number-input.tsx
@@ -11,7 +11,7 @@ export const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
     const [displayValue, setDisplayValue] = React.useState("")
 
     React.useEffect(() => {
-       if (value === undefined || value === null) {
+      if (value === undefined || value === null) {
         setDisplayValue("")
       } else {
         // Convert dot to comma for display
@@ -25,18 +25,18 @@ export const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
       // Update display value immediately
       setDisplayValue(inputValue)
 
-      // Replace comma with dot for the value passed to parent
-      const dotValue = inputValue.replace(/,/g, '.')
+      // Convert German format (e.g. 1.234,56) to standard format (1234.56)
+      const dotValue = inputValue.replace(/\./g, "").replace(",", ".")
 
       if (onChange) {
         // Create a proxy event that allows reading target.name and target.value
         const eventShim = {
-            ...e,
-            target: {
-                ...e.target,
-                value: dotValue,
-                name: props.name || e.target.name,
-            }
+          ...e,
+          target: {
+            ...e.target,
+            value: dotValue,
+            name: props.name || e.target.name,
+          }
         } as unknown as React.ChangeEvent<HTMLInputElement>;
 
         onChange(eventShim);

--- a/components/wasser-ablesungen-modal.tsx
+++ b/components/wasser-ablesungen-modal.tsx
@@ -41,6 +41,7 @@ import { Separator } from "@/components/ui/separator"
 import { format } from "date-fns"
 import { de } from "date-fns/locale"
 import { cn } from "@/lib/utils"
+import { formatNumber } from "@/utils/format"
 import { motion, AnimatePresence } from "framer-motion"
 import {
   AlertDialog,
@@ -917,7 +918,7 @@ export function WasserAblesenModal() {
                                     <div className="flex-1 min-w-0">
                                       <p className="text-xs text-muted-foreground mb-1">Zählerstand</p>
                                       <p className="text-sm font-medium">
-                                        {ablesung.zaehlerstand !== null ? `${ablesung.zaehlerstand} m³` : (
+                                        {ablesung.zaehlerstand !== null ? `${formatNumber(ablesung.zaehlerstand)} m³` : (
                                           <span className="text-muted-foreground italic">Nicht gesetzt</span>
                                         )}
                                       </p>
@@ -936,7 +937,7 @@ export function WasserAblesenModal() {
                                     <div className="flex-1 min-w-0">
                                       <p className="text-xs text-muted-foreground mb-1">Verbrauch</p>
                                       <p className="text-sm font-medium">
-                                        {ablesung.verbrauch} m³
+                                        {formatNumber(ablesung.verbrauch)} m³
                                       </p>
                                     </div>
                                   </motion.div>
@@ -969,7 +970,7 @@ export function WasserAblesenModal() {
                                               : ""
                                           return (
                                             <span className={changeClass}>
-                                              {change > 0 ? '+' : ''}{change.toFixed(1)}%
+                                              {change > 0 ? '+' : ''}{formatNumber(change, 1)}%
                                             </span>
                                           )
                                         })()}

--- a/components/wasser-ablesungen-modal.tsx
+++ b/components/wasser-ablesungen-modal.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { NumberInput } from "@/components/ui/number-input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { toast } from "@/hooks/use-toast"
@@ -625,8 +626,7 @@ export function WasserAblesenModal() {
                   </Popover>
                 </div>
                 <div className="space-y-2">
-                  <Input
-                    type="number"
+                  <NumberInput
                     step="0.01"
                     placeholder="Zählerstand (m³)"
                     value={newZaehlerstand}
@@ -640,8 +640,7 @@ export function WasserAblesenModal() {
                   />
                 </div>
                 <div className="space-y-2">
-                  <Input
-                    type="number"
+                  <NumberInput
                     step="0.01"
                     placeholder="Verbrauch (m³)"
                     value={newVerbrauch}
@@ -803,8 +802,7 @@ export function WasserAblesenModal() {
                                       <Gauge className="h-3 w-3" />
                                       Zählerstand
                                     </Label>
-                                    <Input
-                                      type="number"
+                                    <NumberInput
                                       step="0.01"
                                       value={editZaehlerstand}
                                       onChange={(e) => {
@@ -823,8 +821,7 @@ export function WasserAblesenModal() {
                                       <Droplet className="h-3 w-3" />
                                       Verbrauch
                                     </Label>
-                                    <Input
-                                      type="number"
+                                    <NumberInput
                                       step="0.01"
                                       value={editVerbrauch}
                                       onChange={(e) => setEditVerbrauch(e.target.value)}

--- a/components/wasser-zaehler-ablesungen-modal.tsx
+++ b/components/wasser-zaehler-ablesungen-modal.tsx
@@ -34,6 +34,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { WasserZaehlerImportModal } from "./wasser-zaehler-import-modal";
 import { WasserZaehler as SharedWasserZaehler, WasserAblesung } from "@/lib/data-fetching";
+import { formatNumber } from "@/utils/format";
 
 // Local interface for UI presentation, compatible with SharedWasserZaehler
 interface WasserZaehler {
@@ -397,11 +398,11 @@ export function WasserZaehlerAblesenModal({
                                           </Badge>
                                           <Badge variant="outline" className="text-xs gap-1 bg-white dark:bg-zinc-900">
                                             <Gauge className="h-3 w-3" />
-                                            {entry.latest_reading.zaehlerstand} m³
+                                            {formatNumber(entry.latest_reading.zaehlerstand)} m³
                                           </Badge>
                                           <Badge variant="outline" className="text-xs gap-1 bg-white dark:bg-zinc-900">
                                             <Droplet className="h-3 w-3" />
-                                            {entry.latest_reading.verbrauch} m³
+                                            {formatNumber(entry.latest_reading.verbrauch)} m³
                                           </Badge>
                                           {consumptionChange !== null && !isNaN(consumptionChange) && (
                                             <Badge
@@ -413,7 +414,7 @@ export function WasserZaehlerAblesenModal({
                                               ) : (
                                                 <TrendingDown className="h-3 w-3" />
                                               )}
-                                              {consumptionChange > 0 ? '+' : ''}{consumptionChange.toFixed(1)}%
+                                              {consumptionChange > 0 ? '+' : ''}{formatNumber(consumptionChange, 1)}%
                                             </Badge>
                                           )}
                                         </div>

--- a/components/wasserzaehler-modal.tsx
+++ b/components/wasserzaehler-modal.tsx
@@ -45,6 +45,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
+import { formatNumber } from "@/utils/format";
 
 // Filter options for the water meter modal
 const filterOptions = [
@@ -648,7 +649,7 @@ export function WasserzaehlerModal() {
                             ) : (
                               <TrendingDown className="h-3 w-3" />
                             )}
-                            {consumptionChange > 0 ? '+' : ''}{consumptionChange.toFixed(1)}%
+                            {consumptionChange > 0 ? '+' : ''}{formatNumber(consumptionChange, 1)}%
                           </div>
                         )}
                       </div>
@@ -661,11 +662,11 @@ export function WasserzaehlerModal() {
                           </Badge>
                           <Badge variant="outline" className="gap-1.5">
                             <Gauge className="h-3 w-3" />
-                            <span>Stand: {entry.previous_reading.zaehlerstand} m³</span>
+                            <span>Stand: {formatNumber(entry.previous_reading.zaehlerstand)} m³</span>
                           </Badge>
                           <Badge variant="outline" className="gap-1.5">
                             <Droplet className="h-3 w-3" />
-                            <span>Verbrauch: {entry.previous_reading.verbrauch} m³</span>
+                            <span>Verbrauch: {formatNumber(entry.previous_reading.verbrauch)} m³</span>
                           </Badge>
                         </div>
                       ) : (

--- a/components/wasserzaehler-modal.tsx
+++ b/components/wasserzaehler-modal.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { DatePicker } from "@/components/ui/date-picker";
 import { format } from "date-fns";
@@ -586,9 +587,8 @@ export function WasserzaehlerModal() {
                     </div>
                     <div className="flex gap-2">
                       <div className="relative flex-1">
-                        <Input
+                        <NumberInput
                           id={`apartment-usage-${wohnungName}`}
-                          type="number"
                           step="0.01"
                           min="0"
                           value={apartmentUsage[wohnungName] || ''}
@@ -692,9 +692,8 @@ export function WasserzaehlerModal() {
                           <Label htmlFor={`zaehlerstand-${entry.mieter_id}`}>
                             Neuer Zählerstand (m³)
                           </Label>
-                          <Input
+                          <NumberInput
                             id={`zaehlerstand-${entry.mieter_id}`}
-                            type="number"
                             step="0.01"
                             value={entry.zaehlerstand}
                             onChange={(e) => handleInputChange(index, 'zaehlerstand', e.target.value)}
@@ -706,9 +705,8 @@ export function WasserzaehlerModal() {
                           <Label htmlFor={`verbrauch-${entry.mieter_id}`}>
                             Verbrauch (m³)
                           </Label>
-                          <Input
+                          <NumberInput
                             id={`verbrauch-${entry.mieter_id}`}
-                            type="number"
                             step="0.01"
                             value={entry.verbrauch}
                             onChange={(e) => handleInputChange(index, 'verbrauch', e.target.value)}

--- a/components/wohnung-edit-modal.tsx
+++ b/components/wohnung-edit-modal.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { LabelWithTooltip } from "@/components/ui/label-with-tooltip";
 import {
@@ -302,10 +303,9 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
             <LabelWithTooltip htmlFor="groesse" infoText="Wohnfläche in Quadratmetern (z.B. 65.5 für 65,5 m²)">
               Größe (m²)
             </LabelWithTooltip>
-            <Input
+            <NumberInput
               id="groesse"
               name="groesse"
-              type="number"
               value={formData.groesse}
               onChange={handleChange}
               placeholder="z.B. 65"
@@ -319,10 +319,9 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
             <LabelWithTooltip htmlFor="miete" infoText="Monatliche Miete in Euro (z.B. 650.50 für 650,50 €)">
               Miete (€)
             </LabelWithTooltip>
-            <Input
+            <NumberInput
               id="miete"
               name="miete"
-              type="number"
               value={formData.miete}
               onChange={handleChange}
               placeholder="z.B. 650.50"


### PR DESCRIPTION
## Description

Introduces a `NumberInput` component with German number formatting and rolls it out across all money/quantity inputs.

## Summary of Changes

- New `components/ui/number-input.tsx`: displays values with a German decimal comma while emitting dot-formatted values through `onChange` (thousands separators tolerated), `inputMode="decimal"`, plus a 4-case test suite
- Replaces every `type="number"` input in 11 modals (apartment, house, wohnung, tenant, finance, kaution, tenant-payment, betriebskosten, sortable cost item, wasser-ablesungen, wasserzaehler)
- Display side: meter readings and consumption-change percentages now render via `formatNumber` (comma format) in the water-meter modals; existing tests updated to the comma format