### PR TITLE
feat(worker): add PostHog logging with backend source

### DIFF
--- a/workers/mietevo-backend/src/index.ts
+++ b/workers/mietevo-backend/src/index.ts
@@ -438,7 +438,7 @@ async function handleAIRequest(request: Request, env: Env, ctx: any): Promise<Re
         // Check for API key
         if (!env.GEMINI_API_KEY) {
             logger.error('Gemini API key not configured');
-            await logger.flush();
+            logger.flush();
             return new Response(JSON.stringify({ error: "API key not configured" }), { status: 500 });
         }
 
@@ -448,7 +448,7 @@ async function handleAIRequest(request: Request, env: Env, ctx: any): Promise<Re
             const { success } = await env.RATE_LIMITER.limit({ key: ip });
             if (!success) {
                 logger.warn('Rate limit exceeded', { ip });
-                await logger.flush();
+                logger.flush();
                 return new Response(JSON.stringify({
                     error: {
                         message: "Too many requests. Please try again later.",
@@ -546,7 +546,7 @@ async function handleAIRequest(request: Request, env: Env, ctx: any): Promise<Re
         // but we can also explicitly flush here if we want to be sure, though synchronous flush might delay response.
         // Better to rely on ctx.waitUntil which WorkerLogger handles in flush().
         logger.info('AI Request stream started', { sessionId });
-        await logger.flush();
+        logger.flush();
 
         return new Response(readableStream, {
             headers: {
@@ -563,7 +563,7 @@ async function handleAIRequest(request: Request, env: Env, ctx: any): Promise<Re
         console.error("AI Request Error:", e);
         if (logger) {
             logger.error('AI Request Error', { error: e.message });
-            await logger.flush();
+            logger.flush();
         }
         const errorMessage = e.message || "An unexpected error occurred.";
         const statusCode = e.status || 500;
@@ -725,7 +725,7 @@ export default {
                     pageCount: totalPages,
                     durationMs: endTime - startTime
                 });
-                await logger.flush();
+                logger.flush();
 
                 return new Response(new Uint8Array(pdfBuffer), {
                     headers: {
@@ -739,7 +739,7 @@ export default {
                 });
             }
 
-            await logger.flush();
+            logger.flush();
             return new Response('Invalid Request Type', { status: 400, headers: corsHeaders });
         } catch (error: any) {
             // We need to instantiate logger here if it wasn't already or ensure we have access to it.
@@ -747,7 +747,7 @@ export default {
             // For now, let's just use console.error as fallback, but if we want PostHog:
             const logger = new WorkerLogger(env, ctx);
             logger.error('Worker Error', { error: error.message });
-            await logger.flush();
+            logger.flush();
 
             return new Response(`Error: ${error.message}`, { status: 500, headers: corsHeaders });
         }

--- a/workers/mietevo-backend/src/logger.ts
+++ b/workers/mietevo-backend/src/logger.ts
@@ -62,6 +62,9 @@ export class WorkerLogger {
     constructor(env: Env, ctx: ExecutionContext) {
         this.env = env;
         this.ctx = ctx;
+        if (!this.env.POSTHOG_API_KEY) {
+            console.warn('[WorkerLogger] POSTHOG_API_KEY not set. Logs will not be sent to PostHog.');
+        }
     }
 
     private buildResourceAttributes() {
@@ -73,6 +76,9 @@ export class WorkerLogger {
     }
 
     log(severity: 'debug' | 'info' | 'warn' | 'error', message: string, attributes: LogAttributes = {}) {
+        // Console log for local debugging / real-time logs in dashboard
+        console.log(`[${severity.toUpperCase()}] ${message}`, JSON.stringify(attributes));
+
         const apiKey = this.env.POSTHOG_API_KEY;
         if (!apiKey) return;
 
@@ -84,9 +90,6 @@ export class WorkerLogger {
             'log.timestamp': timestamp,
             'service.name': SERVICE_NAME,
         };
-
-        // Console log for local debugging / real-time logs in dashboard
-        console.log(`[${severity.toUpperCase()}] ${message}`, JSON.stringify(attributes));
 
         this.logs.push({
             timeUnixNano: String(Date.now() * 1000000),

--- a/workers/mietevo-backend/src/logger.ts
+++ b/workers/mietevo-backend/src/logger.ts
@@ -41,12 +41,25 @@ function getSeverityNumber(severity: string): number {
     return map[severity.toLowerCase()] || 9;
 }
 
-export class WorkerLogger {
-    private logs: any[] = [];
-    private env: Env;
-    private ctx: any;
+// Minimal interface for Cloudflare Worker ExecutionContext
+export interface ExecutionContext {
+    waitUntil(promise: Promise<any>): void;
+}
 
-    constructor(env: Env, ctx: any) {
+interface LogRecord {
+    timeUnixNano: string;
+    severityNumber: number;
+    severityText: string;
+    body: { stringValue: string };
+    attributes: { key: string; value: Record<string, unknown> }[];
+}
+
+export class WorkerLogger {
+    private logs: LogRecord[] = [];
+    private env: Env;
+    private ctx: ExecutionContext;
+
+    constructor(env: Env, ctx: ExecutionContext) {
         this.env = env;
         this.ctx = ctx;
     }

--- a/workers/mietevo-backend/src/logger.ts
+++ b/workers/mietevo-backend/src/logger.ts
@@ -1,0 +1,138 @@
+/**
+ * PostHog Logger for Cloudflare Workers
+ * 
+ * Adapted for the Worker environment where process.env is not available directly
+ * and we need to use ctx.waitUntil for async operations.
+ */
+
+export interface Env {
+    POSTHOG_API_KEY?: string;
+    POSTHOG_HOST?: string;
+    [key: string]: any;
+}
+
+export interface LogAttributes {
+    [key: string]: string | number | boolean | string[] | number[] | null | undefined;
+}
+
+const SERVICE_NAME = 'backend';
+
+// Helper to format attributes for OTLP
+function formatAttributeValue(value: unknown): Record<string, unknown> {
+    if (typeof value === 'string') return { stringValue: value };
+    if (typeof value === 'number') {
+        if (Number.isInteger(value)) return { intValue: String(value) };
+        return { doubleValue: value };
+    }
+    if (typeof value === 'boolean') return { boolValue: value };
+    if (Array.isArray(value)) {
+        return { arrayValue: { values: value.map(v => formatAttributeValue(v)) } };
+    }
+    return { stringValue: String(value) };
+}
+
+function getSeverityNumber(severity: string): number {
+    const map: Record<string, number> = {
+        'debug': 5,
+        'info': 9,
+        'warn': 13,
+        'error': 17,
+    };
+    return map[severity.toLowerCase()] || 9;
+}
+
+export class WorkerLogger {
+    private logs: any[] = [];
+    private env: Env;
+    private ctx: any;
+
+    constructor(env: Env, ctx: any) {
+        this.env = env;
+        this.ctx = ctx;
+    }
+
+    private buildResourceAttributes() {
+        return [
+            { key: 'service.name', value: { stringValue: SERVICE_NAME } },
+            { key: 'deployment.environment', value: { stringValue: 'production' } }, // Workers are usually prod or dev, but valid value needed
+            { key: 'telemetry.sdk.name', value: { stringValue: 'posthog-worker-logger' } },
+        ];
+    }
+
+    log(severity: 'debug' | 'info' | 'warn' | 'error', message: string, attributes: LogAttributes = {}) {
+        const apiKey = this.env.POSTHOG_API_KEY;
+        if (!apiKey) return;
+
+        const timestamp = new Date().toISOString();
+
+        // Enrich attributes
+        const enrichedAttributes = {
+            ...attributes,
+            'log.timestamp': timestamp,
+            'service.name': SERVICE_NAME,
+        };
+
+        // Console log for local debugging / real-time logs in dashboard
+        console.log(`[${severity.toUpperCase()}] ${message}`, JSON.stringify(attributes));
+
+        this.logs.push({
+            timeUnixNano: String(Date.now() * 1000000),
+            severityNumber: getSeverityNumber(severity),
+            severityText: severity.toUpperCase(),
+            body: { stringValue: message },
+            attributes: Object.entries(enrichedAttributes)
+                .filter(([, v]) => v !== null && v !== undefined)
+                .map(([key, value]) => ({
+                    key,
+                    value: formatAttributeValue(value)
+                }))
+        });
+    }
+
+    debug(message: string, attributes?: LogAttributes) { this.log('debug', message, attributes); }
+    info(message: string, attributes?: LogAttributes) { this.log('info', message, attributes); }
+    warn(message: string, attributes?: LogAttributes) { this.log('warn', message, attributes); }
+    error(message: string, attributes?: LogAttributes) { this.log('error', message, attributes); }
+
+    async flush() {
+        if (this.logs.length === 0) return;
+
+        const apiKey = this.env.POSTHOG_API_KEY;
+        const host = this.env.POSTHOG_HOST || 'https://eu.i.posthog.com';
+        const endpoint = `${host.replace(/\/$/, '')}/i/v1/logs`;
+
+        const payload = {
+            resourceLogs: [{
+                resource: {
+                    attributes: this.buildResourceAttributes()
+                },
+                scopeLogs: [{
+                    scope: { name: SERVICE_NAME, version: '1.0.0' },
+                    logRecords: this.logs
+                }]
+            }]
+        };
+
+        // Clear logs immediately to avoid double sending if flush called twice
+        const logsCount = this.logs.length;
+        this.logs = [];
+
+        const promise = fetch(endpoint, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${apiKey}`,
+            },
+            body: JSON.stringify(payload),
+        }).catch(err => {
+            console.error('Failed to send logs to PostHog', err);
+        });
+
+        // Use waitUntil if available to ensure logs are sent even if response is already returned
+        if (this.ctx && this.ctx.waitUntil) {
+            this.ctx.waitUntil(promise);
+        } else {
+            await promise;
+        }
+    }
+}


### PR DESCRIPTION
## Description

Introduces a PostHog-backed logger for the Cloudflare worker and instruments the AI endpoint.

## Summary of Changes

- New `logger.ts`: `WorkerLogger` ships OTLP log records to PostHog (`/i/v1/logs`) with severity mapping and attribute typing; `flush()` uses `ctx.waitUntil` so logs survive the response
- `handleAIRequest`: logs request received, missing API key, rate-limit hits, stream start and errors
- Main fetch handler: logs incoming file-generation requests and PDF completion (pages + duration), plus a single error log on failure
- New optional env: `POSTHOG_API_KEY`, `POSTHOG_HOST`