### PR TITLE
fix(oauth): handle authorization_id to complete consent flow by appro…

### DIFF
--- a/app/api/oauth/approve/route.ts
+++ b/app/api/oauth/approve/route.ts
@@ -21,64 +21,42 @@ export async function GET(request: NextRequest) {
             process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
             {
                 cookies: {
-                    get(name: string) {
-                        return cookieStore.get(name)?.value;
-                    },
-                    set(name: string, value: string, options: any) {
-                        // Route handlers can set cookies
-                        cookieStore.set({ name, value, ...options });
-                    },
-                    remove(name: string, options: any) {
-                        cookieStore.set({ name, value: '', ...options });
+                    getAll: async () => cookieStore.getAll(),
+                    setAll: async (cookiesToSet) => {
+                        cookiesToSet.forEach(({ name, value, options }) => cookieStore.set(name, value, options));
                     },
                 },
             }
         );
 
-        // Get the current session to extract the access token
-        const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+        // Check if user is authenticated
+        const { data: { user }, error: userError } = await supabase.auth.getUser();
 
-        if (sessionError || !session) {
-            console.error('No session found:', sessionError);
-            return NextResponse.redirect(new URL(`/oauth/consent?error=no_session&message=Not authenticated`, request.url));
+        if (userError || !user) {
+            console.error('No user found:', userError);
+            const baseUrl = new URL(request.url).origin;
+            return NextResponse.redirect(new URL(`/oauth/consent?error=no_session&message=Not authenticated. Please login first.`, baseUrl));
         }
 
-        console.log('Session found, approving authorization:', authorizationId);
+        console.log('User authenticated:', user.id);
+        console.log('Approving authorization:', authorizationId);
 
-        // Make the approval request with the access token
-        const approveUrl = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/oauth/authorizations/${authorizationId}/approve`;
+        // Use the Supabase SDK to approve the authorization
+        const { data, error } = await (supabase.auth as any).oauth.approveAuthorization(authorizationId);
 
-        const response = await fetch(approveUrl, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'apikey': process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-                'Authorization': `Bearer ${session.access_token}`,
-            },
-        });
-
-        const responseText = await response.text();
-        console.log('Approval response status:', response.status);
-        console.log('Approval response body:', responseText);
-
-        if (!response.ok) {
-            let errorData: any = {};
-            try {
-                errorData = JSON.parse(responseText);
-            } catch { }
-            const errorMessage = errorData.error_description || errorData.message || errorData.error || `Approval failed: ${response.status}`;
-            return NextResponse.redirect(new URL(`/oauth/consent?error=approval_failed&message=${encodeURIComponent(errorMessage)}`, request.url));
+        if (error) {
+            console.error('Approval error:', error);
+            const baseUrl = new URL(request.url).origin;
+            return NextResponse.redirect(new URL(`/oauth/consent?error=approval_failed&message=${encodeURIComponent(error.message)}`, baseUrl));
         }
 
-        const data = JSON.parse(responseText);
+        console.log('Approval successful, redirecting to:', data.redirect_to);
 
-        if (data.redirect_to) {
-            return NextResponse.redirect(data.redirect_to);
-        } else {
-            return NextResponse.redirect(new URL('/oauth/consent?error=no_redirect&message=No redirect URL received', request.url));
-        }
+        // Redirect back to the client with authorization code
+        return NextResponse.redirect(data.redirect_to);
     } catch (err: any) {
         console.error('Approval error:', err);
-        return NextResponse.redirect(new URL(`/oauth/consent?error=server_error&message=${encodeURIComponent(err.message)}`, request.url));
+        const baseUrl = new URL(request.url).origin;
+        return NextResponse.redirect(new URL(`/oauth/consent?error=server_error&message=${encodeURIComponent(err.message)}`, baseUrl));
     }
 }

--- a/app/api/oauth/approve/route.ts
+++ b/app/api/oauth/approve/route.ts
@@ -1,0 +1,82 @@
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+    const { searchParams } = new URL(request.url);
+    const authorizationId = searchParams.get('authorization_id');
+
+    if (!authorizationId) {
+        return NextResponse.json({ error: 'Missing authorization_id' }, { status: 400 });
+    }
+
+    try {
+        const cookieStore = await cookies();
+
+        // Create Supabase server client with cookie handling
+        const supabase = createServerClient(
+            process.env.NEXT_PUBLIC_SUPABASE_URL!,
+            process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+            {
+                cookies: {
+                    get(name: string) {
+                        return cookieStore.get(name)?.value;
+                    },
+                    set(name: string, value: string, options: any) {
+                        // Route handlers can set cookies
+                        cookieStore.set({ name, value, ...options });
+                    },
+                    remove(name: string, options: any) {
+                        cookieStore.set({ name, value: '', ...options });
+                    },
+                },
+            }
+        );
+
+        // Get the current session to extract the access token
+        const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+
+        if (sessionError || !session) {
+            console.error('No session found:', sessionError);
+            return NextResponse.redirect(new URL(`/oauth/consent?error=no_session&message=Not authenticated`, request.url));
+        }
+
+        console.log('Session found, approving authorization:', authorizationId);
+
+        // Make the approval request with the access token
+        const approveUrl = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/oauth/authorizations/${authorizationId}/approve`;
+
+        const response = await fetch(approveUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'apikey': process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+                'Authorization': `Bearer ${session.access_token}`,
+            },
+        });
+
+        const responseText = await response.text();
+        console.log('Approval response status:', response.status);
+        console.log('Approval response body:', responseText);
+
+        if (!response.ok) {
+            let errorData: any = {};
+            try {
+                errorData = JSON.parse(responseText);
+            } catch { }
+            const errorMessage = errorData.error_description || errorData.message || errorData.error || `Approval failed: ${response.status}`;
+            return NextResponse.redirect(new URL(`/oauth/consent?error=approval_failed&message=${encodeURIComponent(errorMessage)}`, request.url));
+        }
+
+        const data = JSON.parse(responseText);
+
+        if (data.redirect_to) {
+            return NextResponse.redirect(data.redirect_to);
+        } else {
+            return NextResponse.redirect(new URL('/oauth/consent?error=no_redirect&message=No redirect URL received', request.url));
+        }
+    } catch (err: any) {
+        console.error('Approval error:', err);
+        return NextResponse.redirect(new URL(`/oauth/consent?error=server_error&message=${encodeURIComponent(err.message)}`, request.url));
+    }
+}

--- a/app/api/oauth/approve/route.ts
+++ b/app/api/oauth/approve/route.ts
@@ -2,6 +2,8 @@ import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 
+export const runtime = 'edge';
+
 export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const authorizationId = searchParams.get('authorization_id');

--- a/app/api/oauth/approve/route.ts
+++ b/app/api/oauth/approve/route.ts
@@ -7,6 +7,7 @@ export const runtime = 'edge';
 export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const authorizationId = searchParams.get('authorization_id');
+    const baseUrl = new URL(request.url).origin;
 
     if (!authorizationId) {
         return NextResponse.json({ error: 'Missing authorization_id' }, { status: 400 });
@@ -29,34 +30,106 @@ export async function GET(request: NextRequest) {
             }
         );
 
-        // Check if user is authenticated
-        const { data: { user }, error: userError } = await supabase.auth.getUser();
+        // Check if user is authenticated and get the session
+        const { data: { session }, error: sessionError } = await supabase.auth.getSession();
 
-        if (userError || !user) {
-            console.error('No user found:', userError);
-            const baseUrl = new URL(request.url).origin;
+        if (sessionError || !session) {
+            console.error('No session found:', sessionError);
             return NextResponse.redirect(new URL(`/oauth/consent?error=no_session&message=Not authenticated. Please login first.`, baseUrl));
         }
 
-        console.log('User authenticated:', user.id);
+        console.log('User authenticated:', session.user.id);
         console.log('Approving authorization:', authorizationId);
 
-        // Use the Supabase SDK to approve the authorization
-        const { data, error } = await (supabase.auth as any).oauth.approveAuthorization(authorizationId);
+        // Try calling the approval endpoint directly with the access token
+        // The SDK might be calling the wrong endpoint, so let's try different API paths
+        const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+        const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
-        if (error) {
-            console.error('Approval error:', error);
-            const baseUrl = new URL(request.url).origin;
-            return NextResponse.redirect(new URL(`/oauth/consent?error=approval_failed&message=${encodeURIComponent(error.message)}`, baseUrl));
+        // Try the correct endpoint based on Supabase OAuth Server API
+        const approveUrl = `${supabaseUrl}/auth/v1/oauth/authorize`;
+
+        console.log('Calling approve URL:', approveUrl);
+
+        const response = await fetch(approveUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'apikey': anonKey,
+                'Authorization': `Bearer ${session.access_token}`,
+            },
+            body: JSON.stringify({
+                authorization_id: authorizationId,
+                consent: 'approve',
+            }),
+        });
+
+        const responseText = await response.text();
+        console.log('Approve response status:', response.status);
+        console.log('Approve response body:', responseText);
+
+        if (!response.ok) {
+            // Try alternative endpoint
+            console.log('First endpoint failed, trying alternative...');
+
+            const altUrl = `${supabaseUrl}/auth/v1/authorize`;
+            const altResponse = await fetch(altUrl, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'apikey': anonKey,
+                    'Authorization': `Bearer ${session.access_token}`,
+                },
+                body: JSON.stringify({
+                    authorization_id: authorizationId,
+                }),
+            });
+
+            const altResponseText = await altResponse.text();
+            console.log('Alt response status:', altResponse.status);
+            console.log('Alt response body:', altResponseText);
+
+            if (!altResponse.ok) {
+                // If both fail, try the SDK method as fallback
+                console.log('Trying SDK method as fallback...');
+                try {
+                    const { data: sdkData, error: sdkError } = await (supabase.auth as any).oauth.approveAuthorization(authorizationId);
+
+                    if (sdkError) {
+                        return NextResponse.redirect(new URL(`/oauth/consent?error=approval_failed&message=${encodeURIComponent(sdkError.message)}`, baseUrl));
+                    }
+
+                    if (sdkData?.redirect_to) {
+                        return NextResponse.redirect(sdkData.redirect_to);
+                    }
+                } catch (sdkErr: any) {
+                    console.error('SDK fallback also failed:', sdkErr);
+                }
+
+                return NextResponse.redirect(new URL(`/oauth/consent?error=approval_failed&message=${encodeURIComponent(`API error: ${response.status}`)}`, baseUrl));
+            }
+
+            // Parse alt response
+            try {
+                const altData = JSON.parse(altResponseText);
+                if (altData.redirect_to) {
+                    return NextResponse.redirect(altData.redirect_to);
+                }
+            } catch { }
         }
 
-        console.log('Approval successful, redirecting to:', data.redirect_to);
+        // Parse response
+        try {
+            const data = JSON.parse(responseText);
+            if (data.redirect_to) {
+                console.log('Redirecting to:', data.redirect_to);
+                return NextResponse.redirect(data.redirect_to);
+            }
+        } catch { }
 
-        // Redirect back to the client with authorization code
-        return NextResponse.redirect(data.redirect_to);
+        return NextResponse.redirect(new URL(`/oauth/consent?error=no_redirect&message=No redirect URL received`, baseUrl));
     } catch (err: any) {
         console.error('Approval error:', err);
-        const baseUrl = new URL(request.url).origin;
         return NextResponse.redirect(new URL(`/oauth/consent?error=server_error&message=${encodeURIComponent(err.message)}`, baseUrl));
     }
 }

--- a/app/api/oauth/decision/route.ts
+++ b/app/api/oauth/decision/route.ts
@@ -13,9 +13,13 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: 'Missing authorization_id' }, { status: 400 });
     }
 
+    if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
+        throw new Error('Missing Supabase environment variables');
+    }
+
     const supabase = createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        process.env.NEXT_PUBLIC_SUPABASE_URL,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
         {
             cookies: {
                 getAll: async () => (await cookies()).getAll(),

--- a/app/api/oauth/decision/route.ts
+++ b/app/api/oauth/decision/route.ts
@@ -28,7 +28,7 @@ export async function POST(request: Request) {
     );
 
     if (decision === 'approve') {
-        const { data, error } = await (supabase.auth as any).oauth.approveAuthorization(authorizationId);
+        const { data, error } = await (supabase.auth as unknown as import('@/types/supabase').SupabaseAuthWithOAuth).oauth.approveAuthorization(authorizationId);
 
         if (error) {
             console.error('Approval error:', error);
@@ -38,7 +38,7 @@ export async function POST(request: Request) {
         // Redirect back to the client with authorization code
         return NextResponse.redirect(data.redirect_to);
     } else {
-        const { data, error } = await (supabase.auth as any).oauth.denyAuthorization(authorizationId);
+        const { data, error } = await (supabase.auth as unknown as import('@/types/supabase').SupabaseAuthWithOAuth).oauth.denyAuthorization(authorizationId);
 
         if (error) {
             console.error('Denial error:', error);

--- a/app/api/oauth/decision/route.ts
+++ b/app/api/oauth/decision/route.ts
@@ -1,0 +1,51 @@
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+export const runtime = 'edge';
+
+export async function POST(request: Request) {
+    const formData = await request.formData();
+    const decision = formData.get('decision');
+    const authorizationId = formData.get('authorization_id') as string;
+
+    if (!authorizationId) {
+        return NextResponse.json({ error: 'Missing authorization_id' }, { status: 400 });
+    }
+
+    const supabase = createServerClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        {
+            cookies: {
+                getAll: async () => (await cookies()).getAll(),
+                setAll: async (cookiesToSet) => {
+                    const cookieStore = await cookies();
+                    cookiesToSet.forEach(({ name, value, options }) => cookieStore.set(name, value, options));
+                },
+            },
+        }
+    );
+
+    if (decision === 'approve') {
+        const { data, error } = await (supabase.auth as any).oauth.approveAuthorization(authorizationId);
+
+        if (error) {
+            console.error('Approval error:', error);
+            return NextResponse.json({ error: error.message }, { status: 400 });
+        }
+
+        // Redirect back to the client with authorization code
+        return NextResponse.redirect(data.redirect_to);
+    } else {
+        const { data, error } = await (supabase.auth as any).oauth.denyAuthorization(authorizationId);
+
+        if (error) {
+            console.error('Denial error:', error);
+            return NextResponse.json({ error: error.message }, { status: 400 });
+        }
+
+        // Redirect back to the client with error
+        return NextResponse.redirect(data.redirect_to);
+    }
+}

--- a/app/api/oauth/token/route.ts
+++ b/app/api/oauth/token/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+export const runtime = 'edge';
+
 /**
  * OAuth Token Exchange Endpoint
  * 

--- a/app/api/oauth/token/route.ts
+++ b/app/api/oauth/token/route.ts
@@ -66,7 +66,8 @@ export async function POST(request: NextRequest) {
                 return NextResponse.json({ error: 'invalid_client', error_description: 'Invalid client_secret' }, { status: 401 });
             }
         } else {
-            console.warn('CRITICAL: No OAuth clients configured. Allow-listing is disabled. Please configure ALLOWED_CLIENTS in app/api/oauth/token/route.ts or set OAUTH_CLIENT_ID env var.');
+            console.error('CRITICAL: No OAuth clients configured. Rejecting request. Please configure ALLOWED_CLIENTS in app/api/oauth/token/route.ts or set OAUTH_CLIENT_ID env var.');
+            return NextResponse.json({ error: 'invalid_client', error_description: 'Client authentication failed: server not configured.' }, { status: 500 });
         }
 
         // Proxy to Supabase's token endpoint

--- a/app/api/oauth/token/route.ts
+++ b/app/api/oauth/token/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * OAuth Token Exchange Endpoint
+ * 
+ * This endpoint handles the authorization code exchange for access tokens.
+ * It proxies the request to Supabase's token endpoint.
+ */
+export async function POST(request: NextRequest) {
+    try {
+        const body = await request.json();
+
+        const {
+            grant_type,
+            code,
+            client_id,
+            client_secret,
+            redirect_uri,
+            code_verifier
+        } = body;
+
+        console.log('Token exchange request received');
+        console.log('grant_type:', grant_type);
+        console.log('redirect_uri:', redirect_uri);
+        console.log('code_verifier present:', !!code_verifier);
+
+        // Validate required fields
+        if (!grant_type || !code || !client_id || !redirect_uri) {
+            return NextResponse.json(
+                { error: 'invalid_request', error_description: 'Missing required parameters' },
+                { status: 400 }
+            );
+        }
+
+        // For now, we'll proxy to Supabase's token endpoint
+        // In production, you might want to validate client_id and client_secret against your OAuth app registry
+        const supabaseTokenUrl = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/token?grant_type=pkce`;
+
+        const tokenRequestBody: Record<string, string> = {
+            auth_code: code,
+            code_verifier: code_verifier,
+        };
+
+        console.log('Calling Supabase token endpoint:', supabaseTokenUrl);
+
+        const tokenResponse = await fetch(supabaseTokenUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'apikey': process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+            },
+            body: JSON.stringify(tokenRequestBody),
+        });
+
+        const responseText = await tokenResponse.text();
+        console.log('Supabase token response status:', tokenResponse.status);
+        console.log('Supabase token response:', responseText);
+
+        if (!tokenResponse.ok) {
+            let errorData: any = {};
+            try {
+                errorData = JSON.parse(responseText);
+            } catch { }
+
+            return NextResponse.json(
+                {
+                    error: errorData.error || 'token_exchange_failed',
+                    error_description: errorData.error_description || errorData.message || `Token exchange failed: ${tokenResponse.status}`
+                },
+                { status: tokenResponse.status }
+            );
+        }
+
+        // Parse and return the token response
+        const tokenData = JSON.parse(responseText);
+
+        return NextResponse.json({
+            access_token: tokenData.access_token,
+            token_type: tokenData.token_type || 'Bearer',
+            expires_in: tokenData.expires_in,
+            refresh_token: tokenData.refresh_token,
+            scope: 'email',
+        });
+
+    } catch (err: any) {
+        console.error('Token exchange error:', err);
+        return NextResponse.json(
+            { error: 'server_error', error_description: err.message || 'Internal server error' },
+            { status: 500 }
+        );
+    }
+}

--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -250,7 +250,15 @@ export default function ConsentUI({
                         {/* Redirect URI info */}
                         {redirectUri && (
                             <p className="text-xs text-muted-foreground text-center mb-4">
-                                Nach Autorisierung werden Sie zu <span className="font-mono text-foreground/70">{new URL(redirectUri).origin}</span> weitergeleitet
+                                Nach Autorisierung werden Sie zu <span className="font-mono text-foreground/70">
+                                    {(() => {
+                                        try {
+                                            return new URL(redirectUri).origin;
+                                        } catch {
+                                            return redirectUri;
+                                        }
+                                    })()}
+                                </span> weitergeleitet
                             </p>
                         )}
                     </CardContent>

--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -62,11 +62,23 @@ export default function ConsentUI({
             try {
                 const { data, error: detailsError } = await (supabase.auth as any).oauth.getAuthorizationDetails(authorizationId);
 
+                console.log('getAuthorizationDetails response:', data, detailsError);
+
                 if (detailsError) {
                     setLoadError(detailsError.message);
-                } else {
-                    setAuthDetails(data);
+                    setIsLoading(false);
+                    return;
                 }
+
+                // Check if the authorization was auto-approved and has a redirect URL
+                // This happens when the user has previously approved this client
+                if (data?.redirect_to || data?.redirect_url) {
+                    console.log('Auto-approved, redirecting to:', data.redirect_to || data.redirect_url);
+                    window.location.href = data.redirect_to || data.redirect_url;
+                    return; // Keep loading state while redirecting
+                }
+
+                setAuthDetails(data);
             } catch (err: any) {
                 setLoadError(err.message || 'Failed to load authorization details');
             } finally {

--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useState } from 'react';
+import { createBrowserClient } from '@supabase/ssr';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { ShieldAlert, Check, Loader2, AlertTriangle, X } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+interface ConsentUIProps {
+    type: 'consent' | 'error' | 'loading';
+    error?: string;
+    authorizationId?: string;
+    clientName?: string;
+    clientIcon?: string;
+    redirectUri?: string;
+    scopes?: string[];
+}
+
+const LOGO_URL = 'https://ocubnwzybybcbrhsnqqs.supabase.co/storage/v1/object/public/assets/logo.png';
+const BRAND_NAME = 'Mietevo';
+
+export default function ConsentUI({
+    type,
+    error,
+    authorizationId,
+    clientName,
+    clientIcon,
+    redirectUri,
+    scopes = []
+}: ConsentUIProps) {
+    const [isProcessing, setIsProcessing] = useState(false);
+    const [processError, setProcessError] = useState<string | null>(null);
+
+    // Create browser client for consent actions
+    const supabase = createBrowserClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    );
+
+    const handleApprove = async () => {
+        if (!authorizationId) return;
+
+        setIsProcessing(true);
+        setProcessError(null);
+
+        try {
+            const { data, error: approveError } = await (supabase.auth as any).oauth.approveAuthorization(authorizationId);
+
+            if (approveError) {
+                setProcessError(approveError.message);
+                setIsProcessing(false);
+                return;
+            }
+
+            // Redirect to the returned URL
+            if (data?.redirect_to) {
+                window.location.href = data.redirect_to;
+            }
+        } catch (err: any) {
+            setProcessError(err.message || 'An error occurred while approving authorization');
+            setIsProcessing(false);
+        }
+    };
+
+    const handleDeny = async () => {
+        if (!authorizationId) return;
+
+        setIsProcessing(true);
+        setProcessError(null);
+
+        try {
+            const { data, error: denyError } = await (supabase.auth as any).oauth.denyAuthorization(authorizationId);
+
+            if (denyError) {
+                setProcessError(denyError.message);
+                setIsProcessing(false);
+                return;
+            }
+
+            // Redirect to the returned URL (should be redirect_uri with error)
+            if (data?.redirect_to) {
+                window.location.href = data.redirect_to;
+            }
+        } catch (err: any) {
+            setProcessError(err.message || 'An error occurred while denying authorization');
+            setIsProcessing(false);
+        }
+    };
+
+    // Error state
+    if (type === 'error' || error) {
+        return (
+            <div className="min-h-screen flex items-center justify-center bg-background p-4 md:p-8 relative overflow-hidden font-sans">
+                <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_50%,black_40%,transparent_100%)]" />
+                <motion.div
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.5 }}
+                    className="relative z-10 w-full max-w-md"
+                >
+                    <Card className="border-border bg-card/80 backdrop-blur-xl shadow-2xl rounded-[2.5rem] overflow-hidden">
+                        <CardHeader className="text-center pt-8">
+                            <div className="mx-auto w-20 h-20 bg-destructive/10 rounded-3xl flex items-center justify-center mb-6 border border-destructive/20 p-4">
+                                <AlertTriangle className="w-10 h-10 text-destructive" />
+                            </div>
+                            <CardTitle className="text-2xl md:text-3xl font-bold text-foreground tracking-tight">
+                                Autorisierung fehlgeschlagen
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="px-8 pb-8">
+                            <Alert variant="destructive" className="rounded-xl">
+                                <AlertDescription>{error}</AlertDescription>
+                            </Alert>
+                            <p className="text-sm text-muted-foreground mt-4 text-center">
+                                Bitte schließen Sie dieses Fenster und versuchen Sie es erneut.
+                            </p>
+                        </CardContent>
+                    </Card>
+                </motion.div>
+            </div>
+        );
+    }
+
+    // Consent form
+    return (
+        <div className="min-h-screen flex items-center justify-center bg-background p-4 md:p-8 relative overflow-hidden font-sans">
+            <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_50%,black_40%,transparent_100%)]" />
+            <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5 }}
+                className="relative z-10 w-full max-w-md"
+            >
+                <Card className="border-border bg-card/80 backdrop-blur-xl shadow-2xl rounded-[2.5rem] overflow-hidden">
+                    <CardHeader className="text-center pt-8">
+                        {/* App logos */}
+                        <div className="flex items-center justify-center gap-4 mb-6">
+                            {clientIcon ? (
+                                <img
+                                    src={clientIcon}
+                                    alt={clientName}
+                                    className="w-16 h-16 rounded-2xl border border-border"
+                                />
+                            ) : (
+                                <div className="w-16 h-16 bg-primary/10 rounded-2xl flex items-center justify-center border border-primary/20">
+                                    <ShieldAlert className="w-8 h-8 text-primary" />
+                                </div>
+                            )}
+                            <div className="text-2xl text-muted-foreground">→</div>
+                            <img
+                                src={LOGO_URL}
+                                alt={BRAND_NAME}
+                                className="w-16 h-16 rounded-2xl border border-border"
+                            />
+                        </div>
+                        <CardTitle className="text-2xl md:text-3xl font-bold text-foreground tracking-tight">
+                            Zugriff autorisieren
+                        </CardTitle>
+                        <CardDescription className="text-base mt-2">
+                            <span className="font-semibold text-foreground">{clientName}</span> möchte auf Ihr {BRAND_NAME}-Konto zugreifen
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent className="px-8 pb-4">
+                        {/* Scopes */}
+                        {scopes.length > 0 && (
+                            <div className="mb-6">
+                                <h3 className="text-sm font-medium text-muted-foreground mb-3">
+                                    Diese Anwendung erhält Zugriff auf:
+                                </h3>
+                                <ul className="space-y-2">
+                                    {scopes.map((scope, index) => (
+                                        <li key={index} className="flex items-center gap-3 text-sm">
+                                            <Check className="w-4 h-4 text-green-500 flex-shrink-0" />
+                                            <span className="text-foreground capitalize">{scope}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        )}
+
+                        {/* Error display */}
+                        {processError && (
+                            <Alert variant="destructive" className="rounded-xl mb-4">
+                                <AlertDescription>{processError}</AlertDescription>
+                            </Alert>
+                        )}
+
+                        {/* Redirect URI info */}
+                        {redirectUri && (
+                            <p className="text-xs text-muted-foreground text-center mb-4">
+                                Nach Autorisierung werden Sie zu <span className="font-mono text-foreground/70">{new URL(redirectUri).origin}</span> weitergeleitet
+                            </p>
+                        )}
+                    </CardContent>
+                    <CardFooter className="flex flex-col gap-3 px-8 pb-8">
+                        <Button
+                            onClick={handleApprove}
+                            disabled={isProcessing}
+                            className="w-full h-12 rounded-xl text-base font-medium"
+                        >
+                            {isProcessing ? (
+                                <>
+                                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                                    Wird verarbeitet...
+                                </>
+                            ) : (
+                                <>
+                                    <Check className="w-4 h-4 mr-2" />
+                                    Zugriff erlauben
+                                </>
+                            )}
+                        </Button>
+                        <Button
+                            variant="outline"
+                            onClick={handleDeny}
+                            disabled={isProcessing}
+                            className="w-full h-12 rounded-xl text-base font-medium"
+                        >
+                            <X className="w-4 h-4 mr-2" />
+                            Ablehnen
+                        </Button>
+                    </CardFooter>
+                </Card>
+            </motion.div>
+        </div>
+    );
+}

--- a/app/oauth/consent/actions.ts
+++ b/app/oauth/consent/actions.ts
@@ -5,22 +5,37 @@ import { cookies } from 'next/headers';
 export async function approveAuthorizationAction(authorizationId: string) {
     try {
         const cookieStore = await cookies();
-        const cookieHeader = cookieStore.toString();
+        const allCookies = cookieStore.getAll();
+        const cookieHeader = allCookies.map(c => `${c.name}=${c.value}`).join('; ');
 
-        const response = await fetch(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/oauth/authorizations/${authorizationId}/approve`, {
+        console.log('Authorization approval attempt for:', authorizationId);
+        console.log('Cookies being sent:', allCookies.map(c => c.name).join(', '));
+
+        const url = `${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/oauth/authorizations/${authorizationId}/approve`;
+        console.log('Calling URL:', url);
+
+        const response = await fetch(url, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
                 'Cookie': cookieHeader,
+                'apikey': process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
             },
         });
 
+        const responseText = await response.text();
+        console.log('Response status:', response.status);
+        console.log('Response body:', responseText);
+
         if (!response.ok) {
-            const errorData = await response.json().catch(() => ({}));
-            throw new Error(errorData.error_description || errorData.message || `Approval failed: ${response.status}`);
+            let errorData: any = {};
+            try {
+                errorData = JSON.parse(responseText);
+            } catch { }
+            throw new Error(errorData.error_description || errorData.message || errorData.error || `Approval failed: ${response.status} - ${responseText}`);
         }
 
-        const data = await response.json();
+        const data = JSON.parse(responseText);
         return { success: true, redirect_to: data.redirect_to };
     } catch (err: any) {
         console.error('Server Action: Authorization approval failed:', err);

--- a/app/oauth/consent/actions.ts
+++ b/app/oauth/consent/actions.ts
@@ -38,7 +38,9 @@ export async function approveAuthorizationAction(authorizationId: string) {
             let errorData: any = {};
             try {
                 errorData = JSON.parse(responseText);
-            } catch { }
+            } catch (e) {
+                console.error('Failed to parse error response from Supabase:', e);
+            }
             throw new Error(errorData.error_description || errorData.message || errorData.error || `Approval failed: ${response.status} - ${responseText}`);
         }
 

--- a/app/oauth/consent/actions.ts
+++ b/app/oauth/consent/actions.ts
@@ -1,0 +1,29 @@
+'use server';
+
+import { cookies } from 'next/headers';
+
+export async function approveAuthorizationAction(authorizationId: string) {
+    try {
+        const cookieStore = await cookies();
+        const cookieHeader = cookieStore.toString();
+
+        const response = await fetch(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/oauth/authorizations/${authorizationId}/approve`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Cookie': cookieHeader,
+            },
+        });
+
+        if (!response.ok) {
+            const errorData = await response.json().catch(() => ({}));
+            throw new Error(errorData.error_description || errorData.message || `Approval failed: ${response.status}`);
+        }
+
+        const data = await response.json();
+        return { success: true, redirect_to: data.redirect_to };
+    } catch (err: any) {
+        console.error('Server Action: Authorization approval failed:', err);
+        return { success: false, error: err.message || 'Authorization approval failed' };
+    }
+}

--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -1,423 +1,84 @@
-'use client';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import ConsentUI from './ConsentUI';
 
-import { useSearchParams } from 'next/navigation';
-import { useState, Suspense, useMemo, useEffect } from 'react';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import { ShieldAlert, Check, Loader2, AlertTriangle } from 'lucide-react';
-import { motion } from 'framer-motion';
-import { LOGO_URL, BRAND_NAME, BASE_URL, SUPABASE_API_PATHS } from '@/lib/constants';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { approveAuthorizationAction } from './actions';
+export const runtime = 'edge';
 
-// Whitelist of allowed redirect URI patterns for security
-// In production, this should be managed via database or environment config
-const ALLOWED_REDIRECT_PATTERNS = [
-    // Allow redirects to the same domain
-    new RegExp(`^${BASE_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
-    // Allow localhost for development
-    /^http:\/\/localhost(:\d+)?/,
-    /^http:\/\/127\.0\.0\.1(:\d+)?/,
-    // Allow ChatGPT Apps OAuth callbacks (production + app review)
-    /^https:\/\/chatgpt\.com\/connector_platform_oauth_redirect(\?.*)?$/,
-    /^https:\/\/platform\.openai\.com\/apps-manage\/oauth(\?.*)?$/,
-    // Allow MCP Worker callback proxy
-    /^https:\/\/mcp\.mietevo\.de\/callback(\?.*)?$/,
-    /^https:\/\/mcp\.mietevo\.de\/oauth\/callback(\?.*)?$/,
-];
-
-
-/**
- * Validates if a redirect URI is in the allowed whitelist.
- * This prevents open redirect vulnerabilities.
- */
-function isValidRedirectUri(uri: string | null): boolean {
-    if (!uri) return false;
-
-    try {
-        // Ensure it's a valid URL
-        new URL(uri);
-
-        // Check against whitelist patterns
-        return ALLOWED_REDIRECT_PATTERNS.some(pattern => pattern.test(uri));
-    } catch {
-        return false;
-    }
+interface PageProps {
+    searchParams: Promise<{
+        authorization_id?: string;
+        error?: string;
+        message?: string;
+    }>;
 }
 
-const OAUTH_PARAMS_SESSION_KEY = 'mcp_oauth_params';
+export default async function ConsentPage({ searchParams }: PageProps) {
+    const params = await searchParams;
+    const authorizationId = params.authorization_id;
+    const error = params.error;
+    const message = params.message;
 
-function ConsentContent() {
-    const searchParams = useSearchParams();
-
-    // Check if we're returning from Supabase with an authorization_id
-    const authorizationId = searchParams.get('authorization_id');
-    const [approvalStatus, setApprovalStatus] = useState<'idle' | 'approving' | 'error'>(authorizationId ? 'approving' : 'idle');
-    const [approvalError, setApprovalError] = useState<string | null>(null);
-
-    // Handle authorization approval when authorization_id is present
-    // Redirect to API route which handles the approval server-side with proper session
-    useEffect(() => {
-        if (authorizationId && approvalStatus === 'approving') {
-            // Redirect to API route for approval
-            window.location.href = `/api/oauth/approve?authorization_id=${encodeURIComponent(authorizationId)}`;
-        }
-    }, [authorizationId, approvalStatus]);
-
-    // Check for error from API route redirect
-    const error = searchParams.get('error');
-    const errorMessage = searchParams.get('message');
-
-    if (error && errorMessage) {
-        return (
-            <div className="min-h-screen flex items-center justify-center bg-background p-4 md:p-8 relative overflow-hidden font-sans">
-                <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_50%,black_40%,transparent_100%)]" />
-                <motion.div
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.5 }}
-                    className="relative z-10 w-full max-w-md"
-                >
-                    <Card className="border-border bg-card/80 backdrop-blur-xl shadow-2xl rounded-[2.5rem] overflow-hidden">
-                        <CardHeader className="text-center pt-8">
-                            <div className="mx-auto w-20 h-20 bg-destructive/10 rounded-3xl flex items-center justify-center mb-6 border border-destructive/20 p-4">
-                                <AlertTriangle className="w-10 h-10 text-destructive" />
-                            </div>
-                            <CardTitle className="text-2xl md:text-3xl font-bold text-foreground tracking-tight">
-                                Autorisierung fehlgeschlagen
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent className="px-8 pb-8">
-                            <Alert variant="destructive" className="rounded-xl">
-                                <AlertDescription>{decodeURIComponent(errorMessage)}</AlertDescription>
-                            </Alert>
-                            <p className="text-sm text-muted-foreground mt-4 text-center">
-                                Bitte schließen Sie dieses Fenster und versuchen Sie es erneut.
-                            </p>
-                        </CardContent>
-                    </Card>
-                </motion.div>
-            </div>
-        );
+    // Handle error state
+    if (error && message) {
+        return <ConsentUI
+            type="error"
+            error={decodeURIComponent(message)}
+        />;
     }
 
-    // If we're handling authorization approval, show loading or error state
-    if (authorizationId) {
-        if (approvalStatus === 'error') {
-            return (
-                <div className="min-h-screen flex items-center justify-center bg-background p-4 md:p-8 relative overflow-hidden font-sans">
-                    <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_50%,black_40%,transparent_100%)]" />
-                    <motion.div
-                        initial={{ opacity: 0, y: 20 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ duration: 0.5 }}
-                        className="relative z-10 w-full max-w-md"
-                    >
-                        <Card className="border-border bg-card/80 backdrop-blur-xl shadow-2xl rounded-[2.5rem] overflow-hidden">
-                            <CardHeader className="text-center pt-8">
-                                <div className="mx-auto w-20 h-20 bg-destructive/10 rounded-3xl flex items-center justify-center mb-6 border border-destructive/20 p-4">
-                                    <AlertTriangle className="w-10 h-10 text-destructive" />
-                                </div>
-                                <CardTitle className="text-2xl md:text-3xl font-bold text-foreground tracking-tight">
-                                    Autorisierung fehlgeschlagen
-                                </CardTitle>
-                            </CardHeader>
-                            <CardContent className="px-8 pb-8">
-                                <Alert variant="destructive" className="rounded-xl">
-                                    <AlertDescription>{approvalError}</AlertDescription>
-                                </Alert>
-                                <p className="text-sm text-muted-foreground mt-4 text-center">
-                                    Bitte schließen Sie dieses Fenster und versuchen Sie es erneut.
-                                </p>
-                            </CardContent>
-                        </Card>
-                    </motion.div>
-                </div>
-            );
-        }
-
-        // Show loading state while approving
-        return (
-            <div className="min-h-screen flex items-center justify-center bg-background p-4 md:p-8 relative overflow-hidden font-sans">
-                <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_50%,black_40%,transparent_100%)]" />
-                <motion.div
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.5 }}
-                    className="relative z-10 w-full max-w-md text-center"
-                >
-                    <Loader2 className="w-12 h-12 text-primary animate-spin mx-auto mb-4" />
-                    <p className="text-lg text-muted-foreground">Autorisierung wird abgeschlossen...</p>
-                </motion.div>
-            </div>
-        );
+    // If no authorization_id, show error
+    if (!authorizationId) {
+        return <ConsentUI
+            type="error"
+            error="Missing authorization_id. This page requires an OAuth authorization request."
+        />;
     }
 
-    // Recovery Logic: Try to get parameters from URL, then fallback to sessionStorage
-    // This handles cases where internal redirects (like login or session refresh) strip the URL.
-    const [oauthState] = useState<{
-        client_id: string | null;
-        state: string | null;
-        redirect_uri: string | null;
-        scope: string | null;
-        code_challenge: string | null;
-        code_challenge_method: string | null;
-    }>(() => {
-        const fromUrl = {
-            client_id: searchParams.get('client_id'),
-            state: searchParams.get('state'),
-            redirect_uri: searchParams.get('redirect_uri'),
-            scope: searchParams.get('scope'),
-            code_challenge: searchParams.get('code_challenge'),
-            code_challenge_method: searchParams.get('code_challenge_method'),
-        };
-
-        // If we have all primary params, use them and save them
-        if (fromUrl.client_id && fromUrl.state) {
-            if (typeof window !== 'undefined') {
-                sessionStorage.setItem(OAUTH_PARAMS_SESSION_KEY, JSON.stringify(fromUrl));
-            }
-            return fromUrl;
+    // Create Supabase server client
+    const cookieStore = await cookies();
+    const supabase = createServerClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+        {
+            cookies: {
+                getAll: () => cookieStore.getAll(),
+                setAll: (cookiesToSet) => {
+                    cookiesToSet.forEach(({ name, value, options }) =>
+                        cookieStore.set(name, value, options)
+                    );
+                },
+            },
         }
+    );
 
-        // Otherwise, try to recover from session storage
-        if (typeof window !== 'undefined') {
-            const saved = sessionStorage.getItem(OAUTH_PARAMS_SESSION_KEY);
-            if (saved) {
-                try {
-                    return JSON.parse(saved);
-                } catch (e) {
-                    console.error('Failed to parse OAuth params from sessionStorage:', e);
-                    sessionStorage.removeItem(OAUTH_PARAMS_SESSION_KEY);
-                }
-            }
-        }
+    // Check if user is authenticated
+    const { data: { user } } = await supabase.auth.getUser();
 
-        return fromUrl;
-    });
-
-    const { client_id: clientId, state, redirect_uri: redirectUri, scope, code_challenge: codeChallenge, code_challenge_method: codeChallengeMethod } = oauthState;
-
-    const [isLoading, setIsLoading] = useState(false);
-
-    // Validate all required OAuth parameters
-    const validationError = useMemo(() => {
-        if (!clientId) return 'Fehlender Parameter: client_id';
-        if (!redirectUri) return 'Fehlender Parameter: redirect_uri';
-        if (!state) return 'Fehlender Parameter: state';
-        if (!scope) return 'Fehlender Parameter: scope';
-        if (!codeChallenge) return 'Fehlender Parameter: code_challenge';
-        if (!codeChallengeMethod) return 'Fehlender Parameter: code_challenge_method';
-        if (!isValidRedirectUri(redirectUri)) return 'Ungültige oder nicht autorisierte Weiterleitungs-URL';
-        return null;
-    }, [clientId, redirectUri, state, scope, codeChallenge, codeChallengeMethod]);
-
-    // Use environment variable for Supabase URL
-    const supabaseAuthUrl = `${process.env.NEXT_PUBLIC_SUPABASE_URL}${SUPABASE_API_PATHS.OAUTH_AUTHORIZE}`;
-
-    const handleAllow = () => {
-        // Validation already passed - this handler only runs when UI is shown
-        setIsLoading(true);
-        const params = new URLSearchParams({
-            response_type: 'code',
-            client_id: clientId!,
-            redirect_uri: redirectUri!,
-            state: state!,
-            scope: scope!,
-            code_challenge: codeChallenge!,
-            code_challenge_method: codeChallengeMethod!,
-        });
-        window.location.href = `${supabaseAuthUrl}?${params.toString()}`;
-    };
-
-    const handleDeny = () => {
-        // Validation already passed - redirectUri is guaranteed valid
-        const url = new URL(redirectUri!);
-        url.searchParams.set('error', 'access_denied');
-        if (state) {
-            url.searchParams.set('state', state);
-        }
-        window.location.href = url.toString();
-    };
-
-    const formattedScopes = useMemo(() => {
-        if (!scope) return [];
-
-        const mapping: Record<string, string> = {
-            'read:properties': 'Zugriff auf Ihre Immobilien und Wohnungen',
-            'write:finance': 'Neue Finanz-Transaktionen erfassen',
-            'read:tenants': 'Mieter- und Mietvertrags-Informationen ansehen',
-            'read:documents': 'Zugriff auf Dokumente und Rechnungen',
-        };
-
-        return scope.split(' ').map(s => ({
-            key: s,
-            label: mapping[s] || s.replace(':', ' '),
-        }));
-    }, [scope]);
-
-
-
-    // Show error state if validation fails
-    if (validationError) {
-        return (
-            <div className="min-h-screen flex items-center justify-center bg-background p-4 md:p-8 relative overflow-hidden font-sans">
-                <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_50%,black_40%,transparent_100%)]" />
-
-                <motion.div
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.5 }}
-                    className="relative z-10 w-full max-w-md"
-                >
-                    <Card className="border-border bg-card/80 backdrop-blur-xl shadow-2xl rounded-[2.5rem] overflow-hidden">
-                        <CardHeader className="text-center pt-8">
-                            <div className="mx-auto w-20 h-20 bg-destructive/10 rounded-3xl flex items-center justify-center mb-6 border border-destructive/20 p-4">
-                                <AlertTriangle className="w-10 h-10 text-destructive" />
-                            </div>
-                            <CardTitle className="text-2xl md:text-3xl font-bold text-foreground tracking-tight">
-                                Ungültige Anfrage
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent className="px-8 pb-8">
-                            <Alert variant="destructive" className="rounded-xl">
-                                <AlertDescription>{validationError}</AlertDescription>
-                            </Alert>
-                            <p className="text-sm text-muted-foreground mt-4 text-center">
-                                Bitte schließen Sie dieses Fenster und versuchen Sie es erneut.
-                            </p>
-                        </CardContent>
-                    </Card>
-                </motion.div>
-            </div>
-        );
+    if (!user) {
+        // Redirect to login, preserving authorization_id
+        redirect(`/login?redirect=/oauth/consent?authorization_id=${authorizationId}`);
     }
 
+    // Get authorization details using the authorization_id
+    const { data: authDetails, error: authError } = await (supabase.auth as any).oauth.getAuthorizationDetails(authorizationId);
+
+    if (authError || !authDetails) {
+        return <ConsentUI
+            type="error"
+            error={authError?.message || 'Invalid authorization request. The authorization may have expired.'}
+        />;
+    }
+
+    // Pass the authorization details to the client component for UI rendering
     return (
-        <div className="min-h-screen flex items-center justify-center bg-background p-4 md:p-8 relative overflow-hidden font-sans">
-            {/* Animated grid background - same as login page */}
-            <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_50%,black_40%,transparent_100%)]" />
-
-            {/* Gradient orbs in background */}
-            <motion.div
-                className="hidden md:block absolute top-1/4 left-1/4 w-96 h-96 rounded-full bg-primary/20 blur-[100px]"
-                animate={{
-                    x: [0, 50, 0],
-                    y: [0, 30, 0],
-                    scale: [1, 1.1, 1],
-                }}
-                transition={{ duration: 15, repeat: Infinity, ease: "easeInOut" }}
-            />
-            <motion.div
-                className="hidden md:block absolute bottom-1/4 right-1/4 w-80 h-80 rounded-full bg-secondary/20 blur-[100px]"
-                animate={{
-                    x: [0, -40, 0],
-                    y: [0, -50, 0],
-                    scale: [1, 1.2, 1],
-                }}
-                transition={{ duration: 12, repeat: Infinity, ease: "easeInOut" }}
-            />
-
-            {/* Radial spotlight */}
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,hsl(var(--muted)/0.8)_0%,transparent_50%)]" />
-
-            <motion.div
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.5 }}
-                className="relative z-10 w-full max-w-md"
-            >
-                <Card className="border-border bg-card/80 backdrop-blur-xl shadow-2xl rounded-[2.5rem] overflow-hidden">
-                    <CardHeader className="text-center pt-8">
-                        <motion.div
-                            initial={{ scale: 0.8, opacity: 0 }}
-                            animate={{ scale: 1, opacity: 1 }}
-                            transition={{ delay: 0.2, type: "spring", stiffness: 200 }}
-                            className="mx-auto w-20 h-20 bg-primary/10 rounded-3xl flex items-center justify-center mb-6 border border-primary/20 p-4"
-                        >
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img src={LOGO_URL} alt={BRAND_NAME} className="w-full h-full object-contain" />
-                        </motion.div>
-                        <CardTitle className="text-2xl md:text-3xl font-bold text-foreground tracking-tight">
-                            Berechtigung
-                        </CardTitle>
-                        <CardDescription className="text-muted-foreground mt-2">
-                            Eine externe Anwendung möchte auf Ihren <span className="text-foreground font-semibold">{BRAND_NAME}</span> Account zugreifen.
-                        </CardDescription>
-                    </CardHeader>
-
-                    <CardContent className="space-y-6 px-8">
-                        <div className="rounded-2xl bg-muted/40 border border-border p-5">
-                            <h3 className="text-[10px] font-bold text-muted-foreground uppercase tracking-widest mb-4">Angeforderte Berechtigungen</h3>
-                            <ul className="space-y-4">
-                                {formattedScopes.map((scopeItem, i) => (
-                                    <motion.li
-                                        key={scopeItem.key}
-                                        initial={{ opacity: 0, x: -10 }}
-                                        animate={{ opacity: 1, x: 0 }}
-                                        transition={{ delay: 0.3 + (i * 0.1) }}
-                                        className="flex items-start gap-3 text-sm text-foreground/90 font-medium"
-                                    >
-                                        <div className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full bg-primary/20 flex items-center justify-center">
-                                            <Check className="w-3.5 h-3.5 text-primary" />
-                                        </div>
-                                        {scopeItem.label}
-                                    </motion.li>
-                                ))}
-                            </ul>
-                        </div>
-
-                        <div className="flex items-start gap-4 p-4 rounded-xl bg-destructive/5 border border-destructive/10">
-                            <ShieldAlert className="w-5 h-5 text-destructive flex-shrink-0 mt-0.5" />
-                            <p className="text-xs text-muted-foreground leading-relaxed">
-                                Gewähren Sie nur dann Zugriff, wenn Sie der Anwendung vertrauen. Diese Anwendung kann Aktionen in Ihrem Namen ausführen.
-                            </p>
-                        </div>
-                    </CardContent>
-
-                    <CardFooter className="flex flex-col gap-3 p-8 pt-4">
-                        <Button
-                            className="w-full h-12 rounded-xl text-base font-semibold shadow-lg shadow-primary/10 transition-all hover:scale-[1.02] active:scale-[0.98]"
-                            onClick={handleAllow}
-                            disabled={isLoading}
-                        >
-                            {isLoading ? (
-                                <>
-                                    <Loader2 className="w-4 h-4 animate-spin mr-2" />
-                                    Verbindung wird hergestellt...
-                                </>
-                            ) : (
-                                'Zugriff erlauben'
-                            )}
-                        </Button>
-                        <Button
-                            variant="ghost"
-                            className="w-full h-11 text-muted-foreground hover:text-foreground rounded-xl transition-colors"
-                            onClick={handleDeny}
-                            disabled={isLoading}
-                        >
-                            Abbrechen
-                        </Button>
-                    </CardFooter>
-                </Card>
-
-                <p className="mt-8 text-center text-[10px] text-muted-foreground uppercase tracking-[0.2em] font-bold opacity-60">
-                    Sichere Verbindung via OAuth 2.1
-                </p>
-            </motion.div>
-        </div>
+        <ConsentUI
+            type="consent"
+            authorizationId={authorizationId}
+            clientName={authDetails.client?.name || 'Unknown Application'}
+            clientIcon={authDetails.client?.logo_uri}
+            redirectUri={authDetails.redirect_uri}
+            scopes={authDetails.scopes || []}
+        />
     );
 }
-
-export default function ConsentPage() {
-    return (
-        <Suspense fallback={
-            <div className="flex items-center justify-center min-h-screen bg-background">
-                <Loader2 className="w-10 h-10 text-primary animate-spin" />
-            </div>
-        }>
-            <ConsentContent />
-        </Suspense>
-    );
-}
-

--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useSearchParams } from 'next/navigation';
-import { useState, Suspense, useMemo } from 'react';
+import { useState, Suspense, useMemo, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { ShieldAlert, Check, Loader2, AlertTriangle } from 'lucide-react';
@@ -57,12 +57,12 @@ function ConsentContent() {
 
     // Handle authorization approval when authorization_id is present
     // Redirect to API route which handles the approval server-side with proper session
-    useState(() => {
+    useEffect(() => {
         if (authorizationId && approvalStatus === 'approving') {
             // Redirect to API route for approval
             window.location.href = `/api/oauth/approve?authorization_id=${encodeURIComponent(authorizationId)}`;
         }
-    });
+    }, [authorizationId, approvalStatus]);
 
     // Check for error from API route redirect
     const error = searchParams.get('error');

--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -60,25 +60,13 @@ export default async function ConsentPage({ searchParams }: PageProps) {
         redirect(`/login?redirect=/oauth/consent?authorization_id=${authorizationId}`);
     }
 
-    // Get authorization details using the authorization_id
-    const { data: authDetails, error: authError } = await (supabase.auth as any).oauth.getAuthorizationDetails(authorizationId);
-
-    if (authError || !authDetails) {
-        return <ConsentUI
-            type="error"
-            error={authError?.message || 'Invalid authorization request. The authorization may have expired.'}
-        />;
-    }
-
-    // Pass the authorization details to the client component for UI rendering
+    // Just pass the authorization_id to the client component
+    // The client will call getAuthorizationDetails and approveAuthorization
+    // This avoids any potential issues with server-side calls consuming the authorization
     return (
         <ConsentUI
             type="consent"
             authorizationId={authorizationId}
-            clientName={authDetails.client?.name || 'Unknown Application'}
-            clientIcon={authDetails.client?.logo_uri}
-            redirectUri={authDetails.redirect_uri}
-            scopes={authDetails.scopes || []}
         />
     );
 }

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -11,3 +11,11 @@ export interface Profile {
   onboarding_completed?: boolean;
   setup_completed?: boolean;
 }
+
+export interface SupabaseAuthWithOAuth {
+  oauth: {
+    approveAuthorization(authorizationId: string): Promise<{ data: any; error: any }>;
+    denyAuthorization(authorizationId: string): Promise<{ data: any; error: any }>;
+    getAuthorizationDetails(authorizationId: string): Promise<{ data: any; error: any }>;
+  };
+}


### PR DESCRIPTION
## Description

Implements the full OAuth authorization flow: consent screen, approve/deny endpoints and the token exchange.

## Summary of Changes

- `oauth/consent/page.tsx` rewritten as a server component: session check with login redirect (preserving `authorization_id`), error rendering
- New `ConsentUI.tsx`: fetches authorization details client-side, auto-follows already-approved authorizations, approve/deny via the Supabase OAuth SDK
- New `oauth/consent/actions.ts`: `approveAuthorizationAction` server action (UUID validation, cookie forwarding to the Supabase endpoint)
- New API routes: `/api/oauth/approve` (session-bound approval with SDK fallback + redirect), `/api/oauth/decision` (form POST approve/deny), `/api/oauth/token` (PKCE token exchange proxy with strict client_id/secret validation against an allowlist, fail-closed when unconfigured)
- `types/supabase.ts`: `SupabaseAuthWithOAuth` interface for the OAuth SDK surface