### PR TITLE
feat(oauth): add ChatGPT to redirect URI whitelist

### DIFF
--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -17,6 +17,9 @@ const ALLOWED_REDIRECT_PATTERNS = [
     // Allow localhost for development
     /^http:\/\/localhost(:\d+)?/,
     /^http:\/\/127\.0\.0\.1(:\d+)?/,
+    // Allow ChatGPT Apps OAuth callbacks (production + app review)
+    /^https:\/\/chatgpt\.com\/connector_platform_oauth_redirect(\?.*)?$/,
+    /^https:\/\/platform\.openai\.com\/apps-manage\/oauth(\?.*)?$/,
 ];
 
 /**


### PR DESCRIPTION
Allow chatgpt.com as a valid OAuth redirect destination to enable GPT Actions authentication flow with MietEvo.