### PR TITLE
Refactor type imports to optimize bundle size

### DIFF
--- a/app/meter-actions.ts
+++ b/app/meter-actions.ts
@@ -2,7 +2,7 @@
 
 import { createClient } from "@/utils/supabase/server";
 import { revalidatePath } from "next/cache";
-import { Zaehler, ZaehlerAblesung, Wohnung, Mieter } from "@/lib/data-fetching";
+import type { Zaehler, ZaehlerAblesung, Wohnung, Mieter } from "@/lib/types";
 import { logAction } from '@/lib/logging-middleware';
 import { capturePostHogEvent } from '@/lib/posthog-helpers';
 

--- a/components/charts/nebenkosten-chart.tsx
+++ b/components/charts/nebenkosten-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { NebenkostenChartDatum } from "@/lib/data-fetching";
+import type { NebenkostenChartDatum } from "@/lib/types";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { PieChart, Pie, Cell, Legend, Tooltip, ResponsiveContainer } from "recharts";
 
@@ -81,9 +81,9 @@ export function NebenkostenChart({ nebenkostenData, year }: NebenkostenChartProp
               paddingAngle={2}
             >
               {data.map((entry, idx) => (
-                <Cell 
-                  key={`cell-${idx}`} 
-                  fill={colors[idx % colors.length]} 
+                <Cell
+                  key={`cell-${idx}`}
+                  fill={colors[idx % colors.length]}
                 />
               ))}
             </Pie>

--- a/components/finance/abrechnung-modal.tsx
+++ b/components/finance/abrechnung-modal.tsx
@@ -22,7 +22,7 @@ import { ExportAbrechnungDropdown } from "@/components/abrechnung/export-abrechn
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"; // Added Card imports
 import { HoverCard, HoverCardTrigger, HoverCardContent } from "@/components/ui/hover-card";
 import { CustomCombobox, ComboboxOption } from "@/components/ui/custom-combobox";
-import { Nebenkosten, Mieter, Wohnung, Rechnung, WasserZaehler, WasserAblesung } from "@/lib/data-fetching"; // Updated imports for new water system
+import type { Nebenkosten, Mieter, Wohnung, Rechnung, WasserZaehler, WasserAblesung } from "@/lib/types"; // Updated imports for new water system
 import { WATER_METER_TYPES } from "@/lib/zaehler-types";
 import { sumZaehlerValues } from "@/lib/zaehler-utils";
 import { useEffect, useState, useMemo, useRef } from "react"; // Import useEffect, useState, useMemo, and useRef

--- a/components/finance/betriebskosten-edit-modal.tsx
+++ b/components/finance/betriebskosten-edit-modal.tsx
@@ -37,7 +37,7 @@ import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Mieter, Nebenkosten, RechnungSql } from "@/lib/data-fetching";
+import type { Mieter, Nebenkosten, RechnungSql } from "@/lib/types";
 import { ZAEHLER_CONFIG, ZaehlerTyp } from "@/lib/zaehler-types";
 import { convertZaehlerkostenToStrings } from "@/lib/zaehler-utils";
 import { BerechnungsartValue, BERECHNUNGSART_OPTIONS } from "@/lib/constants";

--- a/components/finance/operating-costs-filters.tsx
+++ b/components/finance/operating-costs-filters.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { SearchInput } from "@/components/ui/search-input"
 import { CustomCombobox } from "@/components/ui/custom-combobox"
-import { Haus } from "@/lib/data-fetching"
+import type { Haus } from "@/lib/types"
 
 const ALL_HOUSES_LABEL = 'Alle Häuser'
 const ALL_HOUSES_VALUE = 'all'
@@ -18,16 +18,16 @@ interface OperatingCostsFiltersProps {
   searchQuery?: string
 }
 
-export function OperatingCostsFilters({ 
-  onFilterChange, 
-  onSearchChange, 
+export function OperatingCostsFilters({
+  onFilterChange,
+  onSearchChange,
   onHouseChange,
   haeuser = [],
   selectedHouseId = ALL_HOUSES_VALUE,
   searchQuery = ""
 }: OperatingCostsFiltersProps) {
   const [activeFilter, setActiveFilter] = useState("all")
-  
+
   const houseOptions = useMemo(() => [
     { value: ALL_HOUSES_VALUE, label: ALL_HOUSES_LABEL },
     ...haeuser.map((haus) => ({ value: haus.id, label: haus.name }))

--- a/components/finance/operating-costs-overview-modal.tsx
+++ b/components/finance/operating-costs-overview-modal.tsx
@@ -5,7 +5,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Button } from "@/components/ui/button"
 import { FileDown } from "lucide-react"
-import { Nebenkosten } from "@/lib/data-fetching"
+import type { Nebenkosten } from "@/lib/types"
 import { ZAEHLER_CONFIG, ZaehlerTyp } from "@/lib/zaehler-types"
 import { OptimizedNebenkosten } from "@/types/optimized-betriebskosten"
 import { isoToGermanDate } from "@/utils/date-calculations"

--- a/components/finance/sortable-cost-item.tsx
+++ b/components/finance/sortable-cost-item.tsx
@@ -13,7 +13,7 @@ import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Mieter } from "@/lib/data-fetching";
+import type { Mieter } from "@/lib/types";
 import { BerechnungsartValue, BERECHNUNGSART_OPTIONS } from "@/lib/constants";
 
 export interface CostItem {

--- a/components/tables/operating-costs-table.tsx
+++ b/components/tables/operating-costs-table.tsx
@@ -24,7 +24,7 @@ import {
   AlertDialogAction,
   AlertDialogCancel
 } from "@/components/ui/alert-dialog"
-import { Nebenkosten, Mieter, Wasserzaehler, Rechnung, Haus } from "@/lib/data-fetching" // Adjusted path, Removed WasserzaehlerFormData
+import type { Nebenkosten, Mieter, Wasserzaehler, Rechnung, Haus } from "@/lib/types" // Adjusted path, Removed WasserzaehlerFormData
 import { OptimizedNebenkosten, AbrechnungModalData } from "@/types/optimized-betriebskosten"; // Removed WasserzaehlerModalData
 import { isoToGermanDate } from "@/utils/date-calculations"
 import { Edit, Trash2, FileText, Droplets, ChevronsUpDown, ArrowUp, ArrowDown, Calendar, Building2, Euro, Calculator, MoreVertical, X, Download, Pencil, Loader2 } from "lucide-react"

--- a/components/water-meters/meter-ablesungen-modal.tsx
+++ b/components/water-meters/meter-ablesungen-modal.tsx
@@ -32,7 +32,7 @@ import { WaterDropletLoader } from "@/components/ui/water-droplet-loader";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { MeterImportModal } from "./meter-import-modal";
-import { Zaehler as SharedMeter, ZaehlerAblesung } from "@/lib/data-fetching";
+import type { Zaehler as SharedMeter, ZaehlerAblesung } from "@/lib/types";
 import { formatNumber } from "@/utils/format";
 import { ZaehlerTyp, ZAEHLER_CONFIG } from "@/lib/zaehler-types";
 import { getMeterIcon, getMeterBgColor } from "@/components/meters/meter-card";

--- a/components/water-meters/meter-import-modal.tsx
+++ b/components/water-meters/meter-import-modal.tsx
@@ -8,7 +8,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useToast } from "@/hooks/use-toast";
 import { Upload, Check, AlertTriangle, X, FileSpreadsheet, Loader2, Hash, Calendar, Gauge, Droplets } from "lucide-react";
-import { Zaehler as SharedMeter, ZaehlerAblesung } from "@/lib/data-fetching";
+import type { Zaehler as SharedMeter, ZaehlerAblesung } from "@/lib/types";
 import { bulkCreateAblesungen } from "@/app/meter-actions";
 import { isoToGermanDate } from "@/utils/date-calculations";
 import { StatCard } from "@/components/common/stat-card";

--- a/components/water-meters/wasserzaehler-modal.tsx
+++ b/components/water-meters/wasserzaehler-modal.tsx
@@ -16,7 +16,7 @@ import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { DatePicker } from "@/components/ui/date-picker";
 import { format } from "date-fns";
-import { Nebenkosten, Mieter, MeterReadingFormEntry, MeterReadingFormData, Wasserzaehler } from "@/lib/data-fetching";
+import type { Nebenkosten, Mieter, MeterReadingFormEntry, MeterReadingFormData, Wasserzaehler } from "@/lib/types";
 import { MeterModalData } from "@/types/optimized-betriebskosten";
 import { useToast } from "@/hooks/use-toast";
 import { useModalStore } from "@/hooks/use-modal-store";

--- a/hooks/use-modal-store.tsx
+++ b/hooks/use-modal-store.tsx
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { Nebenkosten, Mieter, Wasserzaehler, MeterReadingFormData } from '@/lib/data-fetching';
+import type { Nebenkosten, Mieter, Wasserzaehler, MeterReadingFormData } from "@/lib/types";
 import { MeterModalData } from '@/types/optimized-betriebskosten';
 import { Tenant, KautionData } from '@/types/Tenant';
 import { Template } from '@/types/template';

--- a/types/optimized-betriebskosten.ts
+++ b/types/optimized-betriebskosten.ts
@@ -12,7 +12,7 @@
  * @see .kiro/specs/betriebskosten-performance-optimization/design.md
  */
 
-import { Nebenkosten, Mieter, WasserZaehler, WasserAblesung, Rechnung } from "@/lib/data-fetching";
+import type { Nebenkosten, Mieter, WasserZaehler, WasserAblesung, Rechnung } from "@/lib/types";
 
 /**
  * OptimizedNebenkosten extends the existing Nebenkosten type with calculated fields

--- a/utils/abrechnung-calculations.ts
+++ b/utils/abrechnung-calculations.ts
@@ -6,7 +6,7 @@
  * and data validation.
  */
 
-import { Mieter, Nebenkosten, WasserZaehler, WasserAblesung } from "@/lib/data-fetching";
+import type { Mieter, Nebenkosten, WasserZaehler, WasserAblesung } from "@/lib/types";
 import { WATER_METER_TYPES } from "@/lib/zaehler-types";
 import { sumZaehlerValues } from "@/lib/zaehler-utils";
 import { calculateTenantOccupancy, TenantOccupancy } from "./date-calculations";

--- a/utils/water-cost-calculations.ts
+++ b/utils/water-cost-calculations.ts
@@ -8,7 +8,7 @@
  * - Prorated water usage for partial periods
  */
 
-import { Mieter, WasserAblesung, WasserZaehler } from "@/lib/data-fetching";
+import type { Mieter, WasserAblesung, WasserZaehler } from "@/lib/types";
 import { calculateTenantOccupancy } from "./date-calculations";
 
 /**

--- a/utils/wg-cost-calculations.ts
+++ b/utils/wg-cost-calculations.ts
@@ -1,4 +1,4 @@
-import { Mieter } from "@/lib/data-fetching";
+import type { Mieter } from "@/lib/types";
 
 // Get all occupants of an apartment by its ID
 export function getApartmentOccupants(tenants: Mieter[], apartmentId: string | null): Mieter[] {
@@ -34,7 +34,7 @@ export function computeWgFactorsByTenant(tenants: Mieter[], yearOrStartdatum: nu
   // Handle both year-based (backward compatibility) and date-range based calls
   let startDate: Date;
   let endDate: Date;
-  
+
   if (typeof yearOrStartdatum === 'number') {
     // Year-based call (backward compatibility)
     const year = yearOrStartdatum;
@@ -68,12 +68,12 @@ export function computeWgFactorsByTenant(tenants: Mieter[], yearOrStartdatum: nu
     for (let day = 0; day < totalDays; day++) {
       const currentDate = new Date(startDate);
       currentDate.setDate(startDate.getDate() + day);
-      
+
       const activeTenants = group.filter((t) => isTenantActiveOnDate(t, currentDate));
       const count = activeTenants.length;
-      
+
       if (count === 0) continue;
-      
+
       const shareEach = 1 / count;
       for (const t of activeTenants) {
         tenantShares[t.id] += shareEach;
@@ -92,6 +92,6 @@ export function computeWgFactorsByTenant(tenants: Mieter[], yearOrStartdatum: nu
 function isTenantActiveOnDate(tenant: Mieter, date: Date): boolean {
   const einzugDate = tenant.einzug ? new Date(tenant.einzug) : new Date('1900-01-01');
   const auszugDate = tenant.auszug ? new Date(tenant.auszug) : new Date('9999-12-31'); // Far future date for active tenants
-  
+
   return date >= einzugDate && date <= auszugDate;
 }


### PR DESCRIPTION
## Description

Converts domain-model imports to type-only imports from `@/lib/types`.

## Summary of Changes

- `import type` from `@/lib/types` replaces value imports from `@/lib/data-fetching` across meter actions, charts, finance components (abrechnung, betriebskosten edit, operating costs, sortable cost item), water-meter modals, the modal store, optimized-betriebskosten types and the calculation utilities
- Prevents the data-fetching module from being pulled into client bundles just for types