### PR TITLE
fix: update dependabot labels - remove non-existent 'automated' label…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-      - "automated"
+      - "patch"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
## Description

Fixes the Dependabot labels so they match the repository's label set.

## Summary of Changes

- `.github/dependabot.yml`: the non-existent `automated` label replaced with `patch`