### PR TITLE
test: expand backend worker test suite

### DIFF
--- a/workers/mietevo-backend/src/index.test.ts
+++ b/workers/mietevo-backend/src/index.test.ts
@@ -1,12 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import {
-    formatCurrency,
-    isoToGermanDate,
-    sumZaehlerValues,
-    roundToNearest5,
-    handleFileGeneration,
-    processQueue
-} from './index';
+import { describe, it, expect, vi } from 'vitest';
+import { handleFileGeneration, processQueue, Env } from './index';
+import { formatCurrency, isoToGermanDate, sumZaehlerValues, roundToNearest5 } from './utils';
+import { ExecutionContext } from './logger';
 
 describe('Backend Worker Tests', () => {
     const mockEnv = {
@@ -72,7 +67,7 @@ describe('Backend Worker Tests', () => {
                 })
             });
 
-            const response = await handleFileGeneration(request, mockEnv as any, mockCtx as any);
+            const response = await handleFileGeneration(request, mockEnv as unknown as Env, mockCtx as unknown as ExecutionContext);
 
             expect(response.status).toBe(200);
             expect(response.headers.get('Content-Type')).toBe('text/csv');
@@ -102,7 +97,7 @@ describe('Backend Worker Tests', () => {
                 })
             });
 
-            const response = await handleFileGeneration(request, mockEnv as any, mockCtx as any);
+            const response = await handleFileGeneration(request, mockEnv as unknown as Env, mockCtx as unknown as ExecutionContext);
 
             expect(response.status).toBe(200);
             expect(response.headers.get('Content-Type')).toBe('application/pdf');
@@ -118,7 +113,7 @@ describe('Backend Worker Tests', () => {
                 })
             });
 
-            const response = await handleFileGeneration(request, mockEnv as any, mockCtx as any);
+            const response = await handleFileGeneration(request, mockEnv as unknown as Env, mockCtx as unknown as ExecutionContext);
             expect(response.status).toBe(404);
         });
     });
@@ -133,7 +128,7 @@ describe('Backend Worker Tests', () => {
                 body: JSON.stringify({ user_id: 'test-user' })
             });
 
-            const response = await processQueue(request, mockEnv as any, mockCtx as any);
+            const response = await processQueue(request, mockEnv as unknown as Env, mockCtx as unknown as ExecutionContext);
             expect(response.status).toBe(401);
             expect(await response.text()).toBe('Unauthorized');
         });
@@ -149,7 +144,7 @@ describe('Backend Worker Tests', () => {
                 body: JSON.stringify({ user_id: 'test-user' })
             });
 
-            const response = await processQueue(request, mockEnv as any, mockCtx as any);
+            const response = await processQueue(request, mockEnv as unknown as Env, mockCtx as unknown as ExecutionContext);
             // It should probably hit the Supabase client creation and then fail on an RPC call
             expect(response.status).not.toBe(401);
         });
@@ -159,3 +154,4 @@ describe('Backend Worker Tests', () => {
         expect(true).toBe(true);
     });
 });
+

--- a/workers/mietevo-backend/src/index.test.ts
+++ b/workers/mietevo-backend/src/index.test.ts
@@ -1,6 +1,160 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    formatCurrency,
+    isoToGermanDate,
+    sumZaehlerValues,
+    roundToNearest5,
+    handleFileGeneration,
+    processQueue
+} from './index';
 
 describe('Backend Worker Tests', () => {
+    const mockEnv = {
+        GEMINI_API_KEY: 'test-key',
+        SUPABASE_URL: 'https://test.supabase.co',
+        SUPABASE_SERVICE_ROLE_KEY: 'test-role-key',
+        RATE_LIMITER: {
+            limit: vi.fn().mockResolvedValue({ success: true })
+        },
+        WORKER_AUTH_KEY: 'test-auth-key'
+    };
+
+    const mockCtx = {
+        waitUntil: vi.fn()
+    };
+
+    describe('Helper Functions', () => {
+        it('formatCurrency should format numbers as EUR', () => {
+            // Use contains because the output might have non-breaking spaces
+            expect(formatCurrency(10.5)).toContain('10,50');
+            expect(formatCurrency(1000)).toContain('1.000,00');
+            expect(formatCurrency(null)).toBe('-');
+            expect(formatCurrency(undefined)).toBe('-');
+        });
+
+        it('isoToGermanDate should format ISO string to German date', () => {
+            expect(isoToGermanDate('2024-01-01')).toBe('01.01.2024');
+            expect(isoToGermanDate('2024-12-24T12:00:00Z')).toBe('24.12.2024');
+            expect(isoToGermanDate(null)).toBe('N/A');
+            expect(isoToGermanDate('')).toBe('N/A');
+        });
+
+        it('sumZaehlerValues should sum up values in an object', () => {
+            const data = { a: 10, b: '20', c: null, d: undefined, e: 5.5 };
+            expect(sumZaehlerValues(data)).toBe(35.5);
+            expect(sumZaehlerValues({})).toBe(0);
+            expect(sumZaehlerValues(null)).toBe(0);
+        });
+
+        it('roundToNearest5 should round to nearest multiple of 5', () => {
+            expect(roundToNearest5(2.4)).toBe(0);
+            expect(roundToNearest5(2.5)).toBe(5);
+            expect(roundToNearest5(7.4)).toBe(5);
+            expect(roundToNearest5(7.5)).toBe(10);
+            expect(roundToNearest5(12)).toBe(10);
+            expect(roundToNearest5(13)).toBe(15);
+        });
+    });
+
+    describe('File Generation Handler', () => {
+        it('should generate CSV correctly', async () => {
+            const mockData = [
+                { name: 'John', age: 30 },
+                { name: 'Jane', age: 25 }
+            ];
+
+            const request = new Request('https://worker.com/export', {
+                method: 'POST',
+                body: JSON.stringify({
+                    type: 'csv',
+                    data: mockData,
+                    filename: 'test.csv'
+                })
+            });
+
+            const response = await handleFileGeneration(request, mockEnv as any, mockCtx as any);
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get('Content-Type')).toBe('text/csv');
+            expect(response.headers.get('Content-Disposition')).toContain('test.csv');
+
+            const text = await response.text();
+            expect(text).toContain('John,30');
+            expect(text).toContain('Jane,25');
+        });
+
+        it('should generate PDF correctly', async () => {
+            const request = new Request('https://worker.com/export', {
+                method: 'POST',
+                body: JSON.stringify({
+                    type: 'pdf',
+                    template: 'house-overview',
+                    nebenkosten: {
+                        startdatum: '2023-01-01',
+                        enddatum: '2023-12-31',
+                        haus_name: 'Test Haus'
+                    },
+                    totalArea: 100,
+                    totalCosts: 1000,
+                    costPerSqm: 10,
+                    filename: 'test.pdf'
+
+                })
+            });
+
+            const response = await handleFileGeneration(request, mockEnv as any, mockCtx as any);
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get('Content-Type')).toBe('application/pdf');
+            expect(response.headers.get('Content-Disposition')).toContain('test.pdf');
+        });
+
+        it('should return 404 for unknown request type', async () => {
+
+            const request = new Request('https://worker.com/unknown', {
+                method: 'POST',
+                body: JSON.stringify({
+                    type: 'unknown'
+                })
+            });
+
+            const response = await handleFileGeneration(request, mockEnv as any, mockCtx as any);
+            expect(response.status).toBe(404);
+        });
+    });
+
+    describe('Queue Processing Handler', () => {
+        it('should return 401 if auth key is missing or wrong', async () => {
+            const request = new Request('https://worker.com/process-queue', {
+                method: 'POST',
+                headers: {
+                    'x-worker-auth': 'wrong-key'
+                },
+                body: JSON.stringify({ user_id: 'test-user' })
+            });
+
+            const response = await processQueue(request, mockEnv as any, mockCtx as any);
+            expect(response.status).toBe(401);
+            expect(await response.text()).toBe('Unauthorized');
+        });
+
+        it('should proceed if auth key is correct', async () => {
+            // We expect it to fail later because we haven't mocked Supabase RPCs,
+            // but we can check if it gets past the auth check.
+            const request = new Request('https://worker.com/process-queue', {
+                method: 'POST',
+                headers: {
+                    'x-worker-auth': 'test-auth-key'
+                },
+                body: JSON.stringify({ user_id: 'test-user' })
+            });
+
+            const response = await processQueue(request, mockEnv as any, mockCtx as any);
+            // It should probably hit the Supabase client creation and then fail on an RPC call
+            expect(response.status).not.toBe(401);
+        });
+    });
+
     it('should pass a basic smoke test', () => {
         expect(true).toBe(true);
     });

--- a/workers/mietevo-backend/src/index.ts
+++ b/workers/mietevo-backend/src/index.ts
@@ -10,7 +10,7 @@ import { PostHog } from 'posthog-node';
 
 // --- Type Definitions ---
 
-interface Env {
+export interface Env {
     GEMINI_API_KEY: string;
     SUPABASE_URL: string;
     SUPABASE_SERVICE_ROLE_KEY: string;
@@ -41,35 +41,7 @@ interface QueueTask {
 }
 
 
-// --- Helper Functions (Duplicated for Worker Independence) ---
-
-export const formatCurrency = (value: number | null | undefined) => {
-    if (value == null) return "-";
-    return new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(value);
-};
-
-export const isoToGermanDate = (isoString: string | null | undefined) => {
-    if (!isoString) return "N/A";
-    try {
-        const date = new Date(isoString);
-        return date.toLocaleDateString('de-DE', {
-            day: '2-digit',
-            month: '2-digit',
-            year: 'numeric'
-        });
-    } catch (e) {
-        return isoString;
-    }
-};
-
-export const sumZaehlerValues = (obj: Record<string, unknown> | null | undefined): number => {
-    if (!obj || typeof obj !== 'object') return 0;
-    return Object.values(obj).reduce((sum: number, val: unknown) => sum + (Number(val) || 0), 0);
-};
-
-export const roundToNearest5 = (value: number) => {
-    return Math.round(value / 5) * 5;
-};
+import { formatCurrency, isoToGermanDate, sumZaehlerValues, roundToNearest5 } from './utils';
 
 // --- PDF Generation Functions (Preserved) ---
 

--- a/workers/mietevo-backend/src/index.ts
+++ b/workers/mietevo-backend/src/index.ts
@@ -43,12 +43,12 @@ interface QueueTask {
 
 // --- Helper Functions (Duplicated for Worker Independence) ---
 
-const formatCurrency = (value: number | null | undefined) => {
+export const formatCurrency = (value: number | null | undefined) => {
     if (value == null) return "-";
     return new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(value);
 };
 
-const isoToGermanDate = (isoString: string | null | undefined) => {
+export const isoToGermanDate = (isoString: string | null | undefined) => {
     if (!isoString) return "N/A";
     try {
         const date = new Date(isoString);
@@ -62,12 +62,12 @@ const isoToGermanDate = (isoString: string | null | undefined) => {
     }
 };
 
-const sumZaehlerValues = (obj: Record<string, unknown> | null | undefined): number => {
+export const sumZaehlerValues = (obj: Record<string, unknown> | null | undefined): number => {
     if (!obj || typeof obj !== 'object') return 0;
     return Object.values(obj).reduce((sum: number, val: unknown) => sum + (Number(val) || 0), 0);
 };
 
-const roundToNearest5 = (value: number) => {
+export const roundToNearest5 = (value: number) => {
     return Math.round(value / 5) * 5;
 };
 
@@ -102,7 +102,7 @@ interface NebenkostenItem {
     zaehlerverbrauch?: Record<string, number>;
 }
 
-interface SingleTenantPayload {
+export interface SingleTenantPayload {
     tenantData: TenantData;
     nebenkostenItem: NebenkostenItem;
     ownerName?: string;
@@ -304,7 +304,7 @@ const ZAEHLER_CONFIG = {
     heizung: { label: 'Heizung', einheit: 'kWh' },
 };
 
-interface HouseOverviewPayload {
+export interface HouseOverviewPayload {
     nebenkosten: {
         startdatum: string;
         enddatum: string;
@@ -517,7 +517,7 @@ async function fetchDocumentationContext(supabase: SupabaseClient, query: string
     }
 }
 
-async function handleAIRequest(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+export async function handleAIRequest(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const logger = new WorkerLogger(env, ctx);
     try {
         const body = await request.json() as AIRequest;
@@ -812,9 +812,9 @@ async function analyzeApplicantWithAI(env: Env, emailContent: string): Promise<{
     });
 
     const latencyMs = Date.now() - startTime;
-    const typedResult = apiResult as unknown as { 
-        usageMetadata?: { promptTokenCount?: number; input_tokens?: number; candidatesTokenCount?: number; output_tokens?: number; totalTokenCount?: number; total_tokens?: number }; 
-        usage?: { promptTokenCount?: number; input_tokens?: number; candidatesTokenCount?: number; output_tokens?: number; totalTokenCount?: number; total_tokens?: number }; 
+    const typedResult = apiResult as unknown as {
+        usageMetadata?: { promptTokenCount?: number; input_tokens?: number; candidatesTokenCount?: number; output_tokens?: number; totalTokenCount?: number; total_tokens?: number };
+        usage?: { promptTokenCount?: number; input_tokens?: number; candidatesTokenCount?: number; output_tokens?: number; totalTokenCount?: number; total_tokens?: number };
         text?: string | (() => string);
         response?: { text?: string | (() => string) };
         candidates?: { content?: { parts?: { text?: string }[] } }[];
@@ -826,37 +826,37 @@ async function analyzeApplicantWithAI(env: Env, emailContent: string): Promise<{
     // For @google/genai SDK v1.x+, result has .text as a getter property (not a method)
     // Access as property, not function call
 
-        let responseText: string;
+    let responseText: string;
 
-        if (typeof typedResult.text === 'string') {
+    if (typeof typedResult.text === 'string') {
 
-            // Direct .text property (v1.x SDK)
+        // Direct .text property (v1.x SDK)
 
-            responseText = typedResult.text;
+        responseText = typedResult.text;
 
-        } else if (typeof typedResult.text === 'function') {
+    } else if (typeof typedResult.text === 'function') {
 
-            // .text() method (older SDK versions)
+        // .text() method (older SDK versions)
 
-            responseText = typedResult.text();
+        responseText = typedResult.text();
 
-        } else if (typedResult.response?.text) {
+    } else if (typedResult.response?.text) {
 
-            // Nested response structure
+        // Nested response structure
 
-            responseText = typeof typedResult.response.text === 'function'
+        responseText = typeof typedResult.response.text === 'function'
 
-                ? typedResult.response.text()
+            ? typedResult.response.text()
 
-                : typedResult.response.text;
+            : typedResult.response.text;
 
-        } else if (typedResult.candidates?.[0]?.content?.parts?.[0]?.text) {
+    } else if (typedResult.candidates?.[0]?.content?.parts?.[0]?.text) {
 
-            // Raw candidate structure
+        // Raw candidate structure
 
-            responseText = typedResult.candidates[0].content.parts[0].text;
+        responseText = typedResult.candidates[0].content.parts[0].text;
 
-        } else {
+    } else {
         responseText = JSON.stringify(apiResult);
     }
 
@@ -892,7 +892,7 @@ async function analyzeApplicantWithAI(env: Env, emailContent: string): Promise<{
 }
 
 
-async function processQueue(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+export async function processQueue(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     // Auth Check
     const authHeader = request.headers.get('x-worker-auth');
     if (env.WORKER_AUTH_KEY && authHeader !== env.WORKER_AUTH_KEY) {
@@ -1090,7 +1090,7 @@ async function processQueue(request: Request, env: Env, ctx: ExecutionContext): 
 
 // --- File Generation Logic ---
 
-async function handleFileGeneration(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+export async function handleFileGeneration(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const logger = new WorkerLogger(env, ctx);
     let body: {
         type?: string;

--- a/workers/mietevo-backend/src/utils.ts
+++ b/workers/mietevo-backend/src/utils.ts
@@ -1,0 +1,27 @@
+export const formatCurrency = (value: number | null | undefined) => {
+    if (value == null) return "-";
+    return new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(value);
+};
+
+export const isoToGermanDate = (isoString: string | null | undefined) => {
+    if (!isoString) return "N/A";
+    try {
+        const date = new Date(isoString);
+        return date.toLocaleDateString('de-DE', {
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric'
+        });
+    } catch (e) {
+        return isoString;
+    }
+};
+
+export const sumZaehlerValues = (obj: Record<string, unknown> | null | undefined): number => {
+    if (!obj || typeof obj !== 'object') return 0;
+    return Object.values(obj).reduce((sum: number, val: unknown) => sum + (Number(val) || 0), 0);
+};
+
+export const roundToNearest5 = (value: number) => {
+    return Math.round(value / 5) * 5;
+};


### PR DESCRIPTION
## Description

Makes the backend worker testable and adds a first real test suite.

## Summary of Changes

- `index.ts`: `Env`, `SingleTenantPayload`, `HouseOverviewPayload` and the handlers (`handleAIRequest`, `processQueue`, `handleFileGeneration`) are now exported; helpers extracted into the new `utils.ts` (`formatCurrency`, `isoToGermanDate`, `sumZaehlerValues`, `roundToNearest5`)
- `index.test.ts` (+151): unit tests for the helper functions, CSV/PDF generation (incl. 404 for unknown types) and queue auth (401 on wrong key, pass-through on the correct key)