### PR TITLE
chore: update contact email from felix.plant@web.de to support@mietev…

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -4,4 +4,4 @@ export const PAGINATION = {
   DEFAULT_PAGE_SIZE: 25,
 };
 
-export const CONTACT_EMAIL = "felix.plant@web.de";
+export const CONTACT_EMAIL = "support@mietevo.de";

--- a/supabase/mail-templates/change-email-address.html
+++ b/supabase/mail-templates/change-email-address.html
@@ -103,6 +103,12 @@
             border-top: 1px solid var(--border);
         }
 
+        .footer a {
+            color: var(--primary);
+            text-decoration: none;
+            font-weight: 600;
+        }
+
         @media (max-width: 480px) {
             body {
                 padding: 15px;
@@ -160,7 +166,7 @@
         <div class="footer">
             <p>Falls Sie diese Änderung nicht angefordert haben, ignorieren Sie diese E-Mail. Ihre aktuelle
                 E-Mail-Adresse bleibt unverändert.</p>
-            <p>Bei Fragen erreichen Sie uns unter support@mietevo.de</p>
+            <p>Bei Fragen erreichen Sie uns unter <a href="mailto:support@mietevo.de">support@mietevo.de</a></p>
             <p>&copy; 2025 Mietevo. Alle Rechte vorbehalten.</p>
         </div>
     </div>

--- a/supabase/mail-templates/change-email-address.html
+++ b/supabase/mail-templates/change-email-address.html
@@ -160,7 +160,7 @@
         <div class="footer">
             <p>Falls Sie diese Änderung nicht angefordert haben, ignorieren Sie diese E-Mail. Ihre aktuelle
                 E-Mail-Adresse bleibt unverändert.</p>
-            <p>Bei Fragen erreichen Sie uns unter felix.plant@web.de</p>
+            <p>Bei Fragen erreichen Sie uns unter support@mietevo.de</p>
             <p>&copy; 2025 Mietevo. Alle Rechte vorbehalten.</p>
         </div>
     </div>

--- a/supabase/mail-templates/confirm-signup.html
+++ b/supabase/mail-templates/confirm-signup.html
@@ -95,6 +95,12 @@
             border-top: 1px solid var(--border);
         }
 
+        .footer a {
+            color: var(--primary);
+            text-decoration: none;
+            font-weight: 600;
+        }
+
         @media (max-width: 480px) {
             body {
                 padding: 15px;
@@ -136,7 +142,7 @@
 
         <div class="footer">
             <p>Diese Nachricht wurde automatisch erstellt. Bitte antworten Sie nicht darauf.</p>
-            <p>Bei Fragen erreichen Sie uns unter support@mietevo.de</p>
+            <p>Bei Fragen erreichen Sie uns unter <a href="mailto:support@mietevo.de">support@mietevo.de</a></p>
             <p>&copy; 2025 Mietevo. Alle Rechte vorbehalten.</p>
         </div>
     </div>

--- a/supabase/mail-templates/confirm-signup.html
+++ b/supabase/mail-templates/confirm-signup.html
@@ -136,7 +136,7 @@
 
         <div class="footer">
             <p>Diese Nachricht wurde automatisch erstellt. Bitte antworten Sie nicht darauf.</p>
-            <p>Bei Fragen erreichen Sie uns unter felix.plant@web.de</p>
+            <p>Bei Fragen erreichen Sie uns unter support@mietevo.de</p>
             <p>&copy; 2025 Mietevo. Alle Rechte vorbehalten.</p>
         </div>
     </div>

--- a/supabase/mail-templates/invite-user.html
+++ b/supabase/mail-templates/invite-user.html
@@ -104,6 +104,12 @@
             border-top: 1px solid var(--border);
         }
 
+        .footer a {
+            color: var(--primary);
+            text-decoration: none;
+            font-weight: 600;
+        }
+
         @media (max-width: 480px) {
             body {
                 padding: 15px;
@@ -160,7 +166,7 @@
 
         <div class="footer">
             <p>Falls Sie diese Einladung nicht erwartet haben, können Sie diese E-Mail ignorieren.</p>
-            <p>Bei Fragen erreichen Sie uns unter support@mietevo.de</p>
+            <p>Bei Fragen erreichen Sie uns unter <a href="mailto:support@mietevo.de">support@mietevo.de</a></p>
             <p>&copy; 2025 Mietevo. Alle Rechte vorbehalten.</p>
         </div>
     </div>

--- a/supabase/mail-templates/invite-user.html
+++ b/supabase/mail-templates/invite-user.html
@@ -160,7 +160,7 @@
 
         <div class="footer">
             <p>Falls Sie diese Einladung nicht erwartet haben, können Sie diese E-Mail ignorieren.</p>
-            <p>Bei Fragen erreichen Sie uns unter felix.plant@web.de</p>
+            <p>Bei Fragen erreichen Sie uns unter support@mietevo.de</p>
             <p>&copy; 2025 Mietevo. Alle Rechte vorbehalten.</p>
         </div>
     </div>

--- a/supabase/mail-templates/magic-link.html
+++ b/supabase/mail-templates/magic-link.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="de">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -102,17 +103,26 @@
             border-top: 1px solid var(--border);
         }
 
+        .footer a {
+            color: var(--primary);
+            text-decoration: none;
+            font-weight: 600;
+        }
+
         @media (max-width: 480px) {
             body {
                 padding: 15px;
             }
+
             .email-container {
                 padding: 30px 20px;
                 border-radius: 20px;
             }
+
             h1 {
                 font-size: 24px;
             }
+
             .btn-confirm {
                 padding: 16px 0;
                 font-size: 16px;
@@ -120,17 +130,19 @@
         }
     </style>
 </head>
+
 <body>
     <div class="email-container">
         <div class="header">
-            <img src="https://ocubnwzybybcbrhsnqqs.supabase.co/storage/v1/object/public/pwa-images/favicon.png" alt="Mietevo Mascot" class="logo">
+            <img src="https://ocubnwzybybcbrhsnqqs.supabase.co/storage/v1/object/public/pwa-images/favicon.png"
+                alt="Mietevo Mascot" class="logo">
             <h1>Anmeldung bei Mietevo</h1>
         </div>
 
         <p>Hallo,</p>
-        
+
         <p>Sie haben eine passwortlose Anmeldung bei Mietevo angefordert.</p>
-        
+
         <p>Klicken Sie auf den folgenden Button, um sich sicher anzumelden:</p>
 
         <div class="btn-container">
@@ -141,14 +153,16 @@
         <p style="word-break: break-all; color: var(--primary); font-size: 14px;">{{ .ConfirmationURL }}</p>
 
         <div class="security-note">
-            <strong>Sicherheitshinweis:</strong> Dieser Link ist nur 1 Stunde gültig und kann nur einmal verwendet werden.
+            <strong>Sicherheitshinweis:</strong> Dieser Link ist nur 1 Stunde gültig und kann nur einmal verwendet
+            werden.
         </div>
 
         <div class="footer">
             <p>Falls Sie diese Anmeldung nicht angefordert haben, können Sie diese E-Mail ignorieren.</p>
-            <p>Bei Fragen erreichen Sie uns unter support@mietevo.de</p>
+            <p>Bei Fragen erreichen Sie uns unter <a href="mailto:support@mietevo.de">support@mietevo.de</a></p>
             <p>&copy; 2025 Mietevo. Alle Rechte vorbehalten.</p>
         </div>
     </div>
 </body>
+
 </html>

--- a/supabase/mail-templates/magic-link.html
+++ b/supabase/mail-templates/magic-link.html
@@ -146,7 +146,7 @@
 
         <div class="footer">
             <p>Falls Sie diese Anmeldung nicht angefordert haben, können Sie diese E-Mail ignorieren.</p>
-            <p>Bei Fragen erreichen Sie uns unter felix.plant@web.de</p>
+            <p>Bei Fragen erreichen Sie uns unter support@mietevo.de</p>
             <p>&copy; 2025 Mietevo. Alle Rechte vorbehalten.</p>
         </div>
     </div>

--- a/supabase/mail-templates/reauthentication.html
+++ b/supabase/mail-templates/reauthentication.html
@@ -164,7 +164,7 @@
 
         <div class="footer">
             <p>Falls Sie diese Aktion nicht angefordert haben, melden Sie sich bitte umgehend bei unserem Support.</p>
-            <p>Bei Fragen erreichen Sie uns unter felix.plant@web.de</p>
+            <p>Bei Fragen erreichen Sie uns unter support@mietevo.de</p>
             <p>&copy; 2025 Mietevo. Alle Rechte vorbehalten.</p>
         </div>
     </div>

--- a/supabase/mail-templates/reauthentication.html
+++ b/supabase/mail-templates/reauthentication.html
@@ -102,6 +102,12 @@
             border-top: 1px solid var(--border);
         }
 
+        .footer a {
+            color: var(--primary);
+            text-decoration: none;
+            font-weight: 600;
+        }
+
         @media (max-width: 480px) {
             body {
                 padding: 15px;
@@ -164,7 +170,7 @@
 
         <div class="footer">
             <p>Falls Sie diese Aktion nicht angefordert haben, melden Sie sich bitte umgehend bei unserem Support.</p>
-            <p>Bei Fragen erreichen Sie uns unter support@mietevo.de</p>
+            <p>Bei Fragen erreichen Sie uns unter <a href="mailto:support@mietevo.de">support@mietevo.de</a></p>
             <p>&copy; 2025 Mietevo. Alle Rechte vorbehalten.</p>
         </div>
     </div>

--- a/supabase/mail-templates/reset-password.html
+++ b/supabase/mail-templates/reset-password.html
@@ -112,6 +112,12 @@
             border-top: 1px solid var(--border);
         }
 
+        .footer a {
+            color: var(--primary);
+            text-decoration: none;
+            font-weight: 600;
+        }
+
         @media (max-width: 480px) {
             body {
                 padding: 15px;
@@ -170,7 +176,7 @@
         <div class="footer">
             <p>Falls Sie diese Zurücksetzung nicht angefordert haben, können Sie diese E-Mail ignorieren. Ihr Passwort
                 bleibt unverändert.</p>
-            <p>Bei Fragen erreichen Sie uns unter support@mietevo.de</p>
+            <p>Bei Fragen erreichen Sie uns unter <a href="mailto:support@mietevo.de">support@mietevo.de</a></p>
             <p>&copy; 2025 Mietevo. Alle Rechte vorbehalten.</p>
         </div>
     </div>

--- a/supabase/mail-templates/reset-password.html
+++ b/supabase/mail-templates/reset-password.html
@@ -170,7 +170,7 @@
         <div class="footer">
             <p>Falls Sie diese Zurücksetzung nicht angefordert haben, können Sie diese E-Mail ignorieren. Ihr Passwort
                 bleibt unverändert.</p>
-            <p>Bei Fragen erreichen Sie uns unter felix.plant@web.de</p>
+            <p>Bei Fragen erreichen Sie uns unter support@mietevo.de</p>
             <p>&copy; 2025 Mietevo. Alle Rechte vorbehalten.</p>
         </div>
     </div>


### PR DESCRIPTION
## Description

Switches the contact email from the private address to support@mietevo.de everywhere.

## Summary of Changes

- `constants/index.ts`: `CONTACT_EMAIL` now `support@mietevo.de`
- All six Supabase mail templates (signup confirmation, magic link, password reset, email change, invite, re-authentication): the plain-text private address in the footer is now a styled `mailto:` link, with new `.footer a` styling