### PR TITLE
fix: ensure Stripe customer is created at signup and dashboard load

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -45,6 +45,7 @@ const TenantPaymentOverviewModal = dynamic(() => import('@/components/tenant-pay
 import { ConfirmationDialog } from "@/components/ui/confirmation-dialog"; // Added
 import { GlobalDragDropProvider } from "@/components/global-drag-drop-provider"; // Added
 import { NestedDialogProvider } from "@/components/ui/nested-dialog"; // Added
+import { DashboardStripeInitializer } from "@/components/dashboard-stripe-initializer"; // Added
 
 export default function DashboardRootLayout({
   children,
@@ -135,6 +136,7 @@ export default function DashboardRootLayout({
   
   return (
     <AuthProvider>
+      <DashboardStripeInitializer />
       <NestedDialogProvider>
         {/* <GlobalDragDropProvider> */}
           <CommandMenu />

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -13,6 +13,7 @@ import { Label } from "@/components/ui/label"
 import { Building2 } from "lucide-react"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import posthog from 'posthog-js'
+import { ensureStripeCustomerForUser } from "@/app/stripe-customer-actions"
 
 export default function RegisterPage() {
   const router = useRouter()
@@ -74,6 +75,16 @@ export default function RegisterPage() {
         email: data.user.email,
         provider: 'email',
       })
+
+      // Ensure Stripe customer is created
+      if (data.user.email) {
+        try {
+           await ensureStripeCustomerForUser(data.user.email, data.user.id);
+        } catch (err) {
+           console.error('Failed to create Stripe customer during signup:', err);
+           // Don't show error to user, as account is created and dashboard will self-heal
+        }
+      }
     }
 
     setMessage("Überprüfen Sie Ihre E-Mail für den Bestätigungslink.")

--- a/app/stripe-customer-actions.ts
+++ b/app/stripe-customer-actions.ts
@@ -1,0 +1,67 @@
+'use server'
+
+import { createClient as createAdminClient } from '@supabase/supabase-js'
+import { createClient } from '@/utils/supabase/server'
+import { createCustomer } from '@/lib/stripe-server'
+
+export async function ensureStripeCustomerForUser(email: string, userId: string, name?: string) {
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    console.error('SUPABASE_SERVICE_ROLE_KEY is not set')
+    return { success: false, error: 'Server configuration error' }
+  }
+
+  // Use Service Role Key for Admin access
+  const supabaseAdmin = createAdminClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+
+  // Check if profile has customer ID
+  const { data: profile, error: profileError } = await supabaseAdmin
+    .from('profiles')
+    .select('stripe_customer_id')
+    .eq('id', userId)
+    .single()
+
+  // If profile error is not "not found", log it
+  if (profileError && profileError.code !== 'PGRST116') {
+     console.error('Error fetching profile:', profileError)
+     // Continue to try to upsert anyway
+  }
+
+  if (profile?.stripe_customer_id) {
+    return { success: true, customerId: profile.stripe_customer_id }
+  }
+
+  // Create customer in Stripe
+  try {
+    const customer = await createCustomer(email, name)
+
+    // Update profile. Using upsert to handle cases where profile might be missing or race conditions.
+    const { error: updateError } = await supabaseAdmin
+      .from('profiles')
+      .upsert({ id: userId, stripe_customer_id: customer.id })
+      .select()
+
+    if (updateError) {
+        console.error('Error updating/upserting profile:', updateError)
+        return { success: false, error: updateError.message }
+    }
+
+    return { success: true, customerId: customer.id }
+  } catch (err) {
+    console.error('Error in ensureStripeCustomerForUser:', err)
+    return { success: false, error: 'Failed to create customer' }
+  }
+}
+
+export async function ensureStripeCustomerCurrentUser() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+
+  if (!user || !user.email) {
+    return { success: false, error: 'Not authenticated' }
+  }
+
+  return await ensureStripeCustomerForUser(user.email, user.id, user.user_metadata?.name)
+}

--- a/components/dashboard-stripe-initializer.tsx
+++ b/components/dashboard-stripe-initializer.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { ensureStripeCustomerCurrentUser } from '@/app/stripe-customer-actions'
+
+export function DashboardStripeInitializer() {
+  const initialized = useRef(false)
+
+  useEffect(() => {
+    if (initialized.current) return
+    initialized.current = true
+
+    const init = async () => {
+      try {
+        await ensureStripeCustomerCurrentUser()
+      } catch (error) {
+        // Silent failure is acceptable here as it's a background optimization.
+        // It will retry on next page load/session start.
+        console.error('Failed to initialize Stripe customer:', error)
+      }
+    }
+
+    init()
+  }, [])
+
+  return null
+}

--- a/lib/__tests__/stripe-server.test.ts
+++ b/lib/__tests__/stripe-server.test.ts
@@ -5,7 +5,7 @@
 // Mock Stripe before importing
 jest.mock('stripe');
 
-import { getPlanDetails } from '../stripe-server';
+import { getPlanDetails, createCustomer } from '../stripe-server';
 import { STRIPE_API_VERSION } from '../constants/stripe';
 import Stripe from 'stripe';
 
@@ -31,6 +31,44 @@ describe('lib/stripe-server', () => {
 
   afterEach(() => {
     process.env = originalEnv;
+  });
+
+  describe('createCustomer', () => {
+    it('should throw error when STRIPE_SECRET_KEY is not set', async () => {
+      process.env = { ...originalEnv, STRIPE_SECRET_KEY: undefined };
+
+      await expect(createCustomer('test@example.com')).rejects.toThrow('STRIPE_SECRET_KEY is not set');
+    });
+
+    it('should create customer successfully', async () => {
+      process.env = { ...originalEnv, STRIPE_SECRET_KEY: 'sk_test_123' };
+
+      const mockCustomer = {
+        id: 'cus_123',
+        email: 'test@example.com',
+        name: 'Test User'
+      };
+
+      const mockStripeInstance = {
+        customers: {
+          create: jest.fn().mockResolvedValue(mockCustomer)
+        }
+      };
+
+      mockStripe.mockImplementation(() => mockStripeInstance as any);
+
+      const result = await createCustomer('test@example.com', 'Test User');
+
+      expect(mockStripe).toHaveBeenCalledWith('sk_test_123', {
+        apiVersion: STRIPE_API_VERSION
+      });
+      expect(mockStripeInstance.customers.create).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        name: 'Test User'
+      });
+
+      expect(result).toEqual(mockCustomer);
+    });
   });
 
   describe('getPlanDetails', () => {

--- a/lib/stripe-server.ts
+++ b/lib/stripe-server.ts
@@ -1,6 +1,30 @@
 import Stripe from 'stripe';
 import { STRIPE_CONFIG } from './constants/stripe';
 
+export async function createCustomer(email: string, name?: string) {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    throw new Error('STRIPE_SECRET_KEY is not set');
+  }
+
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, STRIPE_CONFIG);
+
+  try {
+    const customerParams: Stripe.CustomerCreateParams = {
+      email,
+    };
+
+    if (name) {
+      customerParams.name = name;
+    }
+
+    const customer = await stripe.customers.create(customerParams);
+    return customer;
+  } catch (error) {
+    console.error('Error creating Stripe customer:', error);
+    throw error;
+  }
+}
+
 export async function getPlanDetails(priceId: string) {
   if (!process.env.STRIPE_SECRET_KEY) {
     throw new Error('STRIPE_SECRET_KEY is not set');


### PR DESCRIPTION
- Added `createCustomer` to `lib/stripe-server.ts`.
- Created `ensureStripeCustomerForUser` server action to create Stripe customer and update Supabase profile.
- Integrated server action into `app/auth/register/page.tsx` for immediate creation after signup.
- Added `DashboardStripeInitializer` component to `app/(dashboard)/layout.tsx` as a self-healing fallback to ensure customer exists.
- Added tests for `createCustomer`.

fix #882 