### PR TITLE
fix(docs): resolve 500 error for SEO crawlers on documentation pages

### DIFF
--- a/lib/documentation-service.ts
+++ b/lib/documentation-service.ts
@@ -24,7 +24,7 @@ export class DocumentationService {
     this.isServer = isServer;
   }
 
-  private async getQueryBuilder() {
+  private getQueryBuilder() {
     if (!this.queryBuilder) {
       // For public documentation, we prefer a cookie-less client on the server to avoid SEO issues
       const client = this.isServer ? getPublicDocumentationClient() : getDocumentationClient();
@@ -38,7 +38,7 @@ export class DocumentationService {
    */
   async getCategories(): Promise<Category[]> {
     try {
-      const queryBuilder = await this.getQueryBuilder();
+      const queryBuilder = this.getQueryBuilder();
       const { data, error } = await queryBuilder.getCategories();
 
       if (error) {
@@ -74,7 +74,7 @@ export class DocumentationService {
    */
   async getArticlesByCategory(kategorie: string): Promise<Article[]> {
     try {
-      const queryBuilder = await this.getQueryBuilder();
+      const queryBuilder = this.getQueryBuilder();
       const { data, error } = await queryBuilder.getByCategory(kategorie);
 
       if (error) {
@@ -97,7 +97,7 @@ export class DocumentationService {
     }
 
     try {
-      const queryBuilder = await this.getQueryBuilder();
+      const queryBuilder = this.getQueryBuilder();
       // Use the custom search function for better ranking
       const { data, error } = await queryBuilder.searchWithRanking(query.trim());
 
@@ -139,7 +139,7 @@ export class DocumentationService {
     }
 
     try {
-      const queryBuilder = await this.getQueryBuilder();
+      const queryBuilder = this.getQueryBuilder();
       const { data, error } = await queryBuilder.getById(id);
 
       if (error) {
@@ -165,7 +165,7 @@ export class DocumentationService {
    */
   async getAllArticles(filters: DocumentationFilters = {}): Promise<Article[]> {
     try {
-      const queryBuilder = await this.getQueryBuilder();
+      const queryBuilder = this.getQueryBuilder();
       let query = queryBuilder.getAll();
 
       // Apply category filter
@@ -258,7 +258,7 @@ export class DocumentationService {
    */
   private async fallbackSearch(query: string): Promise<SearchResult[]> {
     try {
-      const queryBuilder = await this.getQueryBuilder();
+      const queryBuilder = this.getQueryBuilder();
       const { data, error } = await queryBuilder.search(query);
 
       if (error) {


### PR DESCRIPTION
This commit fixes the HTTP 500 errors encountered by search engine crawlers when accessing documentation articles.

Key changes:
1. Updated DocumentationArticleViewer to handle SSR safely by checking for window existence before using DOMPurify.
2. Introduced a public cookie-less Supabase client for documentation to avoid session-related failures on Edge runtime during SEO metadata generation.
3. Implemented proper HTTP 404 status codes using Next.js notFound() for missing articles, replacing previous soft 404s.
4. Optimized DocumentationService to prefer the public client during server-side operations.