### PR TITLE
feat: implement advanced SEO and structured data for documentation pages

### DIFF
--- a/app/(landing)/hilfe/dokumentation/[articleId]/article-page-client.tsx
+++ b/app/(landing)/hilfe/dokumentation/[articleId]/article-page-client.tsx
@@ -1,108 +1,19 @@
 'use client';
 
-import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { DocumentationArticleViewer } from '@/components/documentation/documentation-article-viewer';
-import { Skeleton } from '@/components/ui/skeleton';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { AlertCircle } from 'lucide-react';
-import { useToast } from '@/hooks/use-toast';
 import type { Article } from '@/types/documentation';
 
 interface ArticlePageClientProps {
-  articleId: string;
+  article: Article;
 }
 
-export default function ArticlePageClient({ articleId }: ArticlePageClientProps) {
+export default function ArticlePageClient({ article }: ArticlePageClientProps) {
   const router = useRouter();
-  const { toast } = useToast();
-  const [article, setArticle] = useState<Article | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const loadArticle = async () => {
-      try {
-        setIsLoading(true);
-        setError(null);
-
-        const response = await fetch(`/api/dokumentation/${articleId}`);
-        if (!response.ok) {
-          if (response.status === 404) {
-            setError('Artikel nicht gefunden');
-          } else {
-            throw new Error(`Failed to load article: ${response.statusText}`);
-          }
-          return;
-        }
-
-        const articleData = await response.json();
-        setArticle(articleData);
-      } catch (error) {
-        console.error('Error loading article:', error);
-        setError('Fehler beim Laden des Artikels');
-        toast({
-          title: 'Fehler',
-          description: 'Artikel konnte nicht geladen werden.',
-          variant: 'destructive',
-        });
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    if (articleId) {
-      loadArticle();
-    }
-  }, [articleId, toast]);
 
   const handleBack = () => {
-    router.push('/dokumentation');
+    router.push('/hilfe/dokumentation');
   };
-
-  if (isLoading) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20">
-        <div className="container mx-auto px-4 py-12">
-          <div className="max-w-4xl mx-auto">
-            <Skeleton className="h-8 w-32 mb-8" />
-            <Skeleton className="h-12 w-3/4 mb-4" />
-            <Skeleton className="h-6 w-1/2 mb-8" />
-            <div className="space-y-4">
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-3/4" />
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-2/3" />
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  if (error || !article) {
-    return (
-      <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20">
-        <div className="container mx-auto px-4 py-12">
-          <div className="max-w-4xl mx-auto">
-            <Alert variant="destructive" className="mb-8">
-              <AlertCircle className="h-4 w-4" />
-              <AlertDescription>
-                {error || 'Artikel konnte nicht geladen werden'}
-              </AlertDescription>
-            </Alert>
-            <button
-              onClick={handleBack}
-              className="text-primary hover:text-primary/80 transition-colors"
-            >
-              ← Zurück zur Dokumentation
-            </button>
-          </div>
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20">

--- a/app/(landing)/hilfe/dokumentation/[articleId]/page.tsx
+++ b/app/(landing)/hilfe/dokumentation/[articleId]/page.tsx
@@ -91,22 +91,32 @@ export async function generateMetadata({ params }: ArticlePageProps): Promise<Me
 }
 
 export default async function ArticlePage({ params }: ArticlePageProps) {
-  const { articleId } = await params;
-  const article = await getArticle(articleId);
+  try {
+    const { articleId } = await params;
+    const article = await getArticle(articleId);
 
-  if (!article) {
+    if (!article) {
+      return (
+        <div className="container mx-auto py-20 text-center">
+          <h1 className="text-2xl font-bold">Artikel nicht gefunden</h1>
+          <p className="mt-4 text-muted-foreground">Der angeforderte Artikel konnte nicht gefunden werden.</p>
+        </div>
+      );
+    }
+
+    return (
+      <>
+        <DocumentationArticleJsonLd article={article} />
+        <ArticlePageClient article={article} />
+      </>
+    );
+  } catch (error) {
+    console.error('Error rendering article page:', error);
     return (
       <div className="container mx-auto py-20 text-center">
-        <h1 className="text-2xl font-bold">Artikel nicht gefunden</h1>
-        <p className="mt-4 text-muted-foreground">Der angeforderte Artikel konnte nicht gefunden werden.</p>
+        <h1 className="text-2xl font-bold">Serverfehler</h1>
+        <p className="mt-4 text-muted-foreground">Ein unerwarteter Fehler ist aufgetreten.</p>
       </div>
     );
   }
-
-  return (
-    <>
-      <DocumentationArticleJsonLd article={article} />
-      <ArticlePageClient article={article} />
-    </>
-  );
 }

--- a/components/documentation/documentation-json-ld.tsx
+++ b/components/documentation/documentation-json-ld.tsx
@@ -47,6 +47,7 @@ export function DocumentationArticleJsonLd({ article }: DocumentationArticleJson
                 <HowToJsonLd
                     name={seo.title || article.titel}
                     description={seo.description || getPreviewText(article.seiteninhalt)}
+                    image={seo.og?.image}
                     steps={seo.structuredData.steps.map(step => ({
                         name: step.name,
                         text: step.text
@@ -65,6 +66,7 @@ export function DocumentationArticleJsonLd({ article }: DocumentationArticleJson
                     title={seo?.title || article.titel}
                     description={seo?.description || getPreviewText(article.seiteninhalt)}
                     url={articleUrl}
+                    image={seo?.og?.image}
                     datePublished={article.meta?.created_time || new Date().toISOString()}
                     dateModified={article.meta?.last_edited_time || article.meta?.created_time}
                 />

--- a/components/documentation/documentation-json-ld.tsx
+++ b/components/documentation/documentation-json-ld.tsx
@@ -60,15 +60,16 @@ export function DocumentationArticleJsonLd({ article }: DocumentationArticleJson
             )}
 
             {/* Always include Article schema as a base if not already using a more specific one, 
-          or even alongside HowTo for better coverage */}
-            {(structuredDataType === 'Article' || structuredDataType === 'HowTo') && (
+                or even alongside HowTo for better coverage. 
+                Only show if we have a valid publication date to avoid SEO instability. */}
+            {(structuredDataType === 'Article' || structuredDataType === 'HowTo') && article.meta?.created_time && (
                 <ArticleJsonLd
                     title={seo?.title || article.titel}
                     description={seo?.description || getPreviewText(article.seiteninhalt)}
                     url={articleUrl}
                     image={seo?.og?.image}
-                    datePublished={article.meta?.created_time || new Date().toISOString()}
-                    dateModified={article.meta?.last_edited_time || article.meta?.created_time}
+                    datePublished={article.meta.created_time}
+                    dateModified={article.meta.last_edited_time || article.meta.created_time}
                 />
             )}
         </>

--- a/components/documentation/documentation-json-ld.tsx
+++ b/components/documentation/documentation-json-ld.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Article, ArticleSEO } from '@/types/documentation';
+import {
+    ArticleJsonLd,
+    HowToJsonLd,
+    FAQJsonLd,
+    BreadcrumbJsonLd
+} from '@/components/seo/json-ld';
+import { BASE_URL } from '@/lib/constants';
+
+interface DocumentationArticleJsonLdProps {
+    article: Article;
+}
+
+export function DocumentationArticleJsonLd({ article }: DocumentationArticleJsonLdProps) {
+    const seo = article.seo as ArticleSEO | undefined;
+    const structuredDataType = seo?.structuredData?.type || 'Article';
+
+    // Helper to strip markdown/HTML for plain text description
+    const getPreviewText = (content: string | null, maxLength: number = 160): string => {
+        if (!content) return '';
+        const plainText = content.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+        if (plainText.length <= maxLength) return plainText;
+        const truncated = plainText.substring(0, maxLength);
+        const lastSpaceIndex = truncated.lastIndexOf(' ');
+        return lastSpaceIndex > 0
+            ? truncated.substring(0, lastSpaceIndex) + '...'
+            : truncated + '...';
+    };
+
+    const articleUrl = `${BASE_URL}/hilfe/dokumentation/${article.id}`;
+    const categoryUrl = `${BASE_URL}/hilfe/dokumentation?category=${encodeURIComponent(article.kategorie || '')}`;
+
+    return (
+        <>
+            {/* 1. Breadcrumb Schema */}
+            <BreadcrumbJsonLd items={[
+                { name: 'Startseite', url: BASE_URL },
+                { name: 'Dokumentation', url: `${BASE_URL}/hilfe/dokumentation` },
+                { name: article.kategorie || 'Allgemein', url: categoryUrl },
+                { name: article.titel, url: articleUrl },
+            ]} />
+
+            {/* 2. Structured Data based on type */}
+            {structuredDataType === 'HowTo' && seo?.structuredData?.steps && (
+                <HowToJsonLd
+                    name={seo.title || article.titel}
+                    description={seo.description || getPreviewText(article.seiteninhalt)}
+                    steps={seo.structuredData.steps.map(step => ({
+                        name: step.name,
+                        text: step.text
+                    }))}
+                />
+            )}
+
+            {structuredDataType === 'FAQ' && seo?.structuredData?.faqs && (
+                <FAQJsonLd faqs={seo.structuredData.faqs} />
+            )}
+
+            {/* Always include Article schema as a base if not already using a more specific one, 
+          or even alongside HowTo for better coverage */}
+            {(structuredDataType === 'Article' || structuredDataType === 'HowTo') && (
+                <ArticleJsonLd
+                    title={seo?.title || article.titel}
+                    description={seo?.description || getPreviewText(article.seiteninhalt)}
+                    url={articleUrl}
+                    datePublished={article.meta?.created_time || new Date().toISOString()}
+                    dateModified={article.meta?.last_edited_time || article.meta?.created_time}
+                />
+            )}
+        </>
+    );
+}

--- a/components/seo/json-ld.tsx
+++ b/components/seo/json-ld.tsx
@@ -80,6 +80,7 @@ interface ArticleJsonLdProps {
     url: string
     datePublished: string
     dateModified?: string
+    image?: string
 }
 
 export function ArticleJsonLd({
@@ -87,11 +88,12 @@ export function ArticleJsonLd({
     description,
     url,
     datePublished,
-    dateModified
+    dateModified,
+    image
 }: ArticleJsonLdProps) {
     return (
         <JsonLd
-            data={getArticleSchema(title, description, url, datePublished, dateModified)}
+            data={getArticleSchema(title, description, url, datePublished, dateModified, image)}
         />
     )
 }
@@ -103,10 +105,11 @@ interface HowToJsonLdProps {
     name: string
     description: string
     steps: Array<{ name: string; text: string }>
+    image?: string
 }
 
-export function HowToJsonLd({ name, description, steps }: HowToJsonLdProps) {
-    return <JsonLd data={getHowToSchema(name, description, steps)} />
+export function HowToJsonLd({ name, description, steps, image }: HowToJsonLdProps) {
+    return <JsonLd data={getHowToSchema(name, description, steps, image)} />
 }
 
 /**

--- a/lib/documentation-service.ts
+++ b/lib/documentation-service.ts
@@ -1,15 +1,15 @@
-import { 
-  createDocumentationQueryBuilder, 
-  getDocumentationClient, 
-  getDocumentationServerClient 
+import {
+  createDocumentationQueryBuilder,
+  getDocumentationClient,
+  getDocumentationServerClient
 } from '@/lib/supabase/documentation-client';
 import { naturalSort } from '@/lib/utils';
-import type { 
-  Article, 
-  Category, 
-  DokumentationRecord, 
-  DocumentationFilters, 
-  SearchResult 
+import type {
+  Article,
+  Category,
+  DokumentationRecord,
+  DocumentationFilters,
+  SearchResult
 } from '@/types/documentation';
 
 /**
@@ -38,7 +38,7 @@ export class DocumentationService {
     try {
       const queryBuilder = await this.getQueryBuilder();
       const { data, error } = await queryBuilder.getCategories();
-      
+
       if (error) {
         console.error('Database error in getCategories:', error);
         return [];
@@ -50,7 +50,7 @@ export class DocumentationService {
 
       // Count articles per category
       const categoryMap = new Map<string, number>();
-      
+
       for (const item of data) {
         if (item.kategorie) {
           categoryMap.set(item.kategorie, (categoryMap.get(item.kategorie) || 0) + 1);
@@ -74,7 +74,7 @@ export class DocumentationService {
     try {
       const queryBuilder = await this.getQueryBuilder();
       const { data, error } = await queryBuilder.getByCategory(kategorie);
-      
+
       if (error) {
         throw new Error(`Failed to fetch articles for category ${kategorie}: ${error.message}`);
       }
@@ -98,7 +98,7 @@ export class DocumentationService {
       const queryBuilder = await this.getQueryBuilder();
       // Use the custom search function for better ranking
       const { data, error } = await queryBuilder.searchWithRanking(query.trim());
-      
+
       if (error) {
         throw new Error(`Failed to search articles: ${error.message}`);
       }
@@ -114,7 +114,7 @@ export class DocumentationService {
         relevanceScore: record.relevance_score,
         highlightedTitle: this.highlightText(record.titel, query),
         highlightedContent: this.highlightText(
-          record.seiteninhalt?.substring(0, 200) || '', 
+          record.seiteninhalt?.substring(0, 200) || '',
           query
         )
       }));
@@ -132,7 +132,7 @@ export class DocumentationService {
     try {
       const queryBuilder = await this.getQueryBuilder();
       const { data, error } = await queryBuilder.getById(id);
-      
+
       if (error) {
         throw new Error(`Failed to fetch article ${id}: ${error.message}`);
       }
@@ -164,7 +164,7 @@ export class DocumentationService {
       }
 
       const { data, error } = await query;
-      
+
       if (error) {
         console.error('Database error in getAllArticles:', error);
         // Return empty array instead of throwing to prevent UI crashes
@@ -181,7 +181,7 @@ export class DocumentationService {
         } catch (searchError) {
           console.error('Search error, falling back to basic filter:', searchError);
           // Fallback to basic text filtering
-          articles = articles.filter(article => 
+          articles = articles.filter(article =>
             article.titel.toLowerCase().includes(filters.searchQuery!.toLowerCase()) ||
             (article.seiteninhalt && article.seiteninhalt.toLowerCase().includes(filters.searchQuery!.toLowerCase()))
           );
@@ -221,7 +221,8 @@ export class DocumentationService {
       titel: record.titel,
       kategorie: record.kategorie || 'Uncategorized',
       seiteninhalt: record.seiteninhalt || '',
-      meta: record.meta || {}
+      meta: record.meta || {},
+      seo: record.seo || null
     };
   }
 
@@ -249,7 +250,7 @@ export class DocumentationService {
     try {
       const queryBuilder = await this.getQueryBuilder();
       const { data, error } = await queryBuilder.search(query);
-      
+
       if (error) {
         throw error;
       }
@@ -258,7 +259,7 @@ export class DocumentationService {
         ...this.transformRecordToArticle(record),
         highlightedTitle: this.highlightText(record.titel, query),
         highlightedContent: this.highlightText(
-          record.seiteninhalt?.substring(0, 200) || '', 
+          record.seiteninhalt?.substring(0, 200) || '',
           query
         )
       }));

--- a/lib/seo/schema.ts
+++ b/lib/seo/schema.ts
@@ -223,7 +223,8 @@ export function getArticleSchema(
     description: string,
     url: string,
     datePublished: string,
-    dateModified?: string
+    dateModified?: string,
+    image?: string
 ) {
     return {
         '@context': 'https://schema.org',
@@ -231,6 +232,7 @@ export function getArticleSchema(
         headline: title,
         description,
         url,
+        image: image || OG_IMAGE_URL,
         datePublished,
         dateModified: dateModified || datePublished,
         author: {
@@ -261,13 +263,15 @@ export function getArticleSchema(
 export function getHowToSchema(
     name: string,
     description: string,
-    steps: Array<{ name: string; text: string }>
+    steps: Array<{ name: string; text: string }>,
+    image?: string
 ) {
     return {
         '@context': 'https://schema.org',
         '@type': 'HowTo',
         name,
         description,
+        image: image || OG_IMAGE_URL,
         step: steps.map((step, index) => ({
             '@type': 'HowToStep',
             position: index + 1,

--- a/types/documentation.ts
+++ b/types/documentation.ts
@@ -2,12 +2,30 @@
  * TypeScript interfaces for the Dokumentation table and related types
  */
 
+export interface ArticleSEO {
+  title?: string;
+  description?: string;
+  keywords?: string[];
+  og?: {
+    title?: string;
+    description?: string;
+    image?: string;
+  };
+  structuredData?: {
+    type: 'Article' | 'HowTo' | 'FAQ';
+    steps?: Array<{ name: string; text: string }>;
+    faqs?: Array<{ question: string; answer: string }>;
+  };
+  noIndex?: boolean;
+}
+
 export interface DokumentationRecord {
   id: string;
   titel: string;
   kategorie: string | null;
   seiteninhalt: string | null;
   meta: Record<string, any> | null;
+  seo: ArticleSEO | null;
 }
 
 export interface Category {
@@ -21,6 +39,7 @@ export interface Article {
   kategorie: string | null;
   seiteninhalt: string | null;
   meta: Record<string, any> | null;
+  seo?: ArticleSEO | null;
 }
 
 export interface SearchResult extends Article {


### PR DESCRIPTION
## Description

Gives documentation articles full SEO support: server-side rendering, per-article metadata and structured data.

## Summary of Changes

- Article page is now server-rendered: the article loads once via React `cache()` (shared by `generateMetadata` and the page) through the documentation service; not-found and error states render server-side
- `generateMetadata` honors the new per-article `seo` field (title, description, keywords, OG title/description/image, `noIndex`)
- New `DocumentationArticleJsonLd`: Breadcrumb schema plus Article/HowTo/FAQ structured data driven by the article's `seo.structuredData` config; `Article`/`HowTo` schemas now support images
- `article-page-client` simplified to a pure viewer (article passed as prop, fetching/loading/error UI removed, back link fixed to `/hilfe/dokumentation`)
- `documentation-service`: UUID validation before querying and graceful `null` returns instead of throws (no more 500s on bad IDs); `seo` mapped through
- `types/documentation.ts`: new `ArticleSEO` interface on records and articles