### PR TITLE
Optimize/lazy loading and config

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -28,9 +28,8 @@ import {
   NebenkostenChart
 } from "@/components/dashboard/dashboard-charts-wrapper"
 
-const formatCurrency = (amount: number) => {
-  return new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(amount);
-};
+const currencyFormatter = new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' });
+const formatCurrency = (amount: number) => currencyFormatter.format(amount);
 
 export default async function Dashboard() {
   // Fetch real data from database

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -28,6 +28,10 @@ import {
   NebenkostenChart
 } from "@/components/dashboard/dashboard-charts-wrapper"
 
+const formatCurrency = (amount: number) => {
+  return new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(amount);
+};
+
 export default async function Dashboard() {
   // Fetch real data from database
   const [summary, nebenkostenData] = await Promise.all([
@@ -145,7 +149,7 @@ export default async function Dashboard() {
             </CardHeader>
             <CardContent className="flex-1 flex flex-col justify-between pt-0 pb-6">
               <div className="flex items-center gap-2 mt-1">
-                <div className="text-lg font-bold leading-none">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.monatlicheEinnahmen)}</div>
+                <div className="text-lg font-bold leading-none">{formatCurrency(summary.monatlicheEinnahmen)}</div>
                 <div className="px-2 py-1 bg-muted text-muted-foreground text-xs font-medium rounded-full">
                   /Monat
                 </div>
@@ -165,7 +169,7 @@ export default async function Dashboard() {
             </CardHeader>
             <CardContent className="flex-1 flex flex-col justify-between pt-0 pb-6">
               <div className="flex items-center gap-2 mt-1">
-                <div className="text-lg font-bold leading-none">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.jaehrlicheAusgaben)}</div>
+                <div className="text-lg font-bold leading-none">{formatCurrency(summary.jaehrlicheAusgaben)}</div>
                 <div className="px-2 py-1 bg-muted text-muted-foreground text-xs font-medium rounded-full">
                   /Jahr
                 </div>
@@ -210,7 +214,7 @@ export default async function Dashboard() {
                 </CardHeader>
                 <CardContent className="flex-1 flex flex-col justify-between pt-0 pb-6">
                   <div className="flex items-center gap-2 mt-1">
-                    <div className="text-2xl font-bold leading-none">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.monatlicheEinnahmen)}</div>
+                    <div className="text-2xl font-bold leading-none">{formatCurrency(summary.monatlicheEinnahmen)}</div>
                     <div className="px-2 py-1 bg-muted text-muted-foreground text-xs font-medium rounded-full">
                       /Monat
                     </div>
@@ -230,7 +234,7 @@ export default async function Dashboard() {
                 </CardHeader>
                 <CardContent className="flex-1 flex flex-col justify-between pt-0 pb-6">
                   <div className="flex items-center gap-2 mt-1">
-                    <div className="text-2xl font-bold leading-none">{new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(summary.jaehrlicheAusgaben)}</div>
+                    <div className="text-2xl font-bold leading-none">{formatCurrency(summary.jaehrlicheAusgaben)}</div>
                     <div className="px-2 py-1 bg-muted text-muted-foreground text-xs font-medium rounded-full">
                       /Jahr
                     </div>

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -20,11 +20,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Building2, Home, Users, Wallet, FileSpreadsheet, CheckSquare } from "lucide-react"
 import { TenantPaymentBento } from "@/components/tenants/tenant-payment-bento"
 import { getDashboardSummary, getNebenkostenChartData } from "@/lib/data-fetching"
-import { RevenueExpensesChart } from "@/components/charts/revenue-expenses-chart"
-import { OccupancyChart } from "@/components/charts/occupancy-chart"
-import { MaintenanceDonutChart } from "@/components/charts/maintenance-donut-chart"
-import { NebenkostenChart } from "@/components/charts/nebenkosten-chart"
 import { LastTransactionsContainer } from "@/components/finance/last-transactions-container"
+import {
+  RevenueExpensesChart,
+  OccupancyChart,
+  MaintenanceDonutChart,
+  NebenkostenChart
+} from "@/components/dashboard/dashboard-charts-wrapper"
 
 export default async function Dashboard() {
   // Fetch real data from database

--- a/app/meter-actions.ts
+++ b/app/meter-actions.ts
@@ -2,7 +2,7 @@
 
 import { createClient } from "@/utils/supabase/server";
 import { revalidatePath } from "next/cache";
-import { Zaehler, ZaehlerAblesung, Wohnung, Mieter } from "@/lib/data-fetching";
+import type { Zaehler, ZaehlerAblesung, Wohnung, Mieter } from "@/lib/types";
 import { logAction } from '@/lib/logging-middleware';
 import { capturePostHogEvent } from '@/lib/posthog-helpers';
 

--- a/components/charts/nebenkosten-chart.tsx
+++ b/components/charts/nebenkosten-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { NebenkostenChartDatum } from "@/lib/data-fetching";
+import type { NebenkostenChartDatum } from "@/lib/types";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
 import { PieChart, Pie, Cell, Legend, Tooltip, ResponsiveContainer } from "recharts";
 
@@ -81,9 +81,9 @@ export function NebenkostenChart({ nebenkostenData, year }: NebenkostenChartProp
               paddingAngle={2}
             >
               {data.map((entry, idx) => (
-                <Cell 
-                  key={`cell-${idx}`} 
-                  fill={colors[idx % colors.length]} 
+                <Cell
+                  key={`cell-${idx}`}
+                  fill={colors[idx % colors.length]}
                 />
               ))}
             </Pie>

--- a/components/dashboard/dashboard-charts-wrapper.tsx
+++ b/components/dashboard/dashboard-charts-wrapper.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+// Loading component for charts
+const ChartSkeleton = () => (
+    <div className="h-full w-full flex items-center justify-center bg-gray-50 dark:bg-[#22272e] rounded-[2rem] border border-gray-200 dark:border-[#3C4251]">
+        <div className="animate-pulse flex flex-col items-center gap-2">
+            <div className="h-8 w-8 rounded-full bg-gray-200 dark:bg-gray-700" />
+            <div className="h-4 w-24 rounded bg-gray-200 dark:bg-gray-700" />
+        </div>
+    </div>
+);
+
+export const RevenueExpensesChart = dynamic(
+    () => import("@/components/charts/revenue-expenses-chart").then(mod => mod.RevenueExpensesChart),
+    { ssr: false, loading: () => <ChartSkeleton /> }
+);
+
+export const OccupancyChart = dynamic(
+    () => import("@/components/charts/occupancy-chart").then(mod => mod.OccupancyChart),
+    { ssr: false, loading: () => <ChartSkeleton /> }
+);
+
+export const MaintenanceDonutChart = dynamic(
+    () => import("@/components/charts/maintenance-donut-chart").then(mod => mod.MaintenanceDonutChart),
+    { ssr: false, loading: () => <ChartSkeleton /> }
+);
+
+export const NebenkostenChart = dynamic(
+    () => import("@/components/charts/nebenkosten-chart").then(mod => mod.NebenkostenChart),
+    { ssr: false, loading: () => <ChartSkeleton /> }
+);

--- a/components/finance/abrechnung-modal.tsx
+++ b/components/finance/abrechnung-modal.tsx
@@ -22,7 +22,7 @@ import { ExportAbrechnungDropdown } from "@/components/abrechnung/export-abrechn
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"; // Added Card imports
 import { HoverCard, HoverCardTrigger, HoverCardContent } from "@/components/ui/hover-card";
 import { CustomCombobox, ComboboxOption } from "@/components/ui/custom-combobox";
-import { Nebenkosten, Mieter, Wohnung, Rechnung, WasserZaehler, WasserAblesung } from "@/lib/data-fetching"; // Updated imports for new water system
+import type { Nebenkosten, Mieter, Wohnung, Rechnung, WasserZaehler, WasserAblesung } from "@/lib/types"; // Updated imports for new water system
 import { WATER_METER_TYPES } from "@/lib/zaehler-types";
 import { sumZaehlerValues } from "@/lib/zaehler-utils";
 import { useEffect, useState, useMemo, useRef } from "react"; // Import useEffect, useState, useMemo, and useRef

--- a/components/finance/betriebskosten-edit-modal.tsx
+++ b/components/finance/betriebskosten-edit-modal.tsx
@@ -37,7 +37,7 @@ import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Mieter, Nebenkosten, RechnungSql } from "@/lib/data-fetching";
+import type { Mieter, Nebenkosten, RechnungSql } from "@/lib/types";
 import { ZAEHLER_CONFIG, ZaehlerTyp } from "@/lib/zaehler-types";
 import { convertZaehlerkostenToStrings } from "@/lib/zaehler-utils";
 import { BerechnungsartValue, BERECHNUNGSART_OPTIONS } from "@/lib/constants";

--- a/components/finance/operating-costs-filters.tsx
+++ b/components/finance/operating-costs-filters.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { SearchInput } from "@/components/ui/search-input"
 import { CustomCombobox } from "@/components/ui/custom-combobox"
-import { Haus } from "@/lib/data-fetching"
+import type { Haus } from "@/lib/types"
 
 const ALL_HOUSES_LABEL = 'Alle Häuser'
 const ALL_HOUSES_VALUE = 'all'
@@ -18,16 +18,16 @@ interface OperatingCostsFiltersProps {
   searchQuery?: string
 }
 
-export function OperatingCostsFilters({ 
-  onFilterChange, 
-  onSearchChange, 
+export function OperatingCostsFilters({
+  onFilterChange,
+  onSearchChange,
   onHouseChange,
   haeuser = [],
   selectedHouseId = ALL_HOUSES_VALUE,
   searchQuery = ""
 }: OperatingCostsFiltersProps) {
   const [activeFilter, setActiveFilter] = useState("all")
-  
+
   const houseOptions = useMemo(() => [
     { value: ALL_HOUSES_VALUE, label: ALL_HOUSES_LABEL },
     ...haeuser.map((haus) => ({ value: haus.id, label: haus.name }))

--- a/components/finance/operating-costs-filters.tsx
+++ b/components/finance/operating-costs-filters.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { SearchInput } from "@/components/ui/search-input"
 import { CustomCombobox } from "@/components/ui/custom-combobox"
-import type { Haus } from "@/lib/types"
+import type { Haus } from "@/lib/types";
 
 const ALL_HOUSES_LABEL = 'Alle Häuser'
 const ALL_HOUSES_VALUE = 'all'

--- a/components/finance/operating-costs-overview-modal.tsx
+++ b/components/finance/operating-costs-overview-modal.tsx
@@ -5,7 +5,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Button } from "@/components/ui/button"
 import { FileDown } from "lucide-react"
-import type { Nebenkosten } from "@/lib/types"
+import type { Nebenkosten } from "@/lib/types";
 import { ZAEHLER_CONFIG, ZaehlerTyp } from "@/lib/zaehler-types"
 import { OptimizedNebenkosten } from "@/types/optimized-betriebskosten"
 import { isoToGermanDate } from "@/utils/date-calculations"

--- a/components/finance/operating-costs-overview-modal.tsx
+++ b/components/finance/operating-costs-overview-modal.tsx
@@ -5,7 +5,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Button } from "@/components/ui/button"
 import { FileDown } from "lucide-react"
-import { Nebenkosten } from "@/lib/data-fetching"
+import type { Nebenkosten } from "@/lib/types"
 import { ZAEHLER_CONFIG, ZaehlerTyp } from "@/lib/zaehler-types"
 import { OptimizedNebenkosten } from "@/types/optimized-betriebskosten"
 import { isoToGermanDate } from "@/utils/date-calculations"

--- a/components/finance/sortable-cost-item.tsx
+++ b/components/finance/sortable-cost-item.tsx
@@ -13,7 +13,7 @@ import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Mieter } from "@/lib/data-fetching";
+import type { Mieter } from "@/lib/types";
 import { BerechnungsartValue, BERECHNUNGSART_OPTIONS } from "@/lib/constants";
 
 export interface CostItem {

--- a/components/tables/operating-costs-table.tsx
+++ b/components/tables/operating-costs-table.tsx
@@ -24,7 +24,7 @@ import {
   AlertDialogAction,
   AlertDialogCancel
 } from "@/components/ui/alert-dialog"
-import { Nebenkosten, Mieter, Wasserzaehler, Rechnung, Haus } from "@/lib/data-fetching" // Adjusted path, Removed WasserzaehlerFormData
+import type { Nebenkosten, Mieter, Wasserzaehler, Rechnung, Haus } from "@/lib/types" // Adjusted path, Removed WasserzaehlerFormData
 import { OptimizedNebenkosten, AbrechnungModalData } from "@/types/optimized-betriebskosten"; // Removed WasserzaehlerModalData
 import { isoToGermanDate } from "@/utils/date-calculations"
 import { Edit, Trash2, FileText, Droplets, ChevronsUpDown, ArrowUp, ArrowDown, Calendar, Building2, Euro, Calculator, MoreVertical, X, Download, Pencil, Loader2 } from "lucide-react"

--- a/components/tables/operating-costs-table.tsx
+++ b/components/tables/operating-costs-table.tsx
@@ -24,7 +24,7 @@ import {
   AlertDialogAction,
   AlertDialogCancel
 } from "@/components/ui/alert-dialog"
-import type { Nebenkosten, Mieter, Wasserzaehler, Rechnung, Haus } from "@/lib/types" // Adjusted path, Removed WasserzaehlerFormData
+import type { Nebenkosten, Mieter, Wasserzaehler, Rechnung, Haus } from "@/lib/types";
 import { OptimizedNebenkosten, AbrechnungModalData } from "@/types/optimized-betriebskosten"; // Removed WasserzaehlerModalData
 import { isoToGermanDate } from "@/utils/date-calculations"
 import { Edit, Trash2, FileText, Droplets, ChevronsUpDown, ArrowUp, ArrowDown, Calendar, Building2, Euro, Calculator, MoreVertical, X, Download, Pencil, Loader2 } from "lucide-react"
@@ -216,9 +216,9 @@ export function OperatingCostsTable({
           metersCount: Array.isArray(result.data.meters) ? result.data.meters.length : 'n/a',
           readingsCount: Array.isArray(result.data.readings) ? result.data.readings.length : 'n/a',
           firstTenant: Array.isArray(result.data.tenants) && result.data.tenants.length > 0 ? {
-            id: (result.data.tenants[0] as any).id,
-            name: (result.data.tenants[0] as any).name,
-            wohnung_id: (result.data.tenants[0] as any).wohnung_id,
+            id: result.data.tenants[0].id,
+            name: result.data.tenants[0].name,
+            wohnung_id: result.data.tenants[0].wohnung_id,
           } : null,
         });
         setAbrechnungModalData(result.data);

--- a/components/water-meters/meter-ablesungen-modal.tsx
+++ b/components/water-meters/meter-ablesungen-modal.tsx
@@ -32,7 +32,7 @@ import { WaterDropletLoader } from "@/components/ui/water-droplet-loader";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { MeterImportModal } from "./meter-import-modal";
-import { Zaehler as SharedMeter, ZaehlerAblesung } from "@/lib/data-fetching";
+import type { Zaehler as SharedMeter, ZaehlerAblesung } from "@/lib/types";
 import { formatNumber } from "@/utils/format";
 import { ZaehlerTyp, ZAEHLER_CONFIG } from "@/lib/zaehler-types";
 import { getMeterIcon, getMeterBgColor } from "@/components/meters/meter-card";

--- a/components/water-meters/meter-import-modal.tsx
+++ b/components/water-meters/meter-import-modal.tsx
@@ -8,7 +8,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useToast } from "@/hooks/use-toast";
 import { Upload, Check, AlertTriangle, X, FileSpreadsheet, Loader2, Hash, Calendar, Gauge, Droplets } from "lucide-react";
-import { Zaehler as SharedMeter, ZaehlerAblesung } from "@/lib/data-fetching";
+import type { Zaehler as SharedMeter, ZaehlerAblesung } from "@/lib/types";
 import { bulkCreateAblesungen } from "@/app/meter-actions";
 import { isoToGermanDate } from "@/utils/date-calculations";
 import { StatCard } from "@/components/common/stat-card";

--- a/components/water-meters/wasserzaehler-modal.tsx
+++ b/components/water-meters/wasserzaehler-modal.tsx
@@ -16,7 +16,7 @@ import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { DatePicker } from "@/components/ui/date-picker";
 import { format } from "date-fns";
-import { Nebenkosten, Mieter, MeterReadingFormEntry, MeterReadingFormData, Wasserzaehler } from "@/lib/data-fetching";
+import type { Nebenkosten, Mieter, MeterReadingFormEntry, MeterReadingFormData, Wasserzaehler } from "@/lib/types";
 import { MeterModalData } from "@/types/optimized-betriebskosten";
 import { useToast } from "@/hooks/use-toast";
 import { useModalStore } from "@/hooks/use-modal-store";

--- a/hooks/use-modal-store.tsx
+++ b/hooks/use-modal-store.tsx
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { Nebenkosten, Mieter, Wasserzaehler, MeterReadingFormData } from '@/lib/data-fetching';
+import type { Nebenkosten, Mieter, Wasserzaehler, MeterReadingFormData } from "@/lib/types";
 import { MeterModalData } from '@/types/optimized-betriebskosten';
 import { Tenant, KautionData } from '@/types/Tenant';
 import { Template } from '@/types/template';

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -28,6 +28,19 @@ const nextConfig = {
   experimental: {
     optimizeCss: true,
     scrollRestoration: true,
+    optimizePackageImports: [
+      'recharts',
+      'lucide-react',
+      'framer-motion',
+      'date-fns',
+      '@dnd-kit/core',
+      '@dnd-kit/sortable',
+      '@dnd-kit/utilities',
+      '@radix-ui/react-dialog',
+      '@radix-ui/react-select',
+      '@radix-ui/react-popover',
+      '@radix-ui/react-dropdown-menu',
+    ],
   },
   webpack: (config, { webpack }) => {
     // Stub and ignore 'ws' module in all builds

--- a/types/optimized-betriebskosten.ts
+++ b/types/optimized-betriebskosten.ts
@@ -12,7 +12,7 @@
  * @see .kiro/specs/betriebskosten-performance-optimization/design.md
  */
 
-import { Nebenkosten, Mieter, WasserZaehler, WasserAblesung, Rechnung } from "@/lib/data-fetching";
+import type { Nebenkosten, Mieter, WasserZaehler, WasserAblesung, Rechnung } from "@/lib/types";
 
 /**
  * OptimizedNebenkosten extends the existing Nebenkosten type with calculated fields

--- a/utils/abrechnung-calculations.ts
+++ b/utils/abrechnung-calculations.ts
@@ -6,7 +6,7 @@
  * and data validation.
  */
 
-import { Mieter, Nebenkosten, WasserZaehler, WasserAblesung } from "@/lib/data-fetching";
+import type { Mieter, Nebenkosten, WasserZaehler, WasserAblesung } from "@/lib/types";
 import { WATER_METER_TYPES } from "@/lib/zaehler-types";
 import { sumZaehlerValues } from "@/lib/zaehler-utils";
 import { calculateTenantOccupancy, TenantOccupancy } from "./date-calculations";

--- a/utils/water-cost-calculations.ts
+++ b/utils/water-cost-calculations.ts
@@ -8,7 +8,7 @@
  * - Prorated water usage for partial periods
  */
 
-import { Mieter, WasserAblesung, WasserZaehler } from "@/lib/data-fetching";
+import type { Mieter, WasserAblesung, WasserZaehler } from "@/lib/types";
 import { calculateTenantOccupancy } from "./date-calculations";
 
 /**

--- a/utils/wg-cost-calculations.ts
+++ b/utils/wg-cost-calculations.ts
@@ -1,4 +1,4 @@
-import { Mieter } from "@/lib/data-fetching";
+import type { Mieter } from "@/lib/types";
 
 // Get all occupants of an apartment by its ID
 export function getApartmentOccupants(tenants: Mieter[], apartmentId: string | null): Mieter[] {
@@ -34,7 +34,7 @@ export function computeWgFactorsByTenant(tenants: Mieter[], yearOrStartdatum: nu
   // Handle both year-based (backward compatibility) and date-range based calls
   let startDate: Date;
   let endDate: Date;
-  
+
   if (typeof yearOrStartdatum === 'number') {
     // Year-based call (backward compatibility)
     const year = yearOrStartdatum;
@@ -68,12 +68,12 @@ export function computeWgFactorsByTenant(tenants: Mieter[], yearOrStartdatum: nu
     for (let day = 0; day < totalDays; day++) {
       const currentDate = new Date(startDate);
       currentDate.setDate(startDate.getDate() + day);
-      
+
       const activeTenants = group.filter((t) => isTenantActiveOnDate(t, currentDate));
       const count = activeTenants.length;
-      
+
       if (count === 0) continue;
-      
+
       const shareEach = 1 / count;
       for (const t of activeTenants) {
         tenantShares[t.id] += shareEach;
@@ -92,6 +92,6 @@ export function computeWgFactorsByTenant(tenants: Mieter[], yearOrStartdatum: nu
 function isTenantActiveOnDate(tenant: Mieter, date: Date): boolean {
   const einzugDate = tenant.einzug ? new Date(tenant.einzug) : new Date('1900-01-01');
   const auszugDate = tenant.auszug ? new Date(tenant.auszug) : new Date('9999-12-31'); // Far future date for active tenants
-  
+
   return date >= einzugDate && date <= auszugDate;
 }


### PR DESCRIPTION
## Description

Bundle-size optimization: dashboard charts lazy-loaded, type-only imports everywhere, and package-import optimization enabled.

## Summary of Changes

- New `dashboard-charts-wrapper.tsx`: all four dashboard charts dynamically imported (`ssr: false`) with a skeleton fallback; currency formatter hoisted to module level
- `next.config.mjs`: `optimizePackageImports` for recharts, lucide-react, framer-motion, date-fns, dnd-kit and the radix dialog/select/popover/dropdown-menu packages
- Domain types now imported with `import type` from `@/lib/types` (instead of value imports from `@/lib/data-fetching`) across finance/water-meter components, hooks, types and calculation utils
- `abrechnung-modal.tsx`: `getTenantMeterCost` is a proper import (no runtime `require`), tenant access typed instead of `as any`