### PR TITLE
feat: add feature flag for tenant tabs and status field

### DIFF
--- a/app/(dashboard)/mieter/page.tsx
+++ b/app/(dashboard)/mieter/page.tsx
@@ -17,7 +17,7 @@ export default async function MieterPage() {
 
   const { data: rawMieter, error: mieterError } = await supabase
     .from('Mieter')
-    .select('id,wohnung_id,einzug,auszug,name,nebenkosten,email,telefonnummer,notiz,kaution');
+    .select('id,wohnung_id,einzug,auszug,name,nebenkosten,email,telefonnummer,notiz,kaution,status');
   if (mieterError) console.error('Fehler beim Laden der Mieter:', mieterError);
 
   const today = new Date();
@@ -35,8 +35,8 @@ export default async function MieterPage() {
     } as Wohnung;
   }) : [];
 
-  const mieter: Tenant[] = rawMieter ? rawMieter.map(m => ({...m})) : [];
-  
+  const mieter: Tenant[] = rawMieter ? rawMieter.map(m => ({ ...m })) : [];
+
 
 
   return (

--- a/app/mieter-actions.ts
+++ b/app/mieter-actions.ts
@@ -3,7 +3,7 @@
 import { createClient } from "@/utils/supabase/server";
 import { revalidatePath } from "next/cache";
 import { Mieter } from "../lib/data-fetching";
-import { KautionData, KautionStatus } from "@/types/Tenant";
+import { KautionData, KautionStatus, TenantStatus } from "@/types/Tenant";
 import { logAction } from '@/lib/logging-middleware';
 import { getPostHogServer } from '@/app/posthog-server.mjs';
 import { logger } from '@/utils/logger';
@@ -26,6 +26,7 @@ export async function handleSubmit(formData: FormData): Promise<{ success: boole
       email: formData.get('email') || null,
       telefonnummer: formData.get('telefonnummer') || null,
       notiz: formData.get('notiz') || null,
+      status: (formData.get('status') as TenantStatus) || 'mieter',
       nebenkosten: (() => {
         const nebenkostenRaw = formData.get('nebenkosten');
         if (nebenkostenRaw && typeof nebenkostenRaw === 'string' && nebenkostenRaw.length > 0) {
@@ -75,6 +76,7 @@ export async function handleSubmit(formData: FormData): Promise<{ success: boole
             has_property: !!payload.wohnung_id,
             property_id: payload.wohnung_id,
             has_email: !!payload.email,
+            status: payload.status,
             source: 'server_action'
           }
         });

--- a/supabase/migrations/20260204173924_add_status_to_mieter.sql
+++ b/supabase/migrations/20260204173924_add_status_to_mieter.sql
@@ -1,0 +1,6 @@
+-- Add status column to Mieter table
+ALTER TABLE "Mieter" 
+ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'mieter';
+
+-- Create index for status column
+CREATE INDEX IF NOT EXISTS idx_mieter_status ON "Mieter" (status);

--- a/types/Tenant.ts
+++ b/types/Tenant.ts
@@ -31,4 +31,7 @@ export interface Tenant {
   notiz?: string;
   nebenkosten?: NebenkostenEntry[];
   kaution?: KautionData;    // New optional kaution field
+  status?: TenantStatus;
 }
+
+export type TenantStatus = 'bewerber' | 'mieter';


### PR DESCRIPTION
## Description

Introduces a tenant/applicant split on the Mieter page with a dedicated status field.

## Summary of Changes

- Migration `add_status_to_mieter.sql`: `status` column (default `'mieter'`) + index
- `TenantStatus` type (`'bewerber' | 'mieter'`); page query includes `status`
- `client-wrapper.tsx`: Mieter/Bewerber tabs (behind the `show-tenant-tabs` feature flag) with per-tab stats, search and bulk actions; CSV export includes the status
- `tenant-edit-modal.tsx`: status selector; "Als Mieter übernehmen" conversion action (sets move-in date, hides Auszug/Nebenkosten for applicants)
- `mieter-actions.ts`: status persisted on create/update and tracked in PostHog