### PR TITLE
fix(seo): use relative canonical urls for auth pages and remove redun…

### DIFF
--- a/app/auth/login/layout.tsx
+++ b/app/auth/login/layout.tsx
@@ -1,8 +1,4 @@
 import type { PropsWithChildren } from "react"
-import type { Metadata } from "next"
-import { pageMetadata } from "@/lib/seo/metadata"
-
-export const metadata: Metadata = pageMetadata.authLogin
 
 export default function LoginLayout({ children }: PropsWithChildren) {
     return children

--- a/app/auth/register/layout.tsx
+++ b/app/auth/register/layout.tsx
@@ -1,8 +1,4 @@
 import type { PropsWithChildren } from "react"
-import type { Metadata } from "next"
-import { pageMetadata } from "@/lib/seo/metadata"
-
-export const metadata: Metadata = pageMetadata.authRegister
 
 export default function RegisterLayout({ children }: PropsWithChildren) {
     return children

--- a/lib/seo/metadata.ts
+++ b/lib/seo/metadata.ts
@@ -64,7 +64,7 @@ export const defaultMetadata: Metadata = {
         images: [OG_IMAGE_URL],
     },
     alternates: {
-        canonical: BASE_URL,
+        canonical: '/',
     },
     verification: {
         // Add your verification codes here when available
@@ -125,7 +125,7 @@ export const pageMetadata = {
             description: 'Die moderne Lösung für Ihre Mietverwaltung und Betriebskostenabrechnung. Einfach, schnell und professionell.',
         },
         alternates: {
-            canonical: BASE_URL,
+            canonical: '/',
         },
     } satisfies Metadata,
 
@@ -146,7 +146,7 @@ export const pageMetadata = {
             url: `${BASE_URL}/preise`,
         },
         alternates: {
-            canonical: `${BASE_URL}/preise`,
+            canonical: '/preise',
         },
     } satisfies Metadata,
 
@@ -170,7 +170,7 @@ export const pageMetadata = {
             url: `${BASE_URL}/funktionen/betriebskosten`,
         },
         alternates: {
-            canonical: `${BASE_URL}/funktionen/betriebskosten`,
+            canonical: '/funktionen/betriebskosten',
         },
     } satisfies Metadata,
 
@@ -193,7 +193,7 @@ export const pageMetadata = {
             url: `${BASE_URL}/funktionen/wohnungsverwaltung`,
         },
         alternates: {
-            canonical: `${BASE_URL}/funktionen/wohnungsverwaltung`,
+            canonical: '/funktionen/wohnungsverwaltung',
         },
     } satisfies Metadata,
 
@@ -216,7 +216,7 @@ export const pageMetadata = {
             url: `${BASE_URL}/funktionen/finanzverwaltung`,
         },
         alternates: {
-            canonical: `${BASE_URL}/funktionen/finanzverwaltung`,
+            canonical: '/funktionen/finanzverwaltung',
         },
     } satisfies Metadata,
 
@@ -239,7 +239,7 @@ export const pageMetadata = {
             url: `${BASE_URL}/loesungen/privatvermieter`,
         },
         alternates: {
-            canonical: `${BASE_URL}/loesungen/privatvermieter`,
+            canonical: '/loesungen/privatvermieter',
         },
     } satisfies Metadata,
 
@@ -260,7 +260,7 @@ export const pageMetadata = {
             url: `${BASE_URL}/loesungen/kleine-mittlere-hausverwaltungen`,
         },
         alternates: {
-            canonical: `${BASE_URL}/loesungen/kleine-mittlere-hausverwaltungen`,
+            canonical: '/loesungen/kleine-mittlere-hausverwaltungen',
         },
     } satisfies Metadata,
 
@@ -281,7 +281,7 @@ export const pageMetadata = {
             url: `${BASE_URL}/loesungen/grosse-hausverwaltungen`,
         },
         alternates: {
-            canonical: `${BASE_URL}/loesungen/grosse-hausverwaltungen`,
+            canonical: '/loesungen/grosse-hausverwaltungen',
         },
     } satisfies Metadata,
 
@@ -302,7 +302,7 @@ export const pageMetadata = {
             url: `${BASE_URL}/hilfe/dokumentation`,
         },
         alternates: {
-            canonical: `${BASE_URL}/hilfe/dokumentation`,
+            canonical: '/hilfe/dokumentation',
         },
     } satisfies Metadata,
 
@@ -315,7 +315,7 @@ export const pageMetadata = {
             follow: true,
         },
         alternates: {
-            canonical: `${BASE_URL}/datenschutz`,
+            canonical: '/datenschutz',
         },
     } satisfies Metadata,
 
@@ -328,7 +328,7 @@ export const pageMetadata = {
             follow: true,
         },
         alternates: {
-            canonical: `${BASE_URL}/agb`,
+            canonical: '/agb',
         },
     } satisfies Metadata,
 

--- a/lib/seo/metadata.ts
+++ b/lib/seo/metadata.ts
@@ -352,7 +352,7 @@ export const pageMetadata = {
             url: `${BASE_URL}/auth/login`,
         },
         alternates: {
-            canonical: `${BASE_URL}/auth/login`,
+            canonical: '/auth/login',
         },
     } satisfies Metadata,
 
@@ -373,7 +373,7 @@ export const pageMetadata = {
             url: `${BASE_URL}/auth/register`,
         },
         alternates: {
-            canonical: `${BASE_URL}/auth/register`,
+            canonical: '/auth/register',
         },
     } satisfies Metadata,
 


### PR DESCRIPTION
## Description

Switches canonical URLs to relative paths and removes duplicate auth metadata.

## Summary of Changes

- `lib/seo/metadata.ts`: all `alternates.canonical` values are now relative (`/`, `/preise`, `/funktionen/...`, `/loesungen/...`, `/hilfe/dokumentation`, `/datenschutz`, `/agb`, `/auth/...`) so the `metadataBase` is applied consistently
- `app/auth/login/layout.tsx` / `app/auth/register/layout.tsx`: redundant local `metadata` exports removed (handled centrally)