### PR TITLE
security: add explicit permissions to Lighthouse CI workflow

### DIFF
--- a/.github/workflows/lighthouse-report.yaml
+++ b/.github/workflows/lighthouse-report.yaml
@@ -8,6 +8,9 @@ on:
     branches: [main]
   workflow_dispatch:  # Allows manual triggering from the Actions tab
 
+permissions:
+  contents: read
+
 jobs:
   # Lightweight job to determine if lighthouse should run and which devices to test
   # This allows build and prepare-lhci to run truly in parallel

--- a/.github/workflows/lighthouse-report.yaml
+++ b/.github/workflows/lighthouse-report.yaml
@@ -632,7 +632,7 @@ jobs:
       - name: Create device zip files and send to Discord
         if: always()
         run: |
-          WEBHOOK_URL="https://discord.com/api/webhooks/1427189522764140565/pmtcfhnQiZ_ERvVGvZbdqYHp_pJrFxbIcDLC722-ucw7Z7UX2__Vue9GJpyeuzfMfpPy"
+          WEBHOOK_URL="${{ secrets.DISCORD_WEBHOOK_LIGHTHOUSE_REPORTS }}"
           
           # Create zip files for each available device
           echo "Creating zip files for available device reports..."


### PR DESCRIPTION
## Description

Adds explicit least-privilege permissions to the Lighthouse CI workflow.

## Summary of Changes

- `lighthouse-report.yaml`: workflow-level `permissions: contents: read`
- Discord webhook URL moved from a hardcoded value to the `DISCORD_WEBHOOK_LIGHTHOUSE_REPORTS` secret