### PR TITLE
fix(oauth): allow Supabase-internal redirects in client-side safeRedi…

### DIFF
--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -62,14 +62,14 @@ interface ConsentUIProps {
 
 import { LOGO_URL, BRAND_NAME, OAUTH_CLIENT_IDS, MIETEVO_MCP_URL } from '@/lib/constants';
 
-import { isValidRedirect } from '@/lib/oauth-utils';
+import { isValidRedirect, isValidSupabaseRedirect } from '@/lib/oauth-utils';
 
 /**
  * Validates a redirect URL before navigating to it.
- * Only HTTPS URLs whose origin is in the allowlist are accepted.
+ * Only HTTPS URLs whose origin is in the allowlist or the project's Supabase instance are accepted.
  */
 function safeRedirect(url: string | undefined | null): void {
-    if (isValidRedirect(url)) {
+    if (isValidRedirect(url) || isValidSupabaseRedirect(url)) {
         window.location.href = url!;
     } else if (url) {
         console.error('[OAuth] Blocked redirect to untrusted origin:', url);

--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -70,10 +70,16 @@ export default async function ConsentPage({ searchParams }: PageProps) {
 
     if (success && data?.auto_approved) {
         const autoRedirectUrl = data.redirect_to || data.redirect_url;
+        console.info('[OAuth SSR] auto_approved detected', {
+            authorizationId,
+            redirect_to: data.redirect_to,
+            redirect_url: data.redirect_url,
+            resolved: autoRedirectUrl,
+        });
         if (autoRedirectUrl) {
             safeServerRedirect(autoRedirectUrl);
         }
-        
+
         // auto_approved but no redirect_to — redirect to a user-friendly error page
         // instead of silently rendering the consent UI which would cause a 405 on approve.
         redirect(`/oauth/consent?error=true&message=${encodeURIComponent('Automatische Autorisierung fehlgeschlagen: Kein Weiterleitungs-Link gefunden.')}`);


### PR DESCRIPTION
## Description

Allows Supabase-internal redirect URLs in the client-side safeRedirect of the consent UI and adds SSR diagnostic logging for auto-approved authorizations.

The client-side safeRedirect in ConsentUI only checked isValidRedirect (the client-facing origin allowlist) but not isValidSupabaseRedirect. When Supabase returns a *.supabase.co callback URL as redirect_to for auto_approved flows, the client-side redirect was silently blocked — causing the user to stay on the consent page with no visible error.

Also adds diagnostic logging in page.tsx SSR to trace what redirect_to Supabase returns for auto_approved authorizations.