### PR TITLE
ci: add automated release workflow with label-based semantic versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,344 @@
+# =============================================================================
+# Automated Release Workflow with Label-Based Semantic Versioning
+# =============================================================================
+# 
+# This workflow automatically creates releases when PRs are merged to main.
+# Version bumps are determined by PR labels:
+#   - "major" label → Breaking changes (1.x.x → 2.0.0)
+#   - "minor" label → New features (1.2.x → 1.3.0)
+#   - "patch" label or no label → Bugfixes (1.2.3 → 1.2.4)
+#
+# Priority: major > minor > patch
+# =============================================================================
+
+name: Automated Release
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+# Required permissions for creating releases and pushing commits/tags
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create Release
+    # Only run if the PR was actually merged (not just closed)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      # =========================================================================
+      # Step 1: Checkout Repository
+      # =========================================================================
+      # We need full git history (fetch-depth: 0) to:
+      # - Access all tags for version detection
+      # - Generate accurate changelog from commits
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # =========================================================================
+      # Step 2: Setup Node.js Environment
+      # =========================================================================
+      # Using Node.js 20.x with npm caching for faster installs
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      # =========================================================================
+      # Step 3: Install Dependencies
+      # =========================================================================
+      # Using npm ci for clean, reproducible installs from lock file
+      - name: Install Dependencies
+        run: npm ci
+
+      # =========================================================================
+      # Step 4: Determine Version Bump Level from PR Labels
+      # =========================================================================
+      # Parse PR labels to determine the version bump type
+      # Priority: major > minor > patch (default)
+      - name: Determine Bump Level
+        id: bump
+        run: |
+          echo "📋 Analyzing PR labels for version bump..."
+          
+          # Get all labels from the PR as a JSON array
+          LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
+          echo "PR Labels: $LABELS"
+          
+          # Default to patch if no version label is found
+          BUMP_LEVEL="patch"
+          
+          # Check for version labels (priority: major > minor > patch)
+          if echo "$LABELS" | grep -qi '"major"'; then
+            BUMP_LEVEL="major"
+            echo "🚀 Found 'major' label - breaking change release"
+          elif echo "$LABELS" | grep -qi '"minor"'; then
+            BUMP_LEVEL="minor"
+            echo "✨ Found 'minor' label - new feature release"
+          elif echo "$LABELS" | grep -qi '"patch"'; then
+            BUMP_LEVEL="patch"
+            echo "🐛 Found 'patch' label - bugfix release"
+          else
+            echo "📦 No version label found - defaulting to 'patch'"
+          fi
+          
+          echo "bump_level=$BUMP_LEVEL" >> $GITHUB_OUTPUT
+          echo "Determined bump level: $BUMP_LEVEL"
+
+      # =========================================================================
+      # Step 5: Get Current Version from Latest Git Tag
+      # =========================================================================
+      # Fetch the latest semantic version tag, default to v0.0.0 if none exist
+      - name: Get Current Version
+        id: current
+        run: |
+          echo "🔍 Looking for existing version tags..."
+          
+          # Get the latest tag matching semantic versioning pattern
+          # Sort by version to get the highest version number
+          LATEST_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1)
+          
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="v0.0.0"
+            echo "⚠️  No existing version tags found, starting from v0.0.0"
+          else
+            echo "📌 Found latest tag: $LATEST_TAG"
+          fi
+          
+          echo "current_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          
+          # Extract version numbers (remove 'v' prefix)
+          VERSION="${LATEST_TAG#v}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+          
+          echo "current_major=$MAJOR" >> $GITHUB_OUTPUT
+          echo "current_minor=$MINOR" >> $GITHUB_OUTPUT
+          echo "current_patch=$PATCH" >> $GITHUB_OUTPUT
+          
+          echo "Current version breakdown: Major=$MAJOR, Minor=$MINOR, Patch=$PATCH"
+
+      # =========================================================================
+      # Step 6: Calculate New Version
+      # =========================================================================
+      # Increment the appropriate version segment and reset lower segments
+      # - major: increment major, reset minor and patch to 0
+      # - minor: increment minor, reset patch to 0
+      # - patch: increment patch only
+      - name: Calculate New Version
+        id: version
+        run: |
+          echo "🧮 Calculating new version..."
+          
+          BUMP_LEVEL="${{ steps.bump.outputs.bump_level }}"
+          MAJOR=${{ steps.current.outputs.current_major }}
+          MINOR=${{ steps.current.outputs.current_minor }}
+          PATCH=${{ steps.current.outputs.current_patch }}
+          
+          echo "Bump level: $BUMP_LEVEL"
+          echo "Current version: $MAJOR.$MINOR.$PATCH"
+          
+          case "$BUMP_LEVEL" in
+            major)
+              NEW_MAJOR=$((MAJOR + 1))
+              NEW_MINOR=0
+              NEW_PATCH=0
+              ;;
+            minor)
+              NEW_MAJOR=$MAJOR
+              NEW_MINOR=$((MINOR + 1))
+              NEW_PATCH=0
+              ;;
+            patch)
+              NEW_MAJOR=$MAJOR
+              NEW_MINOR=$MINOR
+              NEW_PATCH=$((PATCH + 1))
+              ;;
+          esac
+          
+          NEW_VERSION="$NEW_MAJOR.$NEW_MINOR.$NEW_PATCH"
+          NEW_TAG="v$NEW_VERSION"
+          
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
+          
+          echo "✅ New version: $NEW_VERSION (tag: $NEW_TAG)"
+
+      # =========================================================================
+      # Step 7: Update package.json Version
+      # =========================================================================
+      # Use jq to safely update the version field in package.json
+      # This handles edge cases like missing version field
+      - name: Update package.json Version
+        run: |
+          echo "📝 Updating package.json version..."
+          
+          NEW_VERSION="${{ steps.version.outputs.new_version }}"
+          
+          # Check if version field exists
+          if jq -e '.version' package.json > /dev/null 2>&1; then
+            echo "Version field exists, updating..."
+          else
+            echo "Version field missing, adding..."
+          fi
+          
+          # Update or add version field using jq
+          jq --arg version "$NEW_VERSION" '.version = $version' package.json > package.json.tmp
+          mv package.json.tmp package.json
+          
+          # Show the updated version
+          echo "Updated package.json version to: $(jq -r '.version' package.json)"
+          
+          # Also update package-lock.json if it exists
+          if [ -f "package-lock.json" ]; then
+            echo "📝 Updating package-lock.json version..."
+            jq --arg version "$NEW_VERSION" '.version = $version | .packages[""].version = $version' package-lock.json > package-lock.json.tmp
+            mv package-lock.json.tmp package-lock.json
+            echo "Updated package-lock.json version to: $(jq -r '.version' package-lock.json)"
+          fi
+
+      # =========================================================================
+      # Step 8: Commit Version Changes
+      # =========================================================================
+      # Configure git with github-actions bot user and commit changes
+      # Using [skip ci] to prevent infinite workflow loops
+      - name: Commit Version Changes
+        run: |
+          echo "📤 Committing version bump..."
+          
+          NEW_TAG="${{ steps.version.outputs.new_tag }}"
+          
+          # Configure git with github-actions bot credentials
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
+          # Stage version files
+          git add package.json
+          if [ -f "package-lock.json" ]; then
+            git add package-lock.json
+          fi
+          
+          # Commit with [skip ci] to prevent infinite workflow loops
+          git commit -m "chore: bump version to $NEW_TAG [skip ci]" || echo "No changes to commit"
+          
+          echo "✅ Version bump committed"
+
+      # =========================================================================
+      # Step 9: Push Commit to Main Branch
+      # =========================================================================
+      - name: Push Commit
+        run: |
+          echo "📤 Pushing commit to main..."
+          git push origin main
+          echo "✅ Commit pushed successfully"
+
+      # =========================================================================
+      # Step 10: Create and Push Git Tag
+      # =========================================================================
+      - name: Create and Push Tag
+        run: |
+          echo "🏷️  Creating and pushing tag..."
+          
+          NEW_TAG="${{ steps.version.outputs.new_tag }}"
+          
+          # Create annotated tag
+          git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
+          
+          # Push the tag
+          git push origin "$NEW_TAG"
+          
+          echo "✅ Tag $NEW_TAG created and pushed"
+
+      # =========================================================================
+      # Step 11: Generate Changelog
+      # =========================================================================
+      # Generate changelog from commits between previous and new tag
+      - name: Generate Changelog
+        id: changelog
+        run: |
+          echo "📋 Generating changelog..."
+          
+          PREVIOUS_TAG="${{ steps.current.outputs.current_tag }}"
+          NEW_TAG="${{ steps.version.outputs.new_tag }}"
+          
+          # Generate changelog with commit messages
+          if [ "$PREVIOUS_TAG" = "v0.0.0" ]; then
+            # First release - get all commits
+            echo "First release - including all commits"
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)" --no-merges HEAD)
+          else
+            # Get commits between tags
+            echo "Getting commits between $PREVIOUS_TAG and $NEW_TAG"
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)" --no-merges "${PREVIOUS_TAG}..HEAD")
+          fi
+          
+          # Handle empty changelog
+          if [ -z "$CHANGELOG" ]; then
+            CHANGELOG="- No notable changes"
+          fi
+          
+          # Write changelog to file for multi-line output
+          echo "$CHANGELOG" > changelog.txt
+          
+          echo "Generated changelog:"
+          cat changelog.txt
+
+      # =========================================================================
+      # Step 12: Create GitHub Release
+      # =========================================================================
+      # Create release with tag, changelog, and auto-generated notes
+      - name: Create GitHub Release
+        id: release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.new_tag }}
+          name: Release ${{ steps.version.outputs.new_tag }}
+          body_path: changelog.txt
+          generate_release_notes: true
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # =========================================================================
+      # Step 13: Output Summary
+      # =========================================================================
+      # Display summary with release details and URL
+      - name: Output Summary
+        run: |
+          echo ""
+          echo "=============================================="
+          echo "🎉 RELEASE CREATED SUCCESSFULLY!"
+          echo "=============================================="
+          echo ""
+          echo "📦 Version: ${{ steps.version.outputs.new_tag }}"
+          echo "📋 Bump Type: ${{ steps.bump.outputs.bump_level }}"
+          echo "📌 Previous Tag: ${{ steps.current.outputs.current_tag }}"
+          echo "🔗 Release URL: ${{ steps.release.outputs.url }}"
+          echo ""
+          echo "=============================================="
+          
+          # Add to GitHub Actions summary
+          echo "## 🎉 Release Created Successfully!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| **Version** | \`${{ steps.version.outputs.new_tag }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Bump Type** | ${{ steps.bump.outputs.bump_level }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Previous Tag** | \`${{ steps.current.outputs.current_tag }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Release URL** | [${{ steps.version.outputs.new_tag }}](${{ steps.release.outputs.url }}) |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 📋 Changelog" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          cat changelog.txt >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Description

Adds an automated release workflow with label-based semantic versioning.

## Summary of Changes

- New `.github/workflows/release.yml` (runs on merged PRs to main):
  - Determines the bump level from PR labels — `major` / `minor` / `patch` (default), priority major > minor > patch
  - Reads the latest `v*` git tag, computes the new version and bumps `package.json` + `package-lock.json` via `jq`
  - Commits the bump as `github-actions[bot]` with `[skip ci]`, pushes to main, creates and pushes the annotated tag
  - Generates a changelog from the commits between tags and creates the GitHub release (with auto release notes) plus a rich step summary