### PR TITLE
Add OAuth Apps management section to Settings modal

### DIFF
--- a/components/modals/settings-modal.test.tsx
+++ b/components/modals/settings-modal.test.tsx
@@ -11,6 +11,7 @@ jest.mock('posthog-js/react', () => ({
 // Mock child components to simplify testing
 jest.mock('../settings/profile-section', () => () => <div data-testid="profile-section">Profile Section</div>);
 jest.mock('../settings/security-section', () => () => <div data-testid="security-section">Security Section</div>);
+jest.mock('../settings/oauth-apps-section', () => () => <div data-testid="oauth-apps-section">OAuth Apps Section</div>);
 jest.mock('../settings/subscription-section', () => () => <div data-testid="subscription-section">Subscription Section</div>);
 jest.mock('../settings/mail-section', () => () => <div data-testid="mail-section">Mail Section</div>);
 jest.mock('../settings/display-section', () => () => <div data-testid="display-section">Display Section</div>);

--- a/components/modals/settings-modal.tsx
+++ b/components/modals/settings-modal.tsx
@@ -10,6 +10,7 @@ import {
   Info,
   Monitor,
   FlaskConical,
+  AppWindow,
   Mail,
 } from "lucide-react";
 import { SettingsSidebar } from "../settings/sidebar"
@@ -17,6 +18,7 @@ import type { Tab } from "@/types/settings"
 import ProfileSection from "../settings/profile-section";
 import DisplaySection from "../settings/display-section";
 import SecuritySection from "../settings/security-section";
+import OAuthAppsSection from "../settings/oauth-apps-section";
 import SubscriptionSection from "../settings/subscription-section";
 import ExportSection from "../settings/export-section";
 import FeaturePreviewSection from "../settings/feature-preview-section";
@@ -44,6 +46,12 @@ export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
       label: "Sicherheit",
       icon: Lock,
       content: <SecuritySection />,
+    },
+    {
+      value: "oauth-apps",
+      label: "OAuth-Apps",
+      icon: AppWindow,
+      content: <OAuthAppsSection />,
     },
     {
       value: "subscription",

--- a/components/settings/oauth-apps-section.tsx
+++ b/components/settings/oauth-apps-section.tsx
@@ -1,0 +1,148 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { SettingsCard, SettingsSection } from "@/components/settings/shared"
+import { useToast } from "@/hooks/use-toast"
+import { createClient } from "@/utils/supabase/client"
+import type { OAuthGrant, SupabaseAuthWithOAuth } from "@/types/supabase"
+import { ExternalLink, Loader2, ShieldCheck } from "lucide-react"
+
+const OAuthAppsSection = () => {
+  const supabase = useMemo(() => createClient(), [])
+  const { toast } = useToast()
+  const [grants, setGrants] = useState<OAuthGrant[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
+  const [revokingId, setRevokingId] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const loadGrants = async () => {
+    setLoading(true)
+    setErrorMessage(null)
+
+    const { data, error } = await (supabase.auth as unknown as SupabaseAuthWithOAuth).oauth.listGrants()
+
+    if (error) {
+      setErrorMessage("Die verbundenen Apps konnten nicht geladen werden.")
+      setGrants([])
+      setLoading(false)
+      return
+    }
+
+    setGrants(data ?? [])
+    setLoading(false)
+  }
+
+  useEffect(() => {
+    void loadGrants()
+  }, [])
+
+  const handleRevoke = async (grant: OAuthGrant) => {
+    setRevokingId(grant.client.id)
+    const { error } = await (supabase.auth as unknown as SupabaseAuthWithOAuth).oauth.revokeGrant({
+      clientId: grant.client.id,
+    })
+
+    if (error) {
+      toast({
+        title: "Fehler",
+        description: "Die Verbindung konnte nicht entfernt werden.",
+        variant: "destructive",
+      })
+      setRevokingId(null)
+      return
+    }
+
+    setGrants((prev) => prev.filter((item) => item.client.id !== grant.client.id))
+    toast({
+      title: "Verbindung entfernt",
+      description: `${grant.client.name} wurde getrennt.`,
+      variant: "success",
+    })
+    setRevokingId(null)
+  }
+
+  return (
+    <SettingsSection
+      title="Verbundene OAuth-Apps"
+      description="Verwalten Sie die Anwendungen, denen Sie Zugriff auf Ihr Konto gewährt haben."
+    >
+      <SettingsCard className="space-y-4">
+        {loading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Lade verbundene Apps...
+          </div>
+        ) : errorMessage ? (
+          <p className="text-sm text-destructive">{errorMessage}</p>
+        ) : grants.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Aktuell sind keine OAuth-Apps verbunden.</p>
+        ) : (
+          <div className="space-y-4">
+            {grants.map((grant) => (
+              <div
+                key={grant.client.id}
+                className="flex flex-col gap-4 rounded-xl border border-border/60 bg-background p-4 md:flex-row md:items-center md:justify-between"
+              >
+                <div className="flex items-start gap-3">
+                  {grant.client.logo_uri ? (
+                    <img
+                      src={grant.client.logo_uri}
+                      alt={`${grant.client.name} Logo`}
+                      className="h-10 w-10 rounded-lg border border-border/60 object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-border/60 bg-muted">
+                      <ShieldCheck className="h-5 w-5 text-muted-foreground" />
+                    </div>
+                  )}
+                  <div className="space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="text-sm font-semibold text-foreground">{grant.client.name}</p>
+                      {grant.client.uri && (
+                        <a
+                          href={grant.client.uri}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+                        >
+                          Website
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      )}
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Zugriff gewährt am {new Date(grant.granted_at).toLocaleDateString("de-DE", {
+                        dateStyle: "medium",
+                      })}
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {grant.scopes.map((scope) => (
+                        <Badge key={scope} variant="secondary" className="text-xs">
+                          {scope}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex justify-end">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleRevoke(grant)}
+                    disabled={revokingId === grant.client.id}
+                  >
+                    {revokingId === grant.client.id ? "Trennen..." : "Verbindung entfernen"}
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </SettingsCard>
+    </SettingsSection>
+  )
+}
+
+export default OAuthAppsSection

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -17,5 +17,20 @@ export interface SupabaseAuthWithOAuth {
     approveAuthorization(authorizationId: string): Promise<{ data: any; error: any }>;
     denyAuthorization(authorizationId: string): Promise<{ data: any; error: any }>;
     getAuthorizationDetails(authorizationId: string): Promise<{ data: any; error: any }>;
+    listGrants(): Promise<{ data: OAuthGrant[] | null; error: any }>;
+    revokeGrant(options: { clientId: string }): Promise<{ data: {}; error: any }>;
   };
 }
+
+export type OAuthGrant = {
+  client: OAuthAuthorizationClient;
+  scopes: string[];
+  granted_at: string;
+};
+
+export type OAuthAuthorizationClient = {
+  id: string;
+  name: string;
+  uri: string;
+  logo_uri: string;
+};


### PR DESCRIPTION
### Motivation
- Provide a UI in the settings modal so users can view and manage (revoke) OAuth apps they previously granted access to. 
- Integrate with Supabase Auth OAuth grant APIs so revocations happen server-side via the existing client.

### Description
- Added a new React section `components/settings/oauth-apps-section.tsx` that lists grants from `supabase.auth.oauth.listGrants()` and allows revoking via `supabase.auth.oauth.revokeGrant()`; shows client name, logo, granted date and scopes, and a revoke button. 
- Registered a new tab in the settings modal by importing the new section and adding an `oauth-apps` tab (icon `AppWindow`) in `components/modals/settings-modal.tsx` so the section is reachable from the sidebar. 
- Extended `types/supabase.ts` with `OAuthGrant`, `OAuthAuthorizationClient` and added `listGrants()` / `revokeGrant()` signatures to `SupabaseAuthWithOAuth` for proper typing of the Supabase auth client usage. 
- Updated `components/modals/settings-modal.test.tsx` to mock the new `oauth-apps-section` to keep tests isolated.

### Testing
- Started the dev server with `NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run dev` and verified the application boots successfully. (Succeeded)
- Ran a Playwright smoke script that loaded `http://localhost:3000` and produced a screenshot artifact to validate the UI loads; the script executed and saved `artifacts/settings-oauth-apps.png`. (Succeeded)
- No unit tests or component snapshots were executed as part of this change; test files were updated to mock the new component but `jest` was not run. (Not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981c39eb24483239ebda980e307bb29)