### PR TITLE
Fix Stripe customer creation on signup

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,8 +1,5 @@
 import { createClient } from "@/utils/supabase/server"
-import { createClient as createSupabaseAdmin } from "@supabase/supabase-js"
 import { NextResponse } from "next/server"
-import Stripe from "stripe"
-import { STRIPE_CONFIG } from "@/lib/constants/stripe"
 
 export const runtime = 'edge'
 
@@ -25,82 +22,15 @@ export async function GET(request: Request) {
       return NextResponse.redirect(`${origin}/auth/login?error=auth_failed`)
     }
 
-    // Successful authentication
+    // Successful authentication, redirect to home with user info for client-side PostHog tracking
+    const redirectUrl = new URL(origin)
     if (data?.user) {
-      // Create Stripe customer if not exists
-      try {
-        const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, STRIPE_CONFIG)
-        const supabaseAdmin = createSupabaseAdmin(
-          process.env.NEXT_PUBLIC_SUPABASE_URL!,
-          process.env.SUPABASE_SERVICE_ROLE_KEY!
-        )
-
-        // Check if profile exists and has stripe_customer_id
-        let { data: profile, error: profileError } = await supabaseAdmin
-          .from('profiles')
-          .select('stripe_customer_id')
-          .eq('id', data.user.id)
-          .single()
-
-        // If profile doesn't exist, create it
-        if (profileError || !profile) {
-          console.log('Profile not found, creating new profile for user:', data.user.id)
-          const { error: insertError } = await supabaseAdmin
-            .from('profiles')
-            .insert({ id: data.user.id, email: data.user.email })
-
-          if (insertError) {
-            console.error('Error creating profile:', insertError)
-            // If insert fails (maybe race condition?), try to fetch again
-            const { data: retryProfile, error: retryError } = await supabaseAdmin
-              .from('profiles')
-              .select('stripe_customer_id')
-              .eq('id', data.user.id)
-              .single()
-
-            if (!retryError && retryProfile) {
-              profile = retryProfile
-            }
-          } else {
-            // Profile created successfully
-            profile = { stripe_customer_id: null }
-          }
-        }
-
-        if (profile && !profile.stripe_customer_id) {
-          console.log('Creating Stripe customer for user:', data.user.id)
-
-          const customer = await stripe.customers.create({
-            email: data.user.email,
-            metadata: {
-              userId: data.user.id,
-            },
-          })
-
-          const { error: updateError } = await supabaseAdmin
-            .from('profiles')
-            .update({ stripe_customer_id: customer.id })
-            .eq('id', data.user.id)
-
-          if (updateError) {
-            console.error('Error updating profile with stripe_customer_id:', updateError)
-          } else {
-            console.log('Successfully created Stripe customer and updated profile')
-          }
-        }
-      } catch (stripeError) {
-        console.error('Error creating Stripe customer:', stripeError)
-        // Don't block login if Stripe fails, but log it
-      }
-
       // Pass user info as URL params for client-side PostHog tracking
-      const redirectUrl = new URL(origin)
       redirectUrl.searchParams.set('login_success', 'true')
       redirectUrl.searchParams.set('provider', data.user.app_metadata?.provider || 'email')
-      return NextResponse.redirect(redirectUrl.toString())
     }
 
-    return NextResponse.redirect(origin)
+    return NextResponse.redirect(redirectUrl.toString())
   } catch (error) {
     console.error('Unexpected error during authentication:', error)
     return NextResponse.redirect(`${origin}/auth/login?error=unexpected_error`)

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,5 +1,8 @@
 import { createClient } from "@/utils/supabase/server"
+import { createClient as createSupabaseAdmin } from "@supabase/supabase-js"
 import { NextResponse } from "next/server"
+import Stripe from "stripe"
+import { STRIPE_CONFIG } from "@/lib/constants/stripe"
 
 export const runtime = 'edge'
 
@@ -16,21 +19,88 @@ export async function GET(request: Request) {
   try {
     const supabase = await createClient()
     const { data, error } = await supabase.auth.exchangeCodeForSession(code)
-    
+
     if (error) {
       console.error('Error exchanging code for session:', error.message)
       return NextResponse.redirect(`${origin}/auth/login?error=auth_failed`)
     }
-    
-    // Successful authentication, redirect to home with user info for client-side PostHog tracking
-    const redirectUrl = new URL(origin)
+
+    // Successful authentication
     if (data?.user) {
+      // Create Stripe customer if not exists
+      try {
+        const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, STRIPE_CONFIG)
+        const supabaseAdmin = createSupabaseAdmin(
+          process.env.NEXT_PUBLIC_SUPABASE_URL!,
+          process.env.SUPABASE_SERVICE_ROLE_KEY!
+        )
+
+        // Check if profile exists and has stripe_customer_id
+        let { data: profile, error: profileError } = await supabaseAdmin
+          .from('profiles')
+          .select('stripe_customer_id')
+          .eq('id', data.user.id)
+          .single()
+
+        // If profile doesn't exist, create it
+        if (profileError || !profile) {
+          console.log('Profile not found, creating new profile for user:', data.user.id)
+          const { error: insertError } = await supabaseAdmin
+            .from('profiles')
+            .insert({ id: data.user.id, email: data.user.email })
+
+          if (insertError) {
+            console.error('Error creating profile:', insertError)
+            // If insert fails (maybe race condition?), try to fetch again
+            const { data: retryProfile, error: retryError } = await supabaseAdmin
+              .from('profiles')
+              .select('stripe_customer_id')
+              .eq('id', data.user.id)
+              .single()
+
+            if (!retryError && retryProfile) {
+              profile = retryProfile
+            }
+          } else {
+            // Profile created successfully
+            profile = { stripe_customer_id: null }
+          }
+        }
+
+        if (profile && !profile.stripe_customer_id) {
+          console.log('Creating Stripe customer for user:', data.user.id)
+
+          const customer = await stripe.customers.create({
+            email: data.user.email,
+            metadata: {
+              userId: data.user.id,
+            },
+          })
+
+          const { error: updateError } = await supabaseAdmin
+            .from('profiles')
+            .update({ stripe_customer_id: customer.id })
+            .eq('id', data.user.id)
+
+          if (updateError) {
+            console.error('Error updating profile with stripe_customer_id:', updateError)
+          } else {
+            console.log('Successfully created Stripe customer and updated profile')
+          }
+        }
+      } catch (stripeError) {
+        console.error('Error creating Stripe customer:', stripeError)
+        // Don't block login if Stripe fails, but log it
+      }
+
       // Pass user info as URL params for client-side PostHog tracking
+      const redirectUrl = new URL(origin)
       redirectUrl.searchParams.set('login_success', 'true')
       redirectUrl.searchParams.set('provider', data.user.app_metadata?.provider || 'email')
+      return NextResponse.redirect(redirectUrl.toString())
     }
-    
-    return NextResponse.redirect(redirectUrl.toString())
+
+    return NextResponse.redirect(origin)
   } catch (error) {
     console.error('Unexpected error during authentication:', error)
     return NextResponse.redirect(`${origin}/auth/login?error=unexpected_error`)

--- a/supabase/migrations/20251129000000_create_profile_trigger.sql
+++ b/supabase/migrations/20251129000000_create_profile_trigger.sql
@@ -1,0 +1,45 @@
+-- Supabase Function to handle new user entries and create a profile with only the ID.
+-- The email will be sourced from auth.users when needed.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER SET SEARCH_PATH = public
+AS $$
+BEGIN
+  -- Log the incoming data
+  RAISE LOG '[handle_new_user] Triggered. NEW.id: %', NEW.id;
+
+  -- Insert a new row into public.profiles, only with the user's ID.
+  -- The 'email' column should be removed from 'profiles' table.
+  INSERT INTO public.profiles (id)
+  VALUES (NEW.id);
+
+  RAISE LOG '[handle_new_user] Successfully inserted profile ID for user: %', NEW.id;
+  RETURN NEW;
+EXCEPTION
+  WHEN OTHERS THEN
+    -- Log any error that occurs during the INSERT
+    RAISE LOG '[handle_new_user] Error inserting profile ID for user %: SQLSTATE: %, SQLERRM: %', NEW.id, SQLSTATE, SQLERRM;
+    -- Return NULL to indicate failure, which might help in debugging if the transaction doesn't roll back.
+    RETURN NULL;
+END;
+$$;
+
+-- Supabase Trigger to call handle_new_user on new user signup
+-- This trigger fires after a new user is inserted into auth.users
+
+-- First, drop the trigger if it already exists to avoid errors during re-creation
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+
+-- Then, create the new trigger
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.handle_new_user();
+
+
+-- Reminder:
+-- 1. Run this SQL in your Supabase SQL Editor.
+-- 2. Ensure your 'public.profiles' table has an 'id' (UUID, primary key) column.
+--    Other columns will be for Stripe data (e.g., stripe_customer_id, etc.).

--- a/supabase/migrations/20251129000000_create_profile_trigger.sql
+++ b/supabase/migrations/20251129000000_create_profile_trigger.sql
@@ -21,8 +21,8 @@ EXCEPTION
   WHEN OTHERS THEN
     -- Log any error that occurs during the INSERT
     RAISE LOG '[handle_new_user] Error inserting profile ID for user %: SQLSTATE: %, SQLERRM: %', NEW.id, SQLSTATE, SQLERRM;
-    -- Return NULL to indicate failure, which might help in debugging if the transaction doesn't roll back.
-    RETURN NULL;
+    -- Re-throw the exception to abort the transaction and ensure data consistency.
+    RAISE;
 END;
 $$;
 


### PR DESCRIPTION
## Description

Fixes Stripe customer creation on signup by simplifying the profile trigger to only insert the user id.

## Summary of Changes

- New migration `create_profile_trigger.sql`: `handle_new_user()` now inserts only `id` into `public.profiles` (email is sourced from `auth.users` when needed, keeping the profile Stripe-ready), with detailed `RAISE LOG` diagnostics and error re-throwing; the `on_auth_user_created` trigger is recreated idempotently
- `auth/callback` route: whitespace cleanup