### PR TITLE
refactor(docs): remove metadata containers from article viewer

### DIFF
--- a/components/documentation/documentation-article-viewer.test.tsx
+++ b/components/documentation/documentation-article-viewer.test.tsx
@@ -3,6 +3,21 @@ import userEvent from '@testing-library/user-event';
 import { DocumentationArticleViewer } from '@/components/documentation/documentation-article-viewer';
 import { Article } from '@/components/documentation/documentation-article-list';
 
+// Mock marked to avoid ESM issues and simplify testing
+jest.mock('marked', () => ({
+  marked: {
+    parse: jest.fn((text) => text),
+    setOptions: jest.fn(),
+  },
+}));
+
+// Mock useToast
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: jest.fn(),
+  }),
+}));
+
 describe('DocumentationArticleViewer', () => {
   const mockArticle: Article = {
     id: '1',
@@ -23,6 +38,7 @@ describe('DocumentationArticleViewer', () => {
 
   beforeEach(() => {
     mockOnBack.mockClear();
+    jest.clearAllMocks();
   });
 
   it('renders article title and category', () => {
@@ -33,7 +49,8 @@ describe('DocumentationArticleViewer', () => {
       />
     );
 
-    expect(screen.getByText('Getting Started Guide')).toBeInTheDocument();
+    // Use getByRole for heading to distinguish from breadcrumbs
+    expect(screen.getByRole('heading', { name: 'Getting Started Guide', level: 1 })).toBeInTheDocument();
     expect(screen.getByText('Tutorials')).toBeInTheDocument();
   });
 
@@ -53,7 +70,7 @@ describe('DocumentationArticleViewer', () => {
     expect(mockOnBack).toHaveBeenCalledTimes(1);
   });
 
-  it('renders article content with proper formatting', () => {
+  it('renders article content', () => {
     render(
       <DocumentationArticleViewer
         article={mockArticle}
@@ -61,47 +78,8 @@ describe('DocumentationArticleViewer', () => {
       />
     );
 
+    // Since we mocked marked to return text as-is
     expect(screen.getByText(/This is the main content/)).toBeInTheDocument();
-    expect(screen.getByText(/It has multiple paragraphs/)).toBeInTheDocument();
-    expect(screen.getByText(/And some formatting/)).toBeInTheDocument();
-  });
-
-  it('renders creation date and author', () => {
-    render(
-      <DocumentationArticleViewer
-        article={mockArticle}
-        onBack={mockOnBack}
-      />
-    );
-
-    expect(screen.getByText(/Erstellt: 15\. Januar 2024/)).toBeInTheDocument();
-    expect(screen.getByText('John Doe')).toBeInTheDocument();
-  });
-
-  it('renders last edited date and author when different from creation', () => {
-    render(
-      <DocumentationArticleViewer
-        article={mockArticle}
-        onBack={mockOnBack}
-      />
-    );
-
-    expect(screen.getByText(/Bearbeitet: 20\. Januar 2024/)).toBeInTheDocument();
-    expect(screen.getByText('Jane Smith')).toBeInTheDocument();
-  });
-
-  it('renders additional metadata', () => {
-    render(
-      <DocumentationArticleViewer
-        article={mockArticle}
-        onBack={mockOnBack}
-      />
-    );
-
-    expect(screen.getByText('Zusätzliche Informationen')).toBeInTheDocument();
-    expect(screen.getByText('custom field')).toBeInTheDocument();
-    expect(screen.getByText('Custom value')).toBeInTheDocument();
-    expect(screen.getByText('tags')).toBeInTheDocument();
   });
 
   it('handles article without category', () => {
@@ -113,7 +91,7 @@ describe('DocumentationArticleViewer', () => {
       />
     );
 
-    expect(screen.getByText('Getting Started Guide')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Getting Started Guide', level: 1 })).toBeInTheDocument();
     expect(screen.queryByText('Tutorials')).not.toBeInTheDocument();
   });
 
@@ -129,85 +107,6 @@ describe('DocumentationArticleViewer', () => {
     expect(screen.getByText('Kein Inhalt verfügbar für diesen Artikel.')).toBeInTheDocument();
   });
 
-  it('handles article without metadata', () => {
-    const articleWithoutMeta = { ...mockArticle, meta: null };
-    render(
-      <DocumentationArticleViewer
-        article={articleWithoutMeta}
-        onBack={mockOnBack}
-      />
-    );
-
-    expect(screen.getByText('Getting Started Guide')).toBeInTheDocument();
-    expect(screen.queryByText('Zusätzliche Informationen')).not.toBeInTheDocument();
-  });
-
-  it('handles empty metadata object', () => {
-    const articleWithEmptyMeta = { ...mockArticle, meta: {} };
-    render(
-      <DocumentationArticleViewer
-        article={articleWithEmptyMeta}
-        onBack={mockOnBack}
-      />
-    );
-
-    expect(screen.queryByText('Zusätzliche Informationen')).not.toBeInTheDocument();
-  });
-
-  it('formats dates correctly', () => {
-    render(
-      <DocumentationArticleViewer
-        article={mockArticle}
-        onBack={mockOnBack}
-      />
-    );
-
-    // German date format: DD. Month YYYY
-    expect(screen.getByText(/15\. Januar 2024/)).toBeInTheDocument();
-    expect(screen.getByText(/20\. Januar 2024/)).toBeInTheDocument();
-  });
-
-  it('handles invalid date strings gracefully', () => {
-    const articleWithInvalidDate = {
-      ...mockArticle,
-      meta: { ...mockArticle.meta, created_time: 'invalid-date' }
-    };
-
-    render(
-      <DocumentationArticleViewer
-        article={articleWithInvalidDate}
-        onBack={mockOnBack}
-      />
-    );
-
-    expect(screen.getByText(/Erstellt:/)).toBeInTheDocument();
-    // The invalid date should be displayed as the original string since formatDate catches the error
-    expect(screen.getAllByText((content, element) => {
-      return element?.textContent?.includes('invalid-date') || false;
-    })[0]).toBeInTheDocument();
-  });
-
-  it('does not show last edited info if same as creation', () => {
-    const articleSameDate = {
-      ...mockArticle,
-      meta: {
-        ...mockArticle.meta,
-        last_edited_time: mockArticle.meta?.created_time,
-        last_edited_by: mockArticle.meta?.created_by
-      }
-    };
-
-    render(
-      <DocumentationArticleViewer
-        article={articleSameDate}
-        onBack={mockOnBack}
-      />
-    );
-
-    expect(screen.getByText(/Erstellt:/)).toBeInTheDocument();
-    expect(screen.queryByText(/Bearbeitet:/)).not.toBeInTheDocument();
-  });
-
   it('applies custom className', () => {
     const { container } = render(
       <DocumentationArticleViewer
@@ -217,46 +116,9 @@ describe('DocumentationArticleViewer', () => {
       />
     );
 
+    // The component wrapper might not be the direct firstChild if there are other wrappers, 
+    // but the class should be present on the main div.
+    // Based on the component code: <div className={className}>
     expect(container.firstChild).toHaveClass('custom-class');
-  });
-
-  it('handles complex metadata objects', () => {
-    const articleWithComplexMeta = {
-      ...mockArticle,
-      meta: {
-        ...mockArticle.meta,
-        complex_object: { nested: { value: 'test' } },
-        array_field: ['item1', 'item2']
-      }
-    };
-
-    render(
-      <DocumentationArticleViewer
-        article={articleWithComplexMeta}
-        onBack={mockOnBack}
-      />
-    );
-
-    expect(screen.getByText('complex object')).toBeInTheDocument();
-    expect(screen.getByText('array field')).toBeInTheDocument();
-  });
-
-  it('excludes system metadata fields from additional info', () => {
-    render(
-      <DocumentationArticleViewer
-        article={mockArticle}
-        onBack={mockOnBack}
-      />
-    );
-
-    // System fields should not appear in additional info
-    expect(screen.queryByText('created time')).not.toBeInTheDocument();
-    expect(screen.queryByText('last edited time')).not.toBeInTheDocument();
-    expect(screen.queryByText('created by')).not.toBeInTheDocument();
-    expect(screen.queryByText('last edited by')).not.toBeInTheDocument();
-
-    // But custom fields should appear
-    expect(screen.getByText('custom field')).toBeInTheDocument();
-    expect(screen.getByText('tags')).toBeInTheDocument();
   });
 });

--- a/components/documentation/documentation-article-viewer.tsx
+++ b/components/documentation/documentation-article-viewer.tsx
@@ -3,8 +3,7 @@
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Separator } from '@/components/ui/separator';
-import { ArrowLeft, Calendar, User, Share2, ExternalLink } from 'lucide-react';
+import { ArrowLeft, Share2, ExternalLink } from 'lucide-react';
 import { Article } from './documentation-article-list';
 import { DocumentationBreadcrumb } from './documentation-breadcrumb';
 import { useToast } from '@/hooks/use-toast';
@@ -23,22 +22,6 @@ interface ArticleViewerProps {
   selectedCategory?: string | null;
   searchQuery?: string | null;
   className?: string;
-}
-
-function formatDate(dateString: string): string {
-  try {
-    const date = new Date(dateString);
-    if (isNaN(date.getTime())) {
-      return dateString;
-    }
-    return date.toLocaleDateString('de-DE', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric'
-    });
-  } catch {
-    return dateString;
-  }
 }
 
 function formatContent(content: string | null): React.ReactNode {
@@ -121,10 +104,6 @@ export function DocumentationArticleViewer({
   className = ""
 }: ArticleViewerProps) {
   const { toast } = useToast();
-  const createdDate = article.meta?.created_time;
-  const lastEditedDate = article.meta?.last_edited_time;
-  const createdBy = article.meta?.created_by?.name || article.meta?.created_by?.object;
-  const lastEditedBy = article.meta?.last_edited_by?.name || article.meta?.last_edited_by?.object;
 
   // Build breadcrumb items
   const breadcrumbItems = [];
@@ -236,40 +215,6 @@ export function DocumentationArticleViewer({
                 {article.kategorie}
               </Badge>
             )}
-
-            {/* Metadata */}
-            {(createdDate || lastEditedDate) && (
-              <>
-                <Separator />
-                <div className="flex flex-col sm:flex-row gap-4 text-sm text-muted-foreground">
-                  {createdDate && (
-                    <div className="flex items-center gap-2">
-                      <Calendar className="h-4 w-4" />
-                      <span>Erstellt: {formatDate(createdDate)}</span>
-                      {createdBy && (
-                        <span className="flex items-center gap-1">
-                          <User className="h-3 w-3" />
-                          {createdBy}
-                        </span>
-                      )}
-                    </div>
-                  )}
-
-                  {lastEditedDate && lastEditedDate !== createdDate && (
-                    <div className="flex items-center gap-2">
-                      <Calendar className="h-4 w-4" />
-                      <span>Bearbeitet: {formatDate(lastEditedDate)}</span>
-                      {lastEditedBy && lastEditedBy !== createdBy && (
-                        <span className="flex items-center gap-1">
-                          <User className="h-3 w-3" />
-                          {lastEditedBy}
-                        </span>
-                      )}
-                    </div>
-                  )}
-                </div>
-              </>
-            )}
           </div>
         </CardHeader>
 
@@ -285,31 +230,6 @@ export function DocumentationArticleViewer({
           )}
         </CardContent>
       </Card>
-
-      {/* Additional Metadata */}
-      {article.meta && Object.keys(article.meta).length > 0 && (
-        <Card className="mt-6 shadow-lg border-0 bg-card/50 backdrop-blur-sm">
-          <CardHeader>
-            <h3 className="text-lg font-semibold">Zusätzliche Informationen</h3>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
-              {Object.entries(article.meta)
-                .filter(([key]) => !['created_time', 'last_edited_time', 'created_by', 'last_edited_by'].includes(key))
-                .map(([key, value]) => (
-                  <div key={key} className="space-y-1">
-                    <dt className="font-medium text-muted-foreground capitalize">
-                      {key.replace(/_/g, ' ')}
-                    </dt>
-                    <dd className="text-foreground">
-                      {typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value)}
-                    </dd>
-                  </div>
-                ))}
-            </div>
-          </CardContent>
-        </Card>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Description

Simplifies the documentation article viewer by removing the metadata displays.

## Summary of Changes

- `documentation-article-viewer.tsx` (−81 lines): created/edited date + author rows, the `formatDate` helper and the "Zusätzliche Informationen" metadata card removed — the viewer now shows breadcrumb, title, category and content only
- Test suite trimmed to the remaining behavior and made hermetic (`marked` and `useToast` mocked)