### PR TITLE
fix: display dynamic version from package.json in settings modal

### DIFF
--- a/components/settings/information-section.tsx
+++ b/components/settings/information-section.tsx
@@ -1,15 +1,12 @@
 "use client"
 
-import { useState, useEffect } from "react"
 import { Info } from "lucide-react";
 import { SettingsCard, SettingsSection } from "@/components/settings/shared";
+import packageJson from "@/package.json";
 
 const InformationSection = () => {
-  const [packageJsonVersion, setPackageJsonVersion] = useState<string>("v2.0.0");
-
-  useEffect(() => {
-    setPackageJsonVersion("v2.0.0");
-  }, []);
+  // Read version directly from package.json at build time
+  const appVersion = `v${packageJson.version}`;
 
   return (
     <div className="space-y-6">
@@ -26,7 +23,7 @@ const InformationSection = () => {
               <div className="flex-1">
                 <h4 className="text-sm font-medium">Mietevo</h4>
                 <p className="text-sm text-muted-foreground">
-                  Version: <span id="app-version" className="font-mono">{packageJsonVersion}</span>
+                  Version: <span id="app-version" className="font-mono">{appVersion}</span>
                 </p>
               </div>
             </div>

--- a/components/settings/information-section.tsx
+++ b/components/settings/information-section.tsx
@@ -2,11 +2,10 @@
 
 import { Info } from "lucide-react";
 import { SettingsCard, SettingsSection } from "@/components/settings/shared";
-import packageJson from "@/package.json";
 
 const InformationSection = () => {
-  // Read version directly from package.json at build time
-  const appVersion = `v${packageJson.version}`;
+  // Read version from environment variable at build time
+  const appVersion = `v${process.env.NEXT_PUBLIC_APP_VERSION}`;
 
   return (
     <div className="space-y-6">

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,11 @@
 /** @type {import('next').NextConfig} */
 const path = require('path');
+const { version } = require('./package.json');
 
 const nextConfig = {
+  env: {
+    NEXT_PUBLIC_APP_VERSION: version,
+  },
   reactStrictMode: true,
   images: {
     domains: ['ocubnwzybybcbrhsnqqs.supabase.co'],


### PR DESCRIPTION
## Description

Shows the real application version in the settings instead of a hardcoded string.

## Summary of Changes

- `next.config.js`: exposes the `package.json` version as `NEXT_PUBLIC_APP_VERSION` at build time
- `information-section.tsx`: reads the version from that env variable (the hardcoded `v2.0.0` state and its effect are gone)