### PR TITLE
Feat/nebenkosten stepper modal

### DIFF
--- a/app/(dashboard)/layout-inner.tsx
+++ b/app/(dashboard)/layout-inner.tsx
@@ -1,6 +1,7 @@
 "use client" // Make this a client component
 import type React from "react"
 import { AuthProvider } from "@/components/auth/auth-provider"
+import { SidebarUserData } from "@/lib/server/user-data"
 import { EmailVerificationNotifier } from '@/components/auth/email-verification-notifier'
 import { Suspense } from "react"
 import { CommandMenu } from "@/components/search/command-menu"
@@ -52,8 +53,10 @@ import { OnboardingTour } from "@/components/onboarding/onboarding-tour";
 
 export default function DashboardInnerLayout({
   children,
+  sidebarData,
 }: Readonly<{
   children: React.ReactNode
+  sidebarData: SidebarUserData
 }>) {
   const {
     // Tenant modal state and actions
@@ -150,7 +153,7 @@ export default function DashboardInnerLayout({
         </Suspense>
         {/* <GlobalDragDropProvider> */}
         <CommandMenu />
-        <DashboardLayout>{children}</DashboardLayout>
+        <DashboardLayout sidebarData={sidebarData}>{children}</DashboardLayout>
         {/* Render modals: They control their own open/close state via the store */}
         {/* TenantEditModal needs serverAction. Other props are from store. */}
         <TenantEditModal serverAction={tenantServerAction} />

--- a/app/(dashboard)/layout-inner.tsx
+++ b/app/(dashboard)/layout-inner.tsx
@@ -1,37 +1,306 @@
-"use client"
-
+"use client" // Make this a client component
 import type React from "react"
 import { AuthProvider } from "@/components/auth/auth-provider"
 import { EmailVerificationNotifier } from '@/components/auth/email-verification-notifier'
 import { Suspense } from "react"
+import { CommandMenu } from "@/components/search/command-menu"
 import { DashboardLayout } from "@/components/dashboard/dashboard-layout"
-import { NestedDialogProvider } from "@/components/ui/nested-dialog"
+import { useModalStore } from "@/hooks/use-modal-store" // Added
 import dynamic from 'next/dynamic'
-import DashboardOverlayLoader from "./dashboard-overlay-loader"
-import { SidebarUserData } from "@/lib/server/user-data"
 
-const OnboardingTour = dynamic(
-  () => import('@/components/onboarding/onboarding-tour').then(mod => mod.OnboardingTour),
-  { ssr: false },
-)
+// Importing server action from its new location
+import { handleSubmit as tenantServerAction } from "@/app/mieter-actions" // Adjusted import path
+import { handleSubmit as houseServerAction } from "@/app/(dashboard)/haeuser/actions" // Added
+import { financeServerAction } from "@/app/finanzen-actions" // Added - Adjusted path due to tool limitation
+import { wohnungServerAction } from "@/app/wohnungen-actions" // Added - Adjusted path
+import { aufgabeServerAction } from "@/app/todos-actions" // Added
+import { updateKautionAction } from "@/app/mieter-actions"; // Added
+
+// Lazy load modals
+const TenantEditModal = dynamic(() => import('@/components/tenants/tenant-edit-modal').then(mod => mod.TenantEditModal), { ssr: false })
+const HouseEditModal = dynamic(() => import('@/components/houses/house-edit-modal').then(mod => mod.HouseEditModal), { ssr: false })
+const FinanceEditModal = dynamic(() => import('@/components/finance/finance-edit-modal').then(mod => mod.FinanceEditModal), { ssr: false })
+const WohnungEditModal = dynamic(() => import('@/components/apartments/wohnung-edit-modal').then(mod => mod.WohnungEditModal), { ssr: false })
+const AufgabeEditModal = dynamic(() => import('@/components/tasks/aufgabe-edit-modal').then(mod => mod.AufgabeEditModal), { ssr: false })
+const BetriebskostenEditModal = dynamic(() => import('@/components/finance/betriebskosten-edit-modal').then(mod => mod.BetriebskostenEditModal), { ssr: false })
+const AblesungenModal = dynamic(() => import('@/components/meters/ablesungen-modal').then(mod => mod.AblesungenModal), { ssr: false })
+const ZaehlerModal = dynamic(() => import('@/components/meters/zaehler-modal').then(mod => mod.ZaehlerModal), { ssr: false })
+const KautionModal = dynamic(() => import('@/components/tenants/kaution-modal').then(mod => mod.KautionModal), { ssr: false })
+const HausOverviewModal = dynamic(() => import('@/components/houses/haus-overview-modal').then(mod => mod.HausOverviewModal), { ssr: false })
+const WohnungOverviewModal = dynamic(() => import('@/components/apartments/wohnung-overview-modal').then(mod => mod.WohnungOverviewModal), { ssr: false })
+const ApartmentTenantDetailsModal = dynamic(() => import('@/components/apartments/apartment-tenant-details-modal').then(mod => mod.ApartmentTenantDetailsModal), { ssr: false })
+const FileUploadModal = dynamic(() => import('@/components/cloud-storage/file-upload-modal').then(mod => mod.FileUploadModal), { ssr: false })
+const FileRenameModal = dynamic(() => import('@/components/cloud-storage/file-rename-modal').then(mod => mod.FileRenameModal), { ssr: false })
+const CreateFolderModal = dynamic(() => import('@/components/cloud-storage/create-folder-modal').then(mod => mod.CreateFolderModal), { ssr: false })
+const CreateFileModal = dynamic(() => import('@/components/cloud-storage/create-file-modal').then(mod => mod.CreateFileModal), { ssr: false })
+const FolderDeleteConfirmationModal = dynamic(() => import('@/components/cloud-storage/folder-delete-confirmation-modal').then(mod => mod.FolderDeleteConfirmationModal), { ssr: false })
+const FileMoveModal = dynamic(() => import('@/components/cloud-storage/file-move-modal').then(mod => mod.FileMoveModal), { ssr: false })
+const ShareDocumentModal = dynamic(() => import('@/components/cloud-storage/share-document-modal').then(mod => mod.ShareDocumentModal), { ssr: false })
+const MarkdownEditorModal = dynamic(() => import('@/components/cloud-storage/markdown-editor-modal').then(mod => mod.MarkdownEditorModal), { ssr: false })
+const TemplatesModal = dynamic(() => import('@/components/templates/templates-modal').then(mod => mod.TemplatesModal), { ssr: false })
+const TenantMailTemplatesModal = dynamic(() => import('@/components/tenants/tenant-mail-templates-modal').then(mod => mod.TenantMailTemplatesModal), { ssr: false })
+const AIAssistantModal = dynamic(() => import('@/components/ai/ai-assistant-modal').then(mod => mod.AIAssistantModal), { ssr: false })
+const OperatingCostsOverviewModal = dynamic(() => import('@/components/finance/operating-costs-overview-modal').then(mod => mod.OperatingCostsOverviewModal), { ssr: false })
+// Default exports
+const TenantPaymentEditModal = dynamic(() => import('@/components/tenants/tenant-payment-edit-modal'), { ssr: false })
+const TenantPaymentOverviewModal = dynamic(() => import('@/components/tenants/tenant-payment-overview-modal'), { ssr: false })
+
+import { ConfirmationDialog } from "@/components/ui/confirmation-dialog"; // Added
+import { GlobalDragDropProvider } from "@/components/cloud-storage/global-drag-drop-provider"; // Added
+import { NestedDialogProvider } from "@/components/ui/nested-dialog"; // Added
+import { OnboardingTour } from "@/components/onboarding/onboarding-tour";
 
 export default function DashboardInnerLayout({
   children,
-  sidebarData,
 }: Readonly<{
   children: React.ReactNode
-  sidebarData: SidebarUserData
 }>) {
+  const {
+    // Tenant modal state and actions
+    isTenantModalOpen,
+    closeTenantModal,
+    tenantInitialData,
+    tenantModalWohnungen,
+    openTenantModal,
+    // House modal state and actions
+    isHouseModalOpen,
+    houseInitialData,
+    houseModalOnSuccess,
+    openHouseModal,
+    closeHouseModal,
+    // Finance modal state and actions
+    isFinanceModalOpen,
+    financeInitialData,
+    financeModalWohnungen,
+    financeModalOnSuccess,
+    openFinanceModal,
+    closeFinanceModal,
+    // Wohnung modal state and actions
+    isWohnungModalOpen,
+    wohnungInitialData,
+    wohnungModalHaeuser,
+    wohnungModalOnSuccess,
+    openWohnungModal,
+    closeWohnungModal,
+    // Additions for Wohnung modal props
+    wohnungApartmentLimit,
+    wohnungIsActiveSubscription,
+    wohnungApartmentCount, // Added
+    // Aufgabe modal state and actions
+    isAufgabeModalOpen,
+    // ... (aufgabeInitialData, aufgabeModalOnSuccess are used internally by AufgabeEditModal)
+    // closeAufgabeModal, // Also internal
+    // openAufgabeModal, // Used by other components to open
+    // Betriebskosten modal state (only need isBetriebskostenModalOpen for conditional rendering if any)
+    isBetriebskostenModalOpen,
+    // Confirmation Modal state
+    isConfirmationModalOpen,
+    confirmationModalConfig,
+    closeConfirmationModal,
+    // File Rename Modal state
+    isFileRenameModalOpen,
+    fileRenameData,
+    closeFileRenameModal,
+    // Create Folder Modal state
+    isCreateFolderModalOpen,
+    createFolderModalData,
+    closeCreateFolderModal,
+    // Create File Modal state
+    isCreateFileModalOpen,
+    createFileModalData,
+    closeCreateFileModal,
+    // Folder Delete Confirmation Modal state
+    isFolderDeleteConfirmationModalOpen,
+    folderDeleteConfirmationData,
+    closeFolderDeleteConfirmationModal,
+    // File Move Modal state
+    isFileMoveModalOpen,
+    fileMoveData,
+    closeFileMoveModal,
+    // Share Document Modal state
+    isShareDocumentModalOpen,
+    shareDocumentData,
+    closeShareDocumentModal,
+    // Markdown Editor Modal state
+    isMarkdownEditorModalOpen,
+    markdownEditorData,
+    closeMarkdownEditorModal,
+    // Templates Modal state
+    isTemplatesModalOpen,
+    templatesModalInitialCategory,
+    closeTemplatesModal,
+    // Tenant Mail Templates Modal state
+    isTenantMailTemplatesModalOpen,
+    tenantMailTemplatesModalData,
+    closeTenantMailTemplatesModal,
+    // AI Assistant Modal state
+    isAIAssistantModalOpen,
+
+    // Operating Costs Overview Modal state
+    isOperatingCostsOverviewModalOpen,
+    operatingCostsOverviewData,
+    closeOperatingCostsOverviewModal,
+  } = useModalStore()
+
   return (
     <AuthProvider>
-      <Suspense fallback={null}>
-        <EmailVerificationNotifier />
-      </Suspense>
       <NestedDialogProvider>
-        <DashboardLayout sidebarData={sidebarData}>
-          {children}
-        </DashboardLayout>
-        <DashboardOverlayLoader />
+        <Suspense fallback={null}>
+          <EmailVerificationNotifier />
+        </Suspense>
+        {/* <GlobalDragDropProvider> */}
+        <CommandMenu />
+        <DashboardLayout>{children}</DashboardLayout>
+        {/* Render modals: They control their own open/close state via the store */}
+        {/* TenantEditModal needs serverAction. Other props are from store. */}
+        <TenantEditModal serverAction={tenantServerAction} />
+        {/* HouseEditModal needs serverAction. */}
+        <HouseEditModal serverAction={houseServerAction} />
+        {/* FinanceEditModal needs serverAction. */}
+        <FinanceEditModal serverAction={financeServerAction} />
+        {/* WohnungEditModal needs serverAction. */}
+        {/* Also pass specific props if they are not part of the store's initialData object for wohnung */}
+        <WohnungEditModal
+          serverAction={wohnungServerAction}
+          currentApartmentLimitFromProps={wohnungApartmentLimit}
+          isActiveSubscriptionFromProps={wohnungIsActiveSubscription}
+          currentApartmentCountFromProps={wohnungApartmentCount}
+        />
+        {/* AufgabeEditModal needs serverAction. */}
+        <AufgabeEditModal serverAction={aufgabeServerAction} />
+        {/* BetriebskostenEditModal - Assuming it handles its own server actions internally or doesn't need a generic one passed */}
+        <BetriebskostenEditModal />
+        {/* ZaehlerModal - Manages all meter types (water, gas, electricity, heat) */}
+        <ZaehlerModal />
+        {/* AblesungenModal - Manages meter readings for all meter types */}
+        <AblesungenModal />
+        {/* KautionModal - Handles kaution management */}
+        <KautionModal serverAction={updateKautionAction} />
+        {/* HausOverviewModal - Displays Haus overview with all Wohnungen */}
+        <HausOverviewModal />
+        {/* WohnungOverviewModal - Displays Wohnung overview with all Mieter */}
+        <WohnungOverviewModal />
+        {/* ApartmentTenantDetailsModal - Displays detailed apartment-tenant information */}
+        <ApartmentTenantDetailsModal />
+        {/* FileUploadModal - Global file upload modal */}
+        <FileUploadModal />
+        {/* FileRenameModal - Global file rename modal */}
+        {isFileRenameModalOpen && fileRenameData && (
+          <FileRenameModal
+            isOpen={isFileRenameModalOpen}
+            onClose={closeFileRenameModal}
+            fileName={fileRenameData.fileName}
+            onRename={fileRenameData.onRename}
+          />
+        )}
+        {/* CreateFolderModal - Global create folder modal */}
+        {isCreateFolderModalOpen && createFolderModalData && (
+          <CreateFolderModal
+            isOpen={isCreateFolderModalOpen}
+            onClose={closeCreateFolderModal}
+            currentPath={createFolderModalData.currentPath}
+            onFolderCreated={createFolderModalData.onFolderCreated}
+          />
+        )}
+        {/* CreateFileModal - Global create file modal */}
+        {isCreateFileModalOpen && createFileModalData && (
+          <CreateFileModal
+            isOpen={isCreateFileModalOpen}
+            onClose={closeCreateFileModal}
+            currentPath={createFileModalData.currentPath}
+            onFileCreated={createFileModalData.onFileCreated}
+          />
+        )}
+        {/* FolderDeleteConfirmationModal - Global folder delete confirmation modal */}
+        {isFolderDeleteConfirmationModalOpen && folderDeleteConfirmationData && (
+          <FolderDeleteConfirmationModal
+            isOpen={isFolderDeleteConfirmationModalOpen}
+            onClose={closeFolderDeleteConfirmationModal}
+            folderName={folderDeleteConfirmationData.folderName}
+            folderPath={folderDeleteConfirmationData.folderPath}
+            fileCount={folderDeleteConfirmationData.fileCount}
+            onConfirm={folderDeleteConfirmationData.onConfirm}
+          />
+        )}
+        {/* FileMoveModal - Global file/folder move modal */}
+        {isFileMoveModalOpen && fileMoveData && (
+          <FileMoveModal
+            isOpen={isFileMoveModalOpen}
+            onClose={closeFileMoveModal}
+            item={fileMoveData.item}
+            itemType={fileMoveData.itemType}
+            currentPath={fileMoveData.currentPath}
+            userId={fileMoveData.userId}
+            onMove={fileMoveData.onMove}
+          />
+        )}
+        {/* ShareDocumentModal - Global document sharing modal */}
+        {isShareDocumentModalOpen && shareDocumentData && (
+          <ShareDocumentModal
+            isOpen={isShareDocumentModalOpen}
+            onClose={closeShareDocumentModal}
+            fileName={shareDocumentData.fileName}
+            filePath={shareDocumentData.filePath}
+          />
+        )}
+        {/* MarkdownEditorModal - Global markdown editor modal */}
+        {isMarkdownEditorModalOpen && markdownEditorData && (
+          <MarkdownEditorModal
+            isOpen={isMarkdownEditorModalOpen}
+            onClose={closeMarkdownEditorModal}
+            filePath={markdownEditorData.filePath}
+            fileName={markdownEditorData.fileName}
+            initialContent={markdownEditorData.initialContent}
+            isNewFile={markdownEditorData.isNewFile}
+            onSave={markdownEditorData.onSave}
+          />
+        )}
+        {/* TemplatesModal - Global templates management modal */}
+        <TemplatesModal
+          isOpen={isTemplatesModalOpen}
+          onClose={closeTemplatesModal}
+          initialCategory={templatesModalInitialCategory}
+        />
+        {/* TenantMailTemplatesModal - Read-only mail templates for tenants */}
+        <TenantMailTemplatesModal
+          isOpen={isTenantMailTemplatesModalOpen}
+          onClose={closeTenantMailTemplatesModal}
+          tenantName={tenantMailTemplatesModalData?.tenantName}
+          tenantEmail={tenantMailTemplatesModalData?.tenantEmail}
+        />
+        {/* AI Assistant Modal - Global AI assistant modal */}
+        <AIAssistantModal />
+        {/* Tenant Payment Edit Modal */}
+        <TenantPaymentEditModal />
+        {/* Tenant Payment Overview Modal */}
+        <TenantPaymentOverviewModal />
+        {/* Operating Costs Overview Modal */}
+        {isOperatingCostsOverviewModalOpen && operatingCostsOverviewData && (
+          <OperatingCostsOverviewModal
+            isOpen={isOperatingCostsOverviewModalOpen}
+            onClose={closeOperatingCostsOverviewModal}
+            nebenkosten={operatingCostsOverviewData}
+          />
+        )}
+        {/* Global Confirmation Dialog */}
+        {isConfirmationModalOpen && confirmationModalConfig && (
+          <ConfirmationDialog
+            isOpen={isConfirmationModalOpen}
+            onClose={closeConfirmationModal}
+            onConfirm={() => {
+              if (confirmationModalConfig.onConfirm) {
+                confirmationModalConfig.onConfirm();
+              }
+              // closeConfirmationModal(); // onConfirm in store should handle this
+            }}
+            title={confirmationModalConfig.title}
+            description={confirmationModalConfig.description}
+            confirmText={confirmationModalConfig.confirmText}
+            cancelText={confirmationModalConfig.cancelText}
+            variant={confirmationModalConfig.variant}
+          />
+        )}
+        {/* </GlobalDragDropProvider> */}
       </NestedDialogProvider>
       <OnboardingTour />
     </AuthProvider>

--- a/app/betriebskosten-actions.ts
+++ b/app/betriebskosten-actions.ts
@@ -112,7 +112,10 @@ export async function createNebenkosten(formData: NebenkostenFormData) {
 
   revalidatePath("/dashboard/betriebskosten");
   logAction(actionName, 'success', { nebenkosten_id: data?.id, house_id: formData.haeuser_id });
-  return { success: true, data };
+
+  // Return optimized data for the UI
+  const { data: optimizedData } = await fetchOptimizedNebenkostenById(data.id);
+  return { success: true, data: optimizedData || data };
 }
 
 // Implement updateNebenkosten function
@@ -169,7 +172,10 @@ export async function updateNebenkosten(id: string, formData: Partial<Nebenkoste
 
   revalidatePath("/dashboard/betriebskosten");
   logAction(actionName, 'success', { nebenkosten_id: id });
-  return { success: true, data };
+
+  // Return optimized data for the UI
+  const { data: optimizedData } = await fetchOptimizedNebenkostenById(id);
+  return { success: true, data: optimizedData || data };
 }
 
 // Implement deleteNebenkosten function
@@ -416,6 +422,45 @@ export async function deleteRechnungenByNebenkostenId(nebenkostenId: string): Pr
   // No revalidatePath here as this is a subordinate action.
   // Revalidation should happen after the primary operation (e.g., updateNebenkosten) is complete.
   return { success: true };
+}
+
+/**
+ * Fetches a single Nebenkosten record with optimized metrics (house name, area, tenant counts)
+ */
+export async function fetchOptimizedNebenkostenById(id: string): Promise<{ success: boolean; data: OptimizedNebenkosten | null; message?: string }> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { success: false, data: null, message: "Not authenticated" };
+
+  try {
+    // We use the RPC defined in modernize_nebenkosten_rpcs.sql
+    // and filter for the specific ID
+    const { data, error } = await supabase.rpc('get_nebenkosten_with_metrics', {
+      user_id: user.id
+    });
+
+    if (error) throw error;
+
+    const record = data?.find((n: any) => n.id === id);
+
+    if (!record) {
+      // Fallback: if not found in the optimized list (rare), fetch raw record
+      const { data: rawData } = await supabase.from('Nebenkosten').select('*, Haeuser(name)').eq('id', id).single();
+      return { success: true, data: rawData as any };
+    }
+
+    return {
+      success: true,
+      data: {
+        ...record,
+        // Map user_id_field to user_id to match OptimizedNebenkosten type
+        user_id: record.user_id_field
+      } as OptimizedNebenkosten
+    };
+  } catch (error: any) {
+    console.error("Error fetching optimized nebenkosten:", error);
+    return { success: false, data: null, message: error.message };
+  }
 }
 
 export async function getNebenkostenDetailsAction(id: string): Promise<{

--- a/components/finance/betriebskosten-edit-modal.tsx
+++ b/components/finance/betriebskosten-edit-modal.tsx
@@ -72,7 +72,7 @@ import { SortableCostItem, type CostItem, type RechnungEinzel } from "./sortable
 import { DateRangePicker } from "@/components/ui/date-range-picker";
 import { getDefaultDateRange, validateDateRange, germanToIsoDate, isoToGermanDate, formatPeriodDuration } from "@/utils/date-calculations";
 
-const SuccessStep = ({ data, onClose, onOverview }: { data: Nebenkosten | null, onClose: () => void, onOverview: () => void }) => {
+const SuccessStep = ({ data, onClose, onOverview }: { data: Nebenkosten | OptimizedNebenkosten | null, onClose: () => void, onOverview: () => void }) => {
   return (
     <div className="flex flex-col items-center justify-center py-12 px-6 text-center space-y-6">
       <div className="relative">
@@ -89,7 +89,7 @@ const SuccessStep = ({ data, onClose, onOverview }: { data: Nebenkosten | null, 
       <div className="space-y-2">
         <h3 className="text-2xl font-bold tracking-tight bg-gradient-to-br from-foreground to-foreground/70 bg-clip-text text-transparent">Abrechnung gespeichert!</h3>
         <p className="text-muted-foreground max-w-sm mx-auto">
-          Die Betriebskosten für das Objekt <span className="font-semibold text-foreground">{data?.house_name || data?.Haeuser?.name || 'Unbekannt'}</span> im Zeitraum <span className="font-semibold text-foreground">{isoToGermanDate(data?.startdatum)} - {isoToGermanDate(data?.enddatum)}</span> wurden erfolgreich erfasst.
+          Die Betriebskosten für das Objekt <span className="font-semibold text-foreground">{(data as any)?.haus_name || (data as any)?.house_name || data?.Haeuser?.name || 'Unbekannt'}</span> im Zeitraum <span className="font-semibold text-foreground">{isoToGermanDate(data?.startdatum || '')} - {isoToGermanDate(data?.enddatum || '')}</span> wurden erfolgreich erfasst.
         </p>
       </div>
 

--- a/components/finance/betriebskosten-edit-modal.tsx
+++ b/components/finance/betriebskosten-edit-modal.tsx
@@ -62,6 +62,7 @@ import {
   deleteRechnungenByNebenkostenId,
   getLatestBetriebskostenByHausId,
 } from "@/app/betriebskosten-actions";
+import { OptimizedNebenkosten } from "@/types/optimized-betriebskosten";
 import { getMieterByHausIdAction } from "@/app/mieter-actions";
 import { useToast } from "@/hooks/use-toast";
 import { useModalStore } from "@/hooks/use-modal-store";
@@ -71,7 +72,7 @@ import { SortableCostItem, type CostItem, type RechnungEinzel } from "./sortable
 import { DateRangePicker } from "@/components/ui/date-range-picker";
 import { getDefaultDateRange, validateDateRange, germanToIsoDate, isoToGermanDate, formatPeriodDuration } from "@/utils/date-calculations";
 
-const SuccessStep = ({ data, onClose, onOverview }: { data: any, onClose: () => void, onOverview: () => void }) => {
+const SuccessStep = ({ data, onClose, onOverview }: { data: Nebenkosten | null, onClose: () => void, onOverview: () => void }) => {
   return (
     <div className="flex flex-col items-center justify-center py-12 px-6 text-center space-y-6">
       <div className="relative">
@@ -978,7 +979,7 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
       } else {
         // Fallback for updates where response data might be partial
         setSavedItemData({
-          ...modalNebenkostenData,
+          ...(modalNebenkostenData || {}),
           startdatum: germanToIsoDate(startdatum),
           enddatum: germanToIsoDate(enddatum),
           haeuser_id: hausId,
@@ -1487,11 +1488,17 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
                           if (savedItemData) {
                             closeBetriebskostenModal();
                             const selectedHaus = betriebskostenModalHaeuser?.find(h => h.id === hausId);
-                            const enrichedData = {
-                              ...savedItemData,
-                              haus_name: selectedHaus?.name || 'Unbekanntes Haus'
+                            // Provide default values for mandatory OptimizedNebenkosten fields
+                            // The modal will fetch the real values using the id anyway
+                            const enrichedData: OptimizedNebenkosten = {
+                              ...(savedItemData as any),
+                              haus_name: selectedHaus?.name || 'Unbekanntes Haus',
+                              gesamt_flaeche: (savedItemData as any).gesamt_flaeche || 0,
+                              anzahl_wohnungen: (savedItemData as any).anzahl_wohnungen || 0,
+                              anzahl_mieter: (savedItemData as any).anzahl_mieter || 0,
+                              user_id: savedItemData.user_id || '',
                             };
-                            openOperatingCostsOverviewModal(enrichedData as any);
+                            openOperatingCostsOverviewModal(enrichedData);
                           }
                         }}
                       />

--- a/components/finance/betriebskosten-edit-modal.tsx
+++ b/components/finance/betriebskosten-edit-modal.tsx
@@ -1104,376 +1104,433 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
     <Dialog open={isBetriebskostenModalOpen} onOpenChange={(open) => !open && attemptClose()}>
       <DialogContent
         id="utility-bill-form-container"
-        className="sm:max-w-3xl md:max-w-4xl max-h-[90vh] flex flex-col p-0 gap-0 overflow-hidden"
+        className="sm:max-w-4xl md:max-w-5xl max-h-[85vh] flex flex-col p-0 gap-0 overflow-hidden rounded-[2rem] border-none shadow-2xl"
         onAttemptClose={attemptClose}
         isDirty={isBetriebskostenModalDirty}
-      >  <form onSubmit={(e) => { e.preventDefault(); handleSubmit(); }} className="flex flex-col flex-1 overflow-hidden min-h-0">
-          <DialogHeader className="px-6 pt-6 pb-2">
-            <DialogTitle className="text-xl">
-              {betriebskostenInitialData?.id ? "Betriebskosten bearbeiten" : "Neue Betriebskostenabrechnung"}
-            </DialogTitle>
-            <DialogDescription className="text-sm">
-              {currentStep === 1
-                ? "Schritt 1: Wählen Sie das Haus, den Zeitraum und die Abrechnungsmethode."
-                : currentStep === 2
-                  ? "Schritt 2: Erfassen Sie Zählerkosten und ergänzen Sie die Kostenaufstellung."
-                  : "Abrechnung erfolgreich gespeichert."}
-            </DialogDescription>
-          </DialogHeader>
-
-          {/* Stepper Header */}
-          {currentStep < 3 && (
-            <div className="px-6 py-4 border-y border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-white/5">
-              <div className="flex items-center justify-between mb-2">
-                <span className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground/80">Schritt {currentStep} von 2</span>
-                <span className="text-xs font-bold text-primary">
-                  {currentStep === 1 ? 'Basis-Informationen' : 'Kosten & Details'}
-                </span>
+      >
+        <form onSubmit={(e) => { e.preventDefault(); handleSubmit(); }} className="flex-1 flex flex-col overflow-hidden">
+          <div className="flex flex-1 overflow-hidden min-h-0">
+            {/* Sidebar Stepper - Y-Axis Timeline */}
+            <div className="hidden sm:flex w-64 flex-col bg-transparent p-8 space-y-10 shrink-0">
+              <div className="space-y-1">
+                <h2 className="text-xl font-bold tracking-tight text-foreground/90 leading-tight">Nebenkosten</h2>
+                <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-widest opacity-60">Abrechnungs-Assistent</p>
               </div>
-              <Progress value={currentStep === 1 ? 50 : 100} className="h-1.5" />
-            </div>
-          )}
 
-          <div className="flex-1 overflow-y-auto relative min-h-0 custom-scrollbar">
-            <AnimatePresence mode="wait">
-              {currentStep === 1 && (
-                <motion.div
-                  key="step1"
-                  initial={{ opacity: 0, x: 20 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  exit={{ opacity: 0, x: -20 }}
-                  transition={{ duration: 0.2, ease: "easeInOut" }}
-                  className="space-y-6 p-6"
-                >
-                  <div className="bg-gray-50/50 dark:bg-white/5 rounded-3xl border border-gray-200/60 dark:border-gray-800/60 p-5 space-y-6">
-                    {/* House Selection */}
-                    <div className="space-y-2.5">
-                      <LabelWithTooltip htmlFor="formHausId" infoText="Wählen Sie das Haus aus, für das die Nebenkostenabrechnung erstellt wird.">
-                        <span className="text-sm font-semibold tracking-tight">Immobilie auswählen *</span>
-                      </LabelWithTooltip>
-                      {isFormLoading ? <Skeleton className="h-11 w-full rounded-xl" /> : (
-                        <CustomCombobox width="w-full" options={houseOptions} value={hausId} onChange={handleHausIdChange} placeholder="Haus auswählen..." searchPlaceholder="Haus suchen..." emptyText="Kein Haus gefunden." disabled={isSaving || isFormLoading} />
+              <div className="flex flex-col gap-0">
+                {[
+                  { id: 1, label: 'Basis-Daten', desc: 'Haus & Zeitraum' },
+                  { id: 2, label: 'Kostenstellen', desc: 'Zähler & Positionen' },
+                  { id: 3, label: 'Bestätigung', desc: 'Fertigstellung' }
+                ].map((step, idx, arr) => {
+                  const isActive = currentStep === step.id;
+                  const isCompleted = currentStep > step.id;
+                  const isLast = idx === arr.length - 1;
+
+                  return (
+                    <div key={step.id} className="relative flex gap-5 pb-10 last:pb-0">
+                      {!isLast && (
+                        <div className={`absolute left-[17px] top-10 w-[2px] h-[calc(100%-40px)] transition-colors duration-500 ${isCompleted ? 'bg-primary' : 'bg-gray-200 dark:bg-gray-800'}`} />
                       )}
-                    </div>
 
-                    {/* Date Range Selection */}
-                    <div className="space-y-4 pt-2">
-                      <LabelWithTooltip htmlFor="formDates" infoText="Legen Sie den Abrechnungszeitraum fest.">
-                        <span className="text-sm font-semibold tracking-tight">Abrechnungszeitraum *</span>
-                      </LabelWithTooltip>
-                      {isFormLoading ? (
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                          <Skeleton className="h-11 w-full rounded-xl" />
-                          <Skeleton className="h-11 w-full rounded-xl" />
-                        </div>
-                      ) : (
-                        <div className="space-y-4">
-                          <DateRangePicker
-                            startDate={startdatum}
-                            endDate={enddatum}
-                            onStartDateChange={handleStartdatumChange}
-                            onEndDateChange={handleEnddatumChange}
-                            disabled={isSaving || isFormLoading}
-                            showPeriodInfo={false}
-                          />
-
-                          <div className="grid grid-cols-2 gap-3">
-                            <Button
-                              type="button"
-                              variant="outline"
-                              size="sm"
-                              className="h-11 w-full rounded-2xl border-gray-200/60 dark:border-gray-800/60 hover:bg-white dark:hover:bg-gray-800 transition-all shadow-sm"
-                              onClick={() => {
-                                const currentStartYear = startdatum ? parseInt(startdatum.split('.')[2]) : new Date().getFullYear();
-                                const newYear = currentStartYear - 1;
-                                setStartdatum(`01.01.${newYear}`);
-                                setEnddatum(`31.12.${newYear}`);
-                                setBetriebskostenModalDirty(true);
-                              }}
-                              disabled={isSaving || isFormLoading}
-                            >
-                              <CalendarMinus className="w-4 h-4 mr-2 text-muted-foreground" />
-                              <span className="font-medium">-1 Jahr</span>
-                            </Button>
-                            <Button
-                              type="button"
-                              variant="outline"
-                              size="sm"
-                              className="h-11 w-full rounded-2xl border-gray-200/60 dark:border-gray-800/60 hover:bg-white dark:hover:bg-gray-800 transition-all shadow-sm"
-                              onClick={() => {
-                                const currentStartYear = startdatum ? parseInt(startdatum.split('.')[2]) : new Date().getFullYear();
-                                const newYear = currentStartYear + 1;
-                                setStartdatum(`01.01.${newYear}`);
-                                setEnddatum(`31.12.${newYear}`);
-                                setBetriebskostenModalDirty(true);
-                              }}
-                              disabled={isSaving || isFormLoading}
-                            >
-                              <CalendarPlus className="w-4 h-4 mr-2 text-primary" />
-                              <span className="font-medium">+1 Jahr</span>
-                            </Button>
-                          </div>
-
-                          {(() => {
-                            const validation = validateDateRange(startdatum, enddatum);
-                            return validation.isValid && validation.periodDays && (
-                              <div className="text-sm text-blue-700 dark:text-blue-300 bg-blue-50/50 dark:bg-blue-900/20 border border-blue-100/50 dark:border-blue-800/50 p-3.5 rounded-2xl animate-in fade-in slide-in-from-top-1 duration-300">
-                                <div className="flex items-center gap-2">
-                                  <div className="w-1.5 h-1.5 rounded-full bg-blue-500 animate-pulse" />
-                                  <span className="font-medium">Abrechnungszeitraum:</span> {formatPeriodDuration(startdatum, enddatum)}
-                                </div>
-                              </div>
-                            );
-                          })()}
-                        </div>
-                      )}
-                    </div>
-
-                    {/* Vorauszahlungsmethode */}
-                    <div className="space-y-4 pt-2">
-                      <LabelWithTooltip htmlFor="formVorauszahlungsArt" infoText="Soll: Verwendet den vereinbarten Vorauszahlungsbetrag aus dem Mieterprofil. Ist: Verwendet die tatsächlich gebuchten Zahlungen.">
-                        <span className="text-sm font-semibold tracking-tight">Zahlungsmethode</span>
-                      </LabelWithTooltip>
-                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                        <button
-                          type="button"
-                          onClick={() => { setVorauszahlungsArt('soll'); setBetriebskostenModalDirty(true); }}
-                          disabled={isSaving || isFormLoading}
-                          className={`group relative flex items-center gap-4 p-4 rounded-2xl border transition-all disabled:opacity-50 ${vorauszahlungsArt === 'soll' ? 'bg-primary/5 border-primary shadow-sm shadow-primary/10' : 'bg-white dark:bg-white/5 border-gray-200/60 dark:border-gray-800/60 hover:border-primary/30'}`}
+                      <div className="relative flex-none">
+                        <motion.div
+                          initial={false}
+                          animate={{
+                            backgroundColor: isCompleted || isActive ? '#0F172A' : 'transparent', // Darker navy for maximum contrast in light mode
+                            borderColor: isCompleted || isActive ? '#0F172A' : 'rgba(156, 163, 175, 0.4)',
+                          }}
+                          className={`w-9 h-9 rounded-full border-2 flex items-center justify-center text-sm font-bold transition-all duration-300 ${isCompleted || isActive ? 'text-white' : 'text-slate-400'}`}
                         >
-                          <div className={`p-2.5 rounded-xl transition-colors ${vorauszahlungsArt === 'soll' ? 'bg-primary text-primary-foreground' : 'bg-gray-100 dark:bg-gray-800 text-muted-foreground group-hover:text-primary'} shadow-sm`}>
-                            <CalendarClock className="w-5 h-5" />
-                          </div>
-                          <div className="text-left">
-                            <p className={`font-bold transition-colors ${vorauszahlungsArt === 'soll' ? 'text-primary' : 'text-foreground'}`}>Soll-Verfahren</p>
-                            <p className="text-[11px] text-muted-foreground mt-0.5 leading-tight">Geplante Vorauszahlungen</p>
-                          </div>
-                          {vorauszahlungsArt === 'soll' && (
-                            <div className="ml-auto w-5 h-5 rounded-full bg-primary flex items-center justify-center animate-in zoom-in duration-300">
-                              <Check className="w-3 h-3 text-white" strokeWidth={3} />
-                            </div>
-                          )}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => { setVorauszahlungsArt('ist'); setBetriebskostenModalDirty(true); }}
-                          disabled={isSaving || isFormLoading}
-                          className={`group relative flex items-center gap-4 p-4 rounded-2xl border transition-all disabled:opacity-50 ${vorauszahlungsArt === 'ist' ? 'bg-primary/5 border-primary shadow-sm shadow-primary/10' : 'bg-white dark:bg-white/5 border-gray-200/60 dark:border-gray-800/60 hover:border-primary/30'}`}
-                        >
-                          <div className={`p-2.5 rounded-xl transition-colors ${vorauszahlungsArt === 'ist' ? 'bg-primary text-primary-foreground' : 'bg-gray-100 dark:bg-gray-800 text-muted-foreground group-hover:text-primary'} shadow-sm`}>
-                            <Banknote className="w-5 h-5" />
-                          </div>
-                          <div className="text-left">
-                            <p className={`font-bold transition-colors ${vorauszahlungsArt === 'ist' ? 'text-primary' : 'text-foreground'}`}>Ist-Verfahren</p>
-                            <p className="text-[11px] text-muted-foreground mt-0.5 leading-tight">Reale Bankeingänge</p>
-                          </div>
-                          {vorauszahlungsArt === 'ist' && (
-                            <div className="ml-auto w-5 h-5 rounded-full bg-primary flex items-center justify-center animate-in zoom-in duration-300">
-                              <Check className="w-3 h-3 text-white" strokeWidth={3} />
-                            </div>
-                          )}
-                        </button>
+                          {isCompleted ? <Check className="w-5 h-5" strokeWidth={3} /> : step.id}
+                        </motion.div>
+                      </div>
+
+                      <div className="flex flex-col pt-1">
+                        <span className={`text-sm font-bold transition-colors duration-300 ${isActive ? 'text-primary' : isCompleted ? 'text-foreground/80' : 'text-muted-foreground'}`}>
+                          {step.label}
+                        </span>
+                        <span className="text-[11px] text-muted-foreground/60 font-medium leading-tight mt-0.5">
+                          {step.desc}
+                        </span>
                       </div>
                     </div>
+                  );
+                })}
+              </div>
+
+              <div className="mt-auto">
+                <div className="p-4 rounded-2xl bg-blue-50/50 dark:bg-blue-900/10 border border-blue-100/50 dark:border-blue-800/30">
+                  <div className="flex items-center gap-2 mb-1.5">
+                    <div className="w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
+                    <span className="text-[10px] font-bold uppercase tracking-wider text-blue-600 dark:text-blue-400">Tipp</span>
                   </div>
-                </motion.div>
-              )}
+                  <p className="text-[11px] leading-relaxed text-blue-800/70 dark:text-blue-300/60">
+                    Positionen können per Drag & Drop sortiert werden.
+                  </p>
+                </div>
+              </div>
+            </div>
 
-              {currentStep === 2 && (
-                <motion.div
-                  key="step2"
-                  initial={{ opacity: 0, x: 20 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  exit={{ opacity: 0, x: -20 }}
-                  transition={{ duration: 0.2, ease: "easeInOut" }}
-                  className="space-y-8 p-6"
-                >
-                  {/* Meter Costs Section */}
-                  <div className="space-y-4">
-                    <div className="flex items-center gap-3">
-                      <div className="w-10 h-10 rounded-2xl bg-primary/10 flex items-center justify-center text-primary shadow-sm border border-primary/20">
-                        <Gauge className="w-5 h-5" />
-                      </div>
-                      <div>
-                        <h3 className="text-lg font-bold tracking-tight">Verbrauchskosten</h3>
-                        <p className="text-xs text-muted-foreground">Hausweite Gesamtkosten für Zähler</p>
-                      </div>
-                    </div>
+            {/* Main Content Area */}
+            <div className="flex-1 flex flex-col overflow-hidden min-h-0 relative">
+              <div className="sticky top-0 z-10 bg-background/95 backdrop-blur-md px-8 pt-8 pb-4 flex items-center justify-between border-b border-gray-100 dark:border-gray-800/40 sm:border-none">
+                <div className="space-y-0.5">
+                  <h2 className="text-2xl font-black tracking-tight text-foreground/90">
+                    {currentStep === 1 ? 'Objekt & Zeitraum' : currentStep === 2 ? 'Kostenaufstellung' : 'Erfolg'}
+                  </h2>
+                </div>
+              </div>
 
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                      {(Object.keys(ZAEHLER_CONFIG) as ZaehlerTyp[])
-                        .filter(typ => zaehlerkosten[typ] !== undefined)
-                        .map((typ) => {
-                          const config = ZAEHLER_CONFIG[typ];
-                          const Icon = METER_ICON_MAP[config.icon as keyof typeof METER_ICON_MAP];
+              <div className="flex-1 overflow-y-auto relative min-h-0 custom-scrollbar">
+                <AnimatePresence mode="wait">
+                  {currentStep === 1 && (
+                    <motion.div
+                      key="step1"
+                      initial={{ opacity: 0, x: 20 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      exit={{ opacity: 0, x: -20 }}
+                      transition={{ duration: 0.2, ease: "easeInOut" }}
+                      className="space-y-6 p-6"
+                    >
+                      <div className="p-0 space-y-8">
+                        {/* House Selection */}
+                        <div className="space-y-2.5">
+                          <LabelWithTooltip htmlFor="formHausId" infoText="Wählen Sie das Haus aus, für das die Nebenkostenabrechnung erstellt wird.">
+                            <span className="text-sm font-semibold tracking-tight">Immobilie auswählen *</span>
+                          </LabelWithTooltip>
+                          {isFormLoading ? <Skeleton className="h-11 w-full rounded-xl" /> : (
+                            <CustomCombobox width="w-full" options={houseOptions} value={hausId} onChange={handleHausIdChange} placeholder="Haus auswählen..." searchPlaceholder="Haus suchen..." emptyText="Kein Haus gefunden." disabled={isSaving || isFormLoading} />
+                          )}
+                        </div>
 
-                          return (
-                            <div
-                              key={typ}
-                              className="group flex flex-col gap-3 p-4 bg-gray-50/50 dark:bg-white/5 rounded-3xl border border-gray-200/60 dark:border-gray-800/60 shadow-sm transition-all hover:border-primary/40 hover:shadow-md"
-                            >
-                              <div className="flex items-center justify-between">
-                                <div className="flex items-center gap-3">
-                                  <div className="p-2.5 rounded-xl bg-white dark:bg-gray-800 text-foreground group-hover:bg-primary group-hover:text-primary-foreground transition-all duration-300 shadow-sm border border-gray-100 dark:border-gray-700">
-                                    <Icon className="w-4.5 h-4.5" />
-                                  </div>
-                                  <span className="text-sm font-bold">{config.label}</span>
-                                </div>
+                        {/* Date Range Selection */}
+                        <div className="space-y-4 pt-2">
+                          <LabelWithTooltip htmlFor="formDates" infoText="Legen Sie den Abrechnungszeitraum fest.">
+                            <span className="text-sm font-semibold tracking-tight">Abrechnungszeitraum *</span>
+                          </LabelWithTooltip>
+                          {isFormLoading ? (
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                              <Skeleton className="h-11 w-full rounded-xl" />
+                              <Skeleton className="h-11 w-full rounded-xl" />
+                            </div>
+                          ) : (
+                            <div className="space-y-4">
+                              <DateRangePicker
+                                startDate={startdatum}
+                                endDate={enddatum}
+                                onStartDateChange={handleStartdatumChange}
+                                onEndDateChange={handleEnddatumChange}
+                                disabled={isSaving || isFormLoading}
+                                showPeriodInfo={false}
+                              />
+
+                              <div className="grid grid-cols-2 gap-3">
                                 <Button
                                   type="button"
-                                  variant="ghost"
-                                  size="icon"
-                                  className="h-8 w-8 text-muted-foreground/50 hover:text-destructive hover:bg-destructive/10 rounded-full transition-colors"
-                                  onClick={() => handleRemoveZaehlerkosten(typ)}
+                                  variant="outline"
+                                  size="sm"
+                                  className="h-11 w-full rounded-2xl border-gray-200/60 dark:border-gray-800/60 hover:bg-white dark:hover:bg-gray-800 transition-all shadow-sm"
+                                  onClick={() => {
+                                    const currentStartYear = startdatum ? parseInt(startdatum.split('.')[2]) : new Date().getFullYear();
+                                    const newYear = currentStartYear - 1;
+                                    setStartdatum(`01.01.${newYear}`);
+                                    setEnddatum(`31.12.${newYear}`);
+                                    setBetriebskostenModalDirty(true);
+                                  }}
+                                  disabled={isSaving || isFormLoading}
                                 >
-                                  <Trash2 className="w-4 h-4" />
+                                  <CalendarMinus className="w-4 h-4 mr-2 text-muted-foreground" />
+                                  <span className="font-medium">-1 Jahr</span>
+                                </Button>
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  size="sm"
+                                  className="h-11 w-full rounded-2xl border-gray-200/60 dark:border-gray-800/60 hover:bg-white dark:hover:bg-gray-800 transition-all shadow-sm"
+                                  onClick={() => {
+                                    const currentStartYear = startdatum ? parseInt(startdatum.split('.')[2]) : new Date().getFullYear();
+                                    const newYear = currentStartYear + 1;
+                                    setStartdatum(`01.01.${newYear}`);
+                                    setEnddatum(`31.12.${newYear}`);
+                                    setBetriebskostenModalDirty(true);
+                                  }}
+                                  disabled={isSaving || isFormLoading}
+                                >
+                                  <CalendarPlus className="w-4 h-4 mr-2 text-primary" />
+                                  <span className="font-medium">+1 Jahr</span>
                                 </Button>
                               </div>
-                              <div className="relative">
-                                <NumberInput
-                                  id={`zaehlerkosten-${typ}`}
-                                  value={zaehlerkosten[typ] || ''}
-                                  onChange={(e) => handleZaehlerkostenChange(typ, e.target.value)}
-                                  placeholder="0.00"
-                                  step="0.01"
-                                  disabled={isSaving || isFormLoading}
-                                  className="h-11 pl-4 pr-10 rounded-2xl bg-white dark:bg-black/20 border-gray-200 dark:border-gray-800/80 focus:ring-primary/20 transition-all font-medium text-lg"
-                                />
-                                <span className="absolute right-4 top-1/2 -translate-y-1/2 text-sm font-bold text-muted-foreground">€</span>
-                              </div>
+
+                              {(() => {
+                                const validation = validateDateRange(startdatum, enddatum);
+                                return validation.isValid && validation.periodDays && (
+                                  <div className="text-sm text-blue-700 dark:text-blue-300 p-0 rounded-none animate-in fade-in slide-in-from-top-1 duration-300">
+                                    <div className="flex items-center gap-2">
+                                      <div className="w-1.5 h-1.5 rounded-full bg-blue-500 animate-pulse" />
+                                      <span className="font-medium">Abrechnungszeitraum:</span> {formatPeriodDuration(startdatum, enddatum)}
+                                    </div>
+                                  </div>
+                                );
+                              })()}
                             </div>
-                          );
-                        })}
-
-                      <div className="sm:col-span-1">
-                        {addMeterCostSelect}
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Kostenaufstellung Section */}
-                  <div className="space-y-4">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-3">
-                        <div className="w-10 h-10 rounded-2xl bg-primary/10 flex items-center justify-center text-primary shadow-sm border border-primary/20">
-                          <PlusCircle className="w-5 h-5" />
+                          )}
                         </div>
-                        <div>
-                          <h3 className="text-lg font-bold tracking-tight">Betriebskosten</h3>
-                          <p className="text-xs text-muted-foreground">Alle weiteren umlagefähigen Positionen</p>
+
+                        {/* Vorauszahlungsmethode */}
+                        <div className="space-y-4 pt-2">
+                          <LabelWithTooltip htmlFor="formVorauszahlungsArt" infoText="Soll: Verwendet den vereinbarten Vorauszahlungsbetrag aus dem Mieterprofil. Ist: Verwendet die tatsächlich gebuchten Zahlungen.">
+                            <span className="text-sm font-semibold tracking-tight">Zahlungsmethode</span>
+                          </LabelWithTooltip>
+                          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                            <button
+                              type="button"
+                              onClick={() => { setVorauszahlungsArt('soll'); setBetriebskostenModalDirty(true); }}
+                              disabled={isSaving || isFormLoading}
+                              className={`group relative flex items-center gap-4 p-4 rounded-2xl border transition-all disabled:opacity-50 ${vorauszahlungsArt === 'soll' ? 'bg-primary/5 border-primary shadow-sm shadow-primary/10' : 'bg-white dark:bg-white/5 border-gray-200/60 dark:border-gray-800/60 hover:border-primary/30'}`}
+                            >
+                              <div className={`p-2.5 rounded-xl transition-colors ${vorauszahlungsArt === 'soll' ? 'bg-primary text-primary-foreground' : 'bg-gray-100 dark:bg-gray-800 text-muted-foreground group-hover:text-primary'} shadow-sm`}>
+                                <CalendarClock className="w-5 h-5" />
+                              </div>
+                              <div className="text-left">
+                                <p className={`font-bold transition-colors ${vorauszahlungsArt === 'soll' ? 'text-primary' : 'text-foreground'}`}>Soll-Verfahren</p>
+                                <p className="text-[11px] text-muted-foreground mt-0.5 leading-tight">Geplante Vorauszahlungen</p>
+                              </div>
+                              {vorauszahlungsArt === 'soll' && (
+                                <div className="ml-auto w-5 h-5 rounded-full bg-primary flex items-center justify-center animate-in zoom-in duration-300">
+                                  <Check className="w-3 h-3 text-white" strokeWidth={3} />
+                                </div>
+                              )}
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => { setVorauszahlungsArt('ist'); setBetriebskostenModalDirty(true); }}
+                              disabled={isSaving || isFormLoading}
+                              className={`group relative flex items-center gap-4 p-4 rounded-2xl border transition-all disabled:opacity-50 ${vorauszahlungsArt === 'ist' ? 'bg-primary/5 border-primary shadow-sm shadow-primary/10' : 'bg-white dark:bg-white/5 border-gray-200/60 dark:border-gray-800/60 hover:border-primary/30'}`}
+                            >
+                              <div className={`p-2.5 rounded-xl transition-colors ${vorauszahlungsArt === 'ist' ? 'bg-primary text-primary-foreground' : 'bg-gray-100 dark:bg-gray-800 text-muted-foreground group-hover:text-primary'} shadow-sm`}>
+                                <Banknote className="w-5 h-5" />
+                              </div>
+                              <div className="text-left">
+                                <p className={`font-bold transition-colors ${vorauszahlungsArt === 'ist' ? 'text-primary' : 'text-foreground'}`}>Ist-Verfahren</p>
+                                <p className="text-[11px] text-muted-foreground mt-0.5 leading-tight">Reale Bankeingänge</p>
+                              </div>
+                              {vorauszahlungsArt === 'ist' && (
+                                <div className="ml-auto w-5 h-5 rounded-full bg-primary flex items-center justify-center animate-in zoom-in duration-300">
+                                  <Check className="w-3 h-3 text-white" strokeWidth={3} />
+                                </div>
+                              )}
+                            </button>
+                          </div>
                         </div>
                       </div>
-                    </div>
+                    </motion.div>
+                  )}
 
-                    <div className="rounded-3xl bg-gray-50/50 dark:bg-white/5 border border-gray-200/60 dark:border-gray-800/60 p-4 space-y-4">
-                      {isFormLoading ? (
-                        Array.from({ length: 3 }).map((_, idx) => (
-                          <div key={`skel-cost-${idx}`} className="flex flex-col gap-2 py-2">
-                            <Skeleton className="h-14 w-full rounded-2xl" />
+                  {currentStep === 2 && (
+                    <motion.div
+                      key="step2"
+                      initial={{ opacity: 0, x: 20 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      exit={{ opacity: 0, x: -20 }}
+                      transition={{ duration: 0.2, ease: "easeInOut" }}
+                      className="space-y-8 p-6"
+                    >
+                      {/* Meter Costs Section */}
+                      <div className="space-y-4">
+                        <div className="flex items-center gap-3">
+                          <div className="w-10 h-10 rounded-2xl bg-primary/10 flex items-center justify-center text-primary shadow-sm border border-primary/20">
+                            <Gauge className="w-5 h-5" />
                           </div>
-                        ))
-                      ) : (
-                        <DndContext
-                          sensors={sensors}
-                          collisionDetection={closestCenter}
-                          onDragEnd={handleDragEnd}
-                        >
-                          <div className="space-y-3">
-                            <SortableContext items={costItems.map(item => item.id)} strategy={verticalListSortingStrategy}>
-                              {costItems.map((item, index) => (
-                                <SortableCostItem
-                                  key={item.id}
-                                  item={item}
-                                  index={index}
-                                  costItems={costItems}
-                                  selectedHausMieter={selectedHausMieter}
-                                  rechnungen={rechnungen}
-                                  isSaving={isSaving}
-                                  isLoadingDetails={isFormLoading}
-                                  isFetchingTenants={isFetchingTenants}
-                                  hausId={hausId}
-                                  onCostItemChange={handleCostItemChange}
-                                  onRemoveCostItem={removeCostItem}
-                                  onRechnungChange={handleRechnungChange}
-                                  hoveredBerechnungsart={hoveredBerechnungsart}
-                                  selectContentRect={selectContentRect}
-                                  hoveredItemRect={hoveredItemRect}
-                                  tooltipMap={tooltipMap}
-                                  onItemHover={handleItemHover}
-                                  onItemLeave={handleItemLeave}
-                                  selectContentRef={selectContentRef}
-                                />
-                              ))}
-                            </SortableContext>
+                          <div>
+                            <h3 className="text-lg font-bold tracking-tight">Verbrauchskosten</h3>
+                            <p className="text-xs text-muted-foreground">Hausweite Gesamtkosten für Zähler</p>
                           </div>
-                        </DndContext>
-                      )}
+                        </div>
 
-                      <Button
-                        type="button"
-                        onClick={addCostItem}
-                        variant="ghost"
-                        className="w-full h-11 rounded-2xl border border-dashed border-gray-300 dark:border-gray-700 hover:border-primary/50 hover:bg-primary/5 transition-all text-muted-foreground hover:text-primary font-semibold"
-                        disabled={isFormLoading || isSaving}
-                      >
-                        <PlusCircle className="mr-2 h-4 w-4" />
-                        Weitere Kostenposition hinzufügen
-                      </Button>
-                    </div>
-                  </div>
-                </motion.div>
-              )}
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                          <AnimatePresence mode="popLayout">
+                            {(Object.keys(ZAEHLER_CONFIG) as ZaehlerTyp[])
+                              .filter(typ => zaehlerkosten[typ] !== undefined)
+                              .map((typ) => {
+                                const config = ZAEHLER_CONFIG[typ];
+                                const Icon = METER_ICON_MAP[config.icon as keyof typeof METER_ICON_MAP];
 
-              {currentStep === 3 && (
-                <motion.div
-                  key="step3"
-                  initial={{ opacity: 0, scale: 0.95 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  transition={{ duration: 0.4, type: "spring" }}
-                >
-                  <SuccessStep
-                    data={savedItemData}
-                    onClose={closeBetriebskostenModal}
-                    onOverview={() => {
-                      // For now we just close, but ideally we'd trigger the overview
-                      closeBetriebskostenModal();
-                      // Optional: if we can find a way to let parent know to open overview
-                    }}
-                  />
-                </motion.div>
-              )}
-            </AnimatePresence>
+                                return (
+                                  <motion.div
+                                    key={typ}
+                                    layout
+                                    initial={{ opacity: 0, scale: 0.95, y: -10 }}
+                                    animate={{ opacity: 1, scale: 1, y: 0 }}
+                                    exit={{ opacity: 0, scale: 0.95, y: 10 }}
+                                    transition={{ duration: 0.2 }}
+                                    className="group flex flex-col gap-3 p-4 bg-transparent border-transparent"
+                                  >
+                                    <div className="flex items-center justify-between">
+                                      <div className="flex items-center gap-3">
+                                        <div className="p-2.5 rounded-xl bg-white dark:bg-gray-800 text-foreground group-hover:bg-primary group-hover:text-primary-foreground transition-all duration-300 shadow-sm border border-gray-100 dark:border-gray-700">
+                                          <Icon className="w-4.5 h-4.5" />
+                                        </div>
+                                        <span className="text-sm font-bold">{config.label}</span>
+                                      </div>
+                                      <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8 text-muted-foreground/50 hover:text-destructive hover:bg-destructive/10 rounded-full transition-colors"
+                                        onClick={() => handleRemoveZaehlerkosten(typ)}
+                                      >
+                                        <Trash2 className="w-4 h-4" />
+                                      </Button>
+                                    </div>
+                                    <div className="relative">
+                                      <NumberInput
+                                        id={`zaehlerkosten-${typ}`}
+                                        value={zaehlerkosten[typ] || ''}
+                                        onChange={(e) => handleZaehlerkostenChange(typ, e.target.value)}
+                                        placeholder="0.00"
+                                        step="0.01"
+                                        disabled={isSaving || isFormLoading}
+                                        className="h-11 pl-4 pr-10 rounded-2xl bg-white dark:bg-black/20 border-gray-200 dark:border-gray-800/80 focus:ring-primary/20 transition-all font-medium text-lg"
+                                      />
+                                      <span className="absolute right-4 top-1/2 -translate-y-1/2 text-sm font-bold text-muted-foreground">€</span>
+                                    </div>
+                                  </motion.div>
+                                );
+                              })}
+                          </AnimatePresence>
+
+                          <motion.div layout className="sm:col-span-1">
+                            {addMeterCostSelect}
+                          </motion.div>
+                        </div>
+                      </div>
+
+                      {/* Kostenaufstellung Section */}
+                      <div className="space-y-4">
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center gap-3">
+                            <div className="w-10 h-10 rounded-2xl bg-primary/10 flex items-center justify-center text-primary shadow-sm border border-primary/20">
+                              <PlusCircle className="w-5 h-5" />
+                            </div>
+                            <div>
+                              <h3 className="text-lg font-bold tracking-tight">Betriebskosten</h3>
+                              <p className="text-xs text-muted-foreground">Alle weiteren umlagefähigen Positionen</p>
+                            </div>
+                          </div>
+                        </div>
+
+                        <div className="p-0 space-y-3">
+                          {isFormLoading ? (
+                            Array.from({ length: 3 }).map((_, idx) => (
+                              <div key={`skel-cost-${idx}`} className="flex flex-col gap-2 py-2">
+                                <Skeleton className="h-14 w-full rounded-2xl" />
+                              </div>
+                            ))
+                          ) : (
+                            <DndContext
+                              sensors={sensors}
+                              collisionDetection={closestCenter}
+                              onDragEnd={handleDragEnd}
+                            >
+                              <div className="space-y-3">
+                                <SortableContext items={costItems.map(item => item.id)} strategy={verticalListSortingStrategy}>
+                                  {costItems.map((item, index) => (
+                                    <SortableCostItem
+                                      key={item.id}
+                                      item={item}
+                                      index={index}
+                                      costItems={costItems}
+                                      selectedHausMieter={selectedHausMieter}
+                                      rechnungen={rechnungen}
+                                      isSaving={isSaving}
+                                      isLoadingDetails={isFormLoading}
+                                      isFetchingTenants={isFetchingTenants}
+                                      hausId={hausId}
+                                      onCostItemChange={handleCostItemChange}
+                                      onRemoveCostItem={removeCostItem}
+                                      onRechnungChange={handleRechnungChange}
+                                      hoveredBerechnungsart={hoveredBerechnungsart}
+                                      selectContentRect={selectContentRect}
+                                      hoveredItemRect={hoveredItemRect}
+                                      tooltipMap={tooltipMap}
+                                      onItemHover={handleItemHover}
+                                      onItemLeave={handleItemLeave}
+                                      selectContentRef={selectContentRef}
+                                    />
+                                  ))}
+                                </SortableContext>
+                              </div>
+                            </DndContext>
+                          )}
+
+                          <Button
+                            type="button"
+                            onClick={addCostItem}
+                            variant="ghost"
+                            className="w-full h-11 rounded-2xl border border-dashed border-gray-300 dark:border-gray-700 hover:border-primary/50 hover:bg-primary/5 transition-all text-muted-foreground hover:text-primary font-semibold"
+                            disabled={isFormLoading || isSaving}
+                          >
+                            <PlusCircle className="mr-2 h-4 w-4" />
+                            Weitere Kostenposition hinzufügen
+                          </Button>
+                        </div>
+                      </div>
+                    </motion.div>
+                  )}
+
+                  {currentStep === 3 && (
+                    <motion.div
+                      key="step3"
+                      initial={{ opacity: 0, scale: 0.95 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      transition={{ duration: 0.4, type: "spring" }}
+                    >
+                      <SuccessStep
+                        data={savedItemData}
+                        onClose={closeBetriebskostenModal}
+                        onOverview={() => {
+                          // For now we just close, but ideally we'd trigger the overview
+                          closeBetriebskostenModal();
+                          // Optional: if we can find a way to let parent know to open overview
+                        }}
+                      />
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
+
+              <DialogFooter className="px-8 py-6 bg-transparent border-none gap-3 mt-auto">
+                {currentStep === 1 ? (
+                  <>
+                    <Button type="button" variant="ghost" onClick={handleCancelClick} disabled={isSaving || isFormLoading} className="rounded-2xl h-11 px-6 font-semibold hover:bg-gray-100 dark:hover:bg-gray-800">
+                      Abbrechen
+                    </Button>
+                    <Button type="button" onClick={handleNextStep} disabled={isSaving || isFormLoading} className="rounded-2xl h-11 px-8 font-bold shadow-lg shadow-primary/20 flex items-center gap-2">
+                      Weiter
+                      <ArrowRight className="w-4 h-4" />
+                    </Button>
+                  </>
+                ) : currentStep === 2 ? (
+                  <>
+                    <Button type="button" variant="ghost" onClick={handlePrevStep} disabled={isSaving || isFormLoading} className="rounded-2xl h-11 px-6 font-semibold flex items-center gap-2">
+                      <ArrowLeft className="w-4 h-4" />
+                      Zurück
+                    </Button>
+                    <div className="flex-1" />
+                    <Button type="submit" disabled={isSaving || isFetchingTenants || isFormLoading} className="rounded-2xl h-11 px-10 font-bold shadow-lg shadow-primary/25 border-none transition-all active:scale-[0.98]">
+                      {isSaving ? (
+                        <div className="flex items-center gap-2">
+                          <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                          Wird gespeichert...
+                        </div>
+                      ) : (isFormLoading || isFetchingTenants ? "Laden..." : "Speichern & Abschließen")}
+                    </Button>
+                  </>
+                ) : null}
+              </DialogFooter>
+            </div>
           </div>
-
-          <DialogFooter className="px-6 py-4 bg-gray-50/30 dark:bg-white/5 border-t border-gray-100 dark:border-gray-800 gap-3">
-            {currentStep === 1 ? (
-              <>
-                <Button type="button" variant="ghost" onClick={handleCancelClick} disabled={isSaving || isFormLoading} className="rounded-2xl h-11 px-6 font-semibold hover:bg-gray-100 dark:hover:bg-gray-800">
-                  Abbrechen
-                </Button>
-                <Button type="button" onClick={handleNextStep} disabled={isSaving || isFormLoading} className="rounded-2xl h-11 px-8 font-bold shadow-lg shadow-primary/20 flex items-center gap-2">
-                  Weiter
-                  <ArrowRight className="w-4 h-4" />
-                </Button>
-              </>
-            ) : currentStep === 2 ? (
-              <>
-                <Button type="button" variant="ghost" onClick={handlePrevStep} disabled={isSaving || isFormLoading} className="rounded-2xl h-11 px-6 font-semibold flex items-center gap-2">
-                  <ArrowLeft className="w-4 h-4" />
-                  Zurück
-                </Button>
-                <div className="flex-1" />
-                <Button type="submit" disabled={isSaving || isFetchingTenants || isFormLoading} className="rounded-2xl h-11 px-10 font-bold shadow-lg shadow-primary/25 border-none transition-all active:scale-[0.98]">
-                  {isSaving ? (
-                    <div className="flex items-center gap-2">
-                      <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                      Wird gespeichert...
-                    </div>
-                  ) : (isFormLoading || isFetchingTenants ? "Laden..." : "Speichern & Abschließen")}
-                </Button>
-              </>
-            ) : null}
-          </DialogFooter>
         </form>
       </DialogContent>
     </Dialog>

--- a/components/finance/betriebskosten-edit-modal.tsx
+++ b/components/finance/betriebskosten-edit-modal.tsx
@@ -1063,7 +1063,7 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
           value=""
           onValueChange={(value) => handleZaehlerkostenChange(value as ZaehlerTyp, "")}
         >
-          <SelectTrigger className="w-full sm:w-[280px] h-10 rounded-full border-dashed border-2 bg-transparent hover:bg-primary/5 hover:border-primary/50 hover:text-primary transition-all text-muted-foreground">
+          <SelectTrigger className="w-full sm:w-[280px] h-10 rounded-full border-dashed border-2 bg-transparent hover:bg-primary/5 hover:border-primary/50 hover:text-primary dark:hover:text-white transition-all text-muted-foreground">
             <PlusCircle className="w-4 h-4 mr-2" />
             <SelectValue placeholder="Zähler-Kostenstelle hinzufügen" />
           </SelectTrigger>
@@ -1144,7 +1144,7 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
                       </div>
 
                       <div className="flex flex-col pt-1">
-                        <span className={`text-sm font-bold transition-colors duration-300 ${isActive ? 'text-primary' : isCompleted ? 'text-foreground/80' : 'text-muted-foreground'}`}>
+                        <span className={`text-sm font-bold transition-colors duration-300 ${isActive ? 'text-primary dark:text-primary-foreground' : isCompleted ? 'text-foreground/80' : 'text-muted-foreground'}`}>
                           {step.label}
                         </span>
                         <span className="text-[11px] text-muted-foreground/60 font-medium leading-tight mt-0.5">
@@ -1455,7 +1455,7 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
                             type="button"
                             onClick={addCostItem}
                             variant="ghost"
-                            className="w-full h-11 rounded-[2rem] border border-dashed border-gray-300 dark:border-gray-700 hover:border-primary/50 hover:bg-primary/5 transition-all text-muted-foreground hover:text-primary font-semibold mt-4"
+                            className="w-full h-11 rounded-[2rem] border border-dashed border-gray-300 dark:border-gray-700 hover:border-primary/50 hover:bg-primary/5 transition-all text-muted-foreground hover:text-primary dark:hover:text-white font-semibold mt-4"
                             disabled={isFormLoading || isSaving}
                           >
                             <PlusCircle className="mr-2 h-4 w-4" />

--- a/components/finance/betriebskosten-edit-modal.tsx
+++ b/components/finance/betriebskosten-edit-modal.tsx
@@ -128,6 +128,7 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
     betriebskostenModalOnSuccess,
     isBetriebskostenModalDirty,
     setBetriebskostenModalDirty,
+    openOperatingCostsOverviewModal,
   } = useModalStore();
 
   const [startdatum, setStartdatum] = useState("");
@@ -300,10 +301,12 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
   };
 
   const attemptClose = () => {
+    setCurrentStep(1);
     closeBetriebskostenModal();
   };
 
   const handleCancelClick = () => {
+    setCurrentStep(1);
     closeBetriebskostenModal({ force: true });
   };
 
@@ -620,6 +623,7 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
       setVorauszahlungsArt('soll');
       const initialHausId = forNewEntry && betriebskostenModalHaeuser && betriebskostenModalHaeuser.length > 0 ? betriebskostenModalHaeuser[0].id : "";
       setHausId(initialHausId);
+      setCurrentStep(1);
 
       // Always start with a single empty cost item for new entries
       if (forNewEntry) {
@@ -1158,18 +1162,6 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
                   );
                 })}
               </div>
-
-              <div className="mt-auto">
-                <div className="p-4 rounded-2xl bg-blue-50/50 dark:bg-blue-900/10 border border-blue-100/50 dark:border-blue-800/30">
-                  <div className="flex items-center gap-2 mb-1.5">
-                    <div className="w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
-                    <span className="text-[10px] font-bold uppercase tracking-wider text-blue-600 dark:text-blue-400">Tipp</span>
-                  </div>
-                  <p className="text-[11px] leading-relaxed text-blue-800/70 dark:text-blue-300/60">
-                    Positionen können per Drag & Drop sortiert werden.
-                  </p>
-                </div>
-              </div>
             </div>
 
             {/* Main Content Area */}
@@ -1492,9 +1484,15 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
                         data={savedItemData}
                         onClose={closeBetriebskostenModal}
                         onOverview={() => {
-                          // For now we just close, but ideally we'd trigger the overview
-                          closeBetriebskostenModal();
-                          // Optional: if we can find a way to let parent know to open overview
+                          if (savedItemData) {
+                            closeBetriebskostenModal();
+                            const selectedHaus = betriebskostenModalHaeuser?.find(h => h.id === hausId);
+                            const enrichedData = {
+                              ...savedItemData,
+                              haus_name: selectedHaus?.name || 'Unbekanntes Haus'
+                            };
+                            openOperatingCostsOverviewModal(enrichedData as any);
+                          }
                         }}
                       />
                     </motion.div>

--- a/components/finance/betriebskosten-edit-modal.tsx
+++ b/components/finance/betriebskosten-edit-modal.tsx
@@ -1274,7 +1274,7 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
                               disabled={isSaving || isFormLoading}
                               className={`group relative flex items-center gap-4 p-4 rounded-2xl border transition-all disabled:opacity-50 ${vorauszahlungsArt === 'soll' ? 'bg-primary/5 border-primary shadow-sm shadow-primary/10' : 'bg-white dark:bg-white/5 border-gray-200/60 dark:border-gray-800/60 hover:border-primary/30'}`}
                             >
-                              <div className={`p-2.5 rounded-xl transition-colors ${vorauszahlungsArt === 'soll' ? 'bg-primary text-primary-foreground' : 'bg-gray-100 dark:bg-gray-800 text-muted-foreground group-hover:text-primary'} shadow-sm`}>
+                              <div className={`p-2.5 rounded-xl transition-colors ${vorauszahlungsArt === 'soll' ? 'bg-primary text-primary-foreground' : 'bg-gray-100 dark:bg-gray-800 text-muted-foreground group-hover:text-primary dark:group-hover:text-white'} shadow-sm`}>
                                 <CalendarClock className="w-5 h-5" />
                               </div>
                               <div className="text-left">
@@ -1293,7 +1293,7 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
                               disabled={isSaving || isFormLoading}
                               className={`group relative flex items-center gap-4 p-4 rounded-2xl border transition-all disabled:opacity-50 ${vorauszahlungsArt === 'ist' ? 'bg-primary/5 border-primary shadow-sm shadow-primary/10' : 'bg-white dark:bg-white/5 border-gray-200/60 dark:border-gray-800/60 hover:border-primary/30'}`}
                             >
-                              <div className={`p-2.5 rounded-xl transition-colors ${vorauszahlungsArt === 'ist' ? 'bg-primary text-primary-foreground' : 'bg-gray-100 dark:bg-gray-800 text-muted-foreground group-hover:text-primary'} shadow-sm`}>
+                              <div className={`p-2.5 rounded-xl transition-colors ${vorauszahlungsArt === 'ist' ? 'bg-primary text-primary-foreground' : 'bg-gray-100 dark:bg-gray-800 text-muted-foreground group-hover:text-primary dark:group-hover:text-white'} shadow-sm`}>
                                 <Banknote className="w-5 h-5" />
                               </div>
                               <div className="text-left">

--- a/components/finance/betriebskosten-edit-modal.tsx
+++ b/components/finance/betriebskosten-edit-modal.tsx
@@ -72,7 +72,7 @@ import { SortableCostItem, type CostItem, type RechnungEinzel } from "./sortable
 import { DateRangePicker } from "@/components/ui/date-range-picker";
 import { getDefaultDateRange, validateDateRange, germanToIsoDate, isoToGermanDate, formatPeriodDuration } from "@/utils/date-calculations";
 
-const SuccessStep = ({ data, onClose, onOverview }: { data: Nebenkosten | OptimizedNebenkosten | null, onClose: () => void, onOverview: () => void }) => {
+const SuccessStep = ({ data, onClose, onOverview }: { data: OptimizedNebenkosten | null, onClose: () => void, onOverview: () => void }) => {
   return (
     <div className="flex flex-col items-center justify-center py-12 px-6 text-center space-y-6">
       <div className="relative">
@@ -89,7 +89,7 @@ const SuccessStep = ({ data, onClose, onOverview }: { data: Nebenkosten | Optimi
       <div className="space-y-2">
         <h3 className="text-2xl font-bold tracking-tight bg-gradient-to-br from-foreground to-foreground/70 bg-clip-text text-transparent">Abrechnung gespeichert!</h3>
         <p className="text-muted-foreground max-w-sm mx-auto">
-          Die Betriebskosten für das Objekt <span className="font-semibold text-foreground">{(data as any)?.haus_name || (data as any)?.house_name || data?.Haeuser?.name || 'Unbekannt'}</span> im Zeitraum <span className="font-semibold text-foreground">{isoToGermanDate(data?.startdatum || '')} - {isoToGermanDate(data?.enddatum || '')}</span> wurden erfolgreich erfasst.
+          Die Betriebskosten für das Objekt <span className="font-semibold text-foreground">{data?.haus_name || 'Unbekannt'}</span> im Zeitraum <span className="font-semibold text-foreground">{isoToGermanDate(data?.startdatum || '')} - {isoToGermanDate(data?.enddatum || '')}</span> wurden erfolgreich erfasst.
         </p>
       </div>
 
@@ -147,7 +147,7 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
   const [isLoadingTemplate, setIsLoadingTemplate] = useState(false);
   const [modalNebenkostenData, setModalNebenkostenData] = useState<Nebenkosten | null>(null);
   const [currentStep, setCurrentStep] = useState<1 | 2 | 3>(1);
-  const [savedItemData, setSavedItemData] = useState<Nebenkosten | null>(null);
+  const [savedItemData, setSavedItemData] = useState<OptimizedNebenkosten | null>(null);
   const currentlyLoadedNebenkostenId = React.useRef<string | null | undefined>(null);
 
   // Tooltip next to dropdown: track hovered verteilerschlüssel, dropdown rect, and hovered item position
@@ -975,22 +975,14 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
 
       // Store the result for step 3 overview
       if (response.data) {
-        setSavedItemData(response.data);
+        setSavedItemData(response.data as OptimizedNebenkosten);
       } else {
-        // Fallback for updates where response data might be partial
-        setSavedItemData({
-          ...(modalNebenkostenData || {}),
-          startdatum: germanToIsoDate(startdatum),
-          enddatum: germanToIsoDate(enddatum),
-          haeuser_id: hausId,
-          vorauszahlungs_art: vorauszahlungsArt,
-          nebenkostenart: costItems.map(i => i.art),
-          betrag: costItems.map(i => parseFloat(i.betrag) || 0),
-          berechnungsart: costItems.map(i => i.berechnungsart),
-          zaehlerkosten: Object.fromEntries(
-            Object.entries(zaehlerkosten).map(([k, v]) => [k, parseFloat(v) || 0])
-          )
-        } as Nebenkosten);
+        // This should theoretically not happen with the new server action
+        toast({
+          title: "Warnung",
+          description: "Daten konnten nach dem Speichern nicht vollständig geladen werden.",
+          variant: "destructive"
+        });
       }
 
       setCurrentStep(3);
@@ -1487,18 +1479,7 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
                         onOverview={() => {
                           if (savedItemData) {
                             closeBetriebskostenModal();
-                            const selectedHaus = betriebskostenModalHaeuser?.find(h => h.id === hausId);
-                            // Provide default values for mandatory OptimizedNebenkosten fields
-                            // The modal will fetch the real values using the id anyway
-                            const enrichedData: OptimizedNebenkosten = {
-                              ...(savedItemData as any),
-                              haus_name: selectedHaus?.name || 'Unbekanntes Haus',
-                              gesamt_flaeche: (savedItemData as any).gesamt_flaeche || 0,
-                              anzahl_wohnungen: (savedItemData as any).anzahl_wohnungen || 0,
-                              anzahl_mieter: (savedItemData as any).anzahl_mieter || 0,
-                              user_id: savedItemData.user_id || '',
-                            };
-                            openOperatingCostsOverviewModal(enrichedData);
+                            openOperatingCostsOverviewModal(savedItemData);
                           }
                         }}
                       />

--- a/components/finance/betriebskosten-edit-modal.tsx
+++ b/components/finance/betriebskosten-edit-modal.tsx
@@ -1193,7 +1193,7 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
                       transition={{ duration: 0.2, ease: "easeInOut" }}
                       className="space-y-6 p-6"
                     >
-                      <div className="p-0 space-y-8">
+                      <div className="p-6 space-y-8 bg-gray-50/30 dark:bg-gray-900/10 border border-gray-200/60 dark:border-gray-800/60 rounded-[2rem]">
                         {/* House Selection */}
                         <div className="space-y-2.5">
                           <LabelWithTooltip htmlFor="formHausId" infoText="Wählen Sie das Haus aus, für das die Nebenkostenabrechnung erstellt wird.">
@@ -1337,7 +1337,7 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
                       className="space-y-8 p-6"
                     >
                       {/* Meter Costs Section */}
-                      <div className="space-y-4">
+                      <div className="space-y-4 p-6 bg-gray-50/30 dark:bg-gray-900/10 border border-gray-200/60 dark:border-gray-800/60 rounded-[2rem]">
                         <div className="flex items-center gap-3">
                           <div className="w-10 h-10 rounded-2xl bg-primary/10 flex items-center justify-center text-primary shadow-sm border border-primary/20">
                             <Gauge className="w-5 h-5" />
@@ -1364,12 +1364,12 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
                                     animate={{ opacity: 1, scale: 1, y: 0 }}
                                     exit={{ opacity: 0, scale: 0.95, y: 10 }}
                                     transition={{ duration: 0.2 }}
-                                    className="group flex flex-col gap-3 p-4 bg-transparent border-transparent"
+                                    className="group flex flex-col gap-3 p-4 bg-gray-50/50 dark:bg-gray-900/10 border border-gray-200 dark:border-gray-800 rounded-[2rem]"
                                   >
                                     <div className="flex items-center justify-between">
                                       <div className="flex items-center gap-3">
-                                        <div className="p-2.5 rounded-xl bg-white dark:bg-gray-800 text-foreground group-hover:bg-primary group-hover:text-primary-foreground transition-all duration-300 shadow-sm border border-gray-100 dark:border-gray-700">
-                                          <Icon className="w-4.5 h-4.5" />
+                                        <div className="p-2 rounded-[1rem] bg-primary text-primary-foreground transition-all duration-300 shadow-sm border border-primary/20">
+                                          <Icon className="w-4 h-4" />
                                         </div>
                                         <span className="text-sm font-bold">{config.label}</span>
                                       </div>
@@ -1383,12 +1383,12 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
                                         <Trash2 className="w-4 h-4" />
                                       </Button>
                                     </div>
-                                    <div className="relative">
+                                    <div className="relative mt-auto">
                                       <NumberInput
                                         id={`zaehlerkosten-${typ}`}
                                         value={zaehlerkosten[typ] || ''}
                                         onChange={(e) => handleZaehlerkostenChange(typ, e.target.value)}
-                                        placeholder="0.00"
+                                        placeholder="0,00"
                                         step="0.01"
                                         disabled={isSaving || isFormLoading}
                                         className="h-11 pl-4 pr-10 rounded-2xl bg-white dark:bg-black/20 border-gray-200 dark:border-gray-800/80 focus:ring-primary/20 transition-all font-medium text-lg"
@@ -1399,15 +1399,17 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
                                 );
                               })}
                           </AnimatePresence>
+                        </div>
 
-                          <motion.div layout className="sm:col-span-1">
+                        {addMeterCostSelect && (
+                          <motion.div layout>
                             {addMeterCostSelect}
                           </motion.div>
-                        </div>
+                        )}
                       </div>
 
                       {/* Kostenaufstellung Section */}
-                      <div className="space-y-4">
+                      <div className="space-y-4 p-6 bg-gray-50/30 dark:bg-gray-900/10 border border-gray-200/60 dark:border-gray-800/60 rounded-[2rem]">
                         <div className="flex items-center justify-between">
                           <div className="flex items-center gap-3">
                             <div className="w-10 h-10 rounded-2xl bg-primary/10 flex items-center justify-center text-primary shadow-sm border border-primary/20">
@@ -1468,7 +1470,7 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
                             type="button"
                             onClick={addCostItem}
                             variant="ghost"
-                            className="w-full h-11 rounded-2xl border border-dashed border-gray-300 dark:border-gray-700 hover:border-primary/50 hover:bg-primary/5 transition-all text-muted-foreground hover:text-primary font-semibold"
+                            className="w-full h-11 rounded-[2rem] border border-dashed border-gray-300 dark:border-gray-700 hover:border-primary/50 hover:bg-primary/5 transition-all text-muted-foreground hover:text-primary font-semibold mt-4"
                             disabled={isFormLoading || isSaving}
                           >
                             <PlusCircle className="mr-2 h-4 w-4" />

--- a/components/finance/betriebskosten-edit-modal.tsx
+++ b/components/finance/betriebskosten-edit-modal.tsx
@@ -118,6 +118,65 @@ const METER_ICON_MAP = {
   fuel: Fuel,
 };
 
+function MeterCostItem({
+  typ,
+  zaehlerkosten,
+  onValueChange,
+  onRemove,
+  isSaving,
+  isFormLoading,
+}: {
+  typ: ZaehlerTyp;
+  zaehlerkosten: Record<string, string>;
+  onValueChange: (typ: ZaehlerTyp, value: string) => void;
+  onRemove: (typ: ZaehlerTyp) => void;
+  isSaving: boolean;
+  isFormLoading: boolean;
+}) {
+  const config = ZAEHLER_CONFIG[typ];
+  const Icon = METER_ICON_MAP[config.icon as keyof typeof METER_ICON_MAP];
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, scale: 0.95, y: -10 }}
+      animate={{ opacity: 1, scale: 1, y: 0 }}
+      exit={{ opacity: 0, scale: 0.95, y: 10 }}
+      transition={{ duration: 0.2 }}
+      className="group flex flex-col gap-3 p-4 bg-gray-50/50 dark:bg-gray-900/10 border border-gray-200 dark:border-gray-800 rounded-[2rem]"
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-[1rem] bg-primary text-primary-foreground transition-all duration-300 shadow-sm border border-primary/20">
+            <Icon className="w-4 h-4" />
+          </div>
+          <span className="text-sm font-bold">{config.label}</span>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 text-muted-foreground/50 hover:text-destructive hover:bg-destructive/10 rounded-full transition-colors"
+          onClick={() => onRemove(typ)}
+        >
+          <Trash2 className="w-4 h-4" />
+        </Button>
+      </div>
+      <div className="relative mt-auto">
+        <NumberInput
+          id={`zaehlerkosten-${typ}`}
+          value={zaehlerkosten[typ] || ''}
+          onChange={(e) => onValueChange(typ, e.target.value)}
+          placeholder="0,00"
+          step="0.01"
+          disabled={isSaving || isFormLoading}
+          className="h-11 pl-4 pr-10 rounded-2xl bg-white dark:bg-black/20 border-gray-200 dark:border-gray-800/80 focus:ring-primary/20 transition-all font-medium text-lg"
+        />
+        <span className="absolute right-4 top-1/2 -translate-y-1/2 text-sm font-bold text-muted-foreground">€</span>
+      </div>
+    </motion.div>
+  );
+}
+
 interface BetriebskostenEditModalPropsRefactored { }
 
 export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefactored) {
@@ -1337,52 +1396,17 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
                           <AnimatePresence mode="popLayout">
                             {(Object.keys(ZAEHLER_CONFIG) as ZaehlerTyp[])
                               .filter(typ => zaehlerkosten[typ] !== undefined)
-                              .map((typ) => {
-                                const config = ZAEHLER_CONFIG[typ];
-                                const Icon = METER_ICON_MAP[config.icon as keyof typeof METER_ICON_MAP];
-
-                                return (
-                                  <motion.div
-                                    key={typ}
-                                    layout
-                                    initial={{ opacity: 0, scale: 0.95, y: -10 }}
-                                    animate={{ opacity: 1, scale: 1, y: 0 }}
-                                    exit={{ opacity: 0, scale: 0.95, y: 10 }}
-                                    transition={{ duration: 0.2 }}
-                                    className="group flex flex-col gap-3 p-4 bg-gray-50/50 dark:bg-gray-900/10 border border-gray-200 dark:border-gray-800 rounded-[2rem]"
-                                  >
-                                    <div className="flex items-center justify-between">
-                                      <div className="flex items-center gap-3">
-                                        <div className="p-2 rounded-[1rem] bg-primary text-primary-foreground transition-all duration-300 shadow-sm border border-primary/20">
-                                          <Icon className="w-4 h-4" />
-                                        </div>
-                                        <span className="text-sm font-bold">{config.label}</span>
-                                      </div>
-                                      <Button
-                                        type="button"
-                                        variant="ghost"
-                                        size="icon"
-                                        className="h-8 w-8 text-muted-foreground/50 hover:text-destructive hover:bg-destructive/10 rounded-full transition-colors"
-                                        onClick={() => handleRemoveZaehlerkosten(typ)}
-                                      >
-                                        <Trash2 className="w-4 h-4" />
-                                      </Button>
-                                    </div>
-                                    <div className="relative mt-auto">
-                                      <NumberInput
-                                        id={`zaehlerkosten-${typ}`}
-                                        value={zaehlerkosten[typ] || ''}
-                                        onChange={(e) => handleZaehlerkostenChange(typ, e.target.value)}
-                                        placeholder="0,00"
-                                        step="0.01"
-                                        disabled={isSaving || isFormLoading}
-                                        className="h-11 pl-4 pr-10 rounded-2xl bg-white dark:bg-black/20 border-gray-200 dark:border-gray-800/80 focus:ring-primary/20 transition-all font-medium text-lg"
-                                      />
-                                      <span className="absolute right-4 top-1/2 -translate-y-1/2 text-sm font-bold text-muted-foreground">€</span>
-                                    </div>
-                                  </motion.div>
-                                );
-                              })}
+                              .map((typ) => (
+                                <MeterCostItem
+                                  key={typ}
+                                  typ={typ}
+                                  zaehlerkosten={zaehlerkosten}
+                                  onValueChange={handleZaehlerkostenChange}
+                                  onRemove={handleRemoveZaehlerkosten}
+                                  isSaving={isSaving}
+                                  isFormLoading={isFormLoading}
+                                />
+                              ))}
                           </AnimatePresence>
                         </div>
 

--- a/components/finance/betriebskosten-edit-modal.tsx
+++ b/components/finance/betriebskosten-edit-modal.tsx
@@ -1032,10 +1032,10 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
     setBetriebskostenModalDirty(true);
   };
 
-  const handleZaehlerkostenChange = (zaehlerTyp: string, value: string) => {
+  const handleZaehlerkostenChange = useCallback((zaehlerTyp: string, value: string) => {
     setZaehlerkosten(prev => ({ ...prev, [zaehlerTyp]: value }));
     setBetriebskostenModalDirty(true);
-  };
+  }, [setZaehlerkosten, setBetriebskostenModalDirty]);
 
   const handleRemoveZaehlerkosten = (zaehlerTyp: string) => {
     setZaehlerkosten(prev => {

--- a/components/finance/betriebskosten-edit-modal.tsx
+++ b/components/finance/betriebskosten-edit-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import { formatNumber } from "@/utils/format";
 import { createPortal } from "react-dom";
 import {
@@ -30,13 +31,22 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
-import { PlusCircle, Trash2, GripVertical, CalendarPlus, CalendarMinus, FileInput, BookDashed, Droplets, Thermometer, Flame, Gauge, Zap, Fuel, X, CalendarClock, Banknote, Check } from "lucide-react";
+import { PlusCircle, Trash2, GripVertical, CalendarPlus, CalendarMinus, FileInput, BookDashed, Droplets, Thermometer, Flame, Gauge, Zap, Fuel, X, CalendarClock, Banknote, Check, ArrowLeft, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Progress } from "@/components/ui/progress";
+function ConfettiSideCannons() {
+  return (
+    <div className="absolute inset-0 pointer-events-none overflow-hidden z-[100]">
+      <div className="absolute -left-10 bottom-0 rotate-[35deg]">🎊</div>
+      <div className="absolute -right-10 bottom-0 -rotate-[35deg]">🎊</div>
+    </div>
+  );
+}
 import type { Mieter, Nebenkosten, RechnungSql } from "@/lib/types";
 import { ZAEHLER_CONFIG, ZaehlerTyp } from "@/lib/zaehler-types";
 import { convertZaehlerkostenToStrings } from "@/lib/zaehler-utils";
@@ -60,6 +70,39 @@ import { CustomCombobox, type ComboboxOption } from "@/components/ui/custom-comb
 import { SortableCostItem, type CostItem, type RechnungEinzel } from "./sortable-cost-item";
 import { DateRangePicker } from "@/components/ui/date-range-picker";
 import { getDefaultDateRange, validateDateRange, germanToIsoDate, isoToGermanDate, formatPeriodDuration } from "@/utils/date-calculations";
+
+const SuccessStep = ({ data, onClose, onOverview }: { data: any, onClose: () => void, onOverview: () => void }) => {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 px-6 text-center space-y-6">
+      <div className="relative">
+        <motion.div
+          initial={{ scale: 0.5, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          className="w-20 h-20 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center text-green-600 dark:text-green-400 shadow-xl shadow-green-500/10"
+        >
+          <Check className="w-10 h-10" strokeWidth={3} />
+        </motion.div>
+        <ConfettiSideCannons />
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="text-2xl font-bold tracking-tight bg-gradient-to-br from-foreground to-foreground/70 bg-clip-text text-transparent">Abrechnung gespeichert!</h3>
+        <p className="text-muted-foreground max-w-sm mx-auto">
+          Die Betriebskosten für das Objekt <span className="font-semibold text-foreground">{data?.house_name || data?.Haeuser?.name || 'Unbekannt'}</span> im Zeitraum <span className="font-semibold text-foreground">{isoToGermanDate(data?.startdatum)} - {isoToGermanDate(data?.enddatum)}</span> wurden erfolgreich erfasst.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 w-full max-w-md pt-4">
+        <Button variant="outline" onClick={onClose} className="h-12 rounded-2xl border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-all">
+          Schließen
+        </Button>
+        <Button onClick={onOverview} className="h-12 rounded-2xl bg-primary hover:bg-primary/90 text-primary-foreground shadow-lg shadow-primary/25 border-none transition-all active:scale-[0.98]">
+          Zur Übersicht
+        </Button>
+      </div>
+    </div>
+  );
+};
 
 // Re-export for other components that might need it
 export type { CostItem, RechnungEinzel };
@@ -101,6 +144,8 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
   const [isLoadingDetails, setIsLoadingDetails] = useState(false);
   const [isLoadingTemplate, setIsLoadingTemplate] = useState(false);
   const [modalNebenkostenData, setModalNebenkostenData] = useState<Nebenkosten | null>(null);
+  const [currentStep, setCurrentStep] = useState<1 | 2 | 3>(1);
+  const [savedItemData, setSavedItemData] = useState<Nebenkosten | null>(null);
   const currentlyLoadedNebenkostenId = React.useRef<string | null | undefined>(null);
 
   // Tooltip next to dropdown: track hovered verteilerschlüssel, dropdown rect, and hovered item position
@@ -573,7 +618,7 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
       }
       setZaehlerkosten({});
       setVorauszahlungsArt('soll');
-      const initialHausId = betriebskostenInitialData?.haeuser_id || (forNewEntry && betriebskostenModalHaeuser && betriebskostenModalHaeuser.length > 0 ? betriebskostenModalHaeuser[0].id : "");
+      const initialHausId = forNewEntry && betriebskostenModalHaeuser && betriebskostenModalHaeuser.length > 0 ? betriebskostenModalHaeuser[0].id : "";
       setHausId(initialHausId);
 
       // Always start with a single empty cost item for new entries
@@ -732,6 +777,31 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
     }
   }, [selectedHausMieter, costItems, modalNebenkostenData, isBetriebskostenModalOpen, isFormLoading]);
 
+  const handleNextStep = () => {
+    if (currentStep === 1) {
+      if (!hausId) {
+        toast({ title: "Haus erforderlich", description: "Bitte wählen Sie ein Haus aus.", variant: "destructive" });
+        return;
+      }
+      const validation = validateDateRange(startdatum, enddatum);
+      if (!validation.isValid) {
+        toast({
+          title: "Ungültiger Zeitraum",
+          description: validation.errors.range || "Bitte überprüfen Sie den Abrechnungszeitraum.",
+          variant: "destructive"
+        });
+        return;
+      }
+      setCurrentStep(2);
+    }
+  };
+
+  const handlePrevStep = () => {
+    if (currentStep === 2) {
+      setCurrentStep(1);
+    }
+  };
+
   const handleSubmit = async () => {
     setIsSaving(true);
     setBetriebskostenModalDirty(false);
@@ -804,7 +874,7 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
 
       if (item.berechnungsart === 'nach Rechnung') {
         const individualRechnungen = rechnungen[item.id] || [];
-        currentBetragValue = individualRechnungen.reduce((sum, r) => sum + Math.round((parseFloat(r.betrag) || 0) * 100), 0) / 100;
+        currentBetragValue = individualRechnungen.reduce((sum, r) => sum + (parseFloat(r.betrag) || 0), 0);
       } else {
         currentBetragValue = parseFloat(item.betrag);
         if (item.betrag.trim() === '' || isNaN(currentBetragValue)) {
@@ -890,18 +960,41 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
 
       }
 
-      // Only show success and close if everything was successful
+      // Only show success and move to step 3 if everything was successful
       toast({
         title: "Erfolg",
         description: "Betriebskosten erfolgreich gespeichert",
         variant: "success"
       });
       setBetriebskostenModalDirty(false); // Clear dirty state before closing
+
+      // Store the result for step 3 overview
+      if (response.data) {
+        setSavedItemData(response.data);
+      } else {
+        // Fallback for updates where response data might be partial
+        setSavedItemData({
+          ...modalNebenkostenData,
+          startdatum: germanToIsoDate(startdatum),
+          enddatum: germanToIsoDate(enddatum),
+          haeuser_id: hausId,
+          vorauszahlungs_art: vorauszahlungsArt,
+          nebenkostenart: costItems.map(i => i.art),
+          betrag: costItems.map(i => parseFloat(i.betrag) || 0),
+          berechnungsart: costItems.map(i => i.berechnungsart),
+          zaehlerkosten: Object.fromEntries(
+            Object.entries(zaehlerkosten).map(([k, v]) => [k, parseFloat(v) || 0])
+          )
+        } as Nebenkosten);
+      }
+
+      setCurrentStep(3);
+
       if (betriebskostenModalOnSuccess) {
         betriebskostenModalOnSuccess();
       }
       useOnboardingStore.getState().completeStep('create-bill-form');
-      closeBetriebskostenModal();
+      // No longer close modal immediately - wait for Step 3
     } else {
       toast({ title: "Fehler beim Speichern", description: response.message, variant: "destructive" });
       setBetriebskostenModalDirty(true);
@@ -942,10 +1035,10 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
     setBetriebskostenModalDirty(true);
   };
 
-  const handleZaehlerkostenChange = useCallback((zaehlerTyp: string, value: string) => {
+  const handleZaehlerkostenChange = (zaehlerTyp: string, value: string) => {
     setZaehlerkosten(prev => ({ ...prev, [zaehlerTyp]: value }));
     setBetriebskostenModalDirty(true);
-  }, [setZaehlerkosten, setBetriebskostenModalDirty]);
+  };
 
   const handleRemoveZaehlerkosten = (zaehlerTyp: string) => {
     setZaehlerkosten(prev => {
@@ -974,7 +1067,7 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
           onValueChange={(value) => handleZaehlerkostenChange(value as ZaehlerTyp, "")}
         >
           <SelectTrigger className="w-full sm:w-[280px] h-10 rounded-full border-dashed border-2 bg-transparent hover:bg-primary/5 hover:border-primary/50 hover:text-primary transition-all text-muted-foreground">
-            <PlusCircle className="size-4 mr-2" />
+            <PlusCircle className="w-4 h-4 mr-2" />
             <SelectValue placeholder="Zähler-Kostenstelle hinzufügen" />
           </SelectTrigger>
           <SelectContent>
@@ -984,7 +1077,7 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
               return (
                 <SelectItem key={typ} value={typ} className="group">
                   <div className="flex items-center gap-2">
-                    <Icon className="size-4 text-muted-foreground group-focus:text-white transition-colors" />
+                    <Icon className="w-4 h-4 text-muted-foreground group-focus:text-white transition-colors" />
                     <span>{config.label}</span>
                   </div>
                 </SelectItem>
@@ -1014,184 +1107,200 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
         className="sm:max-w-3xl md:max-w-4xl max-h-[90vh] flex flex-col p-0 gap-0 overflow-hidden"
         onAttemptClose={attemptClose}
         isDirty={isBetriebskostenModalDirty}
-      >  <form onSubmit={(e) => { e.preventDefault(); handleSubmit(); }}>
-          <DialogHeader className="px-4">
-            <DialogTitle>
+      >  <form onSubmit={(e) => { e.preventDefault(); handleSubmit(); }} className="flex flex-col flex-1 overflow-hidden min-h-0">
+          <DialogHeader className="px-6 pt-6 pb-2">
+            <DialogTitle className="text-xl">
               {betriebskostenInitialData?.id ? "Betriebskosten bearbeiten" : "Neue Betriebskostenabrechnung"}
             </DialogTitle>
-            <DialogDescription>
-              {isFormLoading ? "Daten werden vorbereitet..." : "Füllen Sie die Details für die Betriebskostenabrechnung aus."}
+            <DialogDescription className="text-sm">
+              {currentStep === 1
+                ? "Schritt 1: Wählen Sie das Haus, den Zeitraum und die Abrechnungsmethode."
+                : currentStep === 2
+                  ? "Schritt 2: Erfassen Sie Zählerkosten und ergänzen Sie die Kostenaufstellung."
+                  : "Abrechnung erfolgreich gespeichert."}
             </DialogDescription>
           </DialogHeader>
 
-          <div className="flex flex-col gap-6 overflow-y-auto max-h-[70vh] p-4">
-            {/* Property & Period Selection Section */}
-            <div className="bg-gray-50 dark:bg-gray-900/20 rounded-2xl border border-gray-200 dark:border-gray-800 p-4 flex flex-col gap-4">
-              {/* House Selection */}
-              <div className="flex flex-col gap-2">
-                <LabelWithTooltip htmlFor="formHausId" infoText="Wählen Sie das Haus aus, für das die Nebenkostenabrechnung erstellt wird.">
-                  Haus *
-                </LabelWithTooltip>
-                {isFormLoading ? <Skeleton className="h-10 w-full" /> : (
-                  <CustomCombobox width="w-full" options={houseOptions} value={hausId} onChange={handleHausIdChange} placeholder="Haus auswählen..." searchPlaceholder="Haus suchen..." emptyText="Kein Haus gefunden." disabled={isSaving || isFormLoading} />
-                )}
+          {/* Stepper Header */}
+          {currentStep < 3 && (
+            <div className="px-6 py-4 border-y border-gray-100 dark:border-gray-800 bg-gray-50/50 dark:bg-white/5">
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground/80">Schritt {currentStep} von 2</span>
+                <span className="text-xs font-bold text-primary">
+                  {currentStep === 1 ? 'Basis-Informationen' : 'Kosten & Details'}
+                </span>
               </div>
+              <Progress value={currentStep === 1 ? 50 : 100} className="h-1.5" />
+            </div>
+          )}
 
-              {/* Date Range Selection */}
-              <div className="flex flex-col gap-3">
-                {isFormLoading ? (
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    <Skeleton className="h-10 w-full" />
-                    <Skeleton className="h-10 w-full" />
-                  </div>
-                ) : (
-                  <>
-                    <DateRangePicker
-                      startDate={startdatum}
-                      endDate={enddatum}
-                      onStartDateChange={handleStartdatumChange}
-                      onEndDateChange={handleEnddatumChange}
-                      disabled={isSaving || isFormLoading}
-                      showPeriodInfo={false}
-                    />
-
-                    {/* Year Navigation Buttons - positioned directly below date inputs */}
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="h-10 w-full rounded-full"
-                        onClick={() => {
-                          // Extract year from current startdatum and subtract 1
-                          const currentStartYear = startdatum ? parseInt(startdatum.split('.')[2]) : new Date().getFullYear();
-                          const newYear = currentStartYear - 1;
-                          setStartdatum(`01.01.${newYear}`);
-                          setEnddatum(`31.12.${newYear}`);
-                          setBetriebskostenModalDirty(true);
-                        }}
-                        disabled={isSaving || isFormLoading}
-                        title="Ein Jahr zurück"
-                      >
-                        <CalendarMinus className="size-4 mr-2" />
-                        -1 Jahr
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="h-10 w-full rounded-full"
-                        onClick={() => {
-                          // Extract year from current startdatum and add 1
-                          const currentStartYear = startdatum ? parseInt(startdatum.split('.')[2]) : new Date().getFullYear();
-                          const newYear = currentStartYear + 1;
-                          setStartdatum(`01.01.${newYear}`);
-                          setEnddatum(`31.12.${newYear}`);
-                          setBetriebskostenModalDirty(true);
-                        }}
-                        disabled={isSaving || isFormLoading}
-                        title="Ein Jahr vor"
-                      >
-                        <CalendarPlus className="size-4 mr-2" />
-                        +1 Jahr
-                      </Button>
+          <div className="flex-1 overflow-y-auto relative min-h-0 custom-scrollbar">
+            <AnimatePresence mode="wait">
+              {currentStep === 1 && (
+                <motion.div
+                  key="step1"
+                  initial={{ opacity: 0, x: 20 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: -20 }}
+                  transition={{ duration: 0.2, ease: "easeInOut" }}
+                  className="space-y-6 p-6"
+                >
+                  <div className="bg-gray-50/50 dark:bg-white/5 rounded-3xl border border-gray-200/60 dark:border-gray-800/60 p-5 space-y-6">
+                    {/* House Selection */}
+                    <div className="space-y-2.5">
+                      <LabelWithTooltip htmlFor="formHausId" infoText="Wählen Sie das Haus aus, für das die Nebenkostenabrechnung erstellt wird.">
+                        <span className="text-sm font-semibold tracking-tight">Immobilie auswählen *</span>
+                      </LabelWithTooltip>
+                      {isFormLoading ? <Skeleton className="h-11 w-full rounded-xl" /> : (
+                        <CustomCombobox width="w-full" options={houseOptions} value={hausId} onChange={handleHausIdChange} placeholder="Haus auswählen..." searchPlaceholder="Haus suchen..." emptyText="Kein Haus gefunden." disabled={isSaving || isFormLoading} />
+                      )}
                     </div>
 
-                    {/* Period information - moved below the year buttons */}
-                    {(() => {
-                      const validation = validateDateRange(startdatum, enddatum);
-                      return (
-                        <div className="flex flex-col gap-2">
-                          {validation.isValid && validation.periodDays && (
-                            <div className="text-sm text-muted-foreground bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 p-3 rounded-xl">
-                              <strong>Abrechnungszeitraum:</strong> {formatPeriodDuration(startdatum, enddatum)}
+                    {/* Date Range Selection */}
+                    <div className="space-y-4 pt-2">
+                      <LabelWithTooltip htmlFor="formDates" infoText="Legen Sie den Abrechnungszeitraum fest.">
+                        <span className="text-sm font-semibold tracking-tight">Abrechnungszeitraum *</span>
+                      </LabelWithTooltip>
+                      {isFormLoading ? (
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                          <Skeleton className="h-11 w-full rounded-xl" />
+                          <Skeleton className="h-11 w-full rounded-xl" />
+                        </div>
+                      ) : (
+                        <div className="space-y-4">
+                          <DateRangePicker
+                            startDate={startdatum}
+                            endDate={enddatum}
+                            onStartDateChange={handleStartdatumChange}
+                            onEndDateChange={handleEnddatumChange}
+                            disabled={isSaving || isFormLoading}
+                            showPeriodInfo={false}
+                          />
+
+                          <div className="grid grid-cols-2 gap-3">
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              className="h-11 w-full rounded-2xl border-gray-200/60 dark:border-gray-800/60 hover:bg-white dark:hover:bg-gray-800 transition-all shadow-sm"
+                              onClick={() => {
+                                const currentStartYear = startdatum ? parseInt(startdatum.split('.')[2]) : new Date().getFullYear();
+                                const newYear = currentStartYear - 1;
+                                setStartdatum(`01.01.${newYear}`);
+                                setEnddatum(`31.12.${newYear}`);
+                                setBetriebskostenModalDirty(true);
+                              }}
+                              disabled={isSaving || isFormLoading}
+                            >
+                              <CalendarMinus className="w-4 h-4 mr-2 text-muted-foreground" />
+                              <span className="font-medium">-1 Jahr</span>
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              size="sm"
+                              className="h-11 w-full rounded-2xl border-gray-200/60 dark:border-gray-800/60 hover:bg-white dark:hover:bg-gray-800 transition-all shadow-sm"
+                              onClick={() => {
+                                const currentStartYear = startdatum ? parseInt(startdatum.split('.')[2]) : new Date().getFullYear();
+                                const newYear = currentStartYear + 1;
+                                setStartdatum(`01.01.${newYear}`);
+                                setEnddatum(`31.12.${newYear}`);
+                                setBetriebskostenModalDirty(true);
+                              }}
+                              disabled={isSaving || isFormLoading}
+                            >
+                              <CalendarPlus className="w-4 h-4 mr-2 text-primary" />
+                              <span className="font-medium">+1 Jahr</span>
+                            </Button>
+                          </div>
+
+                          {(() => {
+                            const validation = validateDateRange(startdatum, enddatum);
+                            return validation.isValid && validation.periodDays && (
+                              <div className="text-sm text-blue-700 dark:text-blue-300 bg-blue-50/50 dark:bg-blue-900/20 border border-blue-100/50 dark:border-blue-800/50 p-3.5 rounded-2xl animate-in fade-in slide-in-from-top-1 duration-300">
+                                <div className="flex items-center gap-2">
+                                  <div className="w-1.5 h-1.5 rounded-full bg-blue-500 animate-pulse" />
+                                  <span className="font-medium">Abrechnungszeitraum:</span> {formatPeriodDuration(startdatum, enddatum)}
+                                </div>
+                              </div>
+                            );
+                          })()}
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Vorauszahlungsmethode */}
+                    <div className="space-y-4 pt-2">
+                      <LabelWithTooltip htmlFor="formVorauszahlungsArt" infoText="Soll: Verwendet den vereinbarten Vorauszahlungsbetrag aus dem Mieterprofil. Ist: Verwendet die tatsächlich gebuchten Zahlungen.">
+                        <span className="text-sm font-semibold tracking-tight">Zahlungsmethode</span>
+                      </LabelWithTooltip>
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                        <button
+                          type="button"
+                          onClick={() => { setVorauszahlungsArt('soll'); setBetriebskostenModalDirty(true); }}
+                          disabled={isSaving || isFormLoading}
+                          className={`group relative flex items-center gap-4 p-4 rounded-2xl border transition-all disabled:opacity-50 ${vorauszahlungsArt === 'soll' ? 'bg-primary/5 border-primary shadow-sm shadow-primary/10' : 'bg-white dark:bg-white/5 border-gray-200/60 dark:border-gray-800/60 hover:border-primary/30'}`}
+                        >
+                          <div className={`p-2.5 rounded-xl transition-colors ${vorauszahlungsArt === 'soll' ? 'bg-primary text-primary-foreground' : 'bg-gray-100 dark:bg-gray-800 text-muted-foreground group-hover:text-primary'} shadow-sm`}>
+                            <CalendarClock className="w-5 h-5" />
+                          </div>
+                          <div className="text-left">
+                            <p className={`font-bold transition-colors ${vorauszahlungsArt === 'soll' ? 'text-primary' : 'text-foreground'}`}>Soll-Verfahren</p>
+                            <p className="text-[11px] text-muted-foreground mt-0.5 leading-tight">Geplante Vorauszahlungen</p>
+                          </div>
+                          {vorauszahlungsArt === 'soll' && (
+                            <div className="ml-auto w-5 h-5 rounded-full bg-primary flex items-center justify-center animate-in zoom-in duration-300">
+                              <Check className="w-3 h-3 text-white" strokeWidth={3} />
                             </div>
                           )}
-
-                          {validation.errors.range && (
-                            <p className={`text-sm ${validation.errors.range.startsWith('Warnung') ? 'text-yellow-600' : 'text-red-600'}`}>
-                              {validation.errors.range}
-                            </p>
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => { setVorauszahlungsArt('ist'); setBetriebskostenModalDirty(true); }}
+                          disabled={isSaving || isFormLoading}
+                          className={`group relative flex items-center gap-4 p-4 rounded-2xl border transition-all disabled:opacity-50 ${vorauszahlungsArt === 'ist' ? 'bg-primary/5 border-primary shadow-sm shadow-primary/10' : 'bg-white dark:bg-white/5 border-gray-200/60 dark:border-gray-800/60 hover:border-primary/30'}`}
+                        >
+                          <div className={`p-2.5 rounded-xl transition-colors ${vorauszahlungsArt === 'ist' ? 'bg-primary text-primary-foreground' : 'bg-gray-100 dark:bg-gray-800 text-muted-foreground group-hover:text-primary'} shadow-sm`}>
+                            <Banknote className="w-5 h-5" />
+                          </div>
+                          <div className="text-left">
+                            <p className={`font-bold transition-colors ${vorauszahlungsArt === 'ist' ? 'text-primary' : 'text-foreground'}`}>Ist-Verfahren</p>
+                            <p className="text-[11px] text-muted-foreground mt-0.5 leading-tight">Reale Bankeingänge</p>
+                          </div>
+                          {vorauszahlungsArt === 'ist' && (
+                            <div className="ml-auto w-5 h-5 rounded-full bg-primary flex items-center justify-center animate-in zoom-in duration-300">
+                              <Check className="w-3 h-3 text-white" strokeWidth={3} />
+                            </div>
                           )}
-                        </div>
-                      );
-                    })()}
-                  </>
-                )}
-              </div>
-
-              {/* Vorauszahlungsmethode */}
-              <div className="flex flex-col gap-2">
-                <LabelWithTooltip htmlFor="formVorauszahlungsArt" infoText="Soll: Verwendet den vereinbarten Vorauszahlungsbetrag, der im Mieterprofil hinterlegt ist. Ist: Verwendet die tatsächlich gebuchten Zahlungen aus der Finanzen-Seite.">
-                  Vorauszahlungsmethode
-                </LabelWithTooltip>
-                {isFormLoading ? (
-                  <div className="grid grid-cols-2 gap-2">
-                    <Skeleton className="h-20 w-full rounded-xl" />
-                    <Skeleton className="h-20 w-full rounded-xl" />
+                        </button>
+                      </div>
+                    </div>
                   </div>
-                ) : (
-                  <div className="grid grid-cols-2 gap-3">
-                    {/* Soll option */}
-                    <button
-                      type="button"
-                      onClick={() => { setVorauszahlungsArt('soll'); setBetriebskostenModalDirty(true); }}
-                      disabled={isSaving || isFormLoading}
-                      className={`group relative flex flex-col gap-2 p-3 rounded-2xl border text-left transition-all shadow-xs disabled:opacity-50 disabled:cursor-not-allowed ${vorauszahlungsArt === 'soll' ? 'bg-primary/5 border-primary/50 shadow-primary/10' : 'bg-white dark:bg-white/5 border-gray-200 dark:border-gray-800 hover:border-primary/30 hover:shadow-md'}`}
-                    >
-                      <div className="flex items-start justify-between w-full">
-                        <div className={`p-1.5 rounded-lg transition-colors ${vorauszahlungsArt === 'soll' ? 'bg-primary/15 text-primary' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 group-hover:bg-primary/10 group-hover:text-primary'}`}>
-                          <CalendarClock className="size-4" />
-                        </div>
-                        <div className={`flex items-center justify-center size-4 rounded-full transition-all ${vorauszahlungsArt === 'soll' ? 'bg-primary opacity-100 scale-100' : 'bg-gray-300 dark:bg-gray-700 opacity-0 scale-75'}`}>
-                          <Check className="w-2.5 h-2.5 text-primary-foreground" strokeWidth={3} />
-                        </div>
+                </motion.div>
+              )}
+
+              {currentStep === 2 && (
+                <motion.div
+                  key="step2"
+                  initial={{ opacity: 0, x: 20 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: -20 }}
+                  transition={{ duration: 0.2, ease: "easeInOut" }}
+                  className="space-y-8 p-6"
+                >
+                  {/* Meter Costs Section */}
+                  <div className="space-y-4">
+                    <div className="flex items-center gap-3">
+                      <div className="w-10 h-10 rounded-2xl bg-primary/10 flex items-center justify-center text-primary shadow-sm border border-primary/20">
+                        <Gauge className="w-5 h-5" />
                       </div>
                       <div>
-                        <p className={`text-sm font-semibold leading-tight transition-colors ${vorauszahlungsArt === 'soll' ? 'text-primary' : 'text-foreground'}`}>Soll</p>
-                        <p className="text-xs text-muted-foreground mt-0.5 leading-snug">Vereinbarte Vorauszahlung<br />aus dem Mieterprofil</p>
+                        <h3 className="text-lg font-bold tracking-tight">Verbrauchskosten</h3>
+                        <p className="text-xs text-muted-foreground">Hausweite Gesamtkosten für Zähler</p>
                       </div>
-                    </button>
-                    {/* Ist option */}
-                    <button
-                      type="button"
-                      onClick={() => { setVorauszahlungsArt('ist'); setBetriebskostenModalDirty(true); }}
-                      disabled={isSaving || isFormLoading}
-                      className={`group relative flex flex-col gap-2 p-3 rounded-2xl border text-left transition-all shadow-xs disabled:opacity-50 disabled:cursor-not-allowed ${vorauszahlungsArt === 'ist' ? 'bg-primary/5 border-primary/50 shadow-primary/10' : 'bg-white dark:bg-white/5 border-gray-200 dark:border-gray-800 hover:border-primary/30 hover:shadow-md'}`}
-                    >
-                      <div className="flex items-start justify-between w-full">
-                        <div className={`p-1.5 rounded-lg transition-colors ${vorauszahlungsArt === 'ist' ? 'bg-primary/15 text-primary' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 group-hover:bg-primary/10 group-hover:text-primary'}`}>
-                          <Banknote className="size-4" />
-                        </div>
-                        <div className={`flex items-center justify-center size-4 rounded-full transition-all ${vorauszahlungsArt === 'ist' ? 'bg-primary opacity-100 scale-100' : 'bg-gray-300 dark:bg-gray-700 opacity-0 scale-75'}`}>
-                          <Check className="w-2.5 h-2.5 text-primary-foreground" strokeWidth={3} />
-                        </div>
-                      </div>
-                      <div>
-                        <p className={`text-sm font-semibold leading-tight transition-colors ${vorauszahlungsArt === 'ist' ? 'text-primary' : 'text-foreground'}`}>Ist</p>
-                        <p className="text-xs text-muted-foreground mt-0.5 leading-snug">Gebuchte Einnahmen<br />aus der Finanzen-Seite</p>
-                      </div>
-                    </button>
-                  </div>
-                )}
-              </div>
+                    </div>
 
-              {/* Meter Costs / Zählerkosten */}
-              <div className="flex flex-col gap-3">
-                <LabelWithTooltip htmlFor="formZaehlerkosten" infoText="Die Kosten je Zählertyp für das ausgewählte Haus in diesem Abrechnungszeitraum. Nur Zähler, für die Kosten anfallen, müssen hier eingetragen werden.">
-                  Zählerkosten (€)
-                </LabelWithTooltip>
-
-                {isFormLoading ? (
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                    {Array.from({ length: 4 }).map((_, idx) => (
-                      <Skeleton key={`skel-zaehler-${idx}`} className="h-10 w-full rounded-xl" />
-                    ))}
-                  </div>
-                ) : (
-                  <div className="flex flex-col gap-4">
-                    {/* Active Meter Costs */}
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                       {(Object.keys(ZAEHLER_CONFIG) as ZaehlerTyp[])
                         .filter(typ => zaehlerkosten[typ] !== undefined)
                         .map((typ) => {
@@ -1201,25 +1310,23 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
                           return (
                             <div
                               key={typ}
-                              className="group flex flex-col gap-2 p-3 bg-white dark:bg-white/5 rounded-2xl border border-gray-200 dark:border-gray-800 shadow-xs transition-all hover:border-primary/30"
+                              className="group flex flex-col gap-3 p-4 bg-gray-50/50 dark:bg-white/5 rounded-3xl border border-gray-200/60 dark:border-gray-800/60 shadow-sm transition-all hover:border-primary/40 hover:shadow-md"
                             >
                               <div className="flex items-center justify-between">
-                                <div className="flex items-center gap-2">
-                                  <div className={`p-1.5 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400 group-hover:bg-primary/10 group-hover:text-primary transition-colors`}>
-                                    <Icon className="size-4" />
+                                <div className="flex items-center gap-3">
+                                  <div className="p-2.5 rounded-xl bg-white dark:bg-gray-800 text-foreground group-hover:bg-primary group-hover:text-primary-foreground transition-all duration-300 shadow-sm border border-gray-100 dark:border-gray-700">
+                                    <Icon className="w-4.5 h-4.5" />
                                   </div>
-                                  <Label htmlFor={`zaehlerkosten-${typ}`} className="text-sm font-medium">
-                                    {config.label}
-                                  </Label>
+                                  <span className="text-sm font-bold">{config.label}</span>
                                 </div>
                                 <Button
                                   type="button"
                                   variant="ghost"
                                   size="icon"
-                                  className="size-7 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded-full"
+                                  className="h-8 w-8 text-muted-foreground/50 hover:text-destructive hover:bg-destructive/10 rounded-full transition-colors"
                                   onClick={() => handleRemoveZaehlerkosten(typ)}
                                 >
-                                  <Trash2 className="size-3.5" />
+                                  <Trash2 className="w-4 h-4" />
                                 </Button>
                               </div>
                               <div className="relative">
@@ -1230,90 +1337,142 @@ export function BetriebskostenEditModal({ }: BetriebskostenEditModalPropsRefacto
                                   placeholder="0.00"
                                   step="0.01"
                                   disabled={isSaving || isFormLoading}
-                                  className="h-10 pl-3 pr-8 bg-gray-50/50 dark:bg-black/20 border-gray-200 dark:border-gray-800 focus:ring-primary/20"
+                                  className="h-11 pl-4 pr-10 rounded-2xl bg-white dark:bg-black/20 border-gray-200 dark:border-gray-800/80 focus:ring-primary/20 transition-all font-medium text-lg"
                                 />
-                                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground font-medium">€</span>
+                                <span className="absolute right-4 top-1/2 -translate-y-1/2 text-sm font-bold text-muted-foreground">€</span>
                               </div>
                             </div>
                           );
                         })}
+
+                      <div className="sm:col-span-1">
+                        {addMeterCostSelect}
+                      </div>
                     </div>
-
-                    {/* Add Meter Cost Select */}
-                    {addMeterCostSelect}
                   </div>
-                )}
-              </div>
-            </div>
 
-            <div className="flex flex-col gap-2">
-              <h3 className="text-lg font-semibold tracking-tight">Kostenaufstellung</h3>
-              <div className="rounded-2xl bg-gray-50 dark:bg-gray-900/20 border border-gray-200 dark:border-gray-800 p-3 flex flex-col gap-3">
-                {isFormLoading ? (
-                  Array.from({ length: 3 }).map((_, idx) => (
-                    <div key={`skel-cost-${idx}`} className="flex flex-col gap-2 py-2 border-b last:border-b-0">
-                      <div className="flex flex-col sm:flex-row items-start gap-2">
-                        <div className="flex items-center justify-center flex-none w-8 h-10">
-                          <Skeleton className="h-6 w-6 rounded" />
+                  {/* Kostenaufstellung Section */}
+                  <div className="space-y-4">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <div className="w-10 h-10 rounded-2xl bg-primary/10 flex items-center justify-center text-primary shadow-sm border border-primary/20">
+                          <PlusCircle className="w-5 h-5" />
                         </div>
-                        <Skeleton className="h-10 w-full sm:flex-[4_1_0%]" />
-                        <Skeleton className="h-10 w-full sm:flex-[3_1_0%]" />
-                        <Skeleton className="h-10 w-full sm:flex-[4_1_0%]" />
-                        <div className="flex items-center justify-center flex-none size-10">
-                          <Skeleton className="h-8 w-8 rounded" />
+                        <div>
+                          <h3 className="text-lg font-bold tracking-tight">Betriebskosten</h3>
+                          <p className="text-xs text-muted-foreground">Alle weiteren umlagefähigen Positionen</p>
                         </div>
                       </div>
                     </div>
-                  ))
-                ) : (
-                  <DndContext
-                    sensors={sensors}
-                    collisionDetection={closestCenter}
-                    onDragEnd={handleDragEnd}
-                  >
-                    <SortableContext items={costItems.map(item => item.id)} strategy={verticalListSortingStrategy}>
-                      {costItems.map((item, index) => (
-                        <SortableCostItem
-                          key={item.id}
-                          item={item}
-                          index={index}
-                          costItems={costItems}
-                          selectedHausMieter={selectedHausMieter}
-                          rechnungen={rechnungen}
-                          isSaving={isSaving}
-                          isLoadingDetails={isFormLoading}
-                          isFetchingTenants={isFetchingTenants}
-                          hausId={hausId}
-                          onCostItemChange={handleCostItemChange}
-                          onRemoveCostItem={removeCostItem}
-                          onRechnungChange={handleRechnungChange}
-                          hoveredBerechnungsart={hoveredBerechnungsart}
-                          selectContentRect={selectContentRect}
-                          hoveredItemRect={hoveredItemRect}
-                          tooltipMap={tooltipMap}
-                          onItemHover={handleItemHover}
-                          onItemLeave={handleItemLeave}
-                          selectContentRef={selectContentRef}
-                        />
-                      ))}
-                    </SortableContext>
-                  </DndContext>
-                )}
-                <Button type="button" onClick={addCostItem} variant="outline" size="sm" className="mt-2" disabled={isFormLoading || isSaving}>
-                  <PlusCircle className="mr-2 size-4" />
-                  Kostenposition hinzufügen
-                </Button>
-              </div>
-            </div>
+
+                    <div className="rounded-3xl bg-gray-50/50 dark:bg-white/5 border border-gray-200/60 dark:border-gray-800/60 p-4 space-y-4">
+                      {isFormLoading ? (
+                        Array.from({ length: 3 }).map((_, idx) => (
+                          <div key={`skel-cost-${idx}`} className="flex flex-col gap-2 py-2">
+                            <Skeleton className="h-14 w-full rounded-2xl" />
+                          </div>
+                        ))
+                      ) : (
+                        <DndContext
+                          sensors={sensors}
+                          collisionDetection={closestCenter}
+                          onDragEnd={handleDragEnd}
+                        >
+                          <div className="space-y-3">
+                            <SortableContext items={costItems.map(item => item.id)} strategy={verticalListSortingStrategy}>
+                              {costItems.map((item, index) => (
+                                <SortableCostItem
+                                  key={item.id}
+                                  item={item}
+                                  index={index}
+                                  costItems={costItems}
+                                  selectedHausMieter={selectedHausMieter}
+                                  rechnungen={rechnungen}
+                                  isSaving={isSaving}
+                                  isLoadingDetails={isFormLoading}
+                                  isFetchingTenants={isFetchingTenants}
+                                  hausId={hausId}
+                                  onCostItemChange={handleCostItemChange}
+                                  onRemoveCostItem={removeCostItem}
+                                  onRechnungChange={handleRechnungChange}
+                                  hoveredBerechnungsart={hoveredBerechnungsart}
+                                  selectContentRect={selectContentRect}
+                                  hoveredItemRect={hoveredItemRect}
+                                  tooltipMap={tooltipMap}
+                                  onItemHover={handleItemHover}
+                                  onItemLeave={handleItemLeave}
+                                  selectContentRef={selectContentRef}
+                                />
+                              ))}
+                            </SortableContext>
+                          </div>
+                        </DndContext>
+                      )}
+
+                      <Button
+                        type="button"
+                        onClick={addCostItem}
+                        variant="ghost"
+                        className="w-full h-11 rounded-2xl border border-dashed border-gray-300 dark:border-gray-700 hover:border-primary/50 hover:bg-primary/5 transition-all text-muted-foreground hover:text-primary font-semibold"
+                        disabled={isFormLoading || isSaving}
+                      >
+                        <PlusCircle className="mr-2 h-4 w-4" />
+                        Weitere Kostenposition hinzufügen
+                      </Button>
+                    </div>
+                  </div>
+                </motion.div>
+              )}
+
+              {currentStep === 3 && (
+                <motion.div
+                  key="step3"
+                  initial={{ opacity: 0, scale: 0.95 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={{ duration: 0.4, type: "spring" }}
+                >
+                  <SuccessStep
+                    data={savedItemData}
+                    onClose={closeBetriebskostenModal}
+                    onOverview={() => {
+                      // For now we just close, but ideally we'd trigger the overview
+                      closeBetriebskostenModal();
+                      // Optional: if we can find a way to let parent know to open overview
+                    }}
+                  />
+                </motion.div>
+              )}
+            </AnimatePresence>
           </div>
 
-          <DialogFooter className="px-4">
-            <Button type="button" variant="outline" onClick={handleCancelClick} disabled={isSaving || isFormLoading}>
-              Abbrechen
-            </Button>
-            <Button type="submit" disabled={isSaving || isFetchingTenants || isFormLoading}>
-              {isSaving ? "Speichern..." : (isFormLoading || isFetchingTenants ? "Laden..." : "Speichern")}
-            </Button>
+          <DialogFooter className="px-6 py-4 bg-gray-50/30 dark:bg-white/5 border-t border-gray-100 dark:border-gray-800 gap-3">
+            {currentStep === 1 ? (
+              <>
+                <Button type="button" variant="ghost" onClick={handleCancelClick} disabled={isSaving || isFormLoading} className="rounded-2xl h-11 px-6 font-semibold hover:bg-gray-100 dark:hover:bg-gray-800">
+                  Abbrechen
+                </Button>
+                <Button type="button" onClick={handleNextStep} disabled={isSaving || isFormLoading} className="rounded-2xl h-11 px-8 font-bold shadow-lg shadow-primary/20 flex items-center gap-2">
+                  Weiter
+                  <ArrowRight className="w-4 h-4" />
+                </Button>
+              </>
+            ) : currentStep === 2 ? (
+              <>
+                <Button type="button" variant="ghost" onClick={handlePrevStep} disabled={isSaving || isFormLoading} className="rounded-2xl h-11 px-6 font-semibold flex items-center gap-2">
+                  <ArrowLeft className="w-4 h-4" />
+                  Zurück
+                </Button>
+                <div className="flex-1" />
+                <Button type="submit" disabled={isSaving || isFetchingTenants || isFormLoading} className="rounded-2xl h-11 px-10 font-bold shadow-lg shadow-primary/25 border-none transition-all active:scale-[0.98]">
+                  {isSaving ? (
+                    <div className="flex items-center gap-2">
+                      <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                      Wird gespeichert...
+                    </div>
+                  ) : (isFormLoading || isFetchingTenants ? "Laden..." : "Speichern & Abschließen")}
+                </Button>
+              </>
+            ) : null}
           </DialogFooter>
         </form>
       </DialogContent>

--- a/components/finance/sortable-cost-item.tsx
+++ b/components/finance/sortable-cost-item.tsx
@@ -192,9 +192,9 @@ export function SortableCostItem({
             onClick={() => onRemoveCostItem(index)}
             disabled={costItems.length <= 1 || isLoadingDetails || isSaving}
             aria-label="Kostenposition entfernen"
-            className="h-8 w-8"
+            className="h-10 w-10 rounded-full text-muted-foreground/50 hover:bg-destructive/10 hover:text-destructive transition-colors"
           >
-            <Trash2 className="h-4 w-4 text-destructive" />
+            <Trash2 className="h-5 w-5" />
           </Button>
         </div>
       </div>

--- a/components/finance/sortable-cost-item.tsx
+++ b/components/finance/sortable-cost-item.tsx
@@ -91,15 +91,15 @@ export function SortableCostItem({
     <div
       ref={setNodeRef}
       style={style}
-      className={`flex flex-col gap-2 p-3 bg-gray-50 dark:bg-gray-900/20 border border-gray-200 dark:border-gray-800 rounded-xl ${isDragging ? 'z-10 shadow-lg bg-white dark:bg-gray-800' : ''}`}
+      className={`flex flex-col gap-2 p-3 bg-gray-50/50 dark:bg-gray-900/10 border border-gray-200 dark:border-gray-800 rounded-[2rem] ${isDragging ? 'z-10 shadow-lg bg-white dark:bg-gray-800' : ''}`}
       role="group"
       aria-label={`Kostenposition ${index + 1}`}
     >
       <div className="flex flex-col sm:flex-row items-start gap-2">
-        <div className="flex items-center justify-center flex-none w-8 h-10">
+        <div className="flex items-center justify-center flex-none w-10 h-10">
           <button
             type="button"
-            className="cursor-grab active:cursor-grabbing p-2 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg transition-colors flex items-center justify-center w-8 h-8 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600"
+            className="cursor-grab active:cursor-grabbing p-2 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-full transition-colors flex items-center justify-center w-10 h-10 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700"
             {...attributes}
             {...listeners}
             aria-label="Kostenposition verschieben"
@@ -114,11 +114,12 @@ export function SortableCostItem({
             value={item.art}
             onChange={(e) => onCostItemChange(index, 'art', e.target.value)}
             disabled={isSaving}
+            className="rounded-2xl h-10"
           />
         </div>
         <div className="w-full sm:flex-[3_1_0%]">
           {item.berechnungsart === 'nach Rechnung' ? (
-            <div className="flex items-center justify-center h-10 px-3 py-2 text-sm text-muted-foreground bg-gray-50 border rounded-md">
+            <div className="flex items-center justify-center h-10 px-3 py-2 text-sm text-muted-foreground bg-gray-50 border rounded-2xl">
               Beträge pro Mieter unten
             </div>
           ) : (
@@ -129,6 +130,7 @@ export function SortableCostItem({
               onChange={(e) => onCostItemChange(index, 'betrag', e.target.value)}
               step="0.01"
               disabled={isSaving}
+              className="rounded-2xl h-10"
             />
           )}
         </div>
@@ -148,6 +150,7 @@ export function SortableCostItem({
               onFocus={(e) => item.berechnungsart && onItemHover(e, item.berechnungsart as BerechnungsartValue)}
               onBlur={onItemLeave}
               ref={selectTriggerRef}
+              className="rounded-2xl h-10"
             >
               <SelectValue placeholder="Berechnungsart" />
             </SelectTrigger>
@@ -197,7 +200,7 @@ export function SortableCostItem({
       </div>
 
       {item.berechnungsart === 'nach Rechnung' && (
-        <div className="mt-2 p-3 bg-gray-100 dark:bg-gray-800/50 border border-gray-300 dark:border-gray-600 rounded-xl space-y-2">
+        <div className="mt-2 p-3 bg-gray-100/50 dark:bg-gray-800/30 border border-gray-200 dark:border-gray-700/60 rounded-[2rem] space-y-2">
           <h4 className="text-md font-semibold text-gray-800 dark:text-gray-200">
             Einzelbeträge für: <span className="font-normal italic">"{item.art || 'Unbenannte Kostenart'}"</span>
           </h4>
@@ -237,6 +240,7 @@ export function SortableCostItem({
                             value={rechnungForMieter?.betrag || ''}
                             onChange={(e) => onRechnungChange(item.id, mieter.id, e.target.value)}
                             disabled={isLoadingDetails || isSaving}
+                            className="rounded-2xl h-9"
                           />
                         </div>
                       </div>

--- a/components/tables/operating-costs-table.tsx
+++ b/components/tables/operating-costs-table.tsx
@@ -40,7 +40,7 @@ import {
   deleteNebenkosten as deleteNebenkostenServerAction,
   bulkDeleteNebenkosten
 } from "@/app/betriebskosten-actions" // Removed old wasserzaehler imports
-import { toast } from "@/hooks/use-toast" // For notifications
+import { toast } from "@/hooks/use-toast"
 import { useModalStore } from "@/hooks/use-modal-store"
 import { ActionMenu } from "@/components/ui/action-menu"
 import { useRouter } from "next/navigation"
@@ -72,7 +72,7 @@ export function OperatingCostsTable({
   const router = useRouter()
 
   // Old openWasserzaehlerModalOptimized removed - now using new ZaehlerAblesenModal
-  const [overviewItem, setOverviewItem] = useState<OptimizedNebenkosten | null>(null);
+  const { openOperatingCostsOverviewModal } = useModalStore();
   // Old wasserzähler modal state removed - now using new ZaehlerAblesenModal
   const [isAbrechnungModalOpen, setIsAbrechnungModalOpen] = useState(false);
   const [selectedNebenkostenForAbrechnung, setSelectedNebenkostenForAbrechnung] = useState<OptimizedNebenkosten | null>(null);
@@ -188,11 +188,11 @@ export function OperatingCostsTable({
   };
 
   const handleOpenOverview = (item: OptimizedNebenkosten) => {
-    setOverviewItem(item);
+    openOperatingCostsOverviewModal(item);
   };
 
   const handleCloseOverview = () => {
-    setOverviewItem(null);
+    // No longer needed locally
   };
 
   // Old handleOpenWasserzaehlerModal function removed - now using new WasserZaehlerAblesenModal
@@ -621,14 +621,7 @@ export function OperatingCostsTable({
         </div>
       </div>
 
-      {/* Overview Modal */}
-      {overviewItem && (
-        <OperatingCostsOverviewModal
-          isOpen={!!overviewItem}
-          onClose={handleCloseOverview}
-          nebenkosten={overviewItem}
-        />
-      )}
+      {/* Overview Modal is now handled globally via ModalStore */}
 
       {/* Zaehler Modal is now handled by the modal store */}
 

--- a/components/tables/operating-costs-table.tsx
+++ b/components/tables/operating-costs-table.tsx
@@ -191,10 +191,6 @@ export function OperatingCostsTable({
     openOperatingCostsOverviewModal(item);
   };
 
-  const handleCloseOverview = () => {
-    // No longer needed locally
-  };
-
   // Old handleOpenWasserzaehlerModal function removed - now using new WasserZaehlerAblesenModal
 
   // Old handleSaveWasserzaehler function removed - now using new WasserZaehlerAblesenModal

--- a/hooks/use-modal-store.tsx
+++ b/hooks/use-modal-store.tsx
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import type { Nebenkosten, Mieter, Wasserzaehler, MeterReadingFormData } from "@/lib/types";
-import { MeterModalData } from '@/types/optimized-betriebskosten';
+import { MeterModalData, OptimizedNebenkosten } from '@/types/optimized-betriebskosten';
 import { Tenant, KautionData } from '@/types/Tenant';
 import { Template } from '@/types/template';
 import { ConfirmationDialogVariant } from '@/components/ui/confirmation-dialog';
@@ -494,6 +494,12 @@ export interface ModalState {
   mailPreviewId?: string;
   openMailPreviewModal: (mailId: string) => void;
   closeMailPreviewModal: () => void;
+
+  // Operating Costs Overview Modal State
+  isOperatingCostsOverviewModalOpen: boolean;
+  operatingCostsOverviewData?: OptimizedNebenkosten | null;
+  openOperatingCostsOverviewModal: (nebenkosten: OptimizedNebenkosten) => void;
+  closeOperatingCostsOverviewModal: () => void;
 }
 
 const CONFIRMATION_MODAL_DEFAULTS = {
@@ -691,6 +697,11 @@ const initialMailPreviewModalState = {
   mailPreviewId: undefined,
 };
 
+const initialOperatingCostsOverviewModalState = {
+  isOperatingCostsOverviewModalOpen: false,
+  operatingCostsOverviewData: null,
+};
+
 const createInitialModalState = () => ({
   ...initialTenantModalState,
   ...initialHouseModalState,
@@ -721,6 +732,7 @@ const createInitialModalState = () => ({
   ...initialZaehlerModalState,
   ...initialApplicantScoreModalState,
   ...initialMailPreviewModalState,
+  ...initialOperatingCostsOverviewModalState,
   isConfirmationModalOpen: false,
   confirmationModalConfig: null,
 });
@@ -856,6 +868,13 @@ export const useModalStore = create<ModalState>((set, get) => {
       mailPreviewId: mailId,
     }),
     closeMailPreviewModal: () => set(initialMailPreviewModalState),
+
+    // Operating Costs Overview Modal
+    openOperatingCostsOverviewModal: (nebenkosten) => set({
+      isOperatingCostsOverviewModalOpen: true,
+      operatingCostsOverviewData: nebenkosten,
+    }),
+    closeOperatingCostsOverviewModal: () => set(initialOperatingCostsOverviewModalState),
 
 
 


### PR DESCRIPTION
## Description

Turns the Betriebskosten edit modal into a guided 3-step wizard and wires the operating-costs overview into the global modal store.

## Summary of Changes

- `betriebskosten-edit-modal.tsx` (+514/−286): 3-step flow — Basis-Daten (Haus & Zeitraum) → Kostenstellen → Bestätigung — with a sidebar stepper, per-step validation, animated `MeterCostItem` cards, and a success screen (confetti, saved-period summary, "Zur Übersicht" deep-link)
- `betriebskosten-actions.ts`: create/update now return the freshly computed record via `fetchOptimizedNebenkostenById` (RPC `get_nebenkosten_with_metrics`, raw-row fallback) so step 3 shows real metrics
- `layout-inner.tsx`: modals rendered directly with their server actions instead of the overlay loader; `CommandMenu` added
- `operating-costs-table.tsx` + `use-modal-store.tsx`: overview modal moved into the global modal store (`openOperatingCostsOverviewModal`)
- `sortable-cost-item.tsx`: rounded redesign of the cost items