### PR TITLE
fix(oauth): add pre-flight GET in submitDecisionAction to detect auto…

### DIFF
--- a/app/oauth/consent/actions.ts
+++ b/app/oauth/consent/actions.ts
@@ -163,6 +163,7 @@ export async function submitDecisionAction(authorizationId: string, decision: 'a
                     'apikey': SUPABASE_ANON_KEY,
                 },
             });
+
             if (preCheck.ok) {
                 const preCheckText = await preCheck.text();
                 try {
@@ -172,11 +173,13 @@ export async function submitDecisionAction(authorizationId: string, decision: 'a
                         console.info('[OAuth] submitDecisionAction: auto_approved detected, skipping POST');
                         return { success: true, redirect_to: redirectUrl, error: null };
                     }
-                } catch {
-                    // Pre-check parse failed — proceed with the POST normally
+                } catch (e) {
+                    console.warn('[OAuth] pre-check JSON parse failed, falling through to POST', e);
                 }
             } else if (preCheck.status === 404) {
                 return { success: false, redirect_to: null, error: ERR_AUTH_EXPIRED };
+            } else {
+                console.warn('[OAuth] pre-check GET returned unexpected status', preCheck.status);
             }
         }
 

--- a/app/oauth/consent/actions.ts
+++ b/app/oauth/consent/actions.ts
@@ -152,6 +152,34 @@ export async function submitDecisionAction(authorizationId: string, decision: 'a
         const accessToken = await getAccessToken();
         const url = buildAuthUrl(authorizationId);
 
+        // Pre-flight GET: if Supabase already auto-approved this authorization, POSTing
+        // a decision returns 405 Method Not Allowed. Detect this case server-side and
+        // return the redirect_to directly — no POST needed.
+        if (decision === 'allow') {
+            const preCheck = await fetch(url, {
+                method: 'GET',
+                headers: {
+                    'Authorization': `Bearer ${accessToken}`,
+                    'apikey': SUPABASE_ANON_KEY,
+                },
+            });
+            if (preCheck.ok) {
+                const preCheckText = await preCheck.text();
+                try {
+                    const preCheckData = JSON.parse(preCheckText) as AuthorizationDetails;
+                    if (preCheckData.auto_approved) {
+                        const redirectUrl = preCheckData.redirect_to || preCheckData.redirect_url || null;
+                        console.info('[OAuth] submitDecisionAction: auto_approved detected, skipping POST');
+                        return { success: true, redirect_to: redirectUrl, error: null };
+                    }
+                } catch {
+                    // Pre-check parse failed — proceed with the POST normally
+                }
+            } else if (preCheck.status === 404) {
+                return { success: false, redirect_to: null, error: ERR_AUTH_EXPIRED };
+            }
+        }
+
         const response = await fetch(url, {
             method: 'POST',
             headers: {


### PR DESCRIPTION
## Description

Adds a pre-flight GET in `submitDecisionAction` to detect `auto_approved` authorizations before POSTing a decision.

## Summary of Changes

- For 'allow' decisions, the authorization is fetched first: if `auto_approved` is set, the stored `redirect_to` is returned directly and the POST (which would 405) is skipped entirely
- Pre-flight 404 maps to the expired/already-used error; unexpected statuses log a warning and fall through to the POST