### PR TITLE
feat: integrate Microsoft social login with feature flag

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -18,8 +18,9 @@ import { trackLoginStarted, trackLoginSuccess, trackLoginFailed } from '@/lib/po
 import { getAuthErrorMessage, getUrlErrorMessage } from "@/lib/auth-error-handler"
 import { motion } from "framer-motion"
 import { Auth3DDecorations } from "@/components/auth/auth-3d-decorations"
-import { handleGoogleSignIn } from "@/lib/auth-helpers"
+import { handleGoogleSignIn, handleMicrosoftSignIn } from "@/lib/auth-helpers"
 import { GoogleIcon } from "@/components/icons/google-icon"
+import { MicrosoftIcon } from "@/components/icons/microsoft-icon"
 
 export default function LoginPage() {
   const router = useRouter()
@@ -28,6 +29,9 @@ export default function LoginPage() {
   const redirect = redirectParam || "/home"
 
   const isGoogleLoginEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.GOOGLE_SOCIAL_LOGIN)
+  const isMicrosoftLoginEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.MICROSOFT_SOCIAL_LOGIN)
+
+  const enabledProvidersCount = [isGoogleLoginEnabled, isMicrosoftLoginEnabled].filter(Boolean).length;
 
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
@@ -287,41 +291,72 @@ export default function LoginPage() {
                 )}
               </Button>
 
-              {mounted && isGoogleLoginEnabled && (
+              {mounted && (isGoogleLoginEnabled || isMicrosoftLoginEnabled) && (
                 <div className="pt-4 space-y-4">
                   <div className="relative">
                     <div className="absolute inset-0 flex items-center">
                       <span className="w-full border-t border-border" />
                     </div>
                     <div className="relative flex justify-center text-xs uppercase">
-                      <span className="bg-card px-2 text-muted-foreground">ODER MIT GOOGLE</span>
+                      <span className="bg-card px-2 text-muted-foreground">WEITERE ANMELDEMETHODEN</span>
                     </div>
                   </div>
 
-                  <Button
-                    type="button"
-                    variant="outline"
-                    className="w-full h-12 rounded-xl text-base font-medium border-border hover:bg-muted/50 transition-colors"
-                    onClick={async () => {
-                      setIsLoading(true)
-                      setError(null)
+                  <div className={enabledProvidersCount > 1 ? "flex gap-3" : "space-y-4"}>
+                    {isGoogleLoginEnabled && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-12 rounded-xl text-base font-medium border-border hover:bg-muted/50 transition-colors`}
+                        onClick={async () => {
+                          setIsLoading(true)
+                          setError(null)
 
-                      const { error } = await handleGoogleSignIn('login')
+                          const { error } = await handleGoogleSignIn('login')
 
-                      if (error) {
-                        setError(error)
-                        setIsLoading(false)
-                      }
-                    }}
-                    disabled={isLoading}
-                  >
-                    {isLoading ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <GoogleIcon className="h-5 w-5 mr-2" />
+                          if (error) {
+                            setError(error)
+                            setIsLoading(false)
+                          }
+                        }}
+                        disabled={isLoading}
+                      >
+                        {isLoading ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <GoogleIcon className="h-5 w-5 mr-2" />
+                        )}
+                        {enabledProvidersCount > 1 ? "Google" : "Mit Google anmelden"}
+                      </Button>
                     )}
-                    Mit Google anmelden
-                  </Button>
+
+                    {isMicrosoftLoginEnabled && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-12 rounded-xl text-base font-medium border-border hover:bg-muted/50 transition-colors`}
+                        onClick={async () => {
+                          setIsLoading(true)
+                          setError(null)
+
+                          const { error } = await handleMicrosoftSignIn('login')
+
+                          if (error) {
+                            setError(error)
+                            setIsLoading(false)
+                          }
+                        }}
+                        disabled={isLoading}
+                      >
+                        {isLoading ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <MicrosoftIcon className="h-5 w-5 mr-2" />
+                        )}
+                        {enabledProvidersCount > 1 ? "Microsoft" : "Mit Microsoft anmelden"}
+                      </Button>
+                    )}
+                  </div>
                 </div>
               )}
 

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -48,8 +48,28 @@ export default function RegisterPage() {
 
   const isGoogleLoginEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.GOOGLE_SOCIAL_LOGIN)
   const isMicrosoftLoginEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.MICROSOFT_SOCIAL_LOGIN)
+  const [socialLoading, setSocialLoading] = useState<string | null>(null)
 
   const enabledProvidersCount = [isGoogleLoginEnabled, isMicrosoftLoginEnabled].filter(Boolean).length;
+
+  const socialProviders = [
+    {
+      id: 'google' as const,
+      name: 'Google',
+      fullLabel: 'Mit Google anmelden',
+      Icon: GoogleIcon,
+      enabled: isGoogleLoginEnabled,
+      handler: handleGoogleSignIn,
+    },
+    {
+      id: 'microsoft' as const,
+      name: 'Microsoft',
+      fullLabel: 'Mit Microsoft anmelden',
+      Icon: MicrosoftIcon,
+      enabled: isMicrosoftLoginEnabled,
+      handler: handleMicrosoftSignIn,
+    }
+  ].filter(p => p.enabled);
 
   const handleRegister = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -369,59 +389,33 @@ export default function RegisterPage() {
                   </div>
 
                   <div className={enabledProvidersCount > 1 ? "flex gap-3" : "space-y-4"}>
-                    {isGoogleLoginEnabled && (
+                    {socialProviders.map((provider) => (
                       <Button
+                        key={provider.id}
                         type="button"
                         variant="outline"
                         className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-12 rounded-xl text-base font-medium border-border hover:bg-muted/50 transition-colors`}
                         onClick={async () => {
-                          setIsLoading(true)
+                          setSocialLoading(provider.id)
                           setError(null)
 
-                          const { error } = await handleGoogleSignIn('signup')
+                          const { error } = await provider.handler('signup')
 
                           if (error) {
                             setError(error)
-                            setIsLoading(false)
+                            setSocialLoading(null)
                           }
                         }}
-                        disabled={isLoading}
+                        disabled={isLoading || socialLoading !== null}
                       >
-                        {isLoading ? (
+                        {socialLoading === provider.id ? (
                           <Loader2 className="h-4 w-4 animate-spin" />
                         ) : (
-                          <GoogleIcon className="h-5 w-5 mr-2" />
+                          <provider.Icon className="h-5 w-5 mr-2" />
                         )}
-                        {enabledProvidersCount > 1 ? "Google" : "Mit Google anmelden"}
+                        {enabledProvidersCount > 1 ? provider.name : provider.fullLabel}
                       </Button>
-                    )}
-
-                    {isMicrosoftLoginEnabled && (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-12 rounded-xl text-base font-medium border-border hover:bg-muted/50 transition-colors`}
-                        onClick={async () => {
-                          setIsLoading(true)
-                          setError(null)
-
-                          const { error } = await handleMicrosoftSignIn('signup')
-
-                          if (error) {
-                            setError(error)
-                            setIsLoading(false)
-                          }
-                        }}
-                        disabled={isLoading}
-                      >
-                        {isLoading ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                        ) : (
-                          <MicrosoftIcon className="h-5 w-5 mr-2" />
-                        )}
-                        {enabledProvidersCount > 1 ? "Microsoft" : "Mit Microsoft anmelden"}
-                      </Button>
-                    )}
+                    ))}
                   </div>
                 </div>
               )}

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -18,8 +18,9 @@ import { getAuthErrorMessage } from "@/lib/auth-error-handler"
 import { trackRegisterStarted, trackRegisterSuccess, trackRegisterFailed } from '@/lib/posthog-auth-events'
 import { motion } from "framer-motion"
 import { Auth3DDecorations } from "@/components/auth/auth-3d-decorations"
-import { handleGoogleSignIn } from "@/lib/auth-helpers"
+import { handleGoogleSignIn, handleMicrosoftSignIn } from "@/lib/auth-helpers"
 import { GoogleIcon } from "@/components/icons/google-icon"
+import { MicrosoftIcon } from "@/components/icons/microsoft-icon"
 
 const benefits = [
   "14 Tage kostenlos testen",
@@ -46,6 +47,9 @@ export default function RegisterPage() {
   }, [])
 
   const isGoogleLoginEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.GOOGLE_SOCIAL_LOGIN)
+  const isMicrosoftLoginEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.MICROSOFT_SOCIAL_LOGIN)
+
+  const enabledProvidersCount = [isGoogleLoginEnabled, isMicrosoftLoginEnabled].filter(Boolean).length;
 
   const handleRegister = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -353,41 +357,72 @@ export default function RegisterPage() {
                 )}
               </Button>
 
-              {mounted && isGoogleLoginEnabled && (
+              {mounted && (isGoogleLoginEnabled || isMicrosoftLoginEnabled) && (
                 <div className="pt-4 space-y-4">
                   <div className="relative">
                     <div className="absolute inset-0 flex items-center">
                       <span className="w-full border-t border-border" />
                     </div>
                     <div className="relative flex justify-center text-xs uppercase">
-                      <span className="bg-card px-2 text-muted-foreground">ODER MIT GOOGLE</span>
+                      <span className="bg-card px-2 text-muted-foreground">WEITERE ANMELDEMETHODEN</span>
                     </div>
                   </div>
 
-                  <Button
-                    type="button"
-                    variant="outline"
-                    className="w-full h-12 rounded-xl text-base font-medium border-border hover:bg-muted/50 transition-colors"
-                    onClick={async () => {
-                      setIsLoading(true)
-                      setError(null)
+                  <div className={enabledProvidersCount > 1 ? "flex gap-3" : "space-y-4"}>
+                    {isGoogleLoginEnabled && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-12 rounded-xl text-base font-medium border-border hover:bg-muted/50 transition-colors`}
+                        onClick={async () => {
+                          setIsLoading(true)
+                          setError(null)
 
-                      const { error } = await handleGoogleSignIn('signup')
+                          const { error } = await handleGoogleSignIn('signup')
 
-                      if (error) {
-                        setError(error)
-                        setIsLoading(false)
-                      }
-                    }}
-                    disabled={isLoading}
-                  >
-                    {isLoading ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : (
-                      <GoogleIcon className="h-5 w-5 mr-2" />
+                          if (error) {
+                            setError(error)
+                            setIsLoading(false)
+                          }
+                        }}
+                        disabled={isLoading}
+                      >
+                        {isLoading ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <GoogleIcon className="h-5 w-5 mr-2" />
+                        )}
+                        {enabledProvidersCount > 1 ? "Google" : "Mit Google anmelden"}
+                      </Button>
                     )}
-                    Mit Google anmelden
-                  </Button>
+
+                    {isMicrosoftLoginEnabled && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-12 rounded-xl text-base font-medium border-border hover:bg-muted/50 transition-colors`}
+                        onClick={async () => {
+                          setIsLoading(true)
+                          setError(null)
+
+                          const { error } = await handleMicrosoftSignIn('signup')
+
+                          if (error) {
+                            setError(error)
+                            setIsLoading(false)
+                          }
+                        }}
+                        disabled={isLoading}
+                      >
+                        {isLoading ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <MicrosoftIcon className="h-5 w-5 mr-2" />
+                        )}
+                        {enabledProvidersCount > 1 ? "Microsoft" : "Mit Microsoft anmelden"}
+                      </Button>
+                    )}
+                  </div>
                 </div>
               )}
 

--- a/components/auth/auth-modal.tsx
+++ b/components/auth/auth-modal.tsx
@@ -18,6 +18,12 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { PillTabSwitcher } from "@/components/ui/pill-tab-switcher";
+import { useFeatureFlagEnabled } from 'posthog-js/react'
+import { POSTHOG_FEATURE_FLAGS } from "@/lib/constants"
+import { handleGoogleSignIn, handleMicrosoftSignIn } from "@/lib/auth-helpers"
+import { GoogleIcon } from "@/components/icons/google-icon"
+import { MicrosoftIcon } from "@/components/icons/microsoft-icon"
+import { Loader2 } from "lucide-react"
 
 interface AuthModalProps {
   isOpen: boolean;
@@ -51,6 +57,12 @@ export default function AuthModal({
   const [forgotPasswordError, setForgotPasswordError] = useState<string | null>(null)
   const [forgotPasswordIsLoading, setForgotPasswordIsLoading] = useState(false)
   const [forgotPasswordSuccess, setForgotPasswordSuccess] = useState(false)
+
+  const isGoogleLoginEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.GOOGLE_SOCIAL_LOGIN)
+  const isMicrosoftLoginEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.MICROSOFT_SOCIAL_LOGIN)
+  const [socialLoading, setSocialLoading] = useState<string | null>(null) // 'google' | 'microsoft' | null
+
+  const enabledProvidersCount = [isGoogleLoginEnabled, isMicrosoftLoginEnabled].filter(Boolean).length;
 
   const [activeView, setActiveView] = useState<'login' | 'register' | 'forgotPassword'>(initialTab);
 
@@ -352,6 +364,63 @@ export default function AuthModal({
                 <Button type="submit" className="w-full" disabled={loginIsLoading}>
                   {loginIsLoading ? "Wird angemeldet..." : "Anmelden"}
                 </Button>
+
+                {(isGoogleLoginEnabled || isMicrosoftLoginEnabled) && (
+                  <div className="pt-2 space-y-3">
+                    <div className="relative">
+                      <div className="absolute inset-0 flex items-center">
+                        <span className="w-full border-t border-border" />
+                      </div>
+                      <div className="relative flex justify-center text-xs uppercase">
+                        <span className="bg-card px-2 text-muted-foreground">WEITERE ANMELDEMETHODEN</span>
+                      </div>
+                    </div>
+
+                    <div className={enabledProvidersCount > 1 ? "flex gap-3" : "space-y-3"}>
+                      {isGoogleLoginEnabled && (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-10 rounded-lg text-sm font-medium border-border hover:bg-muted/50 transition-colors`}
+                          onClick={async () => {
+                            setSocialLoading('google')
+                            const { error } = await handleGoogleSignIn('login')
+                            if (error) setSocialLoading(null)
+                          }}
+                          disabled={socialLoading !== null}
+                        >
+                          {socialLoading === 'google' ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <GoogleIcon className="h-4 w-4 mr-2" />
+                          )}
+                          {enabledProvidersCount > 1 ? "Google" : "Mit Google anmelden"}
+                        </Button>
+                      )}
+
+                      {isMicrosoftLoginEnabled && (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-10 rounded-lg text-sm font-medium border-border hover:bg-muted/50 transition-colors`}
+                          onClick={async () => {
+                            setSocialLoading('microsoft')
+                            const { error } = await handleMicrosoftSignIn('login')
+                            if (error) setSocialLoading(null)
+                          }}
+                          disabled={socialLoading !== null}
+                        >
+                          {socialLoading === 'microsoft' ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <MicrosoftIcon className="h-4 w-4 mr-2" />
+                          )}
+                          {enabledProvidersCount > 1 ? "Microsoft" : "Mit Microsoft anmelden"}
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                )}
               </AuthForm>
             </>
           )}
@@ -424,6 +493,63 @@ export default function AuthModal({
                   <Button type="submit" className="w-full" disabled={registerIsLoading || !agbAccepted}>
                     {registerIsLoading ? "Wird registriert..." : "Registrieren"}
                   </Button>
+
+                  {(isGoogleLoginEnabled || isMicrosoftLoginEnabled) && (
+                    <div className="pt-2 space-y-3">
+                      <div className="relative">
+                        <div className="absolute inset-0 flex items-center">
+                          <span className="w-full border-t border-border" />
+                        </div>
+                        <div className="relative flex justify-center text-xs uppercase">
+                          <span className="bg-card px-2 text-muted-foreground">WEITERE ANMELDEMETHODEN</span>
+                        </div>
+                      </div>
+
+                      <div className={enabledProvidersCount > 1 ? "flex gap-3" : "space-y-3"}>
+                        {isGoogleLoginEnabled && (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-10 rounded-lg text-sm font-medium border-border hover:bg-muted/50 transition-colors`}
+                            onClick={async () => {
+                              setSocialLoading('google')
+                              const { error } = await handleGoogleSignIn('signup')
+                              if (error) setSocialLoading(null)
+                            }}
+                            disabled={socialLoading !== null}
+                          >
+                            {socialLoading === 'google' ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              <GoogleIcon className="h-4 w-4 mr-2" />
+                            )}
+                            {enabledProvidersCount > 1 ? "Google" : "Mit Google anmelden"}
+                          </Button>
+                        )}
+
+                        {isMicrosoftLoginEnabled && (
+                          <Button
+                            type="button"
+                            variant="outline"
+                            className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-10 rounded-lg text-sm font-medium border-border hover:bg-muted/50 transition-colors`}
+                            onClick={async () => {
+                              setSocialLoading('microsoft')
+                              const { error } = await handleMicrosoftSignIn('signup')
+                              if (error) setSocialLoading(null)
+                            }}
+                            disabled={socialLoading !== null}
+                          >
+                            {socialLoading === 'microsoft' ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              <MicrosoftIcon className="h-4 w-4 mr-2" />
+                            )}
+                            {enabledProvidersCount > 1 ? "Microsoft" : "Mit Microsoft anmelden"}
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                  )}
                 </form>
               </CardContent>
             </>

--- a/components/auth/auth-modal.tsx
+++ b/components/auth/auth-modal.tsx
@@ -64,6 +64,37 @@ export default function AuthModal({
 
   const enabledProvidersCount = [isGoogleLoginEnabled, isMicrosoftLoginEnabled].filter(Boolean).length;
 
+  const handleSocialAuth = async (provider: 'google' | 'microsoft', flow: 'login' | 'signup') => {
+    setSocialLoading(provider);
+    const errorSetter = flow === 'login' ? setLoginError : setRegisterError;
+    errorSetter(null);
+
+    const handler = provider === 'google' ? handleGoogleSignIn : handleMicrosoftSignIn;
+    const { error } = await handler(flow);
+
+    if (error) {
+      errorSetter(error);
+      setSocialLoading(null);
+    }
+  };
+
+  const socialProviders = [
+    {
+      id: 'google' as const,
+      name: 'Google',
+      fullLabel: 'Mit Google anmelden',
+      Icon: GoogleIcon,
+      enabled: isGoogleLoginEnabled,
+    },
+    {
+      id: 'microsoft' as const,
+      name: 'Microsoft',
+      fullLabel: 'Mit Microsoft anmelden',
+      Icon: MicrosoftIcon,
+      enabled: isMicrosoftLoginEnabled,
+    }
+  ].filter(p => p.enabled);
+
   const [activeView, setActiveView] = useState<'login' | 'register' | 'forgotPassword'>(initialTab);
 
   useEffect(() => {
@@ -377,47 +408,23 @@ export default function AuthModal({
                     </div>
 
                     <div className={enabledProvidersCount > 1 ? "flex gap-3" : "space-y-3"}>
-                      {isGoogleLoginEnabled && (
+                      {socialProviders.map((provider) => (
                         <Button
+                          key={provider.id}
                           type="button"
                           variant="outline"
                           className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-10 rounded-lg text-sm font-medium border-border hover:bg-muted/50 transition-colors`}
-                          onClick={async () => {
-                            setSocialLoading('google')
-                            const { error } = await handleGoogleSignIn('login')
-                            if (error) setSocialLoading(null)
-                          }}
+                          onClick={() => handleSocialAuth(provider.id, 'login')}
                           disabled={socialLoading !== null}
                         >
-                          {socialLoading === 'google' ? (
+                          {socialLoading === provider.id ? (
                             <Loader2 className="h-4 w-4 animate-spin" />
                           ) : (
-                            <GoogleIcon className="h-4 w-4 mr-2" />
+                            <provider.Icon className="h-4 w-4 mr-2" />
                           )}
-                          {enabledProvidersCount > 1 ? "Google" : "Mit Google anmelden"}
+                          {enabledProvidersCount > 1 ? provider.name : provider.fullLabel}
                         </Button>
-                      )}
-
-                      {isMicrosoftLoginEnabled && (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-10 rounded-lg text-sm font-medium border-border hover:bg-muted/50 transition-colors`}
-                          onClick={async () => {
-                            setSocialLoading('microsoft')
-                            const { error } = await handleMicrosoftSignIn('login')
-                            if (error) setSocialLoading(null)
-                          }}
-                          disabled={socialLoading !== null}
-                        >
-                          {socialLoading === 'microsoft' ? (
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                          ) : (
-                            <MicrosoftIcon className="h-4 w-4 mr-2" />
-                          )}
-                          {enabledProvidersCount > 1 ? "Microsoft" : "Mit Microsoft anmelden"}
-                        </Button>
-                      )}
+                      ))}
                     </div>
                   </div>
                 )}
@@ -506,47 +513,23 @@ export default function AuthModal({
                       </div>
 
                       <div className={enabledProvidersCount > 1 ? "flex gap-3" : "space-y-3"}>
-                        {isGoogleLoginEnabled && (
+                        {socialProviders.map((provider) => (
                           <Button
+                            key={provider.id}
                             type="button"
                             variant="outline"
                             className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-10 rounded-lg text-sm font-medium border-border hover:bg-muted/50 transition-colors`}
-                            onClick={async () => {
-                              setSocialLoading('google')
-                              const { error } = await handleGoogleSignIn('signup')
-                              if (error) setSocialLoading(null)
-                            }}
+                            onClick={() => handleSocialAuth(provider.id, 'signup')}
                             disabled={socialLoading !== null}
                           >
-                            {socialLoading === 'google' ? (
+                            {socialLoading === provider.id ? (
                               <Loader2 className="h-4 w-4 animate-spin" />
                             ) : (
-                              <GoogleIcon className="h-4 w-4 mr-2" />
+                              <provider.Icon className="h-4 w-4 mr-2" />
                             )}
-                            {enabledProvidersCount > 1 ? "Google" : "Mit Google anmelden"}
+                            {enabledProvidersCount > 1 ? provider.name : provider.fullLabel}
                           </Button>
-                        )}
-
-                        {isMicrosoftLoginEnabled && (
-                          <Button
-                            type="button"
-                            variant="outline"
-                            className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-10 rounded-lg text-sm font-medium border-border hover:bg-muted/50 transition-colors`}
-                            onClick={async () => {
-                              setSocialLoading('microsoft')
-                              const { error } = await handleMicrosoftSignIn('signup')
-                              if (error) setSocialLoading(null)
-                            }}
-                            disabled={socialLoading !== null}
-                          >
-                            {socialLoading === 'microsoft' ? (
-                              <Loader2 className="h-4 w-4 animate-spin" />
-                            ) : (
-                              <MicrosoftIcon className="h-4 w-4 mr-2" />
-                            )}
-                            {enabledProvidersCount > 1 ? "Microsoft" : "Mit Microsoft anmelden"}
-                          </Button>
-                        )}
+                        ))}
                       </div>
                     </div>
                   )}

--- a/components/icons/microsoft-icon.tsx
+++ b/components/icons/microsoft-icon.tsx
@@ -1,0 +1,21 @@
+import type React from "react"
+
+/**
+ * Microsoft logo icon using the official Microsoft 4-square colored logo
+ */
+export const MicrosoftIcon = (props: React.SVGProps<SVGSVGElement>) => (
+    <svg
+        {...props}
+        viewBox="0 0 21 21"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        {/* Red square - top left */}
+        <rect x="1" y="1" width="9" height="9" fill="#f25022" />
+        {/* Green square - top right */}
+        <rect x="11" y="1" width="9" height="9" fill="#7fba00" />
+        {/* Blue square - bottom left */}
+        <rect x="1" y="11" width="9" height="9" fill="#00a4ef" />
+        {/* Yellow square - bottom right */}
+        <rect x="11" y="11" width="9" height="9" fill="#ffb900" />
+    </svg>
+)

--- a/lib/auth-helpers.ts
+++ b/lib/auth-helpers.ts
@@ -1,6 +1,6 @@
 import { createClient } from "@/utils/supabase/client"
 import { BASE_URL } from "./constants"
-import { trackGoogleAuthInitiated, trackGoogleAuthFailed, AuthFlow } from "./posthog-auth-events"
+import { trackGoogleAuthInitiated, trackGoogleAuthFailed, trackSocialAuthInitiated, trackSocialAuthFailed, AuthFlow } from "./posthog-auth-events"
 
 /**
  * Initiates the Google OAuth sign-in flow.
@@ -26,6 +26,34 @@ export async function handleGoogleSignIn(flow: AuthFlow): Promise<{ error: strin
     if (error) {
         // Track the failure (GDPR-compliant)
         trackGoogleAuthFailed(flow, 'oauth_error', error.message)
+        return { error: error.message }
+    }
+
+    return { error: null }
+}
+
+/**
+ * Initiates the Microsoft (Azure AD) OAuth sign-in flow.
+ * 
+ * @param flow - The authentication flow type ('login' or 'signup')
+ * @returns An error object if the sign-in failed, or null if successful
+ */
+export async function handleMicrosoftSignIn(flow: AuthFlow): Promise<{ error: string | null }> {
+    // Track Microsoft auth initiation (GDPR-compliant - checks consent internally)
+    trackSocialAuthInitiated('microsoft', flow)
+
+    const supabase = createClient()
+    const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'azure',
+        options: {
+            redirectTo: `${BASE_URL}/auth/callback`,
+            scopes: 'email profile openid',
+        },
+    })
+
+    if (error) {
+        // Track the failure (GDPR-compliant)
+        trackSocialAuthFailed('microsoft', flow, 'oauth_error', error.message)
         return { error: error.message }
     }
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -55,6 +55,7 @@ export const POSTHOG_FEATURE_FLAGS = {
   SHOW_PRODUKTE_DROPDOWN: 'show-produkte-dropdown',
   SHOW_LOESUNGEN_DROPDOWN: 'show-loesungen-dropdown',
   GOOGLE_SOCIAL_LOGIN: 'google-social-login',
+  MICROSOFT_SOCIAL_LOGIN: 'microsoft-social-login',
 } as const;
 
 // Application routes - centralized to prevent hardcoded paths


### PR DESCRIPTION
## Description

Integrates Microsoft social login across all authentication surfaces, feature-flagged like the existing Google login.

## Summary of Changes

- Login page, register page and auth modal: Microsoft added as a second OAuth provider — the social section is now a generic provider list (Google + Microsoft) with a shared loading state and side-by-side buttons when both flags are on
- `handleMicrosoftSignIn()` in `auth-helpers.ts`: Azure OAuth via Supabase (`email profile openid` scopes) with GDPR-compliant PostHog tracking (`trackSocialAuthInitiated`/`trackSocialAuthFailed`)
- New `MicrosoftIcon` component (official 4-square logo)
- New `MICROSOFT_SOCIAL_LOGIN` feature flag