### PR TITLE
chore: update metadata to German branding (Mietevo)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,9 +10,8 @@ import { CookieConsentBanner } from "@/components/common/cookie-consent-banner"
 const inter = Inter({ subsets: ["latin"] })
 
 export const metadata: Metadata = {
-  title: "Property Management Dashboard",
-  description: "Modern dashboard for property management",
-  generator: 'v0.dev',
+  title: "Mietevo | Immobilienverwaltung",
+  description: "Moderne Plattform für die Immobilienverwaltung",
   icons: {
     icon: '/favicon.png',
     apple: '/apple-icon.png',

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,9 +10,8 @@ import { CookieConsentBanner } from "@/components/common/cookie-consent-banner"
 const inter = Inter({ subsets: ["latin"] })
 
 export const metadata: Metadata = {
-  title: "Property Management Dashboard",
-  description: "Modern dashboard for property management",
-  generator: 'v0.dev',
+  title: "Mietevo | Immobilienverwaltung",
+  description: "Moderne Plattform für die Immobilienverwaltung",
   icons: {
     icon: '/favicon.png',
     apple: '/apple-icon.png',
@@ -25,7 +24,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning className="light">
+    <html lang="de" suppressHydrationWarning className="light">
       <body className={inter.className}>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem={true}>
           <PostHogProvider>


### PR DESCRIPTION
## Description

Updates the root layout metadata and document language to match the Mietevo brand.

## Summary of Changes

- `app/layout.tsx`: title `Mietevo | Immobilienverwaltung` with a German description (replacing the v0.dev defaults, including the `generator` field)
- `<html lang>` switched from `en` to `de`