### PR TITLE
Feature/sidebar container update

### DIFF
--- a/components/dashboard-sidebar.tsx
+++ b/components/dashboard-sidebar.tsx
@@ -77,8 +77,8 @@ export function DashboardSidebar() {
 
   // Feature flags for navigation items
   const featureFlags = new Map([
-    ['/dateien', documentsEnabled],
-    ['/mails', mailsEnabled],
+    ['/dateien', !!documentsEnabled],
+    ['/mails', !!mailsEnabled],
   ]);
 
   // Handle responsive collapse

--- a/components/dashboard-sidebar.tsx
+++ b/components/dashboard-sidebar.tsx
@@ -271,7 +271,32 @@ function SidebarContent({
                 >
                   <Search className="h-4 w-4 min-w-[1rem] transition-all duration-300 ease-out group-hover:scale-110" />
                   {!isMobile && textVariants && (
-                    <motion.div variants={textVariants} className="flex items-center flex-1 overflow-hidden">
+                    <motion.div
+                      variants={{
+                        expanded: {
+                          opacity: 1,
+                          x: 0,
+                          display: "flex",
+                          transition: {
+                            duration: 0.3,
+                            delay: 0.1,
+                            ease: "easeOut"
+                          }
+                        },
+                        collapsed: {
+                          opacity: 0,
+                          x: -10,
+                          transition: {
+                            duration: 0.2,
+                            ease: "easeIn"
+                          },
+                          transitionEnd: {
+                            display: "none"
+                          }
+                        }
+                      }}
+                      className="flex items-center flex-1 overflow-hidden"
+                    >
                       <span className="transition-all duration-300 ease-out group-hover:font-semibold">
                         Suche
                       </span>

--- a/components/dashboard-sidebar.tsx
+++ b/components/dashboard-sidebar.tsx
@@ -161,7 +161,7 @@ export function DashboardSidebar() {
         animate={isCollapsed ? "collapsed" : "expanded"}
         variants={sidebarVariants}
         className={cn(
-          "hidden md:flex flex-col z-30 ml-6 my-6 h-[calc(100vh-3rem)] rounded-2xl border bg-background shadow-sm sticky top-6 overflow-hidden",
+          "hidden md:flex flex-col z-30 ml-8 my-8 h-[calc(100vh-4rem)] rounded-2xl border bg-background shadow-sm sticky top-8 overflow-hidden",
         )}
         style={{ willChange: "width" }}
       >

--- a/components/dashboard-sidebar.tsx
+++ b/components/dashboard-sidebar.tsx
@@ -100,14 +100,14 @@ export function DashboardSidebar() {
     expanded: {
       width: "18rem",
       transition: {
-        duration: 0.4,
+        duration: 0.5,
         ease: [0.22, 1, 0.36, 1] // Custom bezier for smooth "premium" feel
       }
     },
     collapsed: {
       width: "5rem", // Slightly wider for better visual balance
       transition: {
-        duration: 0.4,
+        duration: 0.5,
         ease: [0.22, 1, 0.36, 1]
       }
     }
@@ -119,7 +119,7 @@ export function DashboardSidebar() {
       x: 0,
       display: "block",
       transition: {
-        duration: 0.3,
+        duration: 0.4,
         delay: 0.1,
         ease: [0.22, 1, 0.36, 1] // Custom bezier for smooth "premium" feel
       }
@@ -128,7 +128,7 @@ export function DashboardSidebar() {
       opacity: 0,
       x: -20,
       transition: {
-        duration: 0.2,
+        duration: 0.3,
         ease: [0.22, 1, 0.36, 1]
       },
       transitionEnd: {
@@ -265,7 +265,7 @@ function SidebarContent({
                 <button
                   onClick={() => setOpen(true)}
                   className={cn(
-                    "group flex w-full items-center gap-3 rounded-xl pl-3 pr-3 py-2.5 text-sm font-medium transition-all duration-300 ease-out hover:bg-accent hover:text-white hover:shadow-md hover:shadow-accent/10",
+                    "group flex w-full items-center gap-3 rounded-xl pl-3 pr-3 h-10 text-sm font-medium transition-all duration-300 ease-out hover:bg-accent hover:text-white hover:shadow-md hover:shadow-accent/10",
                     // Removed conditional layout classes to prevent jiggle
                   )}
                 >
@@ -278,7 +278,7 @@ function SidebarContent({
                           x: 0,
                           display: "flex",
                           transition: {
-                            duration: 0.3,
+                            duration: 0.4,
                             delay: 0.1,
                             ease: [0.22, 1, 0.36, 1]
                           }
@@ -287,7 +287,7 @@ function SidebarContent({
                           opacity: 0,
                           x: -20,
                           transition: {
-                            duration: 0.2,
+                            duration: 0.3,
                             ease: [0.22, 1, 0.36, 1]
                           },
                           transitionEnd: {
@@ -332,7 +332,7 @@ function SidebarContent({
                         href={item.href}
                         onClick={() => setIsOpen(false)}
                         className={cn(
-                          "group flex items-center gap-3 rounded-xl pl-3 pr-3 py-2.5 text-sm font-medium transition-all duration-300 ease-out hover:bg-accent hover:text-white hover:shadow-md hover:shadow-accent/10",
+                          "group flex items-center gap-3 rounded-xl pl-3 pr-3 h-10 text-sm font-medium transition-all duration-300 ease-out hover:bg-accent hover:text-white hover:shadow-md hover:shadow-accent/10",
                           getActiveStateClasses(item.href),
                           // Removed conditional layout classes to prevent jiggle
                         )}
@@ -369,7 +369,7 @@ function SidebarContent({
           <Button
             variant="ghost"
             className={cn(
-              "flex items-center gap-3 rounded-xl pl-3 pr-3 py-2 text-sm font-medium transition-all duration-300 ease-out hover:bg-accent hover:text-white w-full justify-start",
+              "flex items-center gap-3 rounded-xl pl-3 pr-3 h-10 text-sm font-medium transition-all duration-300 ease-out hover:bg-accent hover:text-white w-full justify-start",
             )}
             onClick={toggleCollapse}
           >

--- a/components/dashboard-sidebar.tsx
+++ b/components/dashboard-sidebar.tsx
@@ -121,15 +121,15 @@ export function DashboardSidebar() {
       transition: {
         duration: 0.3,
         delay: 0.1,
-        ease: "easeOut"
+        ease: [0.22, 1, 0.36, 1] // Custom bezier for smooth "premium" feel
       }
     },
     collapsed: {
       opacity: 0,
-      x: -10,
+      x: -20,
       transition: {
         duration: 0.2,
-        ease: "easeIn"
+        ease: [0.22, 1, 0.36, 1]
       },
       transitionEnd: {
         display: "none"
@@ -233,9 +233,9 @@ function SidebarContent({
   return (
     <div className="h-full w-full flex flex-col relative">
       {/* Header section */}
-      <div className={cn("flex items-center pt-6 pb-2", isCollapsed ? "justify-center px-2" : "justify-between pl-6 pr-6")}>
+      <div className="flex items-center pt-6 pb-2 pl-6 pr-6 justify-between">
         <Link href="/" className="flex items-center gap-3 font-semibold overflow-hidden">
-          <div className="relative w-8 h-8 min-w-[2rem] rounded-full overflow-hidden shadow-sm">
+          <div className="relative w-8 h-8 min-w-[2rem] rounded-full overflow-hidden shadow-sm flex-shrink-0">
             <Image
               src={LOGO_URL}
               alt="IV Logo"
@@ -258,18 +258,18 @@ function SidebarContent({
 
       {/* Navigation section - takes remaining space */}
       <div className="flex-1 overflow-y-auto min-h-0 py-4 custom-scrollbar">
-        <nav className={cn("grid gap-1.5", isCollapsed ? "px-2" : "px-4")}>
+        <nav className="grid gap-1.5 px-5">
           <TooltipProvider delayDuration={0}>
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
                   onClick={() => setOpen(true)}
                   className={cn(
-                    "group flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all duration-300 ease-out hover:bg-accent hover:text-white hover:shadow-md hover:shadow-accent/10",
-                    isCollapsed && "justify-center h-10 w-10 p-0 mx-auto"
+                    "group flex w-full items-center gap-3 rounded-xl pl-3 pr-3 py-2.5 text-sm font-medium transition-all duration-300 ease-out hover:bg-accent hover:text-white hover:shadow-md hover:shadow-accent/10",
+                    // Removed conditional layout classes to prevent jiggle
                   )}
                 >
-                  <Search className="h-4 w-4 min-w-[1rem] transition-all duration-300 ease-out group-hover:scale-110" />
+                  <Search className="h-4 w-4 min-w-[1rem] flex-shrink-0 transition-all duration-300 ease-out group-hover:scale-110" />
                   {!isMobile && textVariants && (
                     <motion.div
                       variants={{
@@ -280,15 +280,15 @@ function SidebarContent({
                           transition: {
                             duration: 0.3,
                             delay: 0.1,
-                            ease: "easeOut"
+                            ease: [0.22, 1, 0.36, 1]
                           }
                         },
                         collapsed: {
                           opacity: 0,
-                          x: -10,
+                          x: -20,
                           transition: {
                             duration: 0.2,
-                            ease: "easeIn"
+                            ease: [0.22, 1, 0.36, 1]
                           },
                           transitionEnd: {
                             display: "none"
@@ -332,14 +332,14 @@ function SidebarContent({
                         href={item.href}
                         onClick={() => setIsOpen(false)}
                         className={cn(
-                          "group flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all duration-300 ease-out hover:bg-accent hover:text-white hover:shadow-md hover:shadow-accent/10",
+                          "group flex items-center gap-3 rounded-xl pl-3 pr-3 py-2.5 text-sm font-medium transition-all duration-300 ease-out hover:bg-accent hover:text-white hover:shadow-md hover:shadow-accent/10",
                           getActiveStateClasses(item.href),
-                          isCollapsed && "justify-center h-10 w-10 p-0 mx-auto"
+                          // Removed conditional layout classes to prevent jiggle
                         )}
                         data-active={isActive}
                         aria-current={isActive ? "page" : undefined}
                       >
-                        <item.icon className="h-4 w-4 min-w-[1rem] transition-all duration-300 ease-out group-hover:scale-110" />
+                        <item.icon className="h-4 w-4 min-w-[1rem] flex-shrink-0 transition-all duration-300 ease-out group-hover:scale-110" />
                         {!isMobile && textVariants && (
                           <motion.span
                             variants={textVariants}
@@ -364,18 +364,16 @@ function SidebarContent({
       </div>
 
       {/* Profile section - fixed at bottom */}
-      <div className={cn("pt-2 pb-4 flex flex-col gap-2", isCollapsed ? "px-2" : "px-4")}>
+      <div className="pt-2 pb-4 flex flex-col gap-2 px-5">
         {!isMobile && (
           <Button
             variant="ghost"
             className={cn(
-              "flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-all duration-300 ease-out hover:bg-accent hover:text-white",
-              !isCollapsed && "w-full justify-start",
-              isCollapsed && "justify-center h-10 w-10 p-0 mx-auto"
+              "flex items-center gap-3 rounded-xl pl-3 pr-3 py-2 text-sm font-medium transition-all duration-300 ease-out hover:bg-accent hover:text-white w-full justify-start",
             )}
             onClick={toggleCollapse}
           >
-            {isCollapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
+            {isCollapsed ? <ChevronRight className="h-4 w-4 flex-shrink-0" /> : <ChevronLeft className="h-4 w-4 flex-shrink-0" />}
             {!isCollapsed && textVariants && (
               <motion.span variants={textVariants}>Einklappen</motion.span>
             )}

--- a/components/dashboard-sidebar.tsx
+++ b/components/dashboard-sidebar.tsx
@@ -161,7 +161,7 @@ export function DashboardSidebar() {
         animate={isCollapsed ? "collapsed" : "expanded"}
         variants={sidebarVariants}
         className={cn(
-          "hidden md:flex flex-col z-30 ml-6 my-6 h-[calc(100vh-3rem)] rounded-[2.5rem] border bg-background shadow-sm sticky top-6 overflow-hidden",
+          "hidden md:flex flex-col z-30 ml-6 my-6 h-[calc(100vh-3rem)] rounded-[2.5rem] border bg-white dark:bg-background shadow-sm sticky top-6 overflow-hidden",
         )}
         style={{ willChange: "width" }}
       >

--- a/components/dashboard-sidebar.tsx
+++ b/components/dashboard-sidebar.tsx
@@ -161,7 +161,7 @@ export function DashboardSidebar() {
         animate={isCollapsed ? "collapsed" : "expanded"}
         variants={sidebarVariants}
         className={cn(
-          "hidden md:flex flex-col z-30 ml-8 my-8 h-[calc(100vh-4rem)] rounded-2xl border bg-background shadow-sm sticky top-8 overflow-hidden",
+          "hidden md:flex flex-col z-30 ml-8 my-8 h-[calc(100vh-4rem)] rounded-[2.5rem] border bg-background shadow-sm sticky top-8 overflow-hidden",
         )}
         style={{ willChange: "width" }}
       >

--- a/components/dashboard-sidebar.tsx
+++ b/components/dashboard-sidebar.tsx
@@ -161,7 +161,7 @@ export function DashboardSidebar() {
         animate={isCollapsed ? "collapsed" : "expanded"}
         variants={sidebarVariants}
         className={cn(
-          "hidden md:flex flex-col z-30 ml-8 my-8 h-[calc(100vh-4rem)] rounded-[2.5rem] border bg-background shadow-sm sticky top-8 overflow-hidden",
+          "hidden md:flex flex-col z-30 ml-6 my-6 h-[calc(100vh-3rem)] rounded-[2.5rem] border bg-background shadow-sm sticky top-6 overflow-hidden",
         )}
         style={{ willChange: "width" }}
       >

--- a/components/dashboard-sidebar.tsx
+++ b/components/dashboard-sidebar.tsx
@@ -1,15 +1,15 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import Link from "next/link"
 import Image from "next/image"
 import { usePathname } from "next/navigation"
-import { BarChart3, Building2, Home, Users, Wallet, FileSpreadsheet, CheckSquare, Menu, X, CreditCard, Folder, Mail, Search, ChevronLeft, ChevronRight } from "lucide-react"
+import { BarChart3, Building2, Home, Users, Wallet, FileSpreadsheet, CheckSquare, Menu, X, Folder, Mail, Search, ChevronLeft, ChevronRight } from "lucide-react"
+import { motion, Variants } from "framer-motion"
 import { LOGO_URL } from "@/lib/constants"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
-import { SimpleScrollArea } from "@/components/ui/simple-scroll-area"
 import { UserSettings } from "@/components/user-settings"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { useSidebarActiveState } from "@/hooks/use-active-state-manager"
@@ -81,6 +81,62 @@ export function DashboardSidebar() {
     ['/mails', mailsEnabled],
   ]);
 
+  // Handle responsive collapse
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth < 1024) {
+        setIsCollapsed(true)
+      }
+    }
+
+    // Initial check
+    handleResize()
+
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+
+  const sidebarVariants: Variants = {
+    expanded: {
+      width: "18rem",
+      transition: {
+        duration: 0.4,
+        ease: [0.22, 1, 0.36, 1] // Custom bezier for smooth "premium" feel
+      }
+    },
+    collapsed: {
+      width: "5rem", // Slightly wider for better visual balance
+      transition: {
+        duration: 0.4,
+        ease: [0.22, 1, 0.36, 1]
+      }
+    }
+  }
+
+  const textVariants: Variants = {
+    expanded: {
+      opacity: 1,
+      x: 0,
+      display: "block",
+      transition: {
+        duration: 0.3,
+        delay: 0.1,
+        ease: "easeOut"
+      }
+    },
+    collapsed: {
+      opacity: 0,
+      x: -10,
+      transition: {
+        duration: 0.2,
+        ease: "easeIn"
+      },
+      transitionEnd: {
+        display: "none"
+      }
+    }
+  }
+
   return (
     <>
       <Button
@@ -99,125 +155,209 @@ export function DashboardSidebar() {
         )}
         onClick={() => setIsOpen(false)}
       />
+
+      <motion.aside
+        initial="expanded"
+        animate={isCollapsed ? "collapsed" : "expanded"}
+        variants={sidebarVariants}
+        className={cn(
+          "hidden md:flex flex-col z-30 ml-6 my-6 h-[calc(100vh-3rem)] rounded-2xl border bg-background shadow-sm sticky top-6 overflow-hidden",
+        )}
+        style={{ willChange: "width" }}
+      >
+        {/* Desktop Content */}
+        <div className="hidden md:flex flex-col h-full w-full">
+          <SidebarContent
+            isCollapsed={isCollapsed}
+            pathname={pathname}
+            setOpen={setOpen}
+            featureFlags={featureFlags}
+            isRouteActive={isRouteActive}
+            getActiveStateClasses={getActiveStateClasses}
+            isMobile={false}
+            setIsOpen={setIsOpen}
+            toggleCollapse={() => setIsCollapsed(!isCollapsed)}
+            textVariants={textVariants}
+          />
+        </div>
+      </motion.aside>
+
+      {/* Mobile Drawer (Separate element to avoid conflict with floating desktop sidebar) */}
       <aside
         className={cn(
-          "fixed inset-y-0 left-0 z-[49] flex-col transition-all duration-300 ease-in-out md:sticky md:translate-x-0 hidden md:flex h-screen",
-          isOpen ? "translate-x-0 flex" : "-translate-x-full",
-          isCollapsed ? "w-16" : "w-72"
+          "fixed inset-y-0 left-0 z-[49] flex flex-col bg-background border-r transition-transform duration-300 ease-in-out w-72 md:hidden",
+          isOpen ? "translate-x-0" : "-translate-x-full"
         )}
       >
-        <div className="h-full w-full bg-background border-r border-border dark:sidebar-container flex flex-col relative">
-          {/* Header section */}
-          <div className={cn("flex items-center pt-6 pb-2 dark:sidebar-header", isCollapsed ? "justify-center px-2" : "justify-between pl-8 pr-6")}>
-            {!isCollapsed && (
-              <Link href="/" className="flex items-center gap-2 font-semibold">
-                <div className="relative w-8 h-8 rounded-full overflow-hidden">
-                  <Image
-                    src={LOGO_URL}
-                    alt="IV Logo"
-                    fill
-                    className="object-cover"
-                    sizes="32px"
-                  />
-                </div>
-                <span className="text-lg">Mietfluss</span>
-              </Link>
-            )}
-            {isCollapsed && (
-              <div className="relative w-8 h-8 rounded-full overflow-hidden">
-                <Image
-                  src={LOGO_URL}
-                  alt="IV Logo"
-                  fill
-                  className="object-cover"
-                  sizes="32px"
-                />
-              </div>
-            )}
-          </div>
-
-          {/* Navigation section - takes remaining space */}
-          <div className="flex-1 overflow-y-auto min-h-0 py-2">
-            <nav className={cn("grid gap-1", isCollapsed ? "px-2" : "px-6")}>
-              <TooltipProvider delayDuration={0}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      onClick={() => setOpen(true)}
-                      className={cn(
-                        "group flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-all duration-500 ease-out hover:bg-accent hover:text-white hover:shadow-lg hover:shadow-accent/20",
-                        isCollapsed && "justify-center h-10 w-10 p-0 mx-auto"
-                      )}
-                    >
-                      <Search className="h-4 w-4 transition-all duration-500 ease-out group-hover:scale-125 group-hover:rotate-3" />
-                      {!isCollapsed && (
-                        <>
-                          <span className="transition-all duration-500 ease-out group-hover:font-semibold group-hover:tracking-wide">
-                            Suche
-                          </span>
-                          <kbd className="pointer-events-none ml-auto inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100 group-hover:text-white group-hover:border-white/20">
-                            <span className="text-xs">⌘</span>K
-                          </kbd>
-                        </>
-                      )}
-                    </button>
-                  </TooltipTrigger>
-                  {isCollapsed && <TooltipContent side="right">Suche (⌘K)</TooltipContent>}
-                </Tooltip>
-
-                {sidebarNavItems
-                  .filter(item => !featureFlags.has(item.href) || featureFlags.get(item.href))
-                  .map((item) => {
-                    const isActive = isRouteActive(item.href);
-
-                    return (
-                      <Tooltip key={item.href}>
-                        <TooltipTrigger asChild>
-                          <Link
-                            href={item.href}
-                            onClick={() => setIsOpen(false)}
-                            className={cn(
-                              "group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-all duration-500 ease-out hover:bg-accent hover:text-white hover:shadow-lg hover:shadow-accent/20",
-                              getActiveStateClasses(item.href),
-                              isCollapsed && "justify-center h-10 w-10 p-0 mx-auto"
-                            )}
-                            data-active={isActive}
-                            aria-current={isActive ? "page" : undefined}
-                          >
-                            <item.icon className="h-4 w-4 transition-all duration-500 ease-out group-hover:scale-125 group-hover:rotate-3" />
-                            {!isCollapsed && (
-                              <span className="transition-all duration-500 ease-out group-hover:font-semibold group-hover:tracking-wide">
-                                {item.title}
-                              </span>
-                            )}
-                          </Link>
-                        </TooltipTrigger>
-                        {isCollapsed && <TooltipContent side="right">{item.title}</TooltipContent>}
-                      </Tooltip>
-                    )
-                  })}
-              </TooltipProvider>
-            </nav>
-          </div>
-
-          {/* Profile section - fixed at bottom */}
-          <div className={cn("pt-2 pb-4 dark:sidebar-footer flex flex-col gap-2", isCollapsed ? "px-2" : "px-6")}>
-            <Button
-              variant="ghost"
-              className={cn(
-                "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-all duration-500 ease-out hover:bg-accent hover:text-white",
-                !isCollapsed && "w-full justify-start",
-                isCollapsed && "justify-center h-10 w-10 p-0 mx-auto"
-              )}
-              onClick={() => setIsCollapsed(!isCollapsed)}
-            >
-              {isCollapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
-              {!isCollapsed && <span>Einklappen</span>}
-            </Button>
-            <UserSettings collapsed={isCollapsed} />
-          </div>
-        </div>
+        <SidebarContent
+          isCollapsed={false}
+          pathname={pathname}
+          setOpen={setOpen}
+          featureFlags={featureFlags}
+          isRouteActive={isRouteActive}
+          getActiveStateClasses={getActiveStateClasses}
+          isMobile={true}
+          setIsOpen={setIsOpen}
+        />
       </aside>
     </>
+  )
+}
+
+interface SidebarContentProps {
+  isCollapsed: boolean
+  pathname: string
+  setOpen: (open: boolean) => void
+  featureFlags: Map<string, boolean>
+  isRouteActive: (href: string) => boolean
+  getActiveStateClasses: (href: string) => string
+  isMobile: boolean
+  setIsOpen: (open: boolean) => void
+  toggleCollapse?: () => void
+  textVariants?: Variants
+}
+
+// Extracted content component to reuse
+function SidebarContent({
+  isCollapsed,
+  pathname,
+  setOpen,
+  featureFlags,
+  isRouteActive,
+  getActiveStateClasses,
+  isMobile,
+  setIsOpen,
+  toggleCollapse,
+  textVariants
+}: SidebarContentProps) {
+  return (
+    <div className="h-full w-full flex flex-col relative">
+      {/* Header section */}
+      <div className={cn("flex items-center pt-6 pb-2", isCollapsed ? "justify-center px-2" : "justify-between pl-6 pr-6")}>
+        <Link href="/" className="flex items-center gap-3 font-semibold overflow-hidden">
+          <div className="relative w-8 h-8 min-w-[2rem] rounded-full overflow-hidden shadow-sm">
+            <Image
+              src={LOGO_URL}
+              alt="IV Logo"
+              fill
+              className="object-cover"
+              sizes="32px"
+            />
+          </div>
+          {!isMobile && textVariants && (
+            <motion.span
+              variants={textVariants}
+              className="text-lg whitespace-nowrap"
+            >
+              Mietfluss
+            </motion.span>
+          )}
+          {isMobile && <span className="text-lg">Mietfluss</span>}
+        </Link>
+      </div>
+
+      {/* Navigation section - takes remaining space */}
+      <div className="flex-1 overflow-y-auto min-h-0 py-4 custom-scrollbar">
+        <nav className={cn("grid gap-1.5", isCollapsed ? "px-2" : "px-4")}>
+          <TooltipProvider delayDuration={0}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => setOpen(true)}
+                  className={cn(
+                    "group flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all duration-300 ease-out hover:bg-accent hover:text-white hover:shadow-md hover:shadow-accent/10",
+                    isCollapsed && "justify-center h-10 w-10 p-0 mx-auto"
+                  )}
+                >
+                  <Search className="h-4 w-4 min-w-[1rem] transition-all duration-300 ease-out group-hover:scale-110" />
+                  {!isMobile && textVariants && (
+                    <motion.div variants={textVariants} className="flex items-center flex-1 overflow-hidden">
+                      <span className="transition-all duration-300 ease-out group-hover:font-semibold">
+                        Suche
+                      </span>
+                      <kbd className="pointer-events-none ml-auto inline-flex h-5 select-none items-center gap-1 rounded border bg-muted/50 px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100 group-hover:text-white group-hover:border-white/20">
+                        <span className="text-xs">⌘</span>K
+                      </kbd>
+                    </motion.div>
+                  )}
+                  {isMobile && (
+                    <>
+                      <span className="transition-all duration-300 ease-out group-hover:font-semibold">
+                        Suche
+                      </span>
+                      <kbd className="pointer-events-none ml-auto inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100 group-hover:text-white group-hover:border-white/20">
+                        <span className="text-xs">⌘</span>K
+                      </kbd>
+                    </>
+                  )}
+                </button>
+              </TooltipTrigger>
+              {isCollapsed && <TooltipContent side="right" className="font-medium">Suche (⌘K)</TooltipContent>}
+            </Tooltip>
+
+            {sidebarNavItems
+              .filter(item => !featureFlags.has(item.href) || featureFlags.get(item.href))
+              .map((item) => {
+                const isActive = isRouteActive(item.href);
+
+                return (
+                  <Tooltip key={item.href}>
+                    <TooltipTrigger asChild>
+                      <Link
+                        href={item.href}
+                        onClick={() => setIsOpen(false)}
+                        className={cn(
+                          "group flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all duration-300 ease-out hover:bg-accent hover:text-white hover:shadow-md hover:shadow-accent/10",
+                          getActiveStateClasses(item.href),
+                          isCollapsed && "justify-center h-10 w-10 p-0 mx-auto"
+                        )}
+                        data-active={isActive}
+                        aria-current={isActive ? "page" : undefined}
+                      >
+                        <item.icon className="h-4 w-4 min-w-[1rem] transition-all duration-300 ease-out group-hover:scale-110" />
+                        {!isMobile && textVariants && (
+                          <motion.span
+                            variants={textVariants}
+                            className="whitespace-nowrap transition-all duration-300 ease-out group-hover:font-semibold"
+                          >
+                            {item.title}
+                          </motion.span>
+                        )}
+                        {isMobile && (
+                          <span className="transition-all duration-300 ease-out group-hover:font-semibold">
+                            {item.title}
+                          </span>
+                        )}
+                      </Link>
+                    </TooltipTrigger>
+                    {isCollapsed && <TooltipContent side="right" className="font-medium">{item.title}</TooltipContent>}
+                  </Tooltip>
+                )
+              })}
+          </TooltipProvider>
+        </nav>
+      </div>
+
+      {/* Profile section - fixed at bottom */}
+      <div className={cn("pt-2 pb-4 flex flex-col gap-2", isCollapsed ? "px-2" : "px-4")}>
+        {!isMobile && (
+          <Button
+            variant="ghost"
+            className={cn(
+              "flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-all duration-300 ease-out hover:bg-accent hover:text-white",
+              !isCollapsed && "w-full justify-start",
+              isCollapsed && "justify-center h-10 w-10 p-0 mx-auto"
+            )}
+            onClick={toggleCollapse}
+          >
+            {isCollapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
+            {!isCollapsed && textVariants && (
+              <motion.span variants={textVariants}>Einklappen</motion.span>
+            )}
+          </Button>
+        )}
+        <UserSettings collapsed={isCollapsed} />
+      </div>
+    </div>
   )
 }

--- a/components/user-settings.tsx
+++ b/components/user-settings.tsx
@@ -6,6 +6,7 @@ import { LogOut, Settings, FileText } from "lucide-react"
 import { createClient } from "@/utils/supabase/client"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { cn } from "@/lib/utils"
+import { motion } from "framer-motion"
 
 import { useUserProfile } from "@/hooks/use-user-profile"
 import { useApartmentUsage } from "@/hooks/use-apartment-usage"
@@ -122,7 +123,13 @@ export function UserSettings({ collapsed }: { collapsed?: boolean }) {
               </AvatarFallback>
             </Avatar>
             {!collapsed && (
-              <div className="flex flex-col flex-1 text-left min-w-0">
+              <motion.div
+                initial={{ opacity: 0, width: 0 }}
+                animate={{ opacity: 1, width: "auto" }}
+                exit={{ opacity: 0, width: 0 }}
+                transition={{ duration: 0.2 }}
+                className="flex flex-col flex-1 text-left min-w-0 overflow-hidden"
+              >
                 <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
                   {isLoadingUser ? "Lade..." : userName}
                 </span>
@@ -147,7 +154,7 @@ export function UserSettings({ collapsed }: { collapsed?: boolean }) {
                     <div className="h-full bg-gray-300 dark:bg-gray-600 rounded-full animate-pulse w-1/2"></div>
                   </div>
                 )}
-              </div>
+              </motion.div>
             )}
           </div>
         }


### PR DESCRIPTION
## Description

Redesigns the dashboard sidebar as a floating, animated, collapsible panel.

## Summary of Changes

- `dashboard-sidebar.tsx` (+279/−116): the sidebar is now a floating card (margins, `rounded-[2.5rem]`, sticky) that animates between 18rem and 5rem via Framer Motion with a custom bezier easing; labels fade/slide out on collapse
- Content extracted into a reusable `SidebarContent` used by both the desktop panel and the separate mobile drawer
- Auto-collapses below 1024px viewport width; collapse toggle with chevron button, tooltips for all items in collapsed mode
- `user-settings.tsx`: the user name/plan area animates in/out when collapsing