### PR TITLE
feat: add mcp oauth callback to allowlist

### DIFF
--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -22,6 +22,7 @@ const ALLOWED_REDIRECT_PATTERNS = [
     /^https:\/\/platform\.openai\.com\/apps-manage\/oauth(\?.*)?$/,
     // Allow MCP Worker callback proxy
     /^https:\/\/mcp\.mietevo\.de\/callback(\?.*)?$/,
+    /^https:\/\/mcp\.mietevo\.de\/oauth\/callback(\?.*)?$/,
 ];
 
 /**


### PR DESCRIPTION
## Description

Allows the MCP worker's `/oauth/callback` path as a redirect target in the consent flow.

## Summary of Changes

- `oauth/consent/page.tsx`: `https://mcp.mietevo.de/oauth/callback` added to the redirect-URI whitelist