### PR TITLE
fix: add tags filter to financial summary RPC for correct summary car…

### DIFF
--- a/app/(dashboard)/finanzen/client-wrapper.tsx
+++ b/app/(dashboard)/finanzen/client-wrapper.tsx
@@ -186,7 +186,8 @@ export default function FinanzenClientWrapper({
         search_query: debouncedSearchQueryRef.current,
         apartment_name: filtersRef.current.selectedApartment,
         target_year: filtersRef.current.selectedYear,
-        transaction_type: filtersRef.current.selectedType
+        transaction_type: filtersRef.current.selectedType,
+        filter_tags: filtersRef.current.selectedTags
       });
 
       if (error) {

--- a/supabase/migrations/20260113151900_add_tags_filter_to_financial_summary.sql
+++ b/supabase/migrations/20260113151900_add_tags_filter_to_financial_summary.sql
@@ -1,0 +1,52 @@
+-- Add tags parameter to get_filtered_financial_summary function
+-- This fixes the bug where filtered summary cards don't update when filtering by tags
+
+-- Drop existing function to recreate with new signature
+DROP FUNCTION IF EXISTS get_filtered_financial_summary(TEXT, TEXT, TEXT, TEXT);
+
+-- Create updated function with tags parameter
+CREATE OR REPLACE FUNCTION get_filtered_financial_summary(
+  search_query TEXT DEFAULT '',
+  apartment_name TEXT DEFAULT '',
+  target_year TEXT DEFAULT '',
+  transaction_type TEXT DEFAULT '',
+  filter_tags TEXT[] DEFAULT '{}'
+)
+RETURNS TABLE (
+  total_income DECIMAL,
+  total_expenses DECIMAL,
+  total_balance DECIMAL
+) 
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT 
+    COALESCE(SUM(CASE WHEN f.ist_einnahmen = true THEN f.betrag ELSE 0 END), 0) as total_income,
+    COALESCE(SUM(CASE WHEN f.ist_einnahmen = false THEN f.betrag ELSE 0 END), 0) as total_expenses,
+    COALESCE(SUM(CASE WHEN f.ist_einnahmen = true THEN f.betrag ELSE -f.betrag END), 0) as total_balance
+  FROM "Finanzen" f
+  LEFT JOIN "Wohnungen" w ON f.wohnung_id = w.id
+  WHERE f.user_id = auth.uid()
+    AND f.datum IS NOT NULL
+    -- Text search filter
+    AND (search_query = '' OR 
+         f.name ILIKE '%' || search_query || '%' OR 
+         COALESCE(f.notiz, '') ILIKE '%' || search_query || '%')
+    -- Apartment filter
+    AND (apartment_name = '' OR apartment_name = 'Alle Wohnungen' OR w.name = apartment_name)
+    -- Year filter
+    AND (target_year = '' OR target_year = 'Alle Jahre' OR EXTRACT(YEAR FROM f.datum)::TEXT = target_year)
+    -- Transaction type filter
+    AND (transaction_type = '' OR transaction_type = 'Alle Transaktionen' OR 
+         (transaction_type = 'Einnahme' AND f.ist_einnahmen = true) OR
+         (transaction_type = 'Ausgabe' AND f.ist_einnahmen = false))
+    -- Tags filter - check if entry has at least one of the selected tags
+    AND (array_length(filter_tags, 1) IS NULL OR filter_tags = '{}' OR 
+         f.tags && filter_tags);
+END;
+$$;
+
+-- Grant execute permission to authenticated users with new signature
+GRANT EXECUTE ON FUNCTION get_filtered_financial_summary(TEXT, TEXT, TEXT, TEXT, TEXT[]) TO authenticated;

--- a/supabase/migrations/20260113151900_add_tags_filter_to_financial_summary.sql
+++ b/supabase/migrations/20260113151900_add_tags_filter_to_financial_summary.sql
@@ -43,8 +43,7 @@ BEGIN
          (transaction_type = 'Einnahme' AND f.ist_einnahmen = true) OR
          (transaction_type = 'Ausgabe' AND f.ist_einnahmen = false))
     -- Tags filter - check if entry has at least one of the selected tags
-    AND (array_length(filter_tags, 1) IS NULL OR filter_tags = '{}' OR 
-         f.tags && filter_tags);
+    AND (array_length(filter_tags, 1) IS NULL OR f.tags && filter_tags);
 END;
 $$;
 

--- a/supabase/sql/finance_analytics_setup.sql
+++ b/supabase/sql/finance_analytics_setup.sql
@@ -207,7 +207,8 @@ CREATE OR REPLACE FUNCTION get_filtered_financial_summary(
   search_query TEXT DEFAULT '',
   apartment_name TEXT DEFAULT '',
   target_year TEXT DEFAULT '',
-  transaction_type TEXT DEFAULT ''
+  transaction_type TEXT DEFAULT '',
+  filter_tags TEXT[] DEFAULT '{}'
 )
 RETURNS TABLE (
   total_income DECIMAL,
@@ -238,12 +239,15 @@ BEGIN
     -- Transaction type filter
     AND (transaction_type = '' OR transaction_type = 'Alle Transaktionen' OR 
          (transaction_type = 'Einnahme' AND f.ist_einnahmen = true) OR
-         (transaction_type = 'Ausgabe' AND f.ist_einnahmen = false));
+         (transaction_type = 'Ausgabe' AND f.ist_einnahmen = false))
+    -- Tags filter - check if entry has at least one of the selected tags
+    AND (array_length(filter_tags, 1) IS NULL OR filter_tags = '{}' OR 
+         f.tags && filter_tags);
 END;
 $$;
 
 -- Grant execute permission to authenticated users
-GRANT EXECUTE ON FUNCTION get_filtered_financial_summary(TEXT, TEXT, TEXT, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION get_filtered_financial_summary(TEXT, TEXT, TEXT, TEXT, TEXT[]) TO authenticated;
 
 -- Test the functions (optional - you can run these to verify they work)
 -- SELECT * FROM get_financial_summary_data(2024);

--- a/supabase/sql/finance_analytics_setup.sql
+++ b/supabase/sql/finance_analytics_setup.sql
@@ -241,8 +241,7 @@ BEGIN
          (transaction_type = 'Einnahme' AND f.ist_einnahmen = true) OR
          (transaction_type = 'Ausgabe' AND f.ist_einnahmen = false))
     -- Tags filter - check if entry has at least one of the selected tags
-    AND (array_length(filter_tags, 1) IS NULL OR filter_tags = '{}' OR 
-         f.tags && filter_tags);
+    AND (array_length(filter_tags, 1) IS NULL OR f.tags && filter_tags);
 END;
 $$;
 


### PR DESCRIPTION
## Description

Adds a tags filter to the financial summary RPC so the summary cards correctly reflect the filtered totals when filtering by tags.

## Summary of Changes

- Add filter_tags parameter to get_filtered_financial_summary RPC function
- Update fetchBalance in client-wrapper.tsx to pass selectedTags to RPC
- Summary cards now correctly reflect filtered totals when filtering by tags