### PR TITLE
feat: optimize CI pipeline with parallel build, playwright install, a…

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,10 +38,12 @@ env:
 
 jobs:
   # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  # BUILD JOB - Compiles Next.js application and caches the result
+  # 1. PREPARATION PHASE (Parallel)
   # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  
+  # BUILD JOB - Compiles Next.js application and caches the result
   build:
-    name: Build Application
+    name: 🏗️ Build App
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
@@ -61,14 +63,11 @@ jobs:
       - name: Generate cache keys
         id: cache-key
         run: |
-          # Content-based build cache key for .next folder
           BUILD_HASH=$(find app components lib hooks types utils public -type f \( -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" -o -name "*.css" -o -name "*.json" \) -exec sha256sum {} \; 2>/dev/null | sort | sha256sum | cut -d' ' -f1 || echo "no-files")
           PACKAGE_HASH="${{ hashFiles('**/package-lock.json', '**/package.json', 'next.config.js', 'tsconfig.json', 'tailwind.config.ts') }}"
           
           echo "build-key=build-${{ runner.os }}-${BUILD_HASH}-${PACKAGE_HASH}" >> $GITHUB_OUTPUT
           echo "node-key=${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}" >> $GITHUB_OUTPUT
-          
-          echo "Build cache key generated"
 
       - name: Restore build cache
         id: build-cache
@@ -94,13 +93,7 @@ jobs:
 
       - name: Build application
         if: steps.build-cache.outputs.cache-hit != 'true'
-        run: |
-          echo "🏗️ Building Next.js application..."
-          START_TIME=$(date +%s)
-          npm run build
-          END_TIME=$(date +%s)
-          BUILD_TIME=$((END_TIME - START_TIME))
-          echo "✅ Build completed in ${BUILD_TIME}s"
+        run: npm run build
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'http://localhost:54321' }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'mock-anon-key' }}
@@ -112,20 +105,9 @@ jobs:
           path: .next
           key: ${{ steps.cache-key.outputs.build-key }}
 
-      - name: Build summary
-        run: |
-          echo "### 🏗️ Build Status" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Cache | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Build (.next) | ${{ steps.build-cache.outputs.cache-hit == 'true' && '✅ Restored from cache' || '🔨 Built fresh' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| node_modules | ${{ steps.node-cache.outputs.cache-hit == 'true' && '✅ Restored from cache' || '📦 Installed fresh' }} |" >> $GITHUB_STEP_SUMMARY
-
-  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   # INSTALL PLAYWRIGHT - Runs in parallel with build
-  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   install-playwright:
-    name: Install Playwright Browsers
+    name: 🎭 Setup Playwright
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -143,8 +125,7 @@ jobs:
 
       - name: Generate Playwright cache key
         id: playwright-key
-        run: |
-          echo "key=${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}" >> $GITHUB_OUTPUT
+        run: echo "key=${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright browsers
         id: playwright-cache
@@ -170,24 +151,11 @@ jobs:
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: |
-          echo "🎭 Installing Playwright browsers..."
-          npx playwright install --with-deps
-          echo "✅ Playwright browsers installed"
+        run: npx playwright install --with-deps
 
-      - name: Playwright summary
-        run: |
-          echo "### 🎭 Playwright Status" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Component | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|-----------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Browsers | ${{ steps.playwright-cache.outputs.cache-hit == 'true' && '✅ Restored from cache' || '📥 Downloaded fresh' }} |" >> $GITHUB_STEP_SUMMARY
-
-  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  # TYPE CHECK - Runs in parallel with build (doesn't need build cache)
-  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  # TYPE CHECK - Conceptually part of Prep
   type-check:
-    name: TypeScript Check
+    name: 🔍 Type Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
     
@@ -215,27 +183,11 @@ jobs:
         run: npm ci --prefer-offline
 
       - name: Run TypeScript compiler
-        run: |
-          echo "🔍 Running TypeScript type check..."
-          START_TIME=$(date +%s)
-          npx tsc --noEmit --pretty
-          END_TIME=$(date +%s)
-          CHECK_TIME=$((END_TIME - START_TIME))
-          echo "✅ Type check passed in ${CHECK_TIME}s"
+        run: npx tsc --noEmit --pretty
 
-      - name: Type check summary
-        if: always()
-        run: |
-          echo "### 🔍 TypeScript Check" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ job.status }}" == "success" ]; then
-            echo "✅ **No type errors found**" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "❌ **Type errors detected** - check the logs above" >> $GITHUB_STEP_SUMMARY
-          fi
-  # Setup job to dynamically discover test files and determine which need to run
+  # DISCOVERY - Conceptually part of Prep
   setup:
-    name: Discover & Filter Test Files
+    name: 📂 Discovery
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -514,12 +466,14 @@ jobs:
           echo "files-to-test=$TEST_FILES_TO_RUN" >> $GITHUB_OUTPUT
 
   # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  # E2E TESTS - Depends on build and install-playwright jobs
+  # 2. VERIFICATION PHASE (Sequential to Prep)
   # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  # E2E TESTS - Cleanly aligned after build and setup
   e2e-test:
-    name: E2E Tests
+    name: 🎭 E2E Test
     runs-on: ubuntu-latest
-    needs: [build, install-playwright]
+    needs: [build, install-playwright, setup]
     timeout-minutes: 30
     
     steps:
@@ -558,92 +512,16 @@ jobs:
           key: ${{ needs.install-playwright.outputs.playwright-cache-key }}
           fail-on-cache-miss: true
 
-      - name: Display cache status
-        run: |
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          echo "📦 E2E Test Cache Status"
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          echo "  Build cache: ✅ Restored from build job"
-          echo "  node_modules: ✅ Restored from build job"
-          echo "  Playwright browsers: ✅ Restored from install-playwright job"
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-
       # Install system dependencies for Playwright (not included in browser cache)
       - name: Install Playwright system dependencies
         run: npx playwright install-deps
 
       - name: Run Playwright tests
         id: playwright
-        run: |
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          echo "🎭 Running Playwright E2E Tests"
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          echo "  Browsers: Chromium, Firefox, WebKit"
-          echo "  Base URL: http://localhost:3000"
-          echo "  Workers: 1 (CI mode)"
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          START_TIME=$(date +%s)
-          npx playwright test --reporter=list 2>&1 | tee playwright-output.log
-          TEST_EXIT_CODE=${PIPESTATUS[0]}
-          END_TIME=$(date +%s)
-          TEST_TIME=$((END_TIME - START_TIME))
-          echo "test_time=$TEST_TIME" >> $GITHUB_OUTPUT
-          echo "exit_code=$TEST_EXIT_CODE" >> $GITHUB_OUTPUT
-          
-          # Parse results from output
-          PASSED=$(grep -oP '\d+(?= passed)' playwright-output.log | tail -1 || echo "0")
-          FAILED=$(grep -oP '\d+(?= failed)' playwright-output.log | tail -1 || echo "0")
-          SKIPPED=$(grep -oP '\d+(?= skipped)' playwright-output.log | tail -1 || echo "0")
-          
-          echo "passed=$PASSED" >> $GITHUB_OUTPUT
-          echo "failed=$FAILED" >> $GITHUB_OUTPUT
-          echo "skipped=$SKIPPED" >> $GITHUB_OUTPUT
-          
-          echo ""
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          echo "📊 E2E Test Results"
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          echo "  ✅ Passed:  $PASSED"
-          echo "  ❌ Failed:  $FAILED"
-          echo "  ⏭️  Skipped: $SKIPPED"
-          echo "  ⏱️  Duration: ${TEST_TIME}s"
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          
-          exit $TEST_EXIT_CODE
+        run: npx playwright test --reporter=list
         env:
           CI: true
           NODE_ENV: production
-
-      - name: Generate E2E summary
-        if: always()
-        run: |
-          echo "## 🎭 E2E Test Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          if [ "${{ steps.playwright.outputs.exit_code }}" = "0" ]; then
-            echo "### ✅ All E2E tests passed!" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "### ❌ Some E2E tests failed" >> $GITHUB_STEP_SUMMARY
-          fi
-          
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Metric | Value |" >> $GITHUB_STEP_SUMMARY
-          echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
-          echo "| ✅ Passed | ${{ steps.playwright.outputs.passed || '0' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| ❌ Failed | ${{ steps.playwright.outputs.failed || '0' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| ⏭️ Skipped | ${{ steps.playwright.outputs.skipped || '0' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| ⏱️ Test Duration | ${{ steps.playwright.outputs.test_time || '0' }}s |" >> $GITHUB_STEP_SUMMARY
-          echo "| 🏗️ Build | ✅ Restored from build job |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 📦 Cache Status" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Cache | Source |" >> $GITHUB_STEP_SUMMARY
-          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Build (.next) | ✅ build job |" >> $GITHUB_STEP_SUMMARY
-          echo "| node_modules | ✅ build job |" >> $GITHUB_STEP_SUMMARY
-          echo "| Playwright browsers | ✅ install-playwright job |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "📎 Download the [Playwright Report](../artifacts) for detailed results and traces." >> $GITHUB_STEP_SUMMARY
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
@@ -664,10 +542,11 @@ jobs:
           if-no-files-found: ignore
 
 
+  # UNIT TESTS - Aligned vertically with E2E
   test:
-    name: Run Tests (Group ${{ matrix.test-group }})
+    name: 🧪 Unit Test (${{ matrix.test-group }})
     runs-on: ubuntu-latest
-    needs: setup
+    needs: [setup, build] # Depends on build to align with e2e-test visually
     if: ${{ needs.setup.outputs.total-files != '0' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -105,55 +105,8 @@ jobs:
           path: .next
           key: ${{ steps.cache-key.outputs.build-key }}
 
-  # INSTALL PLAYWRIGHT - Runs in parallel with build
-  install-playwright:
-    name: Install Playwright Browsers
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    outputs:
-      playwright-cache-key: ${{ steps.playwright-key.outputs.key }}
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Generate Playwright cache key
-        id: playwright-key
-        run: echo "key=${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}" >> $GITHUB_OUTPUT
-
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ steps.playwright-key.outputs.key }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-
-      - name: Cache node_modules
-        id: node-cache
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-
-
-      - name: Install dependencies
-        if: steps.node-cache.outputs.cache-hit != 'true'
-        run: npm ci --prefer-offline
-
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
-
-  # TYPE CHECK - Conceptually part of Prep
+  # TYPE CHECK - Validates TypeScript types
   type-check:
     name: TypeScript Check
     runs-on: ubuntu-latest
@@ -185,7 +138,7 @@ jobs:
       - name: Run TypeScript compiler
         run: npx tsc --noEmit --pretty
 
-  # DISCOVERY - Conceptually part of Prep
+  # DISCOVERY - Find and filter test files
   setup:
     name: Discover & Filter Test Files
     runs-on: ubuntu-latest
@@ -464,6 +417,54 @@ jobs:
           # Output
           echo "matrix=$(echo "$MATRIX_JSON" | jq -c .)" >> $GITHUB_OUTPUT
           echo "files-to-test=$TEST_FILES_TO_RUN" >> $GITHUB_OUTPUT
+
+  # INSTALL PLAYWRIGHT - Installs browser binaries for E2E tests
+  install-playwright:
+    name: Install Playwright Browsers
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      playwright-cache-key: ${{ steps.playwright-key.outputs.key }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Generate Playwright cache key
+        id: playwright-key
+        run: echo "key=${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ steps.playwright-key.outputs.key }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Cache node_modules
+        id: node-cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
+
+      - name: Install dependencies
+        if: steps.node-cache.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps
 
   # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   # 2. VERIFICATION PHASE (Sequential to Prep)

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -861,7 +861,7 @@ jobs:
   test-summary:
     name: Test Summary & Notification
     runs-on: ubuntu-latest
-    needs: [test, e2e-test, type-check]
+    needs: [test, e2e-test]
     if: always()
     
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -43,7 +43,7 @@ jobs:
   
   # BUILD JOB - Compiles Next.js application and caches the result
   build:
-    name: 🏗️ Build App
+    name: Build Application
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
@@ -107,7 +107,7 @@ jobs:
 
   # INSTALL PLAYWRIGHT - Runs in parallel with build
   install-playwright:
-    name: 🎭 Setup Playwright
+    name: Install Playwright Browsers
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -155,7 +155,7 @@ jobs:
 
   # TYPE CHECK - Conceptually part of Prep
   type-check:
-    name: 🔍 Type Check
+    name: TypeScript Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
     
@@ -187,7 +187,7 @@ jobs:
 
   # DISCOVERY - Conceptually part of Prep
   setup:
-    name: 📂 Discovery
+    name: Discover & Filter Test Files
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -471,7 +471,7 @@ jobs:
 
   # E2E TESTS - Cleanly aligned after build and setup
   e2e-test:
-    name: 🎭 E2E Test
+    name: E2E Tests
     runs-on: ubuntu-latest
     needs: [build, install-playwright, setup]
     timeout-minutes: 30
@@ -544,7 +544,7 @@ jobs:
 
   # UNIT TESTS - Aligned vertically with E2E
   test:
-    name: 🧪 Unit Test (${{ matrix.test-group }})
+    name: Run Tests (Group ${{ matrix.test-group }})
     runs-on: ubuntu-latest
     needs: [setup, build] # Depends on build to align with e2e-test visually
     if: ${{ needs.setup.outputs.total-files != '0' }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -473,7 +473,7 @@ jobs:
   e2e-test:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: [build, install-playwright, setup]
+    needs: [build, install-playwright, setup, type-check]
     timeout-minutes: 30
     
     steps:
@@ -546,7 +546,7 @@ jobs:
   test:
     name: Run Tests (Group ${{ matrix.test-group }})
     runs-on: ubuntu-latest
-    needs: [setup, build] # Depends on build to align with e2e-test visually
+    needs: [setup, build, type-check] # Depends on build and type-check to align with e2e-test visually
     if: ${{ needs.setup.outputs.total-files != '0' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,9 +14,20 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
-# Limit permissions of GITHUB_TOKEN for security
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# PERMISSIONS (Principle of Least Privilege)
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 permissions:
-  contents: read
+  contents: read      # Read repository contents
+  actions: read       # Read workflow artifacts and caches
+  checks: write       # Write check run results
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# CONCURRENCY (Cancel stale workflow runs on same branch)
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   NODE_ENV: test
@@ -26,6 +37,202 @@ env:
   FORCE_COLOR: '1'
 
 jobs:
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  # BUILD JOB - Compiles Next.js application and caches the result
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  build:
+    name: Build Application
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      build-cache-key: ${{ steps.cache-key.outputs.build-key }}
+      node-modules-key: ${{ steps.cache-key.outputs.node-key }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Generate cache keys
+        id: cache-key
+        run: |
+          # Content-based build cache key for .next folder
+          BUILD_HASH=$(find app components lib hooks types utils public -type f \( -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" -o -name "*.css" -o -name "*.json" \) -exec sha256sum {} \; 2>/dev/null | sort | sha256sum | cut -d' ' -f1 || echo "no-files")
+          PACKAGE_HASH="${{ hashFiles('**/package-lock.json', '**/package.json', 'next.config.js', 'tsconfig.json', 'tailwind.config.ts') }}"
+          
+          echo "build-key=build-${{ runner.os }}-${BUILD_HASH}-${PACKAGE_HASH}" >> $GITHUB_OUTPUT
+          echo "node-key=${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}" >> $GITHUB_OUTPUT
+          
+          echo "Build cache key generated"
+
+      - name: Restore build cache
+        id: build-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .next
+          key: ${{ steps.cache-key.outputs.build-key }}
+          restore-keys: |
+            build-${{ runner.os }}-
+
+      - name: Cache node_modules
+        id: node-cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ steps.cache-key.outputs.node-key }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
+
+      - name: Install dependencies
+        if: steps.node-cache.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline
+
+      - name: Build application
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: |
+          echo "🏗️ Building Next.js application..."
+          START_TIME=$(date +%s)
+          npm run build
+          END_TIME=$(date +%s)
+          BUILD_TIME=$((END_TIME - START_TIME))
+          echo "✅ Build completed in ${BUILD_TIME}s"
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'http://localhost:54321' }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'mock-anon-key' }}
+
+      - name: Save build cache
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .next
+          key: ${{ steps.cache-key.outputs.build-key }}
+
+      - name: Build summary
+        run: |
+          echo "### 🏗️ Build Status" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Cache | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Build (.next) | ${{ steps.build-cache.outputs.cache-hit == 'true' && '✅ Restored from cache' || '🔨 Built fresh' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| node_modules | ${{ steps.node-cache.outputs.cache-hit == 'true' && '✅ Restored from cache' || '📦 Installed fresh' }} |" >> $GITHUB_STEP_SUMMARY
+
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  # INSTALL PLAYWRIGHT - Runs in parallel with build
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  install-playwright:
+    name: Install Playwright Browsers
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      playwright-cache-key: ${{ steps.playwright-key.outputs.key }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Generate Playwright cache key
+        id: playwright-key
+        run: |
+          echo "key=${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ steps.playwright-key.outputs.key }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Cache node_modules
+        id: node-cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
+
+      - name: Install dependencies
+        if: steps.node-cache.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: |
+          echo "🎭 Installing Playwright browsers..."
+          npx playwright install --with-deps
+          echo "✅ Playwright browsers installed"
+
+      - name: Playwright summary
+        run: |
+          echo "### 🎭 Playwright Status" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Component | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-----------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Browsers | ${{ steps.playwright-cache.outputs.cache-hit == 'true' && '✅ Restored from cache' || '📥 Downloaded fresh' }} |" >> $GITHUB_STEP_SUMMARY
+
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  # TYPE CHECK - Runs in parallel with build (doesn't need build cache)
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  type-check:
+    name: TypeScript Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Cache node_modules
+        id: node-cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
+
+      - name: Install dependencies
+        if: steps.node-cache.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline
+
+      - name: Run TypeScript compiler
+        run: |
+          echo "🔍 Running TypeScript type check..."
+          START_TIME=$(date +%s)
+          npx tsc --noEmit --pretty
+          END_TIME=$(date +%s)
+          CHECK_TIME=$((END_TIME - START_TIME))
+          echo "✅ Type check passed in ${CHECK_TIME}s"
+
+      - name: Type check summary
+        if: always()
+        run: |
+          echo "### 🔍 TypeScript Check" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ job.status }}" == "success" ]; then
+            echo "✅ **No type errors found**" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "❌ **Type errors detected** - check the logs above" >> $GITHUB_STEP_SUMMARY
+          fi
   # Setup job to dynamically discover test files and determine which need to run
   setup:
     name: Discover & Filter Test Files
@@ -306,11 +513,13 @@ jobs:
           echo "matrix=$(echo "$MATRIX_JSON" | jq -c .)" >> $GITHUB_OUTPUT
           echo "files-to-test=$TEST_FILES_TO_RUN" >> $GITHUB_OUTPUT
 
-  # E2E Tests with Playwright - runs in parallel with unit tests
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  # E2E TESTS - Depends on build and install-playwright jobs
+  # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   e2e-test:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: setup
+    needs: [build, install-playwright]
     timeout-minutes: 30
     
     steps:
@@ -322,113 +531,46 @@ jobs:
         with:
           node-version: '20'
 
-      # Generate build cache key (same strategy as Lighthouse workflow for cache sharing)
-      - name: Generate build cache key
-        id: build-cache-key
-        run: |
-          # Create a hash of all files that affect the build
-          BUILD_HASH=$(find app components lib hooks types utils public -type f \( -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" -o -name "*.css" -o -name "*.json" \) -exec sha256sum {} \; 2>/dev/null | sort | sha256sum | cut -d' ' -f1 || echo "no-files")
-          PACKAGE_HASH="${{ hashFiles('**/package-lock.json', '**/package.json', 'next.config.js', 'tsconfig.json', 'tailwind.config.ts') }}"
-          CACHE_KEY="build-${BUILD_HASH}-${PACKAGE_HASH}"
-          echo "cache-key=${CACHE_KEY}" >> $GITHUB_OUTPUT
-          echo "Build cache key: ${CACHE_KEY}"
-
-      # Restore full build cache (shared with Lighthouse workflow)
-      - name: Restore build cache
-        id: restore-build-cache
+      # Restore node_modules from the build job
+      - name: Restore node_modules
         uses: actions/cache/restore@v4
-        with:
-          path: .next
-          key: ${{ steps.build-cache-key.outputs.cache-key }}
-          restore-keys: |
-            build-
-
-      # Cache node_modules (shared with other jobs)
-      - name: Cache node_modules
-        uses: actions/cache@v4
         id: cache-node-modules
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-
+          key: ${{ needs.build.outputs.node-modules-key }}
+          fail-on-cache-miss: true
 
-      # Cache Playwright browsers to avoid re-downloading
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
+      # Restore build cache from the build job
+      - name: Restore build cache
+        uses: actions/cache/restore@v4
+        id: restore-build-cache
+        with:
+          path: .next
+          key: ${{ needs.build.outputs.build-cache-key }}
+          fail-on-cache-miss: true
+
+      # Restore Playwright browsers from install-playwright job
+      - name: Restore Playwright browsers
+        uses: actions/cache/restore@v4
         id: cache-playwright
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
+          key: ${{ needs.install-playwright.outputs.playwright-cache-key }}
+          fail-on-cache-miss: true
 
       - name: Display cache status
         run: |
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           echo "📦 E2E Test Cache Status"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          echo "  Build cache: ${{ steps.restore-build-cache.outputs.cache-hit == 'true' && '✅ HIT (skipping build)' || '❌ MISS (will build)' }}"
-          echo "  node_modules: ${{ steps.cache-node-modules.outputs.cache-hit == 'true' && '✅ HIT' || '❌ MISS' }}"
-          echo "  Playwright browsers: ${{ steps.cache-playwright.outputs.cache-hit == 'true' && '✅ HIT' || '❌ MISS' }}"
+          echo "  Build cache: ✅ Restored from build job"
+          echo "  node_modules: ✅ Restored from build job"
+          echo "  Playwright browsers: ✅ Restored from install-playwright job"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-      - name: Install dependencies
-        run: |
-          # Only run npm ci if node_modules doesn't exist or is incomplete
-          if [ ! -d "node_modules" ] || [ ! -f "node_modules/.package-lock.json" ]; then
-            echo "Installing dependencies..."
-            npm ci --prefer-offline
-          else
-            echo "✓ node_modules exists and appears complete - skipping npm ci"
-          fi
-
-      # Only install browsers if not cached
-      - name: Install Playwright Browsers
-        if: steps.cache-playwright.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
-
-      # Install system dependencies if browsers were cached (deps not included in cache)
+      # Install system dependencies for Playwright (not included in browser cache)
       - name: Install Playwright system dependencies
-        if: steps.cache-playwright.outputs.cache-hit == 'true'
         run: npx playwright install-deps
-
-      # Only build if cache miss
-      - name: Build application
-        id: build
-        if: steps.restore-build-cache.outputs.cache-hit != 'true'
-        run: |
-          echo "🏗️ Building Next.js application..."
-          START_TIME=$(date +%s)
-          npm run build
-          END_TIME=$(date +%s)
-          BUILD_TIME=$((END_TIME - START_TIME))
-          echo "build_time=$BUILD_TIME" >> $GITHUB_OUTPUT
-          echo "✅ Build completed in ${BUILD_TIME}s"
-        env:
-          # Add any required build-time environment variables
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'http://localhost:54321' }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'mock-anon-key' }}
-
-      # Save build cache for future runs
-      - name: Save build cache
-        if: steps.restore-build-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: .next
-          key: ${{ steps.build-cache-key.outputs.cache-key }}
-
-      - name: Build status
-        id: build-status
-        run: |
-          if [ "${{ steps.restore-build-cache.outputs.cache-hit }}" == "true" ]; then
-            echo "✓ Build restored from cache (0s)"
-            echo "build_time=0" >> $GITHUB_OUTPUT
-            echo "from_cache=true" >> $GITHUB_OUTPUT
-          else
-            echo "✓ Build completed and cached"
-            echo "from_cache=false" >> $GITHUB_OUTPUT
-          fi
 
       - name: Run Playwright tests
         id: playwright
@@ -470,7 +612,6 @@ jobs:
           exit $TEST_EXIT_CODE
         env:
           CI: true
-          # Use production build for E2E tests
           NODE_ENV: production
 
       - name: Generate E2E summary
@@ -492,19 +633,15 @@ jobs:
           echo "| ❌ Failed | ${{ steps.playwright.outputs.failed || '0' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| ⏭️ Skipped | ${{ steps.playwright.outputs.skipped || '0' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| ⏱️ Test Duration | ${{ steps.playwright.outputs.test_time || '0' }}s |" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ steps.restore-build-cache.outputs.cache-hit }}" == "true" ]; then
-            echo "| 🏗️ Build | ✅ Restored from cache |" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "| 🏗️ Build Duration | ${{ steps.build.outputs.build_time || '0' }}s |" >> $GITHUB_STEP_SUMMARY
-          fi
+          echo "| 🏗️ Build | ✅ Restored from build job |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 📦 Cache Status" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Cache | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "| Cache | Source |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| Build (.next) | ${{ steps.restore-build-cache.outputs.cache-hit == 'true' && '✅ Hit' || '❌ Miss' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| node_modules | ${{ steps.cache-node-modules.outputs.cache-hit == 'true' && '✅ Hit' || '❌ Miss' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Playwright browsers | ${{ steps.cache-playwright.outputs.cache-hit == 'true' && '✅ Hit' || '❌ Miss' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Build (.next) | ✅ build job |" >> $GITHUB_STEP_SUMMARY
+          echo "| node_modules | ✅ build job |" >> $GITHUB_STEP_SUMMARY
+          echo "| Playwright browsers | ✅ install-playwright job |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "📎 Download the [Playwright Report](../artifacts) for detailed results and traces." >> $GITHUB_STEP_SUMMARY
 
@@ -525,6 +662,7 @@ jobs:
           path: test-results/
           retention-days: 7
           if-no-files-found: ignore
+
 
   test:
     name: Run Tests (Group ${{ matrix.test-group }})
@@ -843,7 +981,7 @@ jobs:
   test-summary:
     name: Test Summary & Notification
     runs-on: ubuntu-latest
-    needs: [test, e2e-test]
+    needs: [test, e2e-test, type-check]
     if: always()
     
     steps:


### PR DESCRIPTION
## Description

Restructures the test workflow into a preparation and a verification phase with shared caches.

## Summary of Changes

- Least-privilege permissions (`contents`/`actions` read, `checks` write) and concurrency that cancels stale runs on non-main branches
- New dedicated `build` job: content-hash build cache + node_modules cache, exposes both cache keys as outputs
- New `type-check` and `install-playwright` jobs (Playwright browser binaries cached separately)
- `e2e-test` now runs after `[build, install-playwright, setup, type-check]` and restores all three caches with `fail-on-cache-miss` — no more redundant builds per job
- Unit tests depend on `[setup, build, type-check]`; verbose inline logging/summary steps removed in favor of the lean pipeline