### PR TITLE
Improve user flow: separate login/register pages, verify email step, …

### DIFF
--- a/app/(landing)/page.tsx
+++ b/app/(landing)/page.tsx
@@ -280,7 +280,8 @@ function LandingPageContent() {
         // In browsers without sessionStorage, the redirect intent will be lost
         console.warn('SessionStorage not available. The "get-started" redirect flow will not work as intended.');
       }
-      openAuthModal('login');
+      // Redirect to register page as per user request
+      router.push('/auth/register');
     }
   };
 
@@ -288,7 +289,7 @@ function LandingPageContent() {
     if (sessionUser) {
       await handleAuthFlow(priceId);
     } else {
-      openAuthModal('login');
+      router.push('/auth/register');
     }
   };
 

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -42,6 +42,8 @@ export async function GET(request: Request) {
       // Pass user info as URL params for client-side PostHog tracking
       redirectUrl.searchParams.set('login_success', 'true')
       redirectUrl.searchParams.set('provider', provider)
+      // Redirect to subscription onboarding
+      redirectUrl.pathname = '/onboarding/subscription'
     }
 
     return NextResponse.redirect(redirectUrl.toString())

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -84,7 +84,7 @@ export default function RegisterPage() {
       })
     }
 
-    setMessage("Überprüfen Sie Ihre E-Mail für den Bestätigungslink.")
+    router.push('/auth/verify-email')
     setIsLoading(false)
   }
 

--- a/app/auth/verify-email/page.tsx
+++ b/app/auth/verify-email/page.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import Link from "next/link"
+import { Building2, Mail } from "lucide-react"
+import { motion } from "framer-motion"
+import { Auth3DDecorations } from "@/components/auth-3d-decorations"
+
+export default function VerifyEmailPage() {
+    return (
+        <div className="min-h-screen flex items-center justify-center bg-background p-4 md:p-8 relative overflow-hidden">
+            {/* Animated grid background */}
+            <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_50%,black_40%,transparent_100%)]" />
+
+            {/* Gradient orbs in background */}
+            <motion.div
+                className="absolute top-1/3 right-1/4 w-96 h-96 rounded-full bg-secondary/20 blur-[100px]"
+                animate={{
+                    x: [0, -50, 0],
+                    y: [0, 40, 0],
+                    scale: [1, 1.15, 1],
+                }}
+                transition={{ duration: 14, repeat: Infinity, ease: "easeInOut" }}
+            />
+            <motion.div
+                className="absolute bottom-1/3 left-1/4 w-80 h-80 rounded-full bg-primary/20 blur-[100px]"
+                animate={{
+                    x: [0, 30, 0],
+                    y: [0, -40, 0],
+                    scale: [1, 1.1, 1],
+                }}
+                transition={{ duration: 11, repeat: Infinity, ease: "easeInOut" }}
+            />
+
+            {/* Radial spotlight */}
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,hsl(var(--muted)/0.8)_0%,transparent_50%)]" />
+
+            {/* Main container */}
+            <motion.div
+                initial={{ opacity: 0, scale: 0.98 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ duration: 0.5 }}
+                className="relative z-10 w-full max-w-lg bg-card rounded-[2.5rem] shadow-2xl overflow-hidden min-h-[500px] flex flex-col"
+            >
+                <div className="relative flex-1 bg-gradient-to-br from-primary via-secondary to-primary p-8 md:p-12 flex flex-col items-center justify-center text-center overflow-hidden perspective-[1000px]">
+                    {/* Gradient mesh overlay */}
+                    <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,hsl(var(--accent)/0.3)_0%,transparent_50%)]" />
+                    <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_right,hsl(var(--primary)/0.4)_0%,transparent_50%)]" />
+
+                    {/* Tilted Grid pattern */}
+                    <div className="absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.03)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.03)_1px,transparent_1px)] bg-[size:3rem_3rem] [transform:perspective(500px)_rotateX(20deg)_scale(1.2)] origin-top opacity-50" />
+
+                    {/* 3D Decorative elements */}
+                    <Auth3DDecorations />
+
+                    {/* Content */}
+                    <div className="relative z-10 flex flex-col items-center">
+                        <div className="p-4 rounded-2xl bg-white/10 backdrop-blur-md mb-6 shadow-xl">
+                            <Mail className="h-12 w-12 text-white" />
+                        </div>
+
+                        <motion.h1
+                            initial={{ opacity: 0, y: 20 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ delay: 0.2, duration: 0.5 }}
+                            className="text-2xl md:text-3xl font-bold text-white mb-4"
+                        >
+                            E-Mail bestätigen
+                        </motion.h1>
+
+                        <motion.p
+                            initial={{ opacity: 0, y: 20 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ delay: 0.3, duration: 0.5 }}
+                            className="text-white/80 text-base md:text-lg max-w-xs leading-relaxed mb-8"
+                        >
+                            Wir haben Ihnen einen Bestätigungslink gesendet. Bitte prüfen Sie Ihren Posteingang.
+                        </motion.p>
+
+                        <motion.div
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            transition={{ delay: 0.5, duration: 0.5 }}
+                        >
+                            <Link
+                                href="/auth/login"
+                                className="inline-flex items-center justify-center px-6 py-3 rounded-xl bg-white text-primary font-semibold hover:bg-white/90 transition-colors shadow-lg hover:shadow-xl transform hover:-translate-y-0.5 active:translate-y-0"
+                            >
+                                Zurück zur Anmeldung
+                            </Link>
+                        </motion.div>
+                    </div>
+                </div>
+            </motion.div>
+        </div>
+    )
+}

--- a/app/auth/verify-email/page.tsx
+++ b/app/auth/verify-email/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { Building2, Mail } from "lucide-react"
+import { Mail } from "lucide-react"
 import { motion } from "framer-motion"
 import { Auth3DDecorations } from "@/components/auth-3d-decorations"
 

--- a/app/modern/components/navigation.tsx
+++ b/app/modern/components/navigation.tsx
@@ -7,7 +7,7 @@ import { Menu, X, DollarSign, Home, User as UserIcon, LogIn, LogOut, Check, Layo
 
 import Link from "next/link"
 import Image from "next/image"
-import { usePathname } from "next/navigation"
+import { usePathname, useRouter } from "next/navigation"
 import { LOGO_URL } from "@/lib/constants"
 import { Button } from '@/components/ui/button'
 import { User } from "@supabase/supabase-js";
@@ -60,6 +60,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const pathname = usePathname();
+  const router = useRouter();
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const { userName } = useUserProfile();
@@ -142,7 +143,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
     if (onLogin) {
       onLogin();
     } else {
-      openAuthModal('login');
+      router.push('/auth/login');
     }
   };
 
@@ -301,7 +302,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                             <div className="relative z-10 mt-2">
                               <DropdownMenuItem asChild>
                                 <Button
-                                  onClick={handleOpenLoginModal}
+                                  onClick={() => router.push('/auth/register')}
                                   size="sm"
                                   className="w-full group h-8 text-xs"
                                 >
@@ -450,7 +451,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                         Anmelden
                       </Button>
                       <Button
-                        onClick={scrollToPricing}
+                        onClick={() => router.push('/auth/register')}
                         className="ml-2 px-4 py-2 h-9 text-sm font-medium bg-primary hover:bg-primary/90 text-primary-foreground"
                       >
                         Kostenlos testen
@@ -585,7 +586,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                       <Button onClick={handleOpenLoginModal} className="w-full">
                         Anmelden
                       </Button>
-                      <Button variant="outline" onClick={scrollToPricing} className="w-full">
+                      <Button variant="outline" onClick={() => router.push('/auth/register')} className="w-full">
                         Kostenlos testen
                       </Button>
                     </div>

--- a/app/onboarding/subscription/page.tsx
+++ b/app/onboarding/subscription/page.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { Suspense, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { createClient } from '@/utils/supabase/client';
+import { User } from '@supabase/supabase-js';
+import { Profile } from '@/types/supabase';
+import Pricing from '@/app/modern/components/pricing';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2 } from 'lucide-react';
+
+function SubscriptionPageContent() {
+    const router = useRouter();
+    const { toast } = useToast();
+    const supabase = createClient();
+
+    const [sessionUser, setSessionUser] = useState<User | null>(null);
+    const [userProfile, setUserProfile] = useState<Profile | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isProcessingCheckout, setIsProcessingCheckout] = useState(false);
+
+    useEffect(() => {
+        const initUser = async () => {
+            try {
+                const { data: { user } } = await supabase.auth.getUser();
+                if (!user) {
+                    router.replace('/auth/login');
+                    return;
+                }
+                setSessionUser(user);
+                await fetchUserProfile(user.id);
+            } catch (error) {
+                console.error('Error initializing user:', error);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        initUser();
+    }, [supabase, router]);
+
+    const fetchUserProfile = async (userId: string) => {
+        try {
+            // Retry logic could be added here as the profile might not be created immediately after registration
+            let attempts = 0;
+            const maxAttempts = 5;
+
+            while (attempts < maxAttempts) {
+                const { data, error } = await supabase
+                    .from('profiles')
+                    .select('id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_price_id')
+                    .eq('id', userId)
+                    .single();
+
+                if (data) {
+                    setUserProfile(data as Profile);
+                    return;
+                }
+
+                if (error && error.code !== 'PGRST116') {
+                    console.error('Error fetching profile:', error);
+                    break;
+                }
+
+                // Wait before retrying (backoff)
+                await new Promise(r => setTimeout(r, 1000));
+                attempts++;
+            }
+
+            console.warn('Profile not found after retries');
+        } catch (error) {
+            console.error('Error in fetchUserProfile:', error);
+        }
+    };
+
+    const handleSelectPlan = async (priceId: string) => {
+        if (isProcessingCheckout) return;
+        setIsProcessingCheckout(true);
+
+        if (!sessionUser || !sessionUser.email || !sessionUser.id) {
+            toast({ title: 'Error', description: 'Benutzerinformationen fehlen. Bitte melden Sie sich erneut an.', variant: 'destructive' });
+            setIsProcessingCheckout(false);
+            return;
+        }
+
+        // Check if user has active subscription -> Portal
+        if (userProfile && (userProfile.stripe_subscription_status === 'active' || userProfile.stripe_subscription_status === 'trialing')) {
+            await redirectToCustomerPortal();
+            return;
+        }
+
+        // Create Checkout Session
+        try {
+            const response = await fetch('/api/stripe/checkout-session', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    priceId,
+                    customerEmail: sessionUser.email,
+                    userId: sessionUser.id,
+                }),
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json();
+                throw new Error(errorData.message || errorData.error || 'Fehler beim Starten des Bezahlvorgangs.');
+            }
+
+            const { url } = await response.json();
+            if (url) {
+                router.push(url);
+            } else {
+                throw new Error('Keine Weiterleitungs-URL empfangen.');
+            }
+
+        } catch (error) {
+            console.error('Checkout error:', error);
+            toast({
+                title: 'Fehler',
+                description: (error instanceof Error ? error.message : 'Ein unerwarteter Fehler ist aufgetreten.'),
+                variant: 'destructive'
+            });
+            setIsProcessingCheckout(false);
+        }
+    };
+
+    const redirectToCustomerPortal = async () => {
+        if (!sessionUser) return;
+        try {
+            const response = await fetch('/api/stripe/customer-portal', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ userId: sessionUser.id }),
+            });
+
+            if (!response.ok) throw new Error('Portal session failed');
+            const { url } = await response.json();
+            if (url) window.location.href = url;
+        } catch (error) {
+            toast({ title: 'Fehler', description: 'Kundenportal konnte nicht geöffnet werden.', variant: 'destructive' });
+            setIsProcessingCheckout(false);
+        }
+    };
+
+    if (isLoading) {
+        return (
+            <div className="min-h-screen flex items-center justify-center">
+                <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            </div>
+        );
+    }
+
+    return (
+        <div className="min-h-screen bg-background">
+            <div className="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
+                <div className="text-center mb-12">
+                    <h1 className="text-4xl font-extrabold tracking-tight sm:text-5xl mb-4">
+                        Wählen Sie Ihren Plan
+                    </h1>
+                    <p className="max-w-xl mx-auto text-xl text-muted-foreground">
+                        Starten Sie mit unserer kostenlosen Testphase. Jederzeit kündbar.
+                    </p>
+                </div>
+
+                <Pricing
+                    onSelectPlan={handleSelectPlan}
+                    userProfile={userProfile}
+                    isLoading={isProcessingCheckout}
+                    showComparison={true}
+                />
+            </div>
+        </div>
+    );
+}
+
+export default function SubscriptionPage() {
+    return (
+        <Suspense fallback={<div className="min-h-screen flex items-center justify-center"><Loader2 className="h-8 w-8 animate-spin" /></div>}>
+            <SubscriptionPageContent />
+        </Suspense>
+    );
+}

--- a/app/onboarding/subscription/page.tsx
+++ b/app/onboarding/subscription/page.tsx
@@ -135,7 +135,11 @@ function SubscriptionPageContent() {
 
             if (!response.ok) throw new Error('Portal session failed');
             const { url } = await response.json();
-            if (url) window.location.href = url;
+            if (url) {
+                window.location.href = url;
+            } else {
+                throw new Error('Kundenportal-URL nicht gefunden.');
+            }
         } catch (error) {
             toast({ title: 'Fehler', description: 'Kundenportal konnte nicht geöffnet werden.', variant: 'destructive' });
             setIsProcessingCheckout(false);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2470,7 +2470,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }


### PR DESCRIPTION
## Description

Improves the sign-up user flow: dedicated register page, an email-verification step and a post-verification subscription onboarding.

## Summary of Changes

- Landing page + navigation: "Kostenlos testen" / plan selection now route to `/auth/register` instead of opening the auth modal; login stays on `/auth/login`
- New `/auth/verify-email` page (animated confirmation screen shown after registration instead of an inline message)
- New `/onboarding/subscription` page: plan selection with profile-retry logic (the profile row may lag registration), Stripe checkout for new customers and customer portal for existing subscribers
- OAuth callback redirects new sign-ins to the subscription onboarding