### PR TITLE
chore: update dependabot schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
       day: "monday"
       time: "09:00"
       timezone: "Europe/Berlin"


### PR DESCRIPTION
## Description

Switches Dependabot update checks from monthly to weekly.

## Summary of Changes

- `.github/dependabot.yml`: npm schedule interval `monthly` → `weekly` (still Mondays, 09:00 Europe/Berlin)