### PR TITLE
fix(ui): add cursor-pointer to select and combobox triggers for consi…

### DIFF
--- a/components/ui/custom-combobox.tsx
+++ b/components/ui/custom-combobox.tsx
@@ -180,7 +180,7 @@ export function CustomCombobox({
           aria-expanded={open}
           aria-haspopup="listbox"
           aria-label={id ? undefined : (selectedOption ? `Selected: ${selectedOption.label}` : placeholder)}
-          className={cn("justify-between px-3 min-h-[40px] h-auto", width, !value && "text-muted-foreground")}
+          className={cn("justify-between px-3 min-h-[40px] h-auto cursor-pointer", width, !value && "text-muted-foreground")}
           disabled={disabled}
           id={id}
           data-dropdown-trigger

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-xl border border-input bg-background px-4 py-2 text-sm ring-offset-background transition-all duration-200 placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 hover:scale-[1.02] active:scale-[0.98] hover:shadow-md hover:bg-gray-200 hover:text-foreground dark:btn-outline-hover disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full cursor-pointer items-center justify-between rounded-xl border border-input bg-background px-4 py-2 text-sm ring-offset-background transition-all duration-200 placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 hover:scale-[1.02] active:scale-[0.98] hover:shadow-md hover:bg-gray-200 hover:text-foreground dark:btn-outline-hover disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full cursor-pointer items-center justify-between rounded-xl border border-input bg-background px-4 py-2 text-sm ring-offset-background transition-all duration-200 placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 hover:scale-[1.02] active:scale-[0.98] hover:shadow-md hover:bg-gray-200 hover:text-foreground dark:btn-outline-hover disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full cursor-pointer items-center justify-between rounded-xl border border-input bg-background px-4 py-2 text-sm ring-offset-background transition-all duration-200 placeholder:text-muted-foreground focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 hover:scale-[1.02] active:scale-[0.98] hover:shadow-md hover:bg-gray-200 hover:text-foreground dark:btn-outline-hover disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -4,6 +4,8 @@ import * as React from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
 import { Check, ChevronDown, ChevronUp } from "lucide-react"
 
+import { cva, type VariantProps } from "class-variance-authority"
+
 import { cn } from "@/lib/utils"
 
 const Select = SelectPrimitive.Root
@@ -12,16 +14,17 @@ const SelectGroup = SelectPrimitive.Group
 
 const SelectValue = SelectPrimitive.Value
 
+const selectTriggerVariants = cva(
+  "flex h-10 w-full cursor-pointer items-center justify-between rounded-xl border border-input bg-background px-4 py-2 text-sm ring-offset-background transition-all duration-200 placeholder:text-muted-foreground focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 hover:scale-[1.02] active:scale-[0.98] hover:shadow-md hover:bg-gray-200 hover:text-foreground dark:btn-outline-hover disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1"
+)
+
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
 >(({ className, children, ...props }, ref) => (
   <SelectPrimitive.Trigger
     ref={ref}
-    className={cn(
-      "flex h-10 w-full cursor-pointer items-center justify-between rounded-xl border border-input bg-background px-4 py-2 text-sm ring-offset-background transition-all duration-200 placeholder:text-muted-foreground focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 hover:scale-[1.02] active:scale-[0.98] hover:shadow-md hover:bg-gray-200 hover:text-foreground dark:btn-outline-hover disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
-      className
-    )}
+    className={cn(selectTriggerVariants(), className)}
     {...props}
   >
     {children}


### PR DESCRIPTION
## Description

Adds pointer cursors and consistent hover styling to the select and combobox triggers.

## Summary of Changes

- `select.tsx`: trigger styles extracted into a `cva` variant — now includes `cursor-pointer`, hover scale/shadow/background transitions and `focus-visible` ring
- `custom-combobox.tsx`: `cursor-pointer` on the trigger button