### PR TITLE
Fix account deletion flow: correct reauth verification and prevent do…

### DIFF
--- a/components/ui/confirmation-alert-dialog.tsx
+++ b/components/ui/confirmation-alert-dialog.tsx
@@ -24,6 +24,7 @@ interface ConfirmationAlertDialogProps {
   confirmButtonText?: string;
   cancelButtonText?: string;
   confirmButtonVariant?: "default" | "destructive"; // Retained for logic, applied via className
+  isDeleting?: boolean;
 }
 
 export function ConfirmationAlertDialog({
@@ -36,11 +37,11 @@ export function ConfirmationAlertDialog({
   confirmButtonText,
   cancelButtonText,
   confirmButtonVariant = "default", // Default to 'default'
+  isDeleting = false,
 }: ConfirmationAlertDialogProps) {
-  
+
   const handleConfirm = () => {
     onConfirm();
-    onOpenChange(false); // Close dialog after confirmation
   };
 
   const handleCancel = () => {
@@ -61,13 +62,14 @@ export function ConfirmationAlertDialog({
           <AlertDialogCancel onClick={handleCancel}>
             {cancelButtonText || "Abbrechen"}
           </AlertDialogCancel>
-          <AlertDialogAction 
+          <AlertDialogAction
             onClick={handleConfirm}
+            disabled={isDeleting}
             // Apply destructive styling if variant is 'destructive'
             // This uses buttonVariants from ui/button to get the correct classes
             className={confirmButtonVariant === 'destructive' ? buttonVariants({ variant: 'destructive' }) : ''}
           >
-            {confirmButtonText || "Bestätigen"}
+            {isDeleting ? "Wird verarbeitet..." : (confirmButtonText || "Bestätigen")}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>


### PR DESCRIPTION
## Description

Fixes the re-authentication flow for account deletion and prevents double submits.

## Summary of Changes

- `profile-section.tsx`: OTP verification now uses the supported `updateUser({ nonce })` flow (after `reauthenticate()`) instead of the failing `verifyOtp({ type: 'reauthentication' })`; the current user is fetched first and errors are logged in detail
- Initiation guarded against duplicate clicks while deleting
- `confirmation-alert-dialog.tsx`: new `isDeleting` prop — disables the confirm button and shows "Wird verarbeitet..."; the dialog no longer auto-closes on confirm