### PR TITLE
refactor: extract landing page logic into custom hooks to reduce code…

### DIFF
--- a/app/(landing)/page.tsx
+++ b/app/(landing)/page.tsx
@@ -13,82 +13,25 @@ import BottomCTA from '@/components/ui/bottom-cta';
 
 import Pricing from '@/app/modern/components/pricing';
 import NebenkostenSection from '@/app/modern/components/nebenkosten-section';
-import { createClient } from '@/utils/supabase/client';
-import { User } from '@supabase/supabase-js';
-import { Profile } from '@/types/supabase';
-import { useToast } from '@/hooks/use-toast';
-import { loadStripe } from '@stripe/stripe-js';
+import { useStripeIntegration } from '@/hooks/use-stripe-integration';
+import { usePlanSelectionRedirect } from '@/hooks/use-plan-selection-redirect';
+import { useLandingRedirects } from '@/hooks/use-landing-redirects';
 import { trackSectionViewed, type LandingSection } from '@/lib/posthog-landing-events';
 import { ROUTES } from '@/lib/constants';
-
-const stripePromise = loadStripe(
-  process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!
-);
-
-const MAIN_PLAN_PRICE_ID = process.env.NEXT_PUBLIC_STRIPE_PRICE_ID_MAIN || 'price_basic_monthly_placeholder';
-
-function ProfileErrorToastHandler() {
-  const searchParams = useSearchParams();
-  const router = useRouter();
-  const { toast } = useToast();
-
-  useEffect(() => {
-    const errorParam = searchParams.get('error');
-    if (errorParam === 'profile_fetch_failed') {
-      toast({
-        title: "Error",
-        description: "Could not retrieve your user details. Please try logging in again or contact support if the issue persists.",
-        variant: "destructive",
-      });
-      router.replace('/', { scroll: false });
-    }
-  }, [searchParams, router, toast]);
-
-  return null;
-}
-
-// Component that handles URL parameters
-function URLParamHandler() {
-  const searchParams = useSearchParams();
-  const router = useRouter();
-  const [sessionUser, setSessionUser] = useState<User | null>(null);
-  const [isLoadingUser, setIsLoadingUser] = useState(true);
-  const supabase = createClient();
-
-  useEffect(() => {
-    const fetchUser = async () => {
-      const { data: { user } } = await supabase.auth.getUser();
-      setSessionUser(user);
-      setIsLoadingUser(false);
-    };
-    fetchUser();
-  }, [supabase]);
-
-  // Handle URL parameter for "get started" flow
-  useEffect(() => {
-    if (isLoadingUser) {
-      return; // Wait until we've checked the user's auth status
-    }
-
-    const getStarted = searchParams.get('getStarted');
-    if (getStarted === 'true' && !sessionUser) {
-      router.push('/auth/login');
-    }
-  }, [searchParams, sessionUser, router, isLoadingUser]);
-
-  return null;
-}
 
 // Main content component that uses the auth modal context
 function LandingPageContent() {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const { toast } = useToast();
-  const supabase = createClient();
+  const {
+    sessionUser,
+    userProfile,
+    isProcessingCheckout,
+    isLoadingProfile,
+    handleAuthFlow
+  } = useStripeIntegration();
 
-  const [userProfile, setUserProfile] = useState<Profile | null>(null);
-  const [isProcessingCheckout, setIsProcessingCheckout] = useState(false);
-  const [sessionUser, setSessionUser] = useState<User | null>(null);
+  usePlanSelectionRedirect(sessionUser, userProfile, isProcessingCheckout, handleAuthFlow);
+  useLandingRedirects(sessionUser, isLoadingProfile, '/');
 
   // Scroll-depth tracking
   const pageLoadTimeRef = useRef<number>(Date.now());
@@ -135,268 +78,58 @@ function LandingPageContent() {
     return () => observer.disconnect();
   }, []);
 
-  useEffect(() => {
-    const fetchInitialUserAndProfile = async () => {
-      const { data: { user } } = await supabase.auth.getUser();
-      setSessionUser(user);
-      if (user) {
-        fetchUserProfile(user.id);
-      } else {
-        setUserProfile(null);
-      }
-    };
-
-    fetchInitialUserAndProfile();
-
-    const { data: authListener } = supabase.auth.onAuthStateChange(async (event, session) => {
-      setSessionUser(session?.user ?? null);
-      if (event === 'SIGNED_IN' && session?.user) {
-        fetchUserProfile(session.user.id);
-      } else if (event === 'SIGNED_OUT') {
-        setUserProfile(null);
-      }
-    });
-
-    return () => {
-      authListener?.subscription.unsubscribe();
-    };
-  }, [supabase, router]);
-
-  // Handle price selection from URL after redirect back from login
-  useEffect(() => {
-    const priceId = searchParams.get('priceId');
-    if (priceId && sessionUser && userProfile && !isProcessingCheckout) {
-      // Clear the priceId from URL to prevent re-triggering on refresh
-      const newParams = new URLSearchParams(searchParams.toString());
-      newParams.delete('priceId');
-      const searchStr = newParams.toString();
-      const newUrl = `${window.location.pathname}${searchStr ? '?' + searchStr : ''}`;
-      window.history.replaceState({}, '', newUrl);
-
-      handleAuthFlow(priceId);
-    }
-  }, [searchParams, sessionUser, userProfile, isProcessingCheckout]);
-
-  const fetchUserProfile = async (userId: string) => {
-    try {
-      const { data, error } = await supabase
-        .from('profiles')
-        .select('id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_price_id')
-        .eq('id', userId)
-        .single();
-
-      if (error && error.code !== 'PGRST116') {
-        throw error;
-      }
-      setUserProfile(data as Profile | null);
-    } catch (error) {
-      console.error('Error fetching user profile:', error);
-      setUserProfile(null);
-    }
-  };
-
-  const proceedToCheckout = async (priceId: string) => {
-    setIsProcessingCheckout(true);
-    if (!sessionUser) {
-      console.error('User not logged in for proceedToCheckout');
-      toast({ title: 'Authentication Required', description: 'Please log in to proceed with checkout.', variant: 'default' });
-      setIsProcessingCheckout(false);
-      return;
-    }
-
-    if (!sessionUser.email || !sessionUser.id) {
-      console.error('User details missing in proceedToCheckout');
-      toast({ title: 'Error', description: 'User information not fully available. Please try logging in again.', variant: 'destructive' });
-      setIsProcessingCheckout(false);
-      return;
-    }
-
-    const customerEmail = sessionUser.email;
-    const userId = sessionUser.id;
-
-    try {
-      const response = await fetch('/api/stripe/checkout-session', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          priceId: priceId,
-          customerEmail: customerEmail,
-          userId: userId,
-        }),
-      });
-
-      if (response.status === 409) {
-        const errorData = await response.json();
-        toast({
-          title: 'Subscription Information',
-          description: errorData.message || 'You are already subscribed.',
-          variant: 'default',
-        });
-        return;
-      }
-
-      if (!response.ok) {
-        let errorMessage = `HTTP error ${response.status}`;
-        try {
-          const errorBody = await response.json();
-          errorMessage = errorBody.error || errorBody.message || JSON.stringify(errorBody);
-        } catch (e) {
-          try {
-            const textError = await response.text();
-            errorMessage = textError.substring(0, 100);
-          } catch (textE) {
-            errorMessage = response.statusText || `HTTP error ${response.status}`;
-          }
-        }
-        throw new Error(`Failed to create checkout session: ${errorMessage}`);
-      }
-
-      const { url } = await response.json();
-
-      if (url) {
-        router.push(url);
-      } else {
-        throw new Error('URL missing from checkout session response.');
-      }
-    } catch (error) {
-      console.error('Subscription error:', error);
-      toast({ title: 'Subscription Error', description: (error as Error).message || 'Could not initiate subscription.', variant: 'destructive' });
-    } finally {
-      setIsProcessingCheckout(false);
-    }
-  };
-
-  const handleAuthFlow = async (priceId: string) => {
-    if (isProcessingCheckout) return;
-
-    if (sessionUser && userProfile) {
-      const hasActiveSubscription = userProfile.stripe_subscription_status === 'active' || userProfile.stripe_subscription_status === 'trialing';
-      if (hasActiveSubscription) {
-        await redirectToCustomerPortal();
-      } else {
-        await proceedToCheckout(priceId);
-      }
-    } else if (sessionUser && !userProfile) {
-      toast({
-        title: 'Please wait',
-        description: 'User details are still loading. Please try again shortly.',
-        variant: 'default',
-      });
-    } else {
-      // Preserve plan selection for unauthenticated users by redirecting with context.
-      const redirectPath = `${window.location.pathname}?priceId=${priceId}`;
-      router.push(`/auth/login?redirect=${encodeURIComponent(redirectPath)}`);
-    }
-  };
-
-  const redirectToCustomerPortal = async () => {
-    setIsProcessingCheckout(true);
-    if (!sessionUser || !sessionUser.id) {
-      toast({ title: 'Error', description: 'User not found. Please log in again.', variant: 'destructive' });
-      setIsProcessingCheckout(false);
-      return;
-    }
-
-    try {
-      const response = await fetch('/api/stripe/customer-portal', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          userId: sessionUser.id,
-        }),
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to create customer portal session.');
-      }
-
-      const { url } = await response.json();
-      if (url) {
-        window.location.href = url;
-      } else {
-        throw new Error('Customer portal URL not found in response.');
-      }
-    } catch (error) {
-      console.error('Error redirecting to customer portal:', error);
-      toast({ title: 'Error', description: (error as Error).message || 'Could not redirect to customer portal.', variant: 'destructive' });
-    } finally {
-      setIsProcessingCheckout(false);
-    }
+  const handleSelectPlan = async (priceId: string) => {
+    await handleAuthFlow(priceId, window.location.pathname);
   };
 
   const handleGetStarted = async () => {
     if (sessionUser) {
       router.push(ROUTES.HOME);
     } else {
-      // Redirect to login page as per user request
       router.push('/auth/login');
     }
   };
 
-  const handleSelectPlan = async (priceId: string) => {
-    if (sessionUser) {
-      await handleAuthFlow(priceId);
-    } else {
-      // Preserve plan selection for unauthenticated users by redirecting with context.
-      const redirectPath = `${window.location.pathname}?priceId=${priceId}`;
-      router.push(`/auth/login?redirect=${encodeURIComponent(redirectPath)}`);
-    }
-  };
-
-
   return (
-    <>
-      <Suspense fallback={null}>
-        <ProfileErrorToastHandler />
-      </Suspense>
-      <Suspense fallback={null}>
-        <URLParamHandler />
-      </Suspense>
-      <div className="min-h-screen overflow-x-hidden">
-        <div id="hero">
-          <Hero onGetStarted={handleGetStarted} />
-        </div>
-        <div id="product-showcase">
-          <ProductShowcase />
-        </div>
-        <div id="features">
-          <FeatureSections />
-        </div>
-        <div id="nebenkosten">
-          <NebenkostenSection />
-        </div>
-
-        <div id="more-features">
-          <MoreFeatures />
-        </div>
-        <div id="pricing">
-          <Pricing
-            onSelectPlan={handleSelectPlan}
-            userProfile={userProfile}
-            isLoading={isProcessingCheckout}
-            showComparison={false}
-            showViewAllButton={true}
-          />
-        </div>
-        <div id="cta">
-          <BottomCTA
-            onGetStarted={handleGetStarted}
-            theme="city"
-            title="Übernehmen Sie die Kontrolle über Ihre"
-            subtitle="Immobilien noch heute"
-            description="Beginnen Sie noch heute, Ihre Immobilien effizienter zu verwalten und profitieren Sie von einer modernen und benutzerfreundlichen Plattform."
-            badgeText="Bereit zur Vereinfachung?"
-            primaryButtonText="Jetzt loslegen"
-            secondaryButtonText="Demo anfordern"
-          />
-        </div>
+    <div className="min-h-screen overflow-x-hidden">
+      <div id="hero">
+        <Hero onGetStarted={handleGetStarted} />
       </div>
-    </>
+      <div id="product-showcase">
+        <ProductShowcase />
+      </div>
+      <div id="features">
+        <FeatureSections />
+      </div>
+      <div id="nebenkosten">
+        <NebenkostenSection />
+      </div>
+
+      <div id="more-features">
+        <MoreFeatures />
+      </div>
+      <div id="pricing">
+        <Pricing
+          onSelectPlan={handleSelectPlan}
+          userProfile={userProfile}
+          isLoading={isProcessingCheckout}
+          showComparison={false}
+          showViewAllButton={true}
+        />
+      </div>
+      <div id="cta">
+        <BottomCTA
+          onGetStarted={handleGetStarted}
+          theme="city"
+          title="Übernehmen Sie die Kontrolle über Ihre"
+          subtitle="Immobilien noch heute"
+          description="Beginnen Sie noch heute, Ihre Immobilien effizienter zu verwalten und profitieren Sie von einer modernen und benutzerfreundlichen Plattform."
+          badgeText="Bereit zur Vereinfachung?"
+          primaryButtonText="Jetzt loslegen"
+          secondaryButtonText="Demo anfordern"
+        />
+      </div>
+    </div>
   );
 }
 

--- a/app/(landing)/preise/page.tsx
+++ b/app/(landing)/preise/page.tsx
@@ -1,304 +1,39 @@
 'use client';
 
-import { useState, useEffect, Suspense } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense } from 'react';
 
 import Pricing from '@/app/modern/components/pricing';
-import { createClient } from '@/utils/supabase/client';
-import { User } from '@supabase/supabase-js';
-import { Profile } from '@/types/supabase';
-import { useToast } from '@/hooks/use-toast';
-
-function ProfileErrorToastHandler() {
-    const searchParams = useSearchParams();
-    const router = useRouter();
-    const { toast } = useToast();
-
-    useEffect(() => {
-        const errorParam = searchParams.get('error');
-        if (errorParam === 'profile_fetch_failed') {
-            toast({
-                title: "Error",
-                description: "Could not retrieve your user details. Please try logging in again or contact support if the issue persists.",
-                variant: "destructive",
-            });
-            router.replace('/preise', { scroll: false });
-        }
-    }, [searchParams, router, toast]);
-
-    return null;
-}
-
-// Component that handles URL parameters
-function URLParamHandler() {
-    const searchParams = useSearchParams();
-    const router = useRouter();
-    const [sessionUser, setSessionUser] = useState<User | null>(null);
-    const [isLoadingUser, setIsLoadingUser] = useState(true);
-    const supabase = createClient();
-
-    useEffect(() => {
-        const fetchUser = async () => {
-            const { data: { user } } = await supabase.auth.getUser();
-            setSessionUser(user);
-            setIsLoadingUser(false);
-        };
-        fetchUser();
-    }, [supabase]);
-
-    // Handle URL parameter for "get started" flow
-    useEffect(() => {
-        if (isLoadingUser) {
-            return; // Wait until we've checked the user's auth status
-        }
-
-        const getStarted = searchParams.get('getStarted');
-        if (getStarted === 'true' && !sessionUser) {
-            router.push('/auth/login');
-        }
-    }, [searchParams, sessionUser, router, isLoadingUser]);
-
-    return null;
-}
+import { useStripeIntegration } from '@/hooks/use-stripe-integration';
+import { usePlanSelectionRedirect } from '@/hooks/use-plan-selection-redirect';
+import { useLandingRedirects } from '@/hooks/use-landing-redirects';
 
 // Main content component that uses the auth modal context
 function PricingPageContent() {
-    const router = useRouter();
-    const searchParams = useSearchParams();
-    const { toast } = useToast();
-    const supabase = createClient();
+    const {
+        sessionUser,
+        userProfile,
+        isProcessingCheckout,
+        isLoadingProfile,
+        handleAuthFlow
+    } = useStripeIntegration();
 
-    const [userProfile, setUserProfile] = useState<Profile | null>(null);
-    const [isProcessingCheckout, setIsProcessingCheckout] = useState(false);
-    const [sessionUser, setSessionUser] = useState<User | null>(null);
-
-    useEffect(() => {
-        const fetchInitialUserAndProfile = async () => {
-            const { data: { user } } = await supabase.auth.getUser();
-            setSessionUser(user);
-            if (user) {
-                fetchUserProfile(user.id);
-            } else {
-                setUserProfile(null);
-            }
-        };
-
-        fetchInitialUserAndProfile();
-
-        const { data: authListener } = supabase.auth.onAuthStateChange(async (event, session) => {
-            setSessionUser(session?.user ?? null);
-            if (event === 'SIGNED_IN' && session?.user) {
-                fetchUserProfile(session.user.id);
-            } else if (event === 'SIGNED_OUT') {
-                setUserProfile(null);
-            }
-        });
-
-        return () => {
-            authListener?.subscription.unsubscribe();
-        };
-    }, [supabase, router]);
-
-    // Handle price selection from URL after redirect back from login
-    useEffect(() => {
-        const priceId = searchParams.get('priceId');
-        if (priceId && sessionUser && userProfile && !isProcessingCheckout) {
-            // Clear the priceId from URL to prevent re-triggering on refresh
-            const newParams = new URLSearchParams(searchParams.toString());
-            newParams.delete('priceId');
-            const searchStr = newParams.toString();
-            const newUrl = `${window.location.pathname}${searchStr ? '?' + searchStr : ''}`;
-            window.history.replaceState({}, '', newUrl);
-
-            handleAuthFlow(priceId);
-        }
-    }, [searchParams, sessionUser, userProfile, isProcessingCheckout]);
-
-    const fetchUserProfile = async (userId: string) => {
-        try {
-            const { data, error } = await supabase
-                .from('profiles')
-                .select('id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_price_id')
-                .eq('id', userId)
-                .single();
-
-            if (error && error.code !== 'PGRST116') {
-                throw error;
-            }
-            setUserProfile(data as Profile | null);
-        } catch (error) {
-            console.error('Error fetching user profile:', error);
-            setUserProfile(null);
-        }
-    };
-
-    const proceedToCheckout = async (priceId: string) => {
-        setIsProcessingCheckout(true);
-        if (!sessionUser) {
-            console.error('User not logged in for proceedToCheckout');
-            toast({ title: 'Authentication Required', description: 'Please log in to proceed with checkout.', variant: 'default' });
-            setIsProcessingCheckout(false);
-            return;
-        }
-
-        if (!sessionUser.email || !sessionUser.id) {
-            console.error('User details missing in proceedToCheckout');
-            toast({ title: 'Error', description: 'User information not fully available. Please try logging in again.', variant: 'destructive' });
-            setIsProcessingCheckout(false);
-            return;
-        }
-
-        const customerEmail = sessionUser.email;
-        const userId = sessionUser.id;
-
-        try {
-            const response = await fetch('/api/stripe/checkout-session', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    priceId: priceId,
-                    customerEmail: customerEmail,
-                    userId: userId,
-                }),
-            });
-
-            if (response.status === 409) {
-                const errorData = await response.json();
-                toast({
-                    title: 'Subscription Information',
-                    description: errorData.message || 'You are already subscribed.',
-                    variant: 'default',
-                });
-                return;
-            }
-
-            if (!response.ok) {
-                let errorMessage = `HTTP error ${response.status}`;
-                try {
-                    const errorBody = await response.json();
-                    errorMessage = errorBody.error || errorBody.message || JSON.stringify(errorBody);
-                } catch (e) {
-                    try {
-                        const textError = await response.text();
-                        errorMessage = textError.substring(0, 100);
-                    } catch (textE) {
-                        errorMessage = response.statusText || `HTTP error ${response.status}`;
-                    }
-                }
-                throw new Error(`Failed to create checkout session: ${errorMessage}`);
-            }
-
-            const { url } = await response.json();
-
-            if (url) {
-                router.push(url);
-            } else {
-                throw new Error('URL missing from checkout session response.');
-            }
-        } catch (error) {
-            console.error('Subscription error:', error);
-            toast({ title: 'Subscription Error', description: (error as Error).message || 'Could not initiate subscription.', variant: 'destructive' });
-        } finally {
-            setIsProcessingCheckout(false);
-        }
-    };
-
-    const handleAuthFlow = async (priceId: string) => {
-        if (isProcessingCheckout) return;
-
-        if (sessionUser && userProfile) {
-            const hasActiveSubscription = userProfile.stripe_subscription_status === 'active' || userProfile.stripe_subscription_status === 'trialing';
-            if (hasActiveSubscription) {
-                await redirectToCustomerPortal();
-            } else {
-                await proceedToCheckout(priceId);
-            }
-        } else if (sessionUser && !userProfile) {
-            toast({
-                title: 'Please wait',
-                description: 'User details are still loading. Please try again shortly.',
-                variant: 'default',
-            });
-        } else {
-            // Preserve plan selection for unauthenticated users by redirecting with context.
-            const redirectPath = `${window.location.pathname}?priceId=${priceId}`;
-            router.push(`/auth/login?redirect=${encodeURIComponent(redirectPath)}`);
-        }
-    };
-
-    const redirectToCustomerPortal = async () => {
-        setIsProcessingCheckout(true);
-        if (!sessionUser || !sessionUser.id) {
-            toast({ title: 'Error', description: 'User not found. Please log in again.', variant: 'destructive' });
-            setIsProcessingCheckout(false);
-            return;
-        }
-
-        try {
-            const response = await fetch('/api/stripe/customer-portal', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    userId: sessionUser.id,
-                    return_url: `${window.location.origin}/preise`,
-                }),
-            });
-
-            if (!response.ok) {
-                const errorData = await response.json();
-                throw new Error(errorData.error || 'Failed to create customer portal session.');
-            }
-
-            const { url } = await response.json();
-            if (url) {
-                window.location.href = url;
-            } else {
-                throw new Error('Customer portal URL not found in response.');
-            }
-        } catch (error) {
-            console.error('Error redirecting to customer portal:', error);
-            toast({ title: 'Error', description: (error as Error).message || 'Could not redirect to customer portal.', variant: 'destructive' });
-        } finally {
-            setIsProcessingCheckout(false);
-        }
-    };
-
-
+    usePlanSelectionRedirect(sessionUser, userProfile, isProcessingCheckout, handleAuthFlow);
+    useLandingRedirects(sessionUser, isLoadingProfile, '/preise');
 
     const handleSelectPlan = async (priceId: string) => {
-        if (sessionUser) {
-            await handleAuthFlow(priceId);
-        } else {
-            // Preserve plan selection for unauthenticated users by redirecting with context.
-            const redirectPath = `${window.location.pathname}?priceId=${priceId}`;
-            router.push(`/auth/login?redirect=${encodeURIComponent(redirectPath)}`);
-        }
+        await handleAuthFlow(priceId, window.location.pathname);
     };
 
-
     return (
-        <>
-            <Suspense fallback={null}>
-                <ProfileErrorToastHandler />
-            </Suspense>
-            <Suspense fallback={null}>
-                <URLParamHandler />
-            </Suspense>
-            <div className="min-h-screen overflow-x-hidden pt-20">
-                <div id="pricing">
-                    <Pricing
-                        onSelectPlan={handleSelectPlan}
-                        userProfile={userProfile}
-                        isLoading={isProcessingCheckout}
-                    />
-                </div>
-
+        <div className="min-h-screen overflow-x-hidden pt-20">
+            <div id="pricing">
+                <Pricing
+                    onSelectPlan={handleSelectPlan}
+                    userProfile={userProfile}
+                    isLoading={isProcessingCheckout}
+                />
             </div>
-        </>
+        </div>
     );
 }
 

--- a/hooks/use-landing-redirects.ts
+++ b/hooks/use-landing-redirects.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { User } from '@supabase/supabase-js';
+import { useToast } from '@/hooks/use-toast';
+
+export function useLandingRedirects(sessionUser: User | null, isLoadingProfile: boolean, errorRedirectPath: string = '/') {
+    const searchParams = useSearchParams();
+    const router = useRouter();
+    const { toast } = useToast();
+
+    // Handle Profile Error Toast
+    useEffect(() => {
+        const errorParam = searchParams.get('error');
+        if (errorParam === 'profile_fetch_failed') {
+            toast({
+                title: "Error",
+                description: "Could not retrieve your user details. Please try logging in again or contact support if the issue persists.",
+                variant: "destructive",
+            });
+            router.replace(errorRedirectPath, { scroll: false });
+        }
+    }, [searchParams, router, toast, errorRedirectPath]);
+
+    // Handle "getStarted" URL parameter
+    useEffect(() => {
+        if (isLoadingProfile) {
+            return;
+        }
+
+        const getStarted = searchParams.get('getStarted');
+        if (getStarted === 'true' && !sessionUser) {
+            router.push('/auth/login');
+        }
+    }, [searchParams, sessionUser, router, isLoadingProfile]);
+}

--- a/hooks/use-plan-selection-redirect.ts
+++ b/hooks/use-plan-selection-redirect.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { User } from '@supabase/supabase-js';
+import { Profile } from '@/types/supabase';
+
+export function usePlanSelectionRedirect(
+    sessionUser: User | null,
+    userProfile: Profile | null,
+    isProcessingCheckout: boolean,
+    handleAuthFlow: (priceId: string, currentPath: string) => Promise<void>
+) {
+    const searchParams = useSearchParams();
+
+    useEffect(() => {
+        const priceId = searchParams.get('priceId');
+        if (priceId && sessionUser && userProfile && !isProcessingCheckout) {
+            // Clear the priceId from URL to prevent re-triggering on refresh
+            const newParams = new URLSearchParams(searchParams.toString());
+            newParams.delete('priceId');
+            const searchStr = newParams.toString();
+            const newUrl = `${window.location.pathname}${searchStr ? '?' + searchStr : ''}`;
+            window.history.replaceState({}, '', newUrl);
+
+            handleAuthFlow(priceId, window.location.pathname);
+        }
+    }, [searchParams, sessionUser, userProfile, isProcessingCheckout, handleAuthFlow]);
+}

--- a/hooks/use-stripe-integration.ts
+++ b/hooks/use-stripe-integration.ts
@@ -1,0 +1,207 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { User } from '@supabase/supabase-js';
+import { createClient } from '@/utils/supabase/client';
+import { Profile } from '@/types/supabase';
+import { useToast } from '@/hooks/use-toast';
+
+export function useStripeIntegration() {
+    const router = useRouter();
+    const { toast } = useToast();
+    const supabase = createClient();
+
+    const [userProfile, setUserProfile] = useState<Profile | null>(null);
+    const [isProcessingCheckout, setIsProcessingCheckout] = useState(false);
+    const [sessionUser, setSessionUser] = useState<User | null>(null);
+    const [isLoadingProfile, setIsLoadingProfile] = useState(true);
+
+    const fetchUserProfile = useCallback(async (userId: string) => {
+        setIsLoadingProfile(true);
+        try {
+            const { data, error } = await supabase
+                .from('profiles')
+                .select('id, stripe_customer_id, stripe_subscription_id, stripe_subscription_status, stripe_price_id')
+                .eq('id', userId)
+                .single();
+
+            if (error && error.code !== 'PGRST116') {
+                throw error;
+            }
+            setUserProfile(data as Profile | null);
+        } catch (error) {
+            console.error('Error fetching user profile:', error);
+            setUserProfile(null);
+        } finally {
+            setIsLoadingProfile(false);
+        }
+    }, [supabase]);
+
+    useEffect(() => {
+        const fetchInitialUserAndProfile = async () => {
+            const { data: { user } } = await supabase.auth.getUser();
+            setSessionUser(user);
+            if (user) {
+                await fetchUserProfile(user.id);
+            } else {
+                setUserProfile(null);
+                setIsLoadingProfile(false);
+            }
+        };
+
+        fetchInitialUserAndProfile();
+
+        const { data: authListener } = supabase.auth.onAuthStateChange(async (event, session) => {
+            const user = session?.user ?? null;
+            setSessionUser(user);
+            if (event === 'SIGNED_IN' && user) {
+                await fetchUserProfile(user.id);
+            } else if (event === 'SIGNED_OUT') {
+                setUserProfile(null);
+                setIsLoadingProfile(false);
+            }
+        });
+
+        return () => {
+            authListener?.subscription.unsubscribe();
+        };
+    }, [supabase, fetchUserProfile]);
+
+    const redirectToCustomerPortal = useCallback(async (returnPath: string = '/preise') => {
+        setIsProcessingCheckout(true);
+        if (!sessionUser || !sessionUser.id) {
+            toast({ title: 'Error', description: 'User not found. Please log in again.', variant: 'destructive' });
+            setIsProcessingCheckout(false);
+            return;
+        }
+
+        try {
+            const response = await fetch('/api/stripe/customer-portal', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    userId: sessionUser.id,
+                    return_url: `${window.location.origin}${returnPath}`,
+                }),
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json();
+                throw new Error(errorData.error || 'Failed to create customer portal session.');
+            }
+
+            const { url } = await response.json();
+            if (url) {
+                window.location.href = url;
+            } else {
+                throw new Error('Customer portal URL not found in response.');
+            }
+        } catch (error) {
+            console.error('Error redirecting to customer portal:', error);
+            toast({ title: 'Error', description: (error as Error).message || 'Could not redirect to customer portal.', variant: 'destructive' });
+        } finally {
+            setIsProcessingCheckout(false);
+        }
+    }, [sessionUser, toast]);
+
+    const proceedToCheckout = useCallback(async (priceId: string) => {
+        setIsProcessingCheckout(true);
+        if (!sessionUser) {
+            toast({ title: 'Authentication Required', description: 'Please log in to proceed with checkout.', variant: 'default' });
+            setIsProcessingCheckout(false);
+            return;
+        }
+
+        if (!sessionUser.email || !sessionUser.id) {
+            toast({ title: 'Error', description: 'User information not fully available. Please try logging in again.', variant: 'destructive' });
+            setIsProcessingCheckout(false);
+            return;
+        }
+
+        try {
+            const response = await fetch('/api/stripe/checkout-session', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    priceId: priceId,
+                    customerEmail: sessionUser.email,
+                    userId: sessionUser.id,
+                }),
+            });
+
+            if (response.status === 409) {
+                const errorData = await response.json();
+                toast({
+                    title: 'Subscription Information',
+                    description: errorData.message || 'You are already subscribed.',
+                    variant: 'default',
+                });
+                return;
+            }
+
+            if (!response.ok) {
+                let errorMessage = `HTTP error ${response.status}`;
+                try {
+                    const errorBody = await response.json();
+                    errorMessage = errorBody.error || errorBody.message || JSON.stringify(errorBody);
+                } catch (e) {
+                    try {
+                        const textError = await response.text();
+                        errorMessage = textError.substring(0, 100);
+                    } catch (textE) {
+                        errorMessage = response.statusText || `HTTP error ${response.status}`;
+                    }
+                }
+                throw new Error(`Failed to create checkout session: ${errorMessage}`);
+            }
+
+            const { url } = await response.json();
+            if (url) {
+                router.push(url);
+            } else {
+                throw new Error('URL missing from checkout session response.');
+            }
+        } catch (error) {
+            console.error('Subscription error:', error);
+            toast({ title: 'Subscription Error', description: (error as Error).message || 'Could not initiate subscription.', variant: 'destructive' });
+        } finally {
+            setIsProcessingCheckout(false);
+        }
+    }, [sessionUser, router, toast]);
+
+    const handleAuthFlow = useCallback(async (priceId: string, currentPath: string) => {
+        if (isProcessingCheckout || isLoadingProfile) return;
+
+        if (sessionUser && userProfile) {
+            const hasActiveSubscription = userProfile.stripe_subscription_status === 'active' || userProfile.stripe_subscription_status === 'trialing';
+            if (hasActiveSubscription) {
+                await redirectToCustomerPortal(currentPath);
+            } else {
+                await proceedToCheckout(priceId);
+            }
+        } else if (sessionUser && !userProfile) {
+            toast({
+                title: 'Please wait',
+                description: 'User details are still loading. Please try again shortly.',
+                variant: 'default',
+            });
+        } else {
+            const redirectPath = `${currentPath}?priceId=${priceId}`;
+            router.push(`/auth/login?redirect=${encodeURIComponent(redirectPath)}`);
+        }
+    }, [isProcessingCheckout, isLoadingProfile, sessionUser, userProfile, redirectToCustomerPortal, proceedToCheckout, router, toast]);
+
+    return {
+        sessionUser,
+        userProfile,
+        isProcessingCheckout,
+        isLoadingProfile,
+        handleAuthFlow,
+        redirectToCustomerPortal,
+        proceedToCheckout,
+        refreshProfile: () => sessionUser && fetchUserProfile(sessionUser.id)
+    };
+}


### PR DESCRIPTION
## Description

Extracts the duplicated Stripe checkout and profile logic from the landing and pricing pages into shared hooks.

## Summary of Changes

- New `use-stripe-integration.ts` (207 lines): session/profile state with auth listener, `proceedToCheckout`, `redirectToCustomerPortal` (with return path), and the unified `handleAuthFlow` (active subscription → portal, otherwise checkout, unauthenticated → login redirect with preserved `priceId`)
- New `use-plan-selection-redirect.ts`: resumes a pending plan selection from the `priceId` URL parameter after login and cleans the URL
- New `use-landing-redirects.ts`: profile-error toast + `getStarted` redirect handling
- `app/(landing)/page.tsx` (−318 lines) and `preise/page.tsx` (−287 lines): all of the above replaced by the three hooks; rendering unchanged