### PR TITLE
fix: update Datenschutz page with correct mietevo.de URL and remove S…

### DIFF
--- a/app/(landing)/agb/page.tsx
+++ b/app/(landing)/agb/page.tsx
@@ -1,3 +1,5 @@
+import { INFO_EMAIL } from '@/lib/constants';
+
 export default function AGBPage() {
   return (
     <div className="w-full bg-background pt-24 pb-12">
@@ -57,7 +59,7 @@ export default function AGBPage() {
               Kirchbrändelring 21a<br />
               76669 Bad Schönborn<br />
               Deutschland<br />
-              E-Mail: info@mietevo.de
+              E-Mail: {INFO_EMAIL}
             </p>
           </div>
         </div>

--- a/app/(landing)/datenschutz/page.tsx
+++ b/app/(landing)/datenschutz/page.tsx
@@ -85,7 +85,7 @@ export default function DatenschutzPage() {
               Deutschland</p>
 
             <p className="mt-2">E-Mail: {CONTACT_EMAIL}<br />
-              Website: rent-manager.pages.dev</p>
+              Website: mietevo.de</p>
           </div>
 
           <h2 className="text-2xl font-semibold mt-10 mb-4">2. Allgemeine Hinweise zur Datenverarbeitung</h2>
@@ -173,7 +173,7 @@ export default function DatenschutzPage() {
             <li>Erstellung von Nebenkostenabrechnungen</li>
             <li>Datenexport und -sicherung</li>
             <li>Produktentwicklung und -verbesserung</li>
-            <li>Abwicklung von Zahlungen (nur kostenpflichtige Version)</li>
+            <li>Abwicklung von Zahlungen</li>
           </ul>
 
           <h2 className="text-2xl font-semibold mt-10 mb-4">4. Unterschiede zwischen Demo-Version und kostenpflichtiger Version</h2>
@@ -207,7 +207,7 @@ export default function DatenschutzPage() {
           <p><strong>Serverstandort:</strong> EU und USA</p>
           <p><strong>Datenschutz:</strong> Stripe ist PCI-DSS Level 1 zertifiziert</p>
           <p><strong>Drittlandübertragung:</strong> Durch EU-USA Data Privacy Framework abgesichert</p>
-          <p><strong>Anwendung:</strong> Nur bei kostenpflichtiger Version</p>
+
 
           <h3 className="text-xl font-semibold mt-6 mb-2">5.3 PostHog (Produktanalyse)</h3>
           <p>Zur Verbesserung unserer Software nutzen wir PostHog Inc. für Produktanalysen.</p>

--- a/app/(landing)/datenschutz/page.tsx
+++ b/app/(landing)/datenschutz/page.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@/components/ui/button';
 import { Trash2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
-import { CONTACT_EMAIL } from '@/lib/constants';
+import { CONTACT_EMAIL, WEBSITE_DOMAIN } from '@/lib/constants';
 
 // Essential cookies that should not be deleted (authentication, security)
 const ESSENTIAL_COOKIES = [
@@ -85,7 +85,7 @@ export default function DatenschutzPage() {
               Deutschland</p>
 
             <p className="mt-2">E-Mail: {CONTACT_EMAIL}<br />
-              Website: mietevo.de</p>
+              Website: {WEBSITE_DOMAIN}</p>
           </div>
 
           <h2 className="text-2xl font-semibold mt-10 mb-4">2. Allgemeine Hinweise zur Datenverarbeitung</h2>

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -29,6 +29,9 @@ export const CONTACT_EMAIL = INFO_EMAIL;
 // Base URL - centralized to ensure consistency across all environments
 export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://mietevo.de';
 
+// Website domain (without protocol) - for display in legal pages
+export const WEBSITE_DOMAIN = 'mietevo.de';
+
 
 // Feature flags removed as functionality is now standard
 // PostHog feature flag keys - centralized to prevent magic strings


### PR DESCRIPTION
## Description

Updates the legal pages with the correct mietevo.de domain and removes outdated Stripe version restrictions.

## Summary of Changes

- `lib/constants.ts`: new `WEBSITE_DOMAIN` constant (`mietevo.de`)
- Datenschutz page: hardcoded `rent-manager.pages.dev` replaced by the constant; the "(nur kostenpflichtige Version)" qualifiers on payment processing and the Stripe section removed (payments are now generally available)
- AGB page: contact email now rendered via `INFO_EMAIL` instead of a hardcoded string