### PR TITLE
fix(oauth): handle auto_approved authorizations to avoid 405 on POST …

### DIFF
--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -70,6 +70,8 @@ interface AuthorizationDetails {
     scopes?: string | string[];
     redirect_to?: string;
     redirect_url?: string;
+    /** Set to true by Supabase when the OAuth app was previously approved (skip POST on approve) */
+    auto_approved?: boolean;
 }
 
 import { LOGO_URL, BRAND_NAME, OAUTH_CLIENT_IDS, MIETEVO_MCP_URL } from '@/lib/constants';
@@ -152,8 +154,10 @@ export default function ConsentUI({
                     return;
                 }
 
-                // Check if the authorization was auto-approved and has a redirect URL.
-                // We intentionally do NOT auto-follow — always show the manual consent screen.
+                // If auto_approved, Supabase has already granted access and the redirect_to
+                // URL is immediately usable. We still show the consent screen so the user
+                // knows what was approved, but the approve button uses the existing redirect
+                // instead of POSTing to the decision endpoint (which returns 405 on auto-approved).
 
                 setAuthDetails(data);
             } catch (err: any) {
@@ -259,6 +263,15 @@ export default function ConsentUI({
         setProcessError(null);
 
         try {
+            // For auto-approved authorizations, Supabase has already granted access.
+            // POSTing a decision to the endpoint returns 405 Method Not Allowed.
+            // Instead, use the redirect_to from the initial GET details response directly.
+            const autoRedirectUrl = authDetails?.redirect_to || authDetails?.redirect_url;
+            if (decision === 'approve' && authDetails?.auto_approved && autoRedirectUrl) {
+                safeRedirect(autoRedirectUrl);
+                return;
+            }
+
             // All Supabase calls go through server actions to avoid CORS issues.
             // (Supabase returns Access-Control-Allow-Origin: * which browsers block with credentials: include)
             const { success, redirect_to, error } = await submitDecisionAction(

--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -266,8 +266,13 @@ export default function ConsentUI({
             // For auto-approved authorizations, Supabase has already granted access.
             // POSTing a decision to the endpoint returns 405 Method Not Allowed.
             // Instead, use the redirect_to from the initial GET details response directly.
-            const autoRedirectUrl = authDetails?.redirect_to || authDetails?.redirect_url;
-            if (decision === 'approve' && authDetails?.auto_approved && autoRedirectUrl) {
+            if (decision === 'approve' && authDetails?.auto_approved) {
+                const autoRedirectUrl = authDetails.redirect_to || authDetails.redirect_url;
+                if (!autoRedirectUrl) {
+                    setProcessError('Automatically approved authorization has no redirect URL. Please try again.');
+                    setIsProcessing(false);
+                    return;
+                }
                 safeRedirect(autoRedirectUrl);
                 return;
             }

--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -70,7 +70,7 @@ interface AuthorizationDetails {
     scopes?: string | string[];
     redirect_to?: string;
     redirect_url?: string;
-    /** Set to true by Supabase when the OAuth app was previously approved (skip POST on approve) */
+    /** Set to true by Supabase when the app was previously approved — skip the decision POST endpoint */
     auto_approved?: boolean;
 }
 
@@ -266,13 +266,24 @@ export default function ConsentUI({
             // For auto-approved authorizations, Supabase has already granted access.
             // POSTing a decision to the endpoint returns 405 Method Not Allowed.
             // Instead, use the redirect_to from the initial GET details response directly.
-            if (decision === 'approve' && authDetails?.auto_approved) {
+            if (authDetails?.auto_approved) {
+                if (decision === 'deny') {
+                    // For auto-approved, the access is already granted. Denying now would face the same
+                    // 405 constraint, so we gracefully abort and inform the user.
+                    setProcessError('This application is already approved. You can revoke access from your account settings.');
+                    setIsProcessing(false);
+                    return;
+                }
+
+                // redirect_to is set by Supabase on auto-approved flows; redirect_url is the registered fallback
                 const autoRedirectUrl = authDetails.redirect_to || authDetails.redirect_url;
                 if (!autoRedirectUrl) {
                     setProcessError('Automatically approved authorization has no redirect URL. Please try again.');
                     setIsProcessing(false);
                     return;
                 }
+
+                setIsProcessing(false); // defensive reset before navigation
                 safeRedirect(autoRedirectUrl);
                 return;
             }


### PR DESCRIPTION
## Description

Handles auto-approved authorizations in the consent UI to avoid a 405 error when POSTing the decision.

## Summary of Changes

- `ConsentUI.tsx`: when `auto_approved` is set on the fetched authorization, the approve button follows the existing `redirect_to`/`redirect_url` directly instead of POSTing to the decision endpoint (which returns 405 for auto-approved authorizations)
- Denying an auto-approved authorization shows an explanatory message pointing to the account settings for revocation
- `AuthorizationDetails` type extended with the `auto_approved` flag