### PR TITLE
fix(oauth): allow mcp worker callback redirect

### DIFF
--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -20,6 +20,8 @@ const ALLOWED_REDIRECT_PATTERNS = [
     // Allow ChatGPT Apps OAuth callbacks (production + app review)
     /^https:\/\/chatgpt\.com\/connector_platform_oauth_redirect(\?.*)?$/,
     /^https:\/\/platform\.openai\.com\/apps-manage\/oauth(\?.*)?$/,
+    // Allow MCP Worker callback proxy
+    /^https:\/\/mcp\.mietevo\.de\/callback(\?.*)?$/,
 ];
 
 /**


### PR DESCRIPTION
## Description

Allows the MCP worker's `/callback` endpoint as a redirect target in the OAuth consent flow.

## Summary of Changes

- `oauth/consent/page.tsx`: `https://mcp.mietevo.de/callback` added to the redirect-URI whitelist