### PR TITLE
Feat/oauth consent refactor

### DIFF
--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -112,22 +112,24 @@ export default function ConsentUI({
             }
 
             try {
-                const { data, error: detailsError } = await (supabase.auth as unknown as import('@/types/supabase').SupabaseAuthWithOAuth).oauth.getAuthorizationDetails(authorizationId);
+                const response = await fetch(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/oauth/authorizations/${encodeURIComponent(authorizationId)}`, {
+                    headers: { 'apikey': process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY! },
+                    credentials: 'include'
+                });
 
-                console.log('getAuthorizationDetails response:', data, detailsError);
-
-                if (detailsError) {
-                    setLoadError(detailsError.message);
+                if (!response.ok) {
+                    const err = await response.json();
+                    setLoadError(err.message || err.error_description || 'Failed to load details');
                     setIsLoading(false);
                     return;
                 }
 
+                const data = await response.json();
+                console.log('Authorization details:', data);
+
                 // Check if the authorization was auto-approved and has a redirect URL
-                // This happens when the user has previously approved this client
                 if (data?.redirect_to || data?.redirect_url) {
                     console.log('Skipping auto-approval to force manual consent screen. Redirect would have been to:', data.redirect_to || data.redirect_url);
-                    // window.location.href = data.redirect_to || data.redirect_url;
-                    // return; // Keep loading state while redirecting
                 }
 
                 setAuthDetails(data);
@@ -243,22 +245,40 @@ export default function ConsentUI({
                 return;
             }
 
-            const authClient = supabase.auth as unknown as import('@/types/supabase').SupabaseAuthWithOAuth;
-            const { data, error } = decision === 'approve'
-                ? await authClient.oauth.approveAuthorization(authorizationId)
-                : await authClient.oauth.denyAuthorization(authorizationId);
+            // Attempt client-side approve/deny first
+            const response = await fetch(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/oauth/authorizations/${encodeURIComponent(authorizationId)}`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'apikey': process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+                },
+                credentials: 'include',
+                body: JSON.stringify({ decision: decision === 'approve' ? 'allow' : 'deny' })
+            });
 
-            if (error) {
-                setProcessError(error.message);
-                setIsProcessing(false);
-                return;
-            }
-
-            // The SDK should auto-redirect, but check for redirect_url just in case
-            if (data?.redirect_url) {
-                window.location.href = data.redirect_url;
-            } else if (data?.redirect_to) {
-                window.location.href = data.redirect_to;
+            if (response.ok) {
+                const data = await response.json();
+                const redirectTarget = data?.redirect_to || data?.redirect_url;
+                if (redirectTarget) {
+                    window.location.href = redirectTarget;
+                } else {
+                    setIsProcessing(false);
+                }
+            } else {
+                // Fallback to Server Action if client-side POST is blocked (e.g. by Brave/Firefox cross-site policies)
+                if (decision === 'approve') {
+                    const { success, redirect_to, error } = await import('./actions').then(m => m.approveAuthorizationAction(authorizationId));
+                    if (success && redirect_to) {
+                        window.location.href = redirect_to;
+                    } else {
+                        setProcessError(error || 'Action failed');
+                        setIsProcessing(false);
+                    }
+                } else {
+                    const errData = await response.json();
+                    setProcessError(errData.message || 'Denial failed');
+                    setIsProcessing(false);
+                }
             }
         } catch (err: any) {
             setProcessError(err.message || `An error occurred while ${decision === 'approve' ? 'approving' : 'denying'} authorization`);

--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -59,12 +59,17 @@ interface ConsentUIProps {
 }
 
 interface AuthorizationDetails {
+    id?: string;
+    state?: string;
     client?: {
+        id?: string;
         name?: string;
         logo_uri?: string;
     };
     redirect_uri?: string;
-    scopes?: string[];
+    scopes?: string | string[];
+    redirect_to?: string;
+    redirect_url?: string;
 }
 
 import { LOGO_URL, BRAND_NAME } from '@/lib/constants';
@@ -112,9 +117,9 @@ export default function ConsentUI({
                 // Check if the authorization was auto-approved and has a redirect URL
                 // This happens when the user has previously approved this client
                 if (data?.redirect_to || data?.redirect_url) {
-                    console.log('Auto-approved, redirecting to:', data.redirect_to || data.redirect_url);
-                    window.location.href = data.redirect_to || data.redirect_url;
-                    return; // Keep loading state while redirecting
+                    console.log('Skipping auto-approval to force manual consent screen. Redirect would have been to:', data.redirect_to || data.redirect_url);
+                    // window.location.href = data.redirect_to || data.redirect_url;
+                    // return; // Keep loading state while redirecting
                 }
 
                 setAuthDetails(data);
@@ -128,10 +133,55 @@ export default function ConsentUI({
         fetchDetails();
     }, [authorizationId, type]);
 
-    const clientName = authDetails?.client?.name || initialClientName || 'Unknown Application';
-    const clientIcon = authDetails?.client?.logo_uri || initialClientIcon;
+    // Side-channel: Fetch requested scopes directly from the Mietevo Worker 
+    // because Supabase filters out any scopes it doesn't officially support.
+    const [customScopes, setCustomScopes] = useState<string[]>([]);
+    useEffect(() => {
+        const state = authDetails?.state;
+        if (!state) return;
+
+        const fetchCustomScopes = async () => {
+            try {
+                const response = await fetch(`https://mcp.mietevo.de/oauth/scopes?state=${state}`);
+                if (response.ok) {
+                    const data = await response.json();
+                    if (data.scopes) {
+                        // scopes might be a space-separated string or an array
+                        const scopeList = typeof data.scopes === 'string'
+                            ? data.scopes.split(' ')
+                            : data.scopes;
+                        setCustomScopes(scopeList.filter(Boolean));
+                    }
+                }
+            } catch (err) {
+                console.warn('Failed to fetch custom scopes side-channel:', err);
+            }
+        };
+
+        fetchCustomScopes();
+    }, [authDetails]);
+
+    // Known client ID mappings for better UI fallback
+    const KNOWN_MCP_CLIENTS: Record<string, string> = {
+        '4df23a6c-c2d9-43b8-aba8-a2a4f3681892': 'Mietevo',
+        'b7fee65f-13af-4c19-b749-85fad88253fd': 'Mietevo Public MCP'
+    };
+
+    const clientId = authDetails?.client?.id;
+    const clientName = authDetails?.client?.name ||
+        (clientId && KNOWN_MCP_CLIENTS[clientId]) ||
+        initialClientName ||
+        'Mietevo';
+
+    // Set icon - use logo_uri if provided, or mascot if it's a known client
+    const clientIcon = authDetails?.client?.logo_uri ||
+        (clientId && KNOWN_MCP_CLIENTS[clientId] ? LOGO_URL : initialClientIcon);
     const redirectUri = authDetails?.redirect_uri || initialRedirectUri;
-    const scopes = authDetails?.scopes || initialScopes;
+
+    // Merge Supabase scopes with our custom stashed scopes
+    const rawSupabaseScopes = typeof authDetails?.scopes === 'string' ? authDetails.scopes.split(' ') : (authDetails?.scopes || []);
+    const mergedScopes = Array.from(new Set([...rawSupabaseScopes, ...customScopes, ...(initialScopes || [])])).filter(s => s !== 'offline_access');
+    const scopes = mergedScopes.length > 0 ? mergedScopes : ['openid', 'email'];
 
     const handleDecision = async (decision: 'approve' | 'deny') => {
         if (!authorizationId) return;
@@ -140,6 +190,15 @@ export default function ConsentUI({
         setProcessError(null);
 
         try {
+            // If we are approving and we already have a redirect URL from the details (auto-approved case),
+            // just use it instead of calling the API again to avoid "validation_failed" (400) errors.
+            const autoRedirectUrl = authDetails?.redirect_to || authDetails?.redirect_url;
+            if (decision === 'approve' && autoRedirectUrl) {
+                console.log('Manual approval for auto-approved request. Using existing redirect URL:', autoRedirectUrl);
+                window.location.href = autoRedirectUrl;
+                return;
+            }
+
             const authClient = supabase.auth as unknown as import('@/types/supabase').SupabaseAuthWithOAuth;
             const { data, error } = decision === 'approve'
                 ? await authClient.oauth.approveAuthorization(authorizationId)

--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -72,7 +72,42 @@ interface AuthorizationDetails {
     redirect_url?: string;
 }
 
-import { LOGO_URL, BRAND_NAME } from '@/lib/constants';
+import { LOGO_URL, BRAND_NAME, OAUTH_CLIENT_IDS, MIETEVO_MCP_URL } from '@/lib/constants';
+
+/**
+ * Allowlist of trusted redirect origins for the OAuth consent flow.
+ * Only URLs starting with these origins are permitted as redirect targets,
+ * preventing open-redirect / XSS via javascript: URIs.
+ */
+const ALLOWED_REDIRECT_ORIGINS = [
+    'https://api.notion.com',
+    'https://www.notion.so',
+    'https://mcp.mietevo.de',
+    'https://mietevo.de',
+    // Allow any Cloudflare Pages preview deploy for development
+    ...(process.env.NEXT_PUBLIC_EXTRA_REDIRECT_ORIGINS
+        ? process.env.NEXT_PUBLIC_EXTRA_REDIRECT_ORIGINS.split(',')
+        : []),
+];
+
+/**
+ * Validates a redirect URL before navigating to it.
+ * Only HTTPS URLs whose origin is in the allowlist are accepted.
+ */
+function safeRedirect(url: string | undefined | null): void {
+    if (!url) return;
+    try {
+        const parsed = new URL(url);
+        if (parsed.protocol !== 'https:') return;
+        if (!ALLOWED_REDIRECT_ORIGINS.some(allowed => parsed.origin === allowed)) {
+            console.error('[OAuth] Blocked redirect to untrusted origin:', parsed.origin);
+            return;
+        }
+        window.location.href = url;
+    } catch {
+        // Invalid URL — silently ignore
+    }
+}
 
 export default function ConsentUI({
     type,
@@ -127,9 +162,10 @@ export default function ConsentUI({
                 const data = await response.json();
                 console.log('Authorization details:', data);
 
-                // Check if the authorization was auto-approved and has a redirect URL
+                // Check if the authorization was auto-approved and has a redirect URL.
+                // We intentionally do NOT auto-follow — always show the manual consent screen.
                 if (data?.redirect_to || data?.redirect_url) {
-                    console.log('Skipping auto-approval to force manual consent screen. Redirect would have been to:', data.redirect_to || data.redirect_url);
+                    // Redirect URL present, but user must still explicitly approve below.
                 }
 
                 setAuthDetails(data);
@@ -152,7 +188,7 @@ export default function ConsentUI({
 
         const fetchCustomScopes = async () => {
             try {
-                const response = await fetch(`https://mcp.mietevo.de/oauth/scopes?state=${state}`);
+                const response = await fetch(`${MIETEVO_MCP_URL}/oauth/scopes?state=${encodeURIComponent(state)}`);
                 if (response.ok) {
                     const data = await response.json();
                     if (data.scopes) {
@@ -176,8 +212,8 @@ export default function ConsentUI({
         const lowerName = (name || '').toLowerCase();
 
         // 1. Check known IDs first
-        if (id === '4df23a6c-c2d9-43b8-aba8-a2a4f3681892') return { name: 'Mietevo', icon: LOGO_URL };
-        if (id === 'b7fee65f-13af-4c19-b749-85fad88253fd') return { name: 'Mietevo Public MCP', icon: LOGO_URL };
+        if (id === OAUTH_CLIENT_IDS.MIETEVO) return { name: 'Mietevo', icon: LOGO_URL };
+        if (id === OAUTH_CLIENT_IDS.MIETEVO_PUBLIC_MCP) return { name: 'Mietevo Public MCP', icon: LOGO_URL };
 
         // 2. Use provided URI if it exists
         if (providedUri) return { name: name || 'Unbekannte Anwendung', icon: providedUri };
@@ -240,8 +276,7 @@ export default function ConsentUI({
             // just use it instead of calling the API again to avoid "validation_failed" (400) errors.
             const autoRedirectUrl = authDetails?.redirect_to || authDetails?.redirect_url;
             if (decision === 'approve' && autoRedirectUrl) {
-                console.log('Manual approval for auto-approved request. Using existing redirect URL:', autoRedirectUrl);
-                window.location.href = autoRedirectUrl;
+                safeRedirect(autoRedirectUrl);
                 return;
             }
 
@@ -259,17 +294,14 @@ export default function ConsentUI({
             if (response.ok) {
                 const data = await response.json();
                 const redirectTarget = data?.redirect_to || data?.redirect_url;
-                if (redirectTarget) {
-                    window.location.href = redirectTarget;
-                } else {
-                    setIsProcessing(false);
-                }
+                safeRedirect(redirectTarget);
+                if (!redirectTarget) setIsProcessing(false);
             } else {
                 // Fallback to Server Action if client-side POST is blocked (e.g. by Brave/Firefox cross-site policies)
                 if (decision === 'approve') {
                     const { success, redirect_to, error } = await import('./actions').then(m => m.approveAuthorizationAction(authorizationId));
                     if (success && redirect_to) {
-                        window.location.href = redirect_to;
+                        safeRedirect(redirect_to);
                     } else {
                         setProcessError(error || 'Action failed');
                         setIsProcessing(false);

--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -1,13 +1,12 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { createBrowserClient } from '@supabase/ssr';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { ShieldAlert, Check, Loader2, AlertTriangle, X } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 
 // Scope descriptions mapping
 const SCOPE_DETAILS: Record<string, { title: string; description: string }> = {
@@ -56,6 +55,7 @@ interface ConsentUIProps {
     clientIcon?: string;
     redirectUri?: string;
     scopes?: string[];
+    isDemo?: boolean;
 }
 
 interface AuthorizationDetails {
@@ -81,12 +81,20 @@ export default function ConsentUI({
     clientName: initialClientName,
     clientIcon: initialClientIcon,
     redirectUri: initialRedirectUri,
-    scopes: initialScopes = []
+    scopes: initialScopes = [],
+    isDemo = false
 }: ConsentUIProps) {
     const [isProcessing, setIsProcessing] = useState(false);
     const [processError, setProcessError] = useState<string | null>(null);
-    const [isLoading, setIsLoading] = useState(true);
-    const [authDetails, setAuthDetails] = useState<AuthorizationDetails | null>(null);
+    const [isLoading, setIsLoading] = useState(!isDemo);
+    const [authDetails, setAuthDetails] = useState<AuthorizationDetails | null>(
+        isDemo ? {
+            id: authorizationId,
+            client: { name: initialClientName, logo_uri: initialClientIcon },
+            redirect_uri: initialRedirectUri,
+            scopes: initialScopes
+        } : null
+    );
     const [loadError, setLoadError] = useState<string | null>(null);
 
     // Create browser client for consent actions
@@ -98,7 +106,7 @@ export default function ConsentUI({
     // Fetch authorization details on mount
     useEffect(() => {
         const fetchDetails = async () => {
-            if (!authorizationId || type === 'error') {
+            if (isDemo || !authorizationId || type === 'error') {
                 setIsLoading(false);
                 return;
             }
@@ -131,7 +139,7 @@ export default function ConsentUI({
         };
 
         fetchDetails();
-    }, [authorizationId, type]);
+    }, [authorizationId, type, isDemo]);
 
     // Side-channel: Fetch requested scopes directly from the Mietevo Worker 
     // because Supabase filters out any scopes it doesn't officially support.
@@ -161,27 +169,63 @@ export default function ConsentUI({
         fetchCustomScopes();
     }, [authDetails]);
 
-    // Known client ID mappings for better UI fallback
-    const KNOWN_MCP_CLIENTS: Record<string, string> = {
-        '4df23a6c-c2d9-43b8-aba8-a2a4f3681892': 'Mietevo',
-        'b7fee65f-13af-4c19-b749-85fad88253fd': 'Mietevo Public MCP'
+    // Smart client logo detection based on name or ID
+    const getSmartClientConfig = (id?: string, name?: string, providedUri?: string) => {
+        const lowerName = (name || '').toLowerCase();
+
+        // 1. Check known IDs first
+        if (id === '4df23a6c-c2d9-43b8-aba8-a2a4f3681892') return { name: 'Mietevo', icon: LOGO_URL };
+        if (id === 'b7fee65f-13af-4c19-b749-85fad88253fd') return { name: 'Mietevo Public MCP', icon: LOGO_URL };
+
+        // 2. Use provided URI if it exists
+        if (providedUri) return { name: name || 'Unbekannte Anwendung', icon: providedUri };
+
+        // 3. Smart guess based on popular tools you might integrate
+        if (lowerName.includes('notion')) return { name: name || 'Notion', icon: 'https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png' };
+        if (lowerName.includes('claude') || lowerName.includes('anthropic')) return { name: name || 'Claude', icon: 'https://upload.wikimedia.org/wikipedia/commons/1/14/Claude_AI_logo.svg' };
+        if (lowerName.includes('chatgpt') || lowerName.includes('openai')) return { name: name || 'ChatGPT', icon: 'https://upload.wikimedia.org/wikipedia/commons/0/04/ChatGPT_logo.svg' };
+
+        // 4. Default fallback
+        return { name: name || initialClientName || 'Unbekannte Anwendung', icon: initialClientIcon || null };
     };
 
     const clientId = authDetails?.client?.id;
-    const clientName = authDetails?.client?.name ||
-        (clientId && KNOWN_MCP_CLIENTS[clientId]) ||
-        initialClientName ||
-        'Mietevo';
+    const { name: clientName, icon: clientIcon } = getSmartClientConfig(
+        clientId,
+        authDetails?.client?.name || initialClientName,
+        authDetails?.client?.logo_uri
+    );
 
-    // Set icon - use logo_uri if provided, or mascot if it's a known client
-    const clientIcon = authDetails?.client?.logo_uri ||
-        (clientId && KNOWN_MCP_CLIENTS[clientId] ? LOGO_URL : initialClientIcon);
     const redirectUri = authDetails?.redirect_uri || initialRedirectUri;
 
     // Merge Supabase scopes with our custom stashed scopes
     const rawSupabaseScopes = typeof authDetails?.scopes === 'string' ? authDetails.scopes.split(' ') : (authDetails?.scopes || []);
     const mergedScopes = Array.from(new Set([...rawSupabaseScopes, ...customScopes, ...(initialScopes || [])])).filter(s => s !== 'offline_access');
     const scopes = mergedScopes.length > 0 ? mergedScopes : ['openid', 'email'];
+
+    // Dynamic scroll indicators for scopes list
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const [showTopFade, setShowTopFade] = useState(false);
+    const [showBottomFade, setShowBottomFade] = useState(false);
+
+    const handleScroll = () => {
+        if (!scrollRef.current) return;
+        const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
+        setShowTopFade(scrollTop > 0);
+        // Add a 1px threshold to prevent precision issues causing flashing
+        setShowBottomFade(Math.ceil(scrollTop + clientHeight) < scrollHeight - 1);
+    };
+
+    // Check scroll state when scopes change or window resizes
+    useEffect(() => {
+        // give the DOM time to render the scopes before checking scroll height
+        const timeout = setTimeout(handleScroll, 50);
+        window.addEventListener('resize', handleScroll);
+        return () => {
+            clearTimeout(timeout);
+            window.removeEventListener('resize', handleScroll);
+        }
+    }, [scopes]);
 
     const handleDecision = async (decision: 'approve' | 'deny') => {
         if (!authorizationId) return;
@@ -285,80 +329,157 @@ export default function ConsentUI({
     return (
         <div className="min-h-screen flex items-center justify-center bg-background p-4 md:p-8 relative overflow-hidden font-sans">
             <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_50%,black_40%,transparent_100%)]" />
+
+            {/* Ambient background glow (softer in light mode) */}
             <motion.div
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.5 }}
-                className="relative z-10 w-full max-w-md"
+                initial={{ opacity: 0, scale: 0.8 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ duration: 1.5, ease: "easeOut" }}
+                className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-primary/10 dark:bg-primary/20 blur-[100px] dark:blur-[120px] rounded-full pointer-events-none"
+            />
+
+            <motion.div
+                initial={{ opacity: 0, y: 30, scale: 0.95 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                transition={{ duration: 0.6, type: "spring", bounce: 0.4 }}
+                className="relative z-10 w-full max-w-md group"
             >
-                <Card className="border-border bg-card/80 backdrop-blur-xl shadow-2xl rounded-[2.5rem] overflow-hidden">
-                    <CardHeader className="text-center pt-8">
+                {/* Gradient glowing border effect (adapted for light/dark) */}
+                <div className="absolute -inset-0.5 bg-gradient-to-br from-primary/30 to-primary/0 dark:from-primary/40 dark:to-primary/5 rounded-[2.5rem] blur-md opacity-30 dark:opacity-50 group-hover:opacity-60 dark:group-hover:opacity-80 transition duration-1000 group-hover:duration-300" />
+
+                <Card className="relative border-border/50 dark:border-border/30 bg-background/80 dark:bg-background/60 backdrop-blur-2xl shadow-xl dark:shadow-2xl rounded-[2.5rem] overflow-hidden">
+                    <CardHeader className="text-center pt-10 px-8">
                         {/* App logos */}
-                        <div className="flex items-center justify-center gap-4 mb-6">
-                            {clientIcon ? (
-                                <img
-                                    src={clientIcon}
-                                    alt={clientName}
-                                    className="w-16 h-16 rounded-2xl border border-border"
-                                />
-                            ) : (
-                                <div className="w-16 h-16 bg-primary/10 rounded-2xl flex items-center justify-center border border-primary/20">
-                                    <ShieldAlert className="w-8 h-8 text-primary" />
+                        <div className="flex items-center justify-center gap-6 mb-8">
+                            <motion.div
+                                initial={{ x: -20, opacity: 0 }}
+                                animate={{ x: 0, opacity: 1 }}
+                                transition={{ delay: 0.2, duration: 0.5 }}
+                                className="relative"
+                            >
+                                <div className="absolute inset-0 bg-primary/10 dark:bg-primary/20 blur-xl rounded-full" />
+                                {clientIcon ? (
+                                    <div className="w-16 h-16 rounded-[1.25rem] bg-white border border-border/40 dark:border-border/50 shadow-md dark:shadow-xl flex items-center justify-center overflow-hidden flex-shrink-0 relative z-10">
+                                        <div className="absolute inset-0 bg-gradient-to-tr from-black/5 to-transparent mix-blend-multiply dark:mix-blend-normal dark:from-white/10 dark:to-transparent" />
+                                        <img
+                                            src={clientIcon}
+                                            alt={clientName}
+                                            className="w-10 h-10 object-contain drop-shadow-sm relative z-10"
+                                        />
+                                    </div>
+                                ) : (
+                                    <div className="w-16 h-16 rounded-[1.25rem] bg-card border border-border/40 dark:border-border/70 shadow-md dark:shadow-xl flex items-center justify-center flex-shrink-0 relative overflow-hidden z-10">
+                                        <div className="absolute inset-0 bg-primary/5 dark:bg-primary/10" />
+                                        <ShieldAlert className="w-7 h-7 text-primary relative z-10" />
+                                    </div>
+                                )}
+                            </motion.div>
+
+                            <motion.div
+                                initial={{ scale: 0, opacity: 0 }}
+                                animate={{ scale: 1, opacity: 1 }}
+                                transition={{ delay: 0.4, type: "spring" }}
+                                className="flex flex-col items-center justify-center"
+                            >
+                                <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-muted dark:bg-secondary/50 border border-border/30 dark:border-border/50 shadow-sm dark:shadow-inner">
+                                    <div className="w-1.5 h-1.5 rounded-full bg-primary/80 animate-pulse" />
+                                    <div className="w-1.5 h-1.5 rounded-full bg-primary/50 animate-pulse" style={{ animationDelay: '200ms' }} />
+                                    <div className="w-1.5 h-1.5 rounded-full bg-primary/30 animate-pulse" style={{ animationDelay: '400ms' }} />
                                 </div>
-                            )}
-                            <div className="text-2xl text-muted-foreground">→</div>
-                            <img
-                                src={LOGO_URL}
-                                alt={BRAND_NAME}
-                                className="w-16 h-16 rounded-2xl border border-border"
-                            />
+                            </motion.div>
+
+                            <motion.div
+                                initial={{ x: 20, opacity: 0 }}
+                                animate={{ x: 0, opacity: 1 }}
+                                transition={{ delay: 0.3, duration: 0.5 }}
+                                className="relative"
+                            >
+                                <div className="absolute inset-0 bg-primary/10 dark:bg-primary/20 blur-xl rounded-full" />
+                                <div className="w-16 h-16 rounded-[1.25rem] bg-card border border-border/40 dark:border-border/70 shadow-md dark:shadow-xl flex items-center justify-center flex-shrink-0 relative overflow-hidden z-10">
+                                    <div className="absolute inset-0 bg-gradient-to-tr from-black/5 dark:from-black/20 to-transparent" />
+                                    <img
+                                        src={LOGO_URL}
+                                        alt={BRAND_NAME}
+                                        className="w-10 h-10 object-contain relative z-10 dark:brightness-110"
+                                    />
+                                </div>
+                            </motion.div>
                         </div>
-                        <CardTitle className="text-2xl md:text-3xl font-bold text-foreground tracking-tight">
-                            Zugriff autorisieren
+                        <CardTitle className="text-2xl md:text-3xl font-extrabold tracking-tight leading-tight bg-clip-text text-transparent bg-gradient-to-br from-foreground to-muted-foreground pb-1">
+                            Verknüpfung erlauben
                         </CardTitle>
-                        <CardDescription className="text-base mt-2">
-                            <span className="font-semibold text-foreground">{clientName}</span> möchte auf Ihr {BRAND_NAME}-Konto zugreifen
+                        <CardDescription className="text-base mt-2 max-w-sm mx-auto text-muted-foreground">
+                            <span className="font-semibold text-foreground">{clientName}</span> fordert Zugriff auf Ihr {BRAND_NAME}-Konto an.
                         </CardDescription>
                     </CardHeader>
                     <CardContent className="px-8 pb-4">
-                        {/* Scopes */}
                         {scopes.length > 0 && (
                             <div className="mb-8">
                                 <h3 className="text-sm font-medium text-muted-foreground mb-4 text-center">
                                     Diese Anwendung darf:
                                 </h3>
-                                <div className="rounded-2xl border border-border/50 bg-card/50 overflow-hidden">
-                                    <Accordion type="single" collapsible className="w-full">
-                                        {scopes.map((scope) => {
+                                <div className="relative rounded-2xl border border-border/40 bg-muted/30 dark:bg-background/50 overflow-hidden flex flex-col shadow-inner backdrop-blur-sm">
+                                    {/* Top scroll fade */}
+                                    {showTopFade && (
+                                        <motion.div
+                                            initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+                                            className="absolute top-0 left-0 right-0 h-6 bg-gradient-to-b from-muted/90 dark:from-background/90 to-transparent z-10 pointer-events-none"
+                                        />
+                                    )}
+
+                                    <div
+                                        ref={scrollRef}
+                                        onScroll={handleScroll}
+                                        className="max-h-60 overflow-y-auto p-3 space-y-2 custom-scrollbar relative z-0"
+                                    >
+                                        {scopes.map((scope, index) => {
                                             const details = getScopeDetails(scope);
                                             return (
-                                                <AccordionItem key={scope} value={scope} className="border-border/50 first:border-t-0 last:border-b-0 px-4">
-                                                    <AccordionTrigger className="hover:no-underline hover:bg-secondary/30 py-4 -mx-4 px-4 transition-colors">
-                                                        <div className="flex items-center gap-4 text-left">
-                                                            <div className="w-8 h-8 rounded-full bg-green-500/10 flex items-center justify-center flex-shrink-0">
-                                                                <Check className="w-4 h-4 text-green-600" />
-                                                            </div>
-                                                            <div className="flex-1 min-w-0">
-                                                                <p className="text-sm font-medium text-foreground truncate">
-                                                                    {details.title}
-                                                                </p>
-                                                            </div>
-                                                        </div>
-                                                    </AccordionTrigger>
-                                                    <AccordionContent className="text-muted-foreground px-1 pl-12">
-                                                        {details.description}
-                                                    </AccordionContent>
-                                                </AccordionItem>
+                                                <motion.div
+                                                    initial={{ opacity: 0, x: -10 }}
+                                                    animate={{ opacity: 1, x: 0 }}
+                                                    transition={{ delay: 0.1 * index }}
+                                                    key={scope}
+                                                    className="group/scope flex items-start gap-4 p-3.5 rounded-xl bg-card border border-border/40 hover:border-primary/30 dark:border-border/30 dark:hover:border-border/80 hover:bg-card hover:shadow-sm dark:hover:shadow-md transition-all duration-300"
+                                                >
+                                                    <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0 mt-0.5 group-hover/scope:bg-primary/20 group-hover/scope:scale-110 transition-all duration-300">
+                                                        <Check className="w-4 h-4 text-primary" />
+                                                    </div>
+                                                    <div className="flex-1 min-w-0">
+                                                        <p className="text-sm font-semibold text-foreground mb-0.5">
+                                                            {details.title}
+                                                        </p>
+                                                        <p className="text-xs text-muted-foreground leading-relaxed">
+                                                            {details.description}
+                                                        </p>
+                                                    </div>
+                                                </motion.div>
                                             );
                                         })}
-                                    </Accordion>
+                                    </div>
+
+                                    {/* Bottom scroll fade with bouncing arrow */}
+                                    {showBottomFade && (
+                                        <motion.div
+                                            initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+                                            className="absolute bottom-0 left-0 right-0 h-10 bg-gradient-to-t from-muted/90 dark:from-background/90 to-transparent z-10 pointer-events-none flex items-end justify-center pb-1.5"
+                                        >
+                                            <motion.div
+                                                animate={{ y: [0, 3, 0] }}
+                                                transition={{ repeat: Infinity, duration: 1.5, ease: "easeInOut" }}
+                                                className="w-5 h-5 rounded-full bg-background/50 border border-border/50 flex items-center justify-center backdrop-blur-md shadow-sm"
+                                            >
+                                                <div className="w-1.5 h-1.5 border-b-2 border-r-2 border-muted-foreground rotate-45 mb-0.5" />
+                                            </motion.div>
+                                        </motion.div>
+                                    )}
                                 </div>
                             </div>
                         )}
 
                         {/* Error display */}
                         {processError && (
-                            <Alert variant="destructive" className="rounded-xl mb-4">
+                            <Alert variant="destructive" className="rounded-xl mb-4 bg-destructive/10 text-destructive border-destructive/20">
                                 <AlertDescription>{processError}</AlertDescription>
                             </Alert>
                         )}
@@ -382,28 +503,28 @@ export default function ConsentUI({
                         <Button
                             onClick={handleApprove}
                             disabled={isProcessing}
-                            className="w-full h-12 rounded-xl text-base font-medium"
+                            className="w-full h-12 rounded-xl text-base font-semibold border-none bg-primary text-primary-foreground hover:bg-primary/90 shadow-[0_4px_14px_rgba(var(--primary),0.2)] dark:shadow-[0_0_20px_rgba(var(--primary),0.3)] hover:shadow-[0_6px_20px_rgba(var(--primary),0.3)] dark:hover:shadow-[0_0_25px_rgba(var(--primary),0.5)] transition-all duration-300"
                         >
                             {isProcessing ? (
                                 <>
-                                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                                    <Loader2 className="w-5 h-5 mr-2 animate-spin" />
                                     Wird verarbeitet...
                                 </>
                             ) : (
                                 <>
-                                    <Check className="w-4 h-4 mr-2" />
+                                    <Check className="w-5 h-5 mr-2" />
                                     Zugriff erlauben
                                 </>
                             )}
                         </Button>
                         <Button
-                            variant="outline"
+                            variant="ghost"
                             onClick={handleDeny}
                             disabled={isProcessing}
-                            className="w-full h-12 rounded-xl text-base font-medium"
+                            className="w-full h-12 rounded-xl text-base font-medium hover:bg-destructive/10 hover:text-destructive transition-colors"
                         >
                             <X className="w-4 h-4 mr-2" />
-                            Ablehnen
+                            Abbrechen
                         </Button>
                     </CardFooter>
                 </Card>

--- a/app/oauth/consent/actions.ts
+++ b/app/oauth/consent/actions.ts
@@ -4,9 +4,8 @@ import { cookies } from 'next/headers';
 
 export async function approveAuthorizationAction(authorizationId: string) {
     try {
-        // Validate the authorizationId to prevent SSRF and unexpected paths.
-        const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-        if (!uuidPattern.test(authorizationId)) {
+        // Validate the authorizationId — it can be a UUID or a Supabase URL-safe base64 string
+        if (!authorizationId || authorizationId.length < 10 || authorizationId.length > 64) {
             throw new Error('Invalid authorization identifier format');
         }
 
@@ -18,7 +17,9 @@ export async function approveAuthorizationAction(authorizationId: string) {
         console.log('Cookies being sent:', allCookies.map(c => c.name).join(', '));
 
         const baseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-        const url = new URL('/auth/v1/oauth/authorizations/' + encodeURIComponent(authorizationId) + '/approve', baseUrl);
+        // Correct Supabase OAuth authorization approval endpoint:
+        // POST /auth/v1/oauth/authorizations/{id}  with body { decision: "allow" }
+        const url = new URL('/auth/v1/oauth/authorizations/' + encodeURIComponent(authorizationId), baseUrl);
         console.log('Calling URL:', url.toString());
 
         const response = await fetch(url.toString(), {
@@ -28,6 +29,7 @@ export async function approveAuthorizationAction(authorizationId: string) {
                 'Cookie': cookieHeader,
                 'apikey': process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
             },
+            body: JSON.stringify({ decision: 'allow' }),
         });
 
         const responseText = await response.text();

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -86,6 +86,15 @@ export const ROUTES = {
   IMPRESSUM: '/impressum',
 } as const;
 
+// MCP Worker URL
+export const MIETEVO_MCP_URL = process.env.NEXT_PUBLIC_MIETEVO_MCP_URL || 'https://mcp.mietevo.de';
+
+// Known OAuth Client IDs for first-party clients (display branding overrides)
+export const OAUTH_CLIENT_IDS = {
+  MIETEVO: '4df23a6c-c2d9-43b8-aba8-a2a4f3681892',
+  MIETEVO_PUBLIC_MCP: 'b7fee65f-13af-4c19-b749-85fad88253fd',
+} as const;
+
 // Supabase API paths
 export const SUPABASE_API_PATHS = {
   OAUTH_AUTHORIZE: '/auth/v1/oauth/authorize',

--- a/supabase/migrations/20260226180000_fix_authorized_apps_use_sessions.sql
+++ b/supabase/migrations/20260226180000_fix_authorized_apps_use_sessions.sql
@@ -1,0 +1,62 @@
+-- Fix: get_authorized_apps was reading from auth.oauth_authorizations which always
+-- has user_id=null and status='pending' when the MCP proxy intercepts the OAuth flow.
+-- Instead, we read from auth.sessions which correctly has user_id set after the token
+-- exchange and groups by OAuth client to show one entry per connected app.
+
+CREATE OR REPLACE FUNCTION public.get_authorized_apps()
+RETURNS TABLE(
+    authorization_id uuid,
+    client_name text,
+    client_logo text,
+    scopes text,
+    created_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT DISTINCT ON (c.id)
+        s.id AS authorization_id,
+        c.client_name,
+        c.logo_uri AS client_logo,
+        s.scopes AS scopes,
+        s.created_at
+    FROM auth.sessions s
+    JOIN auth.oauth_clients c ON s.oauth_client_id = c.id
+    WHERE s.user_id = auth.uid()
+      AND s.oauth_client_id IS NOT NULL
+    ORDER BY c.id, s.created_at DESC;
+END;
+$$;
+
+-- Fix: revoke_app_access now deletes all sessions for the given OAuth client
+-- (identified by the session id passed in) rather than trying to delete a
+-- non-existent approved authorization record.
+
+CREATE OR REPLACE FUNCTION public.revoke_app_access(auth_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+    v_client_id uuid;
+BEGIN
+    -- Find the OAuth client for this session, checking ownership
+    SELECT oauth_client_id INTO v_client_id
+    FROM auth.sessions
+    WHERE id = auth_id
+      AND user_id = auth.uid();
+
+    IF v_client_id IS NULL THEN
+        RAISE EXCEPTION 'Session not found or access denied';
+    END IF;
+
+    -- Revoke all active sessions for this user + client
+    DELETE FROM auth.sessions
+    WHERE user_id = auth.uid()
+      AND oauth_client_id = v_client_id;
+END;
+$$;


### PR DESCRIPTION
## Description

Complete redesign of the OAuth consent screen plus fixes to the authorize/approve plumbing and the authorized-apps backend.

## Summary of Changes

- `ConsentUI.tsx` redesigned (+323/−91): premium consent card with gradient glow border, animated app/Mietevo logos with connecting pulse dots, scrollable scope list with top/bottom fade indicators and bouncing arrow, smart client-logo detection (known IDs, Notion/Claude/ChatGPT heuristics), side-channel scope fetching from the MCP worker, demo mode
- `actions.ts`: approve endpoint fixed — `POST /auth/v1/oauth/authorizations/{id}` with `{ decision }` body instead of the non-existent `/approve` suffix; relaxed authorization-id validation (UUID or URL-safe base64)
- `lib/constants.ts`: `MIETEVO_MCP_URL` and known first-party `OAUTH_CLIENT_IDS`
- New migration `fix_authorized_apps_use_sessions.sql`: `get_authorized_apps()` reads from `auth.sessions` grouped by client (the authorizations table is unusable behind the MCP proxy); `revoke_app_access()` deletes the client's sessions