### PR TITLE
Feature/standardize date pickers

### DIFF
--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -161,11 +161,11 @@ function Calendar({
         day: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].range_end)]:rounded-r-md [&:has([aria-selected].outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
         day_button: cn(
           buttonVariants({ variant: "ghost" }),
-          "h-9 w-9 p-0 font-normal aria-selected:opacity-100"
+          "h-9 w-9 p-0 font-normal aria-selected:opacity-100 rounded-full"
         ),
         range_end: "range_end",
         selected:
-          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground rounded-full",
         today: "bg-accent text-accent-foreground",
         outside:
           "outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground",

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -76,7 +76,7 @@ function CustomMonthCaption({
   }));
 
   return (
-    <div className="flex items-center justify-between pt-1 relative w-full">
+    <div className="flex items-center justify-between relative w-full">
       {/* Left arrow button */}
       <Button
         variant="outline"
@@ -145,31 +145,31 @@ function Calendar({
   return (
     <DayPicker
       showOutsideDays={showOutsideDays}
-      className={cn("p-3", className)}
+      className={cn("p-4", className)}
       classNames={{
-        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
-        month: "space-y-4",
-        month_caption: "flex justify-center pt-1 relative items-center",
+        months: "flex flex-col sm:flex-row gap-4",
+        month: "space-y-4 w-full",
+        month_caption: "flex justify-center pt-1 relative items-center w-full",
         caption_label: "text-sm font-medium hidden",
-        nav: "hidden", // Hide default navigation since we have custom navigation in MonthCaption
+        nav: "hidden",
         button_previous: "hidden",
         button_next: "hidden",
-        month_grid: "w-full border-collapse space-y-1",
-        weekdays: "flex",
-        weekday: "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
-        week: "flex w-full mt-2",
-        day: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].range_end)]:rounded-r-md [&:has([aria-selected].outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+        month_grid: "w-full border-collapse",
+        weekdays: "flex justify-between w-full",
+        weekday: "text-muted-foreground w-9 font-normal text-[0.8rem] text-center",
+        week: "flex justify-between w-full mt-1",
+        day: "h-9 w-9 text-center text-sm p-0 relative focus-within:relative focus-within:z-20",
         day_button: cn(
           buttonVariants({ variant: "ghost" }),
-          "h-9 w-9 p-0 font-normal aria-selected:opacity-100 rounded-full"
+          "h-9 w-9 p-0 font-normal aria-selected:opacity-100 rounded-full hover:bg-accent hover:text-accent-foreground"
         ),
         range_end: "range_end",
         selected:
           "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground rounded-full",
-        today: "bg-red-500 text-white rounded-full",
+        today: "bg-red-500 text-white rounded-full hover:bg-red-600",
         outside:
-          "outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground",
-        disabled: "text-muted-foreground opacity-50",
+          "text-muted-foreground/50 aria-selected:bg-accent/50 aria-selected:text-muted-foreground",
+        disabled: "text-muted-foreground opacity-50 cursor-not-allowed",
         range_middle:
           "aria-selected:bg-accent aria-selected:text-accent-foreground",
         hidden: "invisible",

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -81,7 +81,7 @@ function CustomMonthCaption({
       <Button
         variant="outline"
         size="icon"
-        className="h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 disabled:opacity-25 flex-shrink-0"
+        className="h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 disabled:opacity-25 flex-shrink-0 rounded-lg"
         onClick={handlePreviousMonth}
         disabled={!canGoPrevious()}
         type="button"
@@ -93,7 +93,7 @@ function CustomMonthCaption({
       {/* Center dropdowns - dynamically sized */}
       <div className="flex items-center gap-2 flex-1 justify-center px-2 min-w-0">
         <Select value={currentMonth.toString()} onValueChange={handleMonthChange}>
-          <SelectTrigger className="h-7 flex-1 min-w-[50px] max-w-[80px] text-xs">
+          <SelectTrigger className="h-7 flex-1 min-w-[50px] max-w-[80px] text-xs rounded-lg">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -105,7 +105,7 @@ function CustomMonthCaption({
           </SelectContent>
         </Select>
         <Select value={currentYear.toString()} onValueChange={handleYearChange}>
-          <SelectTrigger className="h-7 flex-1 min-w-[50px] max-w-[80px] text-xs">
+          <SelectTrigger className="h-7 flex-1 min-w-[50px] max-w-[80px] text-xs rounded-lg">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -122,7 +122,7 @@ function CustomMonthCaption({
       <Button
         variant="outline"
         size="icon"
-        className="h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 disabled:opacity-25 flex-shrink-0"
+        className="h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 disabled:opacity-25 flex-shrink-0 rounded-lg"
         onClick={handleNextMonth}
         disabled={!canGoNext()}
         type="button"

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -166,7 +166,7 @@ function Calendar({
         range_end: "range_end",
         selected:
           "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground rounded-full",
-        today: "bg-accent text-accent-foreground",
+        today: "bg-accent text-accent-foreground rounded-full",
         outside:
           "outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground",
         disabled: "text-muted-foreground opacity-50",

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -139,7 +139,7 @@ function Calendar({
   classNames,
   showOutsideDays = true,
   fromYear = new Date().getFullYear() - 100, // Default fromYear
-  toYear = new Date().getFullYear(), // Default toYear
+  toYear = 2100, // Default toYear
   ...props
 }: CalendarProps) {
   return (

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -166,7 +166,7 @@ function Calendar({
         range_end: "range_end",
         selected:
           "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground rounded-full",
-        today: "bg-accent text-accent-foreground rounded-full",
+        today: "bg-red-500 text-white rounded-full",
         outside:
           "outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground",
         disabled: "text-muted-foreground opacity-50",

--- a/components/ui/date-picker.tsx
+++ b/components/ui/date-picker.tsx
@@ -179,7 +179,7 @@ export function DatePicker({
           </div>
         </PopoverTrigger>
         <PopoverContent
-          className="w-auto p-0 rounded-2xl overflow-hidden"
+          className="w-auto p-0 rounded-3xl overflow-hidden"
           align="start"
         >
           <Calendar
@@ -197,7 +197,7 @@ export function DatePicker({
               <Button
                 variant="ghost"
                 size="sm"
-                className="w-full text-xs rounded-xl"
+                className="w-full text-xs rounded-lg"
                 onClick={() => {
                   handleSelect(undefined);
                 }}

--- a/components/ui/date-picker.tsx
+++ b/components/ui/date-picker.tsx
@@ -179,7 +179,7 @@ export function DatePicker({
           </div>
         </PopoverTrigger>
         <PopoverContent
-          className="w-auto p-0"
+          className="w-auto p-0 rounded-2xl overflow-hidden"
           align="start"
         >
           <Calendar
@@ -193,11 +193,11 @@ export function DatePicker({
             initialFocus
           />
           {showClearButton && selectedDate && (
-            <div className="p-3 border-t">
+            <div className="px-4 py-3 border-t bg-muted/30">
               <Button
                 variant="ghost"
                 size="sm"
-                className="w-full text-xs"
+                className="w-full text-xs rounded-xl"
                 onClick={() => {
                   handleSelect(undefined);
                 }}

--- a/components/ui/date-picker.tsx
+++ b/components/ui/date-picker.tsx
@@ -23,9 +23,26 @@ interface DatePickerProps {
   className?: string
   disabled?: boolean
   id?: string
+  fromYear?: number
+  toYear?: number
+  showClearButton?: boolean
+  variant?: "input" | "button"
+  closeOnSelect?: boolean
 }
 
-export function DatePicker({ value, onChange, placeholder = "Datum auswählen", className, disabled, id }: DatePickerProps) {
+export function DatePicker({
+  value,
+  onChange,
+  placeholder = "Datum auswählen",
+  className,
+  disabled,
+  id,
+  fromYear = 1900,
+  toYear = 2100,
+  showClearButton = true,
+  variant = "input",
+  closeOnSelect = false
+}: DatePickerProps) {
   const [selectedDate, setSelectedDate] = useState<Date | undefined>(undefined);
   const [inputValue, setInputValue] = useState<string>("");
   const [isOpen, setIsOpen] = useState(false);
@@ -65,7 +82,9 @@ export function DatePicker({ value, onChange, placeholder = "Datum auswählen", 
     setSelectedDate(date);
     setInputValue(date ? format(date, "dd.MM.yyyy", { locale: de }) : "");
     onChange?.(date);
-    setIsOpen(false); // Close popover on selection
+    if (closeOnSelect) {
+      setIsOpen(false); // Close popover on selection if closeOnSelect is true
+    }
   }
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -100,41 +119,63 @@ export function DatePicker({ value, onChange, placeholder = "Datum auswählen", 
       <Popover open={isOpen} onOpenChange={setIsOpen}>
         <PopoverTrigger asChild>
           <div className="relative">
-            <Input
-              id={id}
-              type="text"
-              placeholder={placeholder}
-              value={inputValue}
-              onChange={handleInputChange}
-              className={cn("pr-10", !selectedDate && "text-muted-foreground")}
-              disabled={disabled}
-              onClick={(e) => {
-                e.preventDefault();
-                if (!disabled) {
-                  setIsOpen(true);
-                }
-              }}
-            />
-            <Button
-              variant="outline"
-              size="icon"
-              className={cn(
-                "absolute right-1 top-1/2 h-8 w-8 -translate-y-1/2 rounded-full text-muted-foreground hover:text-foreground border-0 bg-muted/50 hover:bg-muted hover:scale-105 transition-all duration-200",
-                disabled && "cursor-not-allowed opacity-50"
-              )}
-              disabled={disabled}
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                if (!disabled) {
-                  setIsOpen(!isOpen);
-                }
-              }}
-              type="button"
-              aria-label="Kalender öffnen"
-            >
-              <CalendarIcon className="h-4 w-4" />
-            </Button>
+            {variant === "input" ? (
+              <>
+                <Input
+                  id={id}
+                  type="text"
+                  placeholder={placeholder}
+                  value={inputValue}
+                  onChange={handleInputChange}
+                  className={cn("pr-10", !selectedDate && "text-muted-foreground")}
+                  disabled={disabled}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    if (!disabled) {
+                      setIsOpen(true);
+                    }
+                  }}
+                />
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className={cn(
+                    "absolute right-1 top-1/2 h-8 w-8 -translate-y-1/2 rounded-full text-muted-foreground hover:text-foreground border-0 bg-muted/50 hover:bg-muted hover:scale-105 transition-all duration-200",
+                    disabled && "cursor-not-allowed opacity-50"
+                  )}
+                  disabled={disabled}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (!disabled) {
+                      setIsOpen(!isOpen);
+                    }
+                  }}
+                  type="button"
+                  aria-label="Kalender öffnen"
+                >
+                  <CalendarIcon className="h-4 w-4" />
+                </Button>
+              </>
+            ) : (
+              <Button
+                variant="outline"
+                className={cn(
+                  "w-full justify-start text-left font-normal",
+                  !selectedDate && "text-muted-foreground"
+                )}
+                disabled={disabled}
+                onClick={() => !disabled && setIsOpen(true)}
+                type="button"
+              >
+                <CalendarIcon className="mr-2 h-4 w-4" />
+                {selectedDate ? (
+                  format(selectedDate, "dd.MM.yyyy", { locale: de })
+                ) : (
+                  <span>{placeholder}</span>
+                )}
+              </Button>
+            )}
           </div>
         </PopoverTrigger>
         <PopoverContent
@@ -147,10 +188,24 @@ export function DatePicker({ value, onChange, placeholder = "Datum auswählen", 
             onSelect={handleSelect}
             disabled={disabled}
             locale={de as unknown as Parameters<typeof Calendar>[0]['locale']}
-            fromYear={1900}
-            toYear={2100}
+            fromYear={fromYear}
+            toYear={toYear}
             initialFocus
           />
+          {showClearButton && selectedDate && (
+            <div className="p-3 border-t">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="w-full text-xs"
+                onClick={() => {
+                  handleSelect(undefined);
+                }}
+              >
+                Datum löschen
+              </Button>
+            </div>
+          )}
         </PopoverContent>
       </Popover>
     </div>

--- a/components/wasser-ablesungen-modal.tsx
+++ b/components/wasser-ablesungen-modal.tsx
@@ -37,6 +37,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Calendar } from "@/components/ui/calendar"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { DatePicker } from "@/components/ui/date-picker"
 import { Separator } from "@/components/ui/separator"
 import { format } from "date-fns"
 import { de } from "date-fns/locale"
@@ -582,48 +583,15 @@ export function WasserAblesenModal() {
               <Label className="text-sm font-medium">Neue Ablesung hinzufügen</Label>
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
                 <div className="space-y-2">
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
-                        className={cn(
-                          "w-full justify-start text-left font-normal",
-                          !newAbleseDatum && "text-muted-foreground"
-                        )}
-                        disabled={isSaving}
-                      >
-                        <CalendarIcon className="mr-2 h-4 w-4" />
-                        {newAbleseDatum ? (
-                          format(newAbleseDatum, "dd.MM.yyyy", { locale: de })
-                        ) : (
-                          <span>Datum</span>
-                        )}
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0" align="start">
-                      <Calendar
-                        mode="single"
-                        selected={newAbleseDatum}
-                        onSelect={setNewAbleseDatum}
-                        locale={de as unknown as Parameters<typeof Calendar>[0]['locale']}
-                        fromYear={1990}
-                        toYear={2100}
-                        initialFocus
-                      />
-                      {newAbleseDatum && (
-                        <div className="p-3 border-t">
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="w-full"
-                            onClick={() => setNewAbleseDatum(undefined)}
-                          >
-                            Datum löschen
-                          </Button>
-                        </div>
-                      )}
-                    </PopoverContent>
-                  </Popover>
+                  <DatePicker
+                    value={newAbleseDatum}
+                    onChange={setNewAbleseDatum}
+                    placeholder="Datum"
+                    disabled={isSaving}
+                    variant="button"
+                    fromYear={1990}
+                    toYear={2100}
+                  />
                 </div>
                 <div className="space-y-2">
                   <NumberInput
@@ -753,48 +721,16 @@ export function WasserAblesenModal() {
                                       <CalendarIcon className="h-3 w-3" />
                                       Datum
                                     </Label>
-                                    <Popover>
-                                      <PopoverTrigger asChild>
-                                        <Button
-                                          variant="outline"
-                                          className={cn(
-                                            "w-full justify-start text-left font-normal mt-1.5",
-                                            !editAbleseDatum && "text-muted-foreground"
-                                          )}
-                                          disabled={isSaving}
-                                        >
-                                          <CalendarIcon className="mr-2 h-4 w-4" />
-                                          {editAbleseDatum ? (
-                                            format(editAbleseDatum, "dd.MM.yyyy", { locale: de })
-                                          ) : (
-                                            <span>Datum wählen</span>
-                                          )}
-                                        </Button>
-                                      </PopoverTrigger>
-                                      <PopoverContent className="w-auto p-0" align="start">
-                                        <Calendar
-                                          mode="single"
-                                          selected={editAbleseDatum}
-                                          onSelect={(date) => currentAblesung && handleEditDateChange(date, currentAblesung)}
-                                          locale={de as unknown as Parameters<typeof Calendar>[0]['locale']}
-                                          fromYear={1990}
-                                          toYear={2100}
-                                          initialFocus
-                                        />
-                                        {editAbleseDatum && (
-                                          <div className="p-3 border-t">
-                                            <Button
-                                              variant="ghost"
-                                              size="sm"
-                                              className="w-full"
-                                              onClick={() => setEditAbleseDatum(undefined)}
-                                            >
-                                              Datum löschen
-                                            </Button>
-                                          </div>
-                                        )}
-                                      </PopoverContent>
-                                    </Popover>
+                                    <DatePicker
+                                      value={editAbleseDatum}
+                                      onChange={(date) => currentAblesung && handleEditDateChange(date, currentAblesung)}
+                                      placeholder="Datum wählen"
+                                      disabled={isSaving}
+                                      variant="button"
+                                      fromYear={1990}
+                                      toYear={2100}
+                                      className="mt-1.5"
+                                    />
                                   </div>
                                   <div>
                                     <Label className="text-xs text-muted-foreground flex items-center gap-1">

--- a/components/wasser-zaehler-modal.tsx
+++ b/components/wasser-zaehler-modal.tsx
@@ -35,6 +35,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Calendar } from "@/components/ui/calendar"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { DatePicker } from "@/components/ui/date-picker"
 import { Separator } from "@/components/ui/separator"
 import { format } from "date-fns"
 import { de } from "date-fns/locale"
@@ -357,48 +358,15 @@ export function WasserZaehlerModal() {
                   />
                 </div>
                 <div className="flex-1 space-y-2">
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
-                        className={cn(
-                          "w-full justify-start text-left font-normal",
-                          !newEichungsdatum && "text-muted-foreground"
-                        )}
-                        disabled={isSaving}
-                      >
-                        <CalendarIcon className="mr-2 h-4 w-4" />
-                        {newEichungsdatum ? (
-                          format(newEichungsdatum, "dd.MM.yyyy", { locale: de })
-                        ) : (
-                          <span>Eichungsdatum (optional)</span>
-                        )}
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="w-auto p-0" align="start">
-                      <Calendar
-                        mode="single"
-                        selected={newEichungsdatum}
-                        onSelect={setNewEichungsdatum}
-                        locale={de as unknown as Parameters<typeof Calendar>[0]['locale']}
-                        fromYear={1990}
-                        toYear={2100}
-                        initialFocus
-                      />
-                      {newEichungsdatum && (
-                        <div className="p-3 border-t">
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="w-full"
-                            onClick={() => setNewEichungsdatum(undefined)}
-                          >
-                            Datum löschen
-                          </Button>
-                        </div>
-                      )}
-                    </PopoverContent>
-                  </Popover>
+                  <DatePicker
+                    value={newEichungsdatum}
+                    onChange={setNewEichungsdatum}
+                    placeholder="Eichungsdatum (optional)"
+                    disabled={isSaving}
+                    variant="button"
+                    fromYear={1990}
+                    toYear={2100}
+                  />
                 </div>
                 <Button
                   onClick={handleAddZaehler}
@@ -522,48 +490,17 @@ export function WasserZaehlerModal() {
                                       <CalendarIcon className="h-3 w-3" />
                                       Eichungsdatum
                                     </Label>
-                                    <Popover>
-                                      <PopoverTrigger asChild>
-                                        <Button
-                                          variant="outline"
-                                          className={cn(
-                                            "w-full justify-start text-left font-normal mt-1.5",
-                                            !editEichungsdatum && "text-muted-foreground"
-                                          )}
-                                          disabled={isSaving}
-                                        >
-                                          <CalendarIcon className="mr-2 h-4 w-4" />
-                                          {editEichungsdatum ? (
-                                            format(editEichungsdatum, "dd.MM.yyyy", { locale: de })
-                                          ) : (
-                                            <span>Datum wählen</span>
-                                          )}
-                                        </Button>
-                                      </PopoverTrigger>
-                                      <PopoverContent className="w-auto p-0" align="start">
-                                        <Calendar
-                                          mode="single"
-                                          selected={editEichungsdatum}
-                                          onSelect={setEditEichungsdatum}
-                                          locale={de as unknown as Parameters<typeof Calendar>[0]['locale']}
-                                          fromYear={1990}
-                                          toYear={2100}
-                                          initialFocus
-                                        />
-                                        {editEichungsdatum && (
-                                          <div className="p-3 border-t">
-                                            <Button
-                                              variant="ghost"
-                                              size="sm"
-                                              className="w-full"
-                                              onClick={() => setEditEichungsdatum(undefined)}
-                                            >
-                                              Datum löschen
-                                            </Button>
-                                          </div>
-                                        )}
-                                      </PopoverContent>
-                                    </Popover>
+                                    <DatePicker
+                                      id={`edit-eichungsdatum-${zaehler.id}`}
+                                      value={editEichungsdatum}
+                                      onChange={setEditEichungsdatum}
+                                      placeholder="Datum wählen"
+                                      disabled={isSaving}
+                                      variant="button"
+                                      fromYear={1990}
+                                      toYear={2100}
+                                      className="mt-1.5"
+                                    />
                                   </motion.div>
                                 </div>
                               </motion.div>


### PR DESCRIPTION
## Description

Standardizes the date pickers across the app on a single, more capable `DatePicker` component.

## Summary of Changes

- `date-picker.tsx`: new options — `fromYear`/`toYear`, `showClearButton` (adds a "Datum löschen" footer), `variant: 'input' | 'button'` and `closeOnSelect`
- `calendar.tsx`: visual overhaul — full-width justified layout, rounded day buttons, red today highlight, rounded controls; default `toYear` now 2100
- `wasser-ablesungen-modal.tsx` and `wasser-zaehler-modal.tsx`: the hand-rolled Popover+Calendar blocks (~84 lines each) replaced by the shared `DatePicker` in button variant