### PR TITLE
fix(seo): use Supabase storage URLs for schema and OG images

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -13,8 +13,12 @@ export const BERECHNUNGSART_VALUES = BERECHNUNGSART_OPTIONS.map(opt => opt.value
 // Supabase PWA images storage URL
 export const PWA_IMAGES_URL = 'https://ocubnwzybybcbrhsnqqs.supabase.co/storage/v1/object/public/pwa-images';
 
-// Logo URL
+// Logo URL (mascot)
 export const LOGO_URL = `${PWA_IMAGES_URL}/mascot/normal.avif`;
+
+// SEO Image URLs - using Supabase storage for reliable crawlability
+export const FAVICON_URL = `${PWA_IMAGES_URL}/favicon.png`;
+export const OG_IMAGE_URL = `${PWA_IMAGES_URL}/cover.avif`;
 
 // Brand Name
 export const BRAND_NAME_PART_1 = 'Miet';

--- a/lib/seo/metadata.ts
+++ b/lib/seo/metadata.ts
@@ -1,5 +1,5 @@
 import { Metadata } from 'next'
-import { BASE_URL, BRAND_NAME } from '@/lib/constants'
+import { BASE_URL, BRAND_NAME, OG_IMAGE_URL } from '@/lib/constants'
 
 /**
  * Default metadata for the entire application.
@@ -46,7 +46,7 @@ export const defaultMetadata: Metadata = {
         description: 'Die moderne Lösung für Ihre Mietverwaltung und Nebenkostenabrechnung. Einfach, schnell und rechtssicher.',
         images: [
             {
-                url: `${BASE_URL}/og-image.png`,
+                url: OG_IMAGE_URL,
                 width: 1200,
                 height: 630,
                 alt: `${BRAND_NAME} - Hausverwaltungssoftware`,
@@ -59,7 +59,7 @@ export const defaultMetadata: Metadata = {
         description: 'Die moderne Lösung für Ihre Mietverwaltung und Nebenkostenabrechnung.',
         site: '@Mietevo',
         creator: '@Mietevo',
-        images: [`${BASE_URL}/og-image.png`],
+        images: [OG_IMAGE_URL],
     },
     alternates: {
         canonical: BASE_URL,

--- a/lib/seo/schema.ts
+++ b/lib/seo/schema.ts
@@ -5,9 +5,7 @@
  * potentially enabling rich snippets in search results.
  */
 
-import { BASE_URL, BRAND_NAME, SUPPORT_EMAIL } from '@/lib/constants'
-
-const LOGO_URL = `${BASE_URL}/favicon.png`
+import { BASE_URL, BRAND_NAME, SUPPORT_EMAIL, FAVICON_URL, OG_IMAGE_URL } from '@/lib/constants'
 
 /**
  * Organization Schema
@@ -26,14 +24,14 @@ export function getOrganizationSchema() {
         logo: {
             '@type': 'ImageObject',
             '@id': `${BASE_URL}/#logo`,
-            url: LOGO_URL,
-            contentUrl: LOGO_URL,
+            url: FAVICON_URL,
+            contentUrl: FAVICON_URL,
             width: 512,
             height: 512,
             caption: `${BRAND_NAME} Logo`,
         },
         // Also provide simple logo reference for broader compatibility
-        image: LOGO_URL,
+        image: FAVICON_URL,
         description: 'Moderne Hausverwaltungssoftware für Vermieter und Hausverwaltungen in Deutschland.',
         slogan: 'Die moderne Lösung für Ihre Mietverwaltung',
         foundingDate: '2024',
@@ -90,7 +88,7 @@ export function getSoftwareApplicationSchema() {
         operatingSystem: 'Web Browser',
         description: 'Hausverwaltungssoftware für Nebenkostenabrechnungen, Mieterverwaltung und Finanzen. Die moderne Lösung für Vermieter in Deutschland.',
         url: BASE_URL,
-        screenshot: `${BASE_URL}/og-image.png`,
+        screenshot: OG_IMAGE_URL,
         featureList: [
             'Nebenkostenabrechnung erstellen',
             'Mieterverwaltung',
@@ -131,7 +129,7 @@ export function getWebsiteSchema() {
             '@type': 'Organization',
             name: BRAND_NAME,
             url: BASE_URL,
-            logo: LOGO_URL,
+            logo: FAVICON_URL,
         },
         potentialAction: {
             '@type': 'SearchAction',
@@ -244,7 +242,7 @@ export function getArticleSchema(
             url: BASE_URL,
             logo: {
                 '@type': 'ImageObject',
-                url: LOGO_URL,
+                url: FAVICON_URL,
             },
         },
         inLanguage: 'de-DE',


### PR DESCRIPTION
- Add FAVICON_URL and OG_IMAGE_URL constants to lib/constants.ts
- Update schema.ts to use centralized Supabase URLs for logo and screenshot
- Update metadata.ts to use OG_IMAGE_URL for OpenGraph and Twitter images
- Ensures all structured data images are crawlable by Google

Fixes issue where mietevo.de/favicon.png and mietevo.de/og-image.png were not accessible for Google's crawler.