### PR TITLE
Update footer copyright year to 2026

### DIFF
--- a/app/modern/components/footer.tsx
+++ b/app/modern/components/footer.tsx
@@ -153,7 +153,7 @@ export default function Footer() {
           viewport={{ once: true }}
           className="pt-8 border-t border-border flex flex-col justify-center items-center text-center gap-3"
         >
-          <p className="text-muted-foreground text-sm">© 2025 {BRAND_NAME}. Alle Rechte vorbehalten.</p>
+          <p className="text-muted-foreground text-sm">© 2026 {BRAND_NAME}. Alle Rechte vorbehalten.</p>
           <p className="text-muted-foreground/70 text-sm">Entwickelt, um die Mietverwaltung für alle zu vereinfachen.</p>
         </motion.div>
       </div>

--- a/app/modern/components/footer.tsx
+++ b/app/modern/components/footer.tsx
@@ -153,7 +153,7 @@ export default function Footer() {
           viewport={{ once: true }}
           className="pt-8 border-t border-border flex flex-col justify-center items-center text-center gap-3"
         >
-          <p className="text-muted-foreground text-sm">© 2026 {BRAND_NAME}. Alle Rechte vorbehalten.</p>
+          <p className="text-muted-foreground text-sm">© {new Date().getFullYear()} {BRAND_NAME}. Alle Rechte vorbehalten.</p>
           <p className="text-muted-foreground/70 text-sm">Entwickelt, um die Mietverwaltung für alle zu vereinfachen.</p>
         </motion.div>
       </div>


### PR DESCRIPTION
## Description

Replaces the hardcoded copyright year in the footer with the current year.

## Summary of Changes

- `app/modern/components/footer.tsx`: `© 2025` → `© {new Date().getFullYear()}` so the notice never goes stale