### PR TITLE
Fix: Conditionally render "Mails" tab in SettingsModal based on featu…

### DIFF
--- a/components/modals/settings-modal.test.tsx
+++ b/components/modals/settings-modal.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import { SettingsModal } from './settings-modal';
+import { useFeatureFlagEnabled } from 'posthog-js/react';
+import { POSTHOG_FEATURE_FLAGS } from '@/lib/constants';
+
+// Mock posthog-js/react
+jest.mock('posthog-js/react', () => ({
+  useFeatureFlagEnabled: jest.fn(),
+}));
+
+// Mock child components to simplify testing
+jest.mock('../settings/profile-section', () => () => <div data-testid="profile-section">Profile Section</div>);
+jest.mock('../settings/security-section', () => () => <div data-testid="security-section">Security Section</div>);
+jest.mock('../settings/subscription-section', () => () => <div data-testid="subscription-section">Subscription Section</div>);
+jest.mock('../settings/mail-section', () => () => <div data-testid="mail-section">Mail Section</div>);
+jest.mock('../settings/display-section', () => () => <div data-testid="display-section">Display Section</div>);
+jest.mock('../settings/export-section', () => () => <div data-testid="export-section">Export Section</div>);
+jest.mock('../settings/feature-preview-section', () => () => <div data-testid="feature-preview-section">Feature Preview Section</div>);
+jest.mock('../settings/information-section', () => () => <div data-testid="information-section">Information Section</div>);
+
+describe('SettingsModal', () => {
+  const mockOnOpenChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the Mails tab when the feature flag is enabled', () => {
+    (useFeatureFlagEnabled as jest.Mock).mockImplementation((flag) => {
+      if (flag === POSTHOG_FEATURE_FLAGS.MAILS_TAB) return true;
+      return false;
+    });
+
+    render(<SettingsModal open={true} onOpenChange={mockOnOpenChange} />);
+
+    expect(screen.getByText('E-Mail')).toBeInTheDocument();
+  });
+
+  it('hides the Mails tab when the feature flag is disabled', () => {
+    (useFeatureFlagEnabled as jest.Mock).mockImplementation((flag) => {
+      if (flag === POSTHOG_FEATURE_FLAGS.MAILS_TAB) return false;
+      return false;
+    });
+
+    render(<SettingsModal open={true} onOpenChange={mockOnOpenChange} />);
+
+    expect(screen.queryByText('E-Mail')).not.toBeInTheDocument();
+  });
+});

--- a/components/modals/settings-modal.test.tsx
+++ b/components/modals/settings-modal.test.tsx
@@ -26,10 +26,7 @@ describe('SettingsModal', () => {
   });
 
   it('shows the Mails tab when the feature flag is enabled', () => {
-    (useFeatureFlagEnabled as jest.Mock).mockImplementation((flag) => {
-      if (flag === POSTHOG_FEATURE_FLAGS.MAILS_TAB) return true;
-      return false;
-    });
+    (useFeatureFlagEnabled as jest.Mock).mockReturnValue(true);
 
     render(<SettingsModal open={true} onOpenChange={mockOnOpenChange} />);
 
@@ -37,10 +34,7 @@ describe('SettingsModal', () => {
   });
 
   it('hides the Mails tab when the feature flag is disabled', () => {
-    (useFeatureFlagEnabled as jest.Mock).mockImplementation((flag) => {
-      if (flag === POSTHOG_FEATURE_FLAGS.MAILS_TAB) return false;
-      return false;
-    });
+    (useFeatureFlagEnabled as jest.Mock).mockReturnValue(false);
 
     render(<SettingsModal open={true} onOpenChange={mockOnOpenChange} />);
 

--- a/components/modals/settings-modal.tsx
+++ b/components/modals/settings-modal.tsx
@@ -22,12 +22,15 @@ import ExportSection from "../settings/export-section";
 import FeaturePreviewSection from "../settings/feature-preview-section";
 import InformationSection from "../settings/information-section";
 import MailSection from "../settings/mail-section";
+import { useFeatureFlagEnabled } from "posthog-js/react";
+import { POSTHOG_FEATURE_FLAGS } from "@/lib/constants";
 
 type SettingsModalProps = { open: boolean; onOpenChange: (open: boolean) => void }
 
 export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
   const [activeTab, setActiveTab] = useState<string>("profile")
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState<boolean>(false)
+  const mailsEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.MAILS_TAB)
 
   const tabs: Tab[] = [
     {
@@ -48,12 +51,12 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
       icon: CreditCard,
       content: <SubscriptionSection />,
     },
-    {
+    ...(mailsEnabled ? [{
       value: "mail",
       label: "E-Mail",
       icon: Mail,
       content: <MailSection />,
-    },
+    }] : []),
     {
       value: "display",
       label: "Darstellung",


### PR DESCRIPTION
## Description

Conditionally renders the "Mails" tab in the settings modal based on the `mails-tab` feature flag. The tab was previously always visible; `SettingsModal` now checks the flag using `useFeatureFlagEnabled` and only renders the tab when it is active.

## Summary of Changes

- Updates `components/modals/settings-modal.tsx` to include the feature flag check
- Adds `components/modals/settings-modal.test.tsx` to verify the logic