### PR TITLE
feat: derive Outlook redirect URIs dynamically from request

### DIFF
--- a/app/api/auth/outlook/callback/route.ts
+++ b/app/api/auth/outlook/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
 import { encryptToken } from "@/lib/encryption"
+import { ROUTES } from "@/lib/constants"
 
 export const runtime = 'edge';
 
@@ -14,7 +15,7 @@ export async function GET(request: NextRequest) {
   const appUrl = request.nextUrl.origin
 
   // Dynamically derive redirect URI from the request URL
-  const redirectUri = `${appUrl}/api/auth/outlook/callback`
+  const redirectUri = `${appUrl}${ROUTES.API_OUTLOOK_CALLBACK}`
 
   // Validate required environment variables early
   const clientId = process.env.OUTLOOK_CLIENT_ID

--- a/app/api/auth/outlook/route.ts
+++ b/app/api/auth/outlook/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
+import { ROUTES } from "@/lib/constants"
 
 export const runtime = 'edge';
 
@@ -25,7 +26,7 @@ export async function GET(request: NextRequest) {
 
   // Dynamically derive redirect URI from the request URL
   const origin = request.nextUrl.origin
-  const redirectUri = `${origin}/api/auth/outlook/callback`
+  const redirectUri = `${origin}${ROUTES.API_OUTLOOK_CALLBACK}`
 
   // Store user ID in state parameter for callback
   const state = Buffer.from(JSON.stringify({ userId: user.id })).toString("base64")

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -65,6 +65,8 @@ export const ROUTES = {
   REGISTER: '/auth/register',
   RESET_PASSWORD: '/auth/reset-password',
   UPDATE_PASSWORD: '/auth/update-password',
+  // API - OAuth callbacks
+  API_OUTLOOK_CALLBACK: '/api/auth/outlook/callback',
   // Dashboard
   HOME: '/home',
   PROPERTIES: '/objekte',


### PR DESCRIPTION
- Remove dependency on NEXT_PUBLIC_APP_URL env variable
- Remove dependency on OUTLOOK_REDIRECT_URI env variable
- Use request.nextUrl.origin to dynamically derive URLs
- URLs now automatically adapt to any domain (localhost, staging, production)