### PR TITLE
fix: resolve onboarding bugs including dropdown z-index issues and em…

### DIFF
--- a/components/onboarding/onboarding-tour.tsx
+++ b/components/onboarding/onboarding-tour.tsx
@@ -189,20 +189,21 @@ export function OnboardingTour() {
             if (isActive) {
                 const step = TOUR_STEPS[currentStepIndex];
                 if (step) {
+                    const buttons: any[] = [];
+                    if (currentStepIndex > 0) {
+                        buttons.push('previous');
+                    }
+
+                    // Add next button
+                    // If it's the last step, driver.js automatically changes logic, but we handle it via store
+                    if (!step.hideNext) {
+                        buttons.push('next');
+                    }
+
+                    // Always show close button since allowClose is false
+                    buttons.push('close');
+
                     try {
-                        const buttons = [];
-                        if (currentStepIndex > 0) {
-                            buttons.push('previous');
-                        }
-
-                        // Add next button
-                        // If it's the last step, driver.js automatically changes logic, but we handle it via store
-                        if (!step.hideNext) {
-                            buttons.push('next');
-                        }
-
-                        // Always show close button since allowClose is false
-                        buttons.push('close');
 
                         // Check if we need to navigate
                         if (step.path && pathname !== step.path) {

--- a/components/onboarding/onboarding-tour.tsx
+++ b/components/onboarding/onboarding-tour.tsx
@@ -197,7 +197,9 @@ export function OnboardingTour() {
 
                         // Add next button
                         // If it's the last step, driver.js automatically changes logic, but we handle it via store
-                        buttons.push('next');
+                        if (!step.hideNext) {
+                            buttons.push('next');
+                        }
 
                         // Always show close button since allowClose is false
                         buttons.push('close');
@@ -241,6 +243,19 @@ export function OnboardingTour() {
                         });
                     } catch (e) {
                         console.warn(`Could not find element ${step.element} for step ${step.id}`);
+                        // Fallback: Show popover in the center if element is not found
+                        driverInstance.highlight({
+                            element: undefined as any,
+                            popover: {
+                                title: step.title,
+                                description: step.description,
+                                side: "over",
+                                align: 'center',
+                                showButtons: buttons,
+                                progressText: `${currentStepIndex + 1} von ${TOUR_STEPS.length}`,
+                                nextBtnText: currentStepIndex === TOUR_STEPS.length - 1 ? 'Beenden' : 'Weiter'
+                            }
+                        });
                     }
                 } else {
                     driverInstance.destroy();

--- a/components/onboarding/onboarding.css
+++ b/components/onboarding/onboarding.css
@@ -10,6 +10,15 @@
     padding: 1.5rem;
     max-width: 400px;
     font-family: inherit;
+    z-index: 100000 !important;
+}
+
+.driver-overlay {
+    z-index: 99999 !important;
+}
+
+.driver-popover-arrow {
+    z-index: 100001 !important;
 }
 
 .driver-popover.driverjs-theme .driver-popover-title {

--- a/components/ui/action-menu.tsx
+++ b/components/ui/action-menu.tsx
@@ -129,6 +129,7 @@ export function ActionMenu({
                 return (
                     <Button
                         key={action.id ?? `${action.label}-${index}`}
+                        id={action.id}
                         variant="ghost"
                         size="icon"
                         onClick={handleClick}

--- a/components/ui/context-menu.tsx
+++ b/components/ui/context-menu.tsx
@@ -46,7 +46,7 @@ const ContextMenuSubContent = React.forwardRef<
   <ContextMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-2xl border bg-popover p-2 text-popover-foreground shadow-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-[999999999] min-w-[8rem] overflow-hidden rounded-2xl border bg-popover p-2 text-popover-foreground shadow-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -62,7 +62,7 @@ const ContextMenuContent = React.forwardRef<
     <ContextMenuPrimitive.Content
       ref={ref}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-2xl border bg-popover p-2 text-popover-foreground shadow-xl animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-[999999999] min-w-[8rem] overflow-hidden rounded-2xl border bg-popover p-2 text-popover-foreground shadow-xl animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -22,7 +22,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[9999] bg-black/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -33,7 +33,7 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 const dialogContentVariants = cva(
   // Base styles - mobile-first: Full-width drawer from bottom
   [
-    "fixed z-50 grid w-full gap-4 border bg-background shadow-xl duration-300",
+    "fixed z-[9999] grid w-full gap-4 border bg-background shadow-xl duration-300",
     // Mobile positioning: bottom sheet style
     "inset-x-0 bottom-0 max-h-[90vh] overflow-y-auto rounded-t-2xl p-4 pb-6",
     // Mobile animations: slide up from bottom

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -19,7 +19,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-2xl border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 pointer-events-auto",
+        "z-[999999999] w-72 rounded-2xl border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 pointer-events-auto",
         className
       )}
       style={style}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -78,7 +78,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-2xl border bg-popover p-1 text-popover-foreground shadow-xl backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-[999999999] max-h-96 min-w-[8rem] overflow-hidden rounded-2xl border bg-popover p-1 text-popover-foreground shadow-xl backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       position={position}

--- a/constants/onboarding-steps.ts
+++ b/constants/onboarding-steps.ts
@@ -6,6 +6,7 @@ export interface TourStep {
     title: string;
     description: string;
     path?: string;
+    hideNext?: boolean;
 }
 
 export const TOUR_STEPS: TourStep[] = [
@@ -15,6 +16,7 @@ export const TOUR_STEPS: TourStep[] = [
         title: 'Objekt anlegen',
         description: 'Beginnen Sie hier, um Ihre erste Immobilie anzulegen.',
         path: '/haeuser',
+        hideNext: true,
     },
     {
         id: 'create-house-form',
@@ -28,6 +30,7 @@ export const TOUR_STEPS: TourStep[] = [
         title: 'Wohnung hinzufügen',
         description: 'Legen Sie nun eine Einheit in diesem Objekt an.',
         path: '/wohnungen',
+        hideNext: true,
     },
     {
         id: 'create-apartment-form',
@@ -41,12 +44,14 @@ export const TOUR_STEPS: TourStep[] = [
         title: 'Wohnungsoptionen',
         description: 'Klicken Sie auf das Menü, um weitere Optionen für die Wohnung zu sehen.',
         path: '/wohnungen',
+        hideNext: true,
     },
     {
         id: 'create-meter-select',
         element: '#context-menu-meter-item',
         title: 'Zähler hinzufügen',
         description: 'Wählen Sie "Wasserzähler", um die Zählerverwaltung zu öffnen.',
+        hideNext: true,
     },
     {
         id: 'create-meter-form',
@@ -60,6 +65,7 @@ export const TOUR_STEPS: TourStep[] = [
         title: 'Mieter zuweisen',
         description: 'Verknüpfen Sie nun einen Mieter mit der Wohnung.',
         path: '/mieter',
+        hideNext: true,
     },
     {
         id: 'assign-tenant-form',
@@ -73,12 +79,14 @@ export const TOUR_STEPS: TourStep[] = [
         title: 'Abrechnung erstellen',
         description: 'Klicken Sie hier, um das Menü für neue Abrechnungen zu öffnen.',
         path: '/betriebskosten',
+        hideNext: true,
     },
     {
         id: 'create-bill-select',
         element: '#utility-bill-template-option',
         title: 'Standard-Vorlage wählen',
         description: 'Wählen Sie die Standard-Vorlage, um eine neue Betriebskostenabrechnung mit vordefinierten Werten zu erstellen.',
+        hideNext: true,
     },
     {
         id: 'create-bill-form',


### PR DESCRIPTION
## Description

Improves the onboarding tour's robustness and fixes layering conflicts between overlays, menus and dialogs.

## Summary of Changes

- `onboarding-tour.tsx`: new `hideNext` step option (interactive steps now wait for the user action instead of offering "Weiter"); if a step's target element is missing, the popover falls back to a centered display instead of breaking the tour
- `onboarding-steps.ts`: `hideNext` set on all interactive steps (create house/apartment/meter/tenant/bill flows)
- `onboarding.css`: driver.js popover/overlay/arrow z-index raised above the app chrome
- UI primitives: context-menu, popover and select content moved to `z-[999999999]`, dialog overlay/content to `z-[9999]` — menus and popovers now render above dialogs reliably
- `action-menu.tsx`: buttons expose the action `id` for the tour anchors