### PR TITLE
fix(posthog): implementation of reverse proxy to bypass ad-blockers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# Supabase Configuration
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-project-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
+
+# Stripe Configuration
+STRIPE_SECRET_KEY=your-stripe-secret-key
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=your-stripe-publishable-key
+STRIPE_WEBHOOK_SECRET=your-stripe-webhook-secret
+
+# PostHog Configuration
+NEXT_PUBLIC_POSTHOG_KEY=your-posthog-key
+NEXT_PUBLIC_POSTHOG_HOST=/ingest
+
+# Notion Configuration (for documentation system)
+NOTION_API_KEY=your-notion-integration-token
+NOTION_DATABASE_ID=your-notion-database-id
+
+# Gemini AI Configuration
+GEMINI_API_KEY=your-gemini-api-key
+
+# Application Configuration
+NEXTAUTH_URL=https://your-domain.com
+NEXTAUTH_SECRET=your-nextauth-secret
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Microsoft Outlook OAuth Configuration
+OUTLOOK_CLIENT_ID=your-azure-client-id
+OUTLOOK_CLIENT_SECRET=your-azure-client-secret
+OUTLOOK_TENANT_ID=your-azure-tenant-id
+OUTLOOK_REDIRECT_URI=http://localhost:3000/api/auth/outlook/callback

--- a/app/api/posthog-config/route.ts
+++ b/app/api/posthog-config/route.ts
@@ -7,7 +7,7 @@ export async function GET() {
   // Use the exact names from Cloudflare: POSTHOG_API_KEY, POSTHOG_HOST, POSTHOG_ENV_ID
   const config = {
     key: process.env.POSTHOG_API_KEY || process.env.NEXT_PUBLIC_POSTHOG_KEY,
-    host: process.env.POSTHOG_HOST || process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.i.posthog.com',
+    host: '/ingest', // Always return the proxy path to the client
     envId: process.env.POSTHOG_ENV_ID
   }
 

--- a/components/providers/posthog-provider.tsx
+++ b/components/providers/posthog-provider.tsx
@@ -13,8 +13,16 @@ async function initializePostHog(nonce?: string) {
 
   let config = {
     key: process.env.NEXT_PUBLIC_POSTHOG_KEY,
-    host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://eu.i.posthog.com'
+    host: process.env.NEXT_PUBLIC_POSTHOG_HOST || '/ingest' // Default to our proxy
   };
+
+  // If host is a relative path, we need to make it absolute for the init call if needed, 
+  // but posthog-js handles paths starting with / as relative to the current origin.
+  if (config.host.startsWith('/')) {
+    if (typeof window !== 'undefined') {
+      config.host = window.location.origin + config.host;
+    }
+  }
 
   // If client-side env vars are not available, try to fetch from API
   if (!config.key || config.key === 'phc_placeholder_key') {

--- a/components/providers/posthog-provider.tsx
+++ b/components/providers/posthog-provider.tsx
@@ -60,6 +60,7 @@ async function initializePostHog(nonce?: string) {
   // This applies to ALL pages including landing and documentation pages
   posthog.init(config.key, {
     api_host: config.host,
+    ui_host: config.host, // Proxy UI assets and flags as well
     capture_pageview: false, // We'll handle this manually
     persistence: 'localStorage',
     enable_recording_console_log: false, // Disabled: don't capture console logs in session recordings

--- a/middleware.ts
+++ b/middleware.ts
@@ -97,7 +97,8 @@ export async function middleware(request: NextRequest) {
     '/loesungen(/.*)?', // All routes under loesungen
     '/funktionen(/.*)?', // All routes under funktionen
     '/warteliste(/.*)?', // All routes under warteliste
-    '/preise' // Pricing page
+    '/preise', // Pricing page
+    '/ingest(.*)?' // PostHog proxy route
   ]
 
   // If we're already on the login page, don't redirect


### PR DESCRIPTION
## Description

Routes all PostHog traffic through the `/ingest` reverse proxy and documents the environment setup.

## Summary of Changes

- `posthog-config` route: always returns `/ingest` as the host so clients never talk to PostHog directly
- `posthog-provider`: defaults to the `/ingest` proxy (resolved against the current origin client-side) and sets `ui_host` so flags/assets go through the proxy too
- Middleware: `/ingest(.*)?` added to the public routes
- New `.env.example`: Supabase, Stripe, PostHog, Notion, Gemini, NextAuth and Outlook variables