### PR TITLE
fix: use maybeSingle to prevent 406 errors and validate meter imports…

### DIFF
--- a/app/api/wasser-ablesungen/[id]/route.ts
+++ b/app/api/wasser-ablesungen/[id]/route.ts
@@ -27,7 +27,7 @@ export async function PATCH(
       .select('id, zaehler_id')
       .eq('id', id)
       .eq('user_id', user.id)
-      .single()
+      .maybeSingle()
 
     if (fetchError || !existing) {
       return NextResponse.json({ error: 'Zaehler_Ablesung not found or access denied' }, { status: 404 })
@@ -89,7 +89,7 @@ export async function DELETE(
       .select('id, zaehler_id')
       .eq('id', id)
       .eq('user_id', user.id)
-      .single()
+      .maybeSingle()
 
     if (fetchError || !existing) {
       return NextResponse.json({ error: 'Zaehler_Ablesung not found or access denied' }, { status: 404 })

--- a/app/api/wasser-ablesungen/route.ts
+++ b/app/api/wasser-ablesungen/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: NextRequest) {
       .select('id')
       .eq('id', wasserZaehlerId)
       .eq('user_id', user.id)
-      .single()
+      .maybeSingle()
 
     if (zaehlerError || !zaehler) {
       return NextResponse.json({ error: 'Wasserzähler not found or access denied' }, { status: 404 })
@@ -77,7 +77,7 @@ export async function POST(request: NextRequest) {
       .select('id')
       .eq('id', meterId)
       .eq('user_id', user.id)
-      .single()
+      .maybeSingle()
 
     if (zaehlerError || !zaehler) {
       return NextResponse.json({ error: 'Wasserzähler not found or access denied' }, { status: 404 })

--- a/app/meter-actions.ts
+++ b/app/meter-actions.ts
@@ -282,6 +282,40 @@ export async function getAblesungenForZaehlerAction(zaehlerId: string) {
 // Legacy alias
 export const getWasserAblesenDataAction = getAblesungenForZaehlerAction;
 
+
+/**
+ * Fetch readings for multiple meters
+ */
+export async function getReadingsForMetersAction(meterIds: string[]) {
+  const supabase = await createClient();
+
+  try {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) {
+      return { success: false, message: "Benutzer nicht authentifiziert." };
+    }
+
+    if (!meterIds || meterIds.length === 0) {
+      return { success: true, data: [] };
+    }
+
+    // Limit to 1000 IDs to stay within safe bounds, though array method handles this largely well
+    // If needed, we could chunk requests, but standard usage won't exceed this.
+    const { data, error } = await supabase
+      .from("Zaehler_Ablesungen")
+      .select("*")
+      .in("zaehler_id", meterIds)
+      .eq("user_id", user.id);
+
+    if (error) throw error;
+
+    return { success: true, data: data as ZaehlerAblesung[] };
+  } catch (error: any) {
+    console.error("Error fetching readings for meters:", error);
+    return { success: false, message: error.message };
+  }
+}
+
 /**
  * Create a new meter
  */

--- a/app/meter-actions.ts
+++ b/app/meter-actions.ts
@@ -301,6 +301,11 @@ export async function getReadingsForMetersAction(meterIds: string[]) {
 
     // Limit to 1000 IDs to stay within safe bounds, though array method handles this largely well
     // If needed, we could chunk requests, but standard usage won't exceed this.
+    if (meterIds.length > 1000) {
+      console.warn("Too many meter IDs provided to getReadingsForMetersAction. Processing first 1000 IDs only.");
+      meterIds = meterIds.slice(0, 1000);
+    }
+
     const { data, error } = await supabase
       .from("Zaehler_Ablesungen")
       .select("*")
@@ -310,9 +315,9 @@ export async function getReadingsForMetersAction(meterIds: string[]) {
     if (error) throw error;
 
     return { success: true, data: data as ZaehlerAblesung[] };
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error("Error fetching readings for meters:", error);
-    return { success: false, message: error.message };
+    return { success: false, message: error instanceof Error ? error.message : "An unknown error occurred." };
   }
 }
 

--- a/components/water-meters/meter-import-modal.tsx
+++ b/components/water-meters/meter-import-modal.tsx
@@ -207,7 +207,7 @@ export function MeterImportModal({
         if (result.success && result.data) {
           freshReadings = result.data as ZaehlerAblesung[];
         } else {
-          console.warn("Could not fetch fresh readings, falling back to props data", result.message);
+          console.warn("Could not fetch fresh readings, falling back to props data. Error:", result.message);
         }
       }
 
@@ -362,9 +362,9 @@ export function MeterImportModal({
 
       setProcessedData(processed);
       setStep("preview");
-    } catch (error) {
+    } catch (error: unknown) {
       console.error("Error validating data:", error);
-      toast({ title: "Fehler", description: "Fehler bei der Validierung der Daten.", variant: "destructive" });
+      toast({ title: "Fehler", description: error instanceof Error ? error.message : "Fehler bei der Validierung der Daten.", variant: "destructive" });
     } finally {
       setIsSubmitting(false);
     }

--- a/components/water-meters/meter-import-modal.tsx
+++ b/components/water-meters/meter-import-modal.tsx
@@ -180,6 +180,9 @@ export function MeterImportModal({
     setIsSubmitting(true);
 
     try {
+      // Create efficient lookup map
+      const metersByCustomId = new Map(meters.map(m => [m.custom_id?.toLowerCase(), m]));
+
       // 1. Identify relevant meters from the parsed data
       const meterIdsToFetch = new Set<string>();
 
@@ -187,7 +190,7 @@ export function MeterImportModal({
         const customIdRaw = row[mapping.custom_id];
         const customId = customIdRaw ? String(customIdRaw).trim() : "";
         if (customId) {
-          const meter = meters.find((m) => m.custom_id?.toLowerCase() === customId.toLowerCase());
+          const meter = metersByCustomId.get(customId.toLowerCase());
           if (meter) {
             meterIdsToFetch.add(meter.id);
           }
@@ -231,7 +234,7 @@ export function MeterImportModal({
           };
         }
 
-        const meter = meters.find((m) => m.custom_id?.toLowerCase() === customId.toLowerCase());
+        const meter = metersByCustomId.get(customId.toLowerCase());
 
         if (!meter) {
           return {


### PR DESCRIPTION
## Description

Makes the meter reading import smarter: fresh database readings are fetched before validation, and consumption is chained across rows within the same file.

## Summary of Changes

- `meter-actions.ts`: new `getReadingsForMetersAction(meterIds)` — batch-fetches readings for up to 1,000 meters
- `meter-import-modal.tsx`: validation is now two-phase — the latest readings for the affected meters are pulled from the server first (deleted readings no longer cause phantom duplicates), then consumption is calculated against DB *and* other valid rows in the same import (multi-row chaining per meter)
- `wasser-ablesungen` API routes: `.single()` → `.maybeSingle()` for clean 404s instead of Postgres errors