### PR TITLE
chore: rename application from rent-manager to mietevo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "rent-manager",
+  "name": "mietevo",
   "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "rent-manager",
+      "name": "mietevo",
       "version": "2.0.3",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rent-manager",
+  "name": "mietevo",
   "version": "2.0.3",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Description

Renames the package from rent-manager to mietevo.

## Summary of Changes

- `package.json` and `package-lock.json`: `name` field updated to `mietevo`