### PR TITLE
feat: implement oauth state recovery and preserve query params on red…

### DIFF
--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -40,12 +40,14 @@ function isValidRedirectUri(uri: string | null): boolean {
     }
 }
 
+const OAUTH_PARAMS_SESSION_KEY = 'mcp_oauth_params';
+
 function ConsentContent() {
     const searchParams = useSearchParams();
 
     // Recovery Logic: Try to get parameters from URL, then fallback to sessionStorage
     // This handles cases where internal redirects (like login or session refresh) strip the URL.
-    const [oauthState, setOauthState] = useState<{
+    const [oauthState] = useState<{
         client_id: string | null;
         state: string | null;
         redirect_uri: string | null;
@@ -65,18 +67,21 @@ function ConsentContent() {
         // If we have all primary params, use them and save them
         if (fromUrl.client_id && fromUrl.state) {
             if (typeof window !== 'undefined') {
-                sessionStorage.setItem('mcp_oauth_params', JSON.stringify(fromUrl));
+                sessionStorage.setItem(OAUTH_PARAMS_SESSION_KEY, JSON.stringify(fromUrl));
             }
             return fromUrl;
         }
 
         // Otherwise, try to recover from session storage
         if (typeof window !== 'undefined') {
-            const saved = sessionStorage.getItem('mcp_oauth_params');
+            const saved = sessionStorage.getItem(OAUTH_PARAMS_SESSION_KEY);
             if (saved) {
                 try {
                     return JSON.parse(saved);
-                } catch { }
+                } catch (e) {
+                    console.error('Failed to parse OAuth params from sessionStorage:', e);
+                    sessionStorage.removeItem(OAUTH_PARAMS_SESSION_KEY);
+                }
             }
         }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -97,7 +97,8 @@ export async function middleware(request: NextRequest) {
     '/loesungen(/.*)?', // All routes under loesungen
     '/funktionen(/.*)?', // All routes under funktionen
     '/warteliste(/.*)?', // All routes under warteliste
-    '/preise' // Pricing page
+    '/preise', // Pricing page
+    '/oauth(.*)?' // OAuth consent and related routes
   ]
 
   // If we're already on the login page, don't redirect
@@ -116,9 +117,11 @@ export async function middleware(request: NextRequest) {
     } else {
       // For non-API routes, redirect to login
       const url = new URL('/auth/login', request.url);
-      // Only set redirect search param if it's not an auth route and not an _next route (already covered by non-API)
-      if (!pathname.startsWith('/_next/')) { // No need to check /api/ here
-        url.searchParams.set('redirect', pathname);
+      // Only set redirect search param if it's not an auth route and not an _next route
+      if (!pathname.startsWith('/_next/')) {
+        // PRESERVE the entire original path including query parameters (like client_id, state, etc.)
+        const fullPath = `${pathname}${request.nextUrl.search}`;
+        url.searchParams.set('redirect', fullPath);
       }
       return NextResponse.redirect(url);
     }


### PR DESCRIPTION
## Description

Preserves the OAuth parameters across internal redirects (login, session refresh) so the consent flow no longer loses context.

## Summary of Changes

- Consent page: parameters from the URL are stored in `sessionStorage` (`mcp_oauth_params`) and recovered when a later redirect strips them
- Middleware: `/oauth(.*)?` added to the public routes; the login redirect now preserves the full original path including query parameters (`client_id`, `state`, etc.)