### PR TITLE
chore: configure dependabot to group only patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,15 +18,14 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    # Group minor and patch updates together to reduce PR noise
+    # Group only patch updates to reduce PR noise
+    # Major and minor updates create individual PRs for easier review
     groups:
-      production-dependencies:
+      production-patch-updates:
         dependency-type: "production"
         update-types:
-          - "minor"
           - "patch"
-      development-dependencies:
+      development-patch-updates:
         dependency-type: "development"
         update-types:
-          - "minor"
           - "patch"


### PR DESCRIPTION
- Major updates: individual PR per dependency for easier review
- Minor updates: individual PR per dependency for easier review
- Patch updates: grouped into production and development PRs
- All PRs receive 'patch' label for release workflow