### PR TITLE
fix(oauth): show success screen when authorization was already proces…

### DIFF
--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -5,8 +5,9 @@ import { getAuthorizationDetailsAction, submitDecisionAction, type Authorization
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { ShieldAlert, Check, Loader2, AlertTriangle, X } from 'lucide-react';
-import { motion } from 'framer-motion';
+import { motion, type HTMLMotionProps } from 'framer-motion';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { cn } from '@/lib/utils';
 
 // Scope descriptions mapping
 const SCOPE_DETAILS: Record<string, { title: string; description: string }> = {
@@ -83,14 +84,20 @@ function safeRedirect(url: string | undefined | null): void {
 function FullScreenLayout({ 
     children, 
     className = "",
-    showGlow = false 
+    showGlow = false,
+    motionProps = {
+        initial: { opacity: 0, y: 20 },
+        animate: { opacity: 1, y: 0 },
+        transition: { duration: 0.5 }
+    }
 }: { 
     children: React.ReactNode; 
     className?: string;
     showGlow?: boolean;
+    motionProps?: HTMLMotionProps<"div">;
 }) {
     return (
-        <div className={`min-h-screen flex items-center justify-center bg-background p-4 md:p-8 relative overflow-hidden font-sans ${className}`}>
+        <div className={cn("min-h-screen flex items-center justify-center bg-background p-4 md:p-8 relative overflow-hidden font-sans", className)}>
             <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_50%,black_40%,transparent_100%)]" />
             
             {showGlow && (
@@ -103,9 +110,7 @@ function FullScreenLayout({
             )}
 
             <motion.div
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.5 }}
+                {...motionProps}
                 className="relative z-10 w-full max-w-md"
             >
                 {children}
@@ -138,18 +143,27 @@ export default function ConsentUI({
         } : (initialData || null)
     );
     const [loadError, setLoadError] = useState<string | null>(initialError || null);
+    const [countdown, setCountdown] = useState(5);
 
-    // Auto-close success window after a delay
+    // Auto-close success window after a delay with visible countdown
     useEffect(() => {
-        if (type === 'success' && typeof window !== 'undefined') {
-            const timer = setTimeout(() => {
-                // Only try to close if it's likely a popup
-                if (window.opener || window.history.length === 1) {
-                    window.close();
-                }
-            }, 5000);
-            return () => clearTimeout(timer);
-        }
+        if (type !== 'success' || typeof window === 'undefined') return;
+
+        const interval = setInterval(() => {
+            setCountdown(prev => Math.max(0, prev - 1));
+        }, 1000);
+
+        const timer = setTimeout(() => {
+            // Only try to close if it's likely a popup
+            if (window.opener || window.history.length === 1) {
+                window.close();
+            }
+        }, 5000);
+
+        return () => {
+            clearInterval(interval);
+            clearTimeout(timer);
+        };
     }, [type]);
 
     // Fetch authorization details on mount
@@ -389,11 +403,15 @@ export default function ConsentUI({
                             Verbindung hergestellt
                         </CardTitle>
                     </CardHeader>
-                    <CardContent className="px-8 pb-8">
-                        <p className="text-muted-foreground text-center">
+                    <CardContent className="px-8 pb-8 flex flex-col items-center">
+                        <p className="text-muted-foreground text-center mb-4">
                             Diese Autorisierung wurde bereits erfolgreich verarbeitet.
                             Sie können dieses Fenster schließen.
                         </p>
+                        <div className="flex items-center gap-2 text-xs text-muted-foreground bg-muted/50 px-3 py-1.5 rounded-full">
+                            <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
+                            Fenster schließt in {countdown}s
+                        </div>
                     </CardContent>
                 </Card>
             </FullScreenLayout>
@@ -402,7 +420,14 @@ export default function ConsentUI({
 
     // Consent form
     return (
-        <FullScreenLayout showGlow>
+        <FullScreenLayout 
+            showGlow 
+            motionProps={{
+                initial: { opacity: 0, y: 30, scale: 0.95 },
+                animate: { opacity: 1, y: 0, scale: 1 },
+                transition: { duration: 0.6, type: "spring", bounce: 0.4 }
+            }}
+        >
             <div className="relative group">
                 {/* Gradient glowing border effect (adapted for light/dark) */}
                 <div className="absolute -inset-0.5 bg-gradient-to-br from-primary/30 to-primary/0 dark:from-primary/40 dark:to-primary/5 rounded-[2.5rem] blur-md opacity-30 dark:opacity-50 group-hover:opacity-60 dark:group-hover:opacity-80 transition duration-1000 group-hover:duration-300" />

--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -76,6 +76,44 @@ function safeRedirect(url: string | undefined | null): void {
     }
 }
 
+/**
+ * Reusable layout wrapper for all full-screen states (loading, error, success, consent).
+ * Handles the ambient background effects and centered container.
+ */
+function FullScreenLayout({ 
+    children, 
+    className = "",
+    showGlow = false 
+}: { 
+    children: React.ReactNode; 
+    className?: string;
+    showGlow?: boolean;
+}) {
+    return (
+        <div className={`min-h-screen flex items-center justify-center bg-background p-4 md:p-8 relative overflow-hidden font-sans ${className}`}>
+            <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_50%,black_40%,transparent_100%)]" />
+            
+            {showGlow && (
+                <motion.div
+                    initial={{ opacity: 0, scale: 0.8 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    transition={{ duration: 1.5, ease: "easeOut" }}
+                    className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-primary/10 dark:bg-primary/20 blur-[100px] dark:blur-[120px] rounded-full pointer-events-none"
+                />
+            )}
+
+            <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5 }}
+                className="relative z-10 w-full max-w-md"
+            >
+                {children}
+            </motion.div>
+        </div>
+    );
+}
+
 export default function ConsentUI({
     type,
     error,
@@ -100,6 +138,19 @@ export default function ConsentUI({
         } : (initialData || null)
     );
     const [loadError, setLoadError] = useState<string | null>(initialError || null);
+
+    // Auto-close success window after a delay
+    useEffect(() => {
+        if (type === 'success' && typeof window !== 'undefined') {
+            const timer = setTimeout(() => {
+                // Only try to close if it's likely a popup
+                if (window.opener || window.history.length === 1) {
+                    window.close();
+                }
+            }, 5000);
+            return () => clearTimeout(timer);
+        }
+    }, [type]);
 
     // Fetch authorization details on mount
     useEffect(() => {
@@ -288,110 +339,71 @@ export default function ConsentUI({
     // Loading state
     if (isLoading) {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-background p-4 md:p-8 relative overflow-hidden font-sans">
-                <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_50%,black_40%,transparent_100%)]" />
-                <motion.div
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.5 }}
-                    className="relative z-10 w-full max-w-md"
-                >
-                    <Card className="border-border bg-card/80 backdrop-blur-xl shadow-2xl rounded-[2.5rem] overflow-hidden">
-                        <CardContent className="flex flex-col items-center justify-center py-16">
-                            <Loader2 className="w-12 h-12 text-primary animate-spin mb-4" />
-                            <p className="text-muted-foreground">Laden...</p>
-                        </CardContent>
-                    </Card>
-                </motion.div>
-            </div>
+            <FullScreenLayout>
+                <Card className="border-border bg-card/80 backdrop-blur-xl shadow-2xl rounded-[2.5rem] overflow-hidden">
+                    <CardContent className="flex flex-col items-center justify-center py-16">
+                        <Loader2 className="w-12 h-12 text-primary animate-spin mb-4" />
+                        <p className="text-muted-foreground">Laden...</p>
+                    </CardContent>
+                </Card>
+            </FullScreenLayout>
         );
     }
 
     // Error state
     if (type === 'error' || error || loadError) {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-background p-4 md:p-8 relative overflow-hidden font-sans">
-                <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_50%,black_40%,transparent_100%)]" />
-                <motion.div
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.5 }}
-                    className="relative z-10 w-full max-w-md"
-                >
-                    <Card className="border-border bg-card/80 backdrop-blur-xl shadow-2xl rounded-[2.5rem] overflow-hidden">
-                        <CardHeader className="text-center pt-8">
-                            <div className="mx-auto w-20 h-20 bg-destructive/10 rounded-3xl flex items-center justify-center mb-6 border border-destructive/20 p-4">
-                                <AlertTriangle className="w-10 h-10 text-destructive" />
-                            </div>
-                            <CardTitle className="text-2xl md:text-3xl font-bold text-foreground tracking-tight">
-                                Autorisierung fehlgeschlagen
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent className="px-8 pb-8">
-                            <Alert variant="destructive" className="rounded-xl">
-                                <AlertDescription>{error || loadError}</AlertDescription>
-                            </Alert>
-                            <p className="text-sm text-muted-foreground mt-4 text-center">
-                                Bitte schließen Sie dieses Fenster und versuchen Sie es erneut.
-                            </p>
-                        </CardContent>
-                    </Card>
-                </motion.div>
-            </div>
+            <FullScreenLayout>
+                <Card className="border-border bg-card/80 backdrop-blur-xl shadow-2xl rounded-[2.5rem] overflow-hidden">
+                    <CardHeader className="text-center pt-8">
+                        <div className="mx-auto w-20 h-20 bg-destructive/10 rounded-3xl flex items-center justify-center mb-6 border border-destructive/20 p-4">
+                            <AlertTriangle className="w-10 h-10 text-destructive" />
+                        </div>
+                        <CardTitle className="text-2xl md:text-3xl font-bold text-foreground tracking-tight">
+                            Autorisierung fehlgeschlagen
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="px-8 pb-8">
+                        <Alert variant="destructive" className="rounded-xl">
+                            <AlertDescription>{error || loadError}</AlertDescription>
+                        </Alert>
+                        <p className="text-sm text-muted-foreground mt-4 text-center">
+                            Bitte schließen Sie dieses Fenster und versuchen Sie es erneut.
+                        </p>
+                    </CardContent>
+                </Card>
+            </FullScreenLayout>
         );
     }
 
     // Success state — authorization already processed
     if (type === 'success') {
         return (
-            <div className="min-h-screen flex items-center justify-center bg-background p-4 md:p-8 relative overflow-hidden font-sans">
-                <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_50%,black_40%,transparent_100%)]" />
-                <motion.div
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ duration: 0.5 }}
-                    className="relative z-10 w-full max-w-md"
-                >
-                    <Card className="border-border bg-card/80 backdrop-blur-xl shadow-2xl rounded-[2.5rem] overflow-hidden">
-                        <CardHeader className="text-center pt-8">
-                            <div className="mx-auto w-20 h-20 bg-green-500/10 rounded-3xl flex items-center justify-center mb-6 border border-green-500/20 p-4">
-                                <Check className="w-10 h-10 text-green-500" />
-                            </div>
-                            <CardTitle className="text-2xl md:text-3xl font-bold text-foreground tracking-tight">
-                                Verbindung hergestellt
-                            </CardTitle>
-                        </CardHeader>
-                        <CardContent className="px-8 pb-8">
-                            <p className="text-muted-foreground text-center">
-                                Diese Autorisierung wurde bereits erfolgreich verarbeitet.
-                                Sie können dieses Fenster schließen.
-                            </p>
-                        </CardContent>
-                    </Card>
-                </motion.div>
-            </div>
+            <FullScreenLayout>
+                <Card className="border-border bg-card/80 backdrop-blur-xl shadow-2xl rounded-[2.5rem] overflow-hidden">
+                    <CardHeader className="text-center pt-8">
+                        <div className="mx-auto w-20 h-20 bg-green-500/10 rounded-3xl flex items-center justify-center mb-6 border border-green-500/20 p-4">
+                            <Check className="w-10 h-10 text-green-500" />
+                        </div>
+                        <CardTitle className="text-2xl md:text-3xl font-bold text-foreground tracking-tight">
+                            Verbindung hergestellt
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="px-8 pb-8">
+                        <p className="text-muted-foreground text-center">
+                            Diese Autorisierung wurde bereits erfolgreich verarbeitet.
+                            Sie können dieses Fenster schließen.
+                        </p>
+                    </CardContent>
+                </Card>
+            </FullScreenLayout>
         );
     }
 
     // Consent form
     return (
-        <div className="min-h-screen flex items-center justify-center bg-background p-4 md:p-8 relative overflow-hidden font-sans">
-            <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_50%,black_40%,transparent_100%)]" />
-
-            {/* Ambient background glow (softer in light mode) */}
-            <motion.div
-                initial={{ opacity: 0, scale: 0.8 }}
-                animate={{ opacity: 1, scale: 1 }}
-                transition={{ duration: 1.5, ease: "easeOut" }}
-                className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-primary/10 dark:bg-primary/20 blur-[100px] dark:blur-[120px] rounded-full pointer-events-none"
-            />
-
-            <motion.div
-                initial={{ opacity: 0, y: 30, scale: 0.95 }}
-                animate={{ opacity: 1, y: 0, scale: 1 }}
-                transition={{ duration: 0.6, type: "spring", bounce: 0.4 }}
-                className="relative z-10 w-full max-w-md group"
-            >
+        <FullScreenLayout showGlow>
+            <div className="relative group">
                 {/* Gradient glowing border effect (adapted for light/dark) */}
                 <div className="absolute -inset-0.5 bg-gradient-to-br from-primary/30 to-primary/0 dark:from-primary/40 dark:to-primary/5 rounded-[2.5rem] blur-md opacity-30 dark:opacity-50 group-hover:opacity-60 dark:group-hover:opacity-80 transition duration-1000 group-hover:duration-300" />
 
@@ -576,7 +588,7 @@ export default function ConsentUI({
                         </Button>
                     </CardFooter>
                 </Card>
-            </motion.div>
-        </div>
+            </div>
+        </FullScreenLayout>
     );
 }

--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -48,7 +48,7 @@ const getScopeDetails = (scope: string) => {
 };
 
 interface ConsentUIProps {
-    type: 'consent' | 'error' | 'loading';
+    type: 'consent' | 'error' | 'loading' | 'success';
     error?: string;
     authorizationId?: string;
     clientName?: string;
@@ -333,6 +333,38 @@ export default function ConsentUI({
                             </Alert>
                             <p className="text-sm text-muted-foreground mt-4 text-center">
                                 Bitte schließen Sie dieses Fenster und versuchen Sie es erneut.
+                            </p>
+                        </CardContent>
+                    </Card>
+                </motion.div>
+            </div>
+        );
+    }
+
+    // Success state — authorization already processed
+    if (type === 'success') {
+        return (
+            <div className="min-h-screen flex items-center justify-center bg-background p-4 md:p-8 relative overflow-hidden font-sans">
+                <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_50%,black_40%,transparent_100%)]" />
+                <motion.div
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.5 }}
+                    className="relative z-10 w-full max-w-md"
+                >
+                    <Card className="border-border bg-card/80 backdrop-blur-xl shadow-2xl rounded-[2.5rem] overflow-hidden">
+                        <CardHeader className="text-center pt-8">
+                            <div className="mx-auto w-20 h-20 bg-green-500/10 rounded-3xl flex items-center justify-center mb-6 border border-green-500/20 p-4">
+                                <Check className="w-10 h-10 text-green-500" />
+                            </div>
+                            <CardTitle className="text-2xl md:text-3xl font-bold text-foreground tracking-tight">
+                                Verbindung hergestellt
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="px-8 pb-8">
+                            <p className="text-muted-foreground text-center">
+                                Diese Autorisierung wurde bereits erfolgreich verarbeitet.
+                                Sie können dieses Fenster schließen.
                             </p>
                         </CardContent>
                     </Card>

--- a/app/oauth/consent/actions.ts
+++ b/app/oauth/consent/actions.ts
@@ -1,7 +1,6 @@
 'use server';
 
 import { createClient } from '@/utils/supabase/server';
-import { ERR_AUTH_ALREADY_PROCESSED } from './constants';
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
@@ -109,6 +108,8 @@ export interface AuthorizationDetailsResult {
     success: boolean;
     data: AuthorizationDetails | null;
     error: string | null;
+    /** True if the authorization was already consumed/processed previously */
+    alreadyProcessed?: boolean;
 }
 
 /**
@@ -133,8 +134,8 @@ export async function getAuthorizationDetailsAction(authorizationId: string): Pr
                 // 400 "authorization request cannot be processed" means the authorization
                 // was already consumed — the auto_approved redirect already completed.
                 // This is a success condition, not an error.
-                if (responseText.toLowerCase().includes('cannot be processed') || responseText.toLowerCase().includes('already_consumed')) {
-                    return { success: false, error: ERR_AUTH_ALREADY_PROCESSED, data: null };
+                if (responseText.toLowerCase().includes('cannot be processed')) {
+                    return { success: true, alreadyProcessed: true, error: null, data: null };
                 }
                 // If it's another 400 error, fall through to generic error handling
                 const msg = parseSupabaseAuthError(responseText, `Failed to fetch details: ${response.status}`);

--- a/app/oauth/consent/actions.ts
+++ b/app/oauth/consent/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { createClient } from '@/utils/supabase/server';
+import { ERR_AUTH_ALREADY_PROCESSED } from './constants';
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
@@ -126,6 +127,12 @@ export async function getAuthorizationDetailsAction(authorizationId: string): Pr
         if (!response.ok) {
             if (response.status === 404) {
                 return { success: false, error: ERR_AUTH_EXPIRED, data: null };
+            }
+            if (response.status === 400) {
+                // 400 "authorization request cannot be processed" means the authorization
+                // was already consumed — the auto_approved redirect already completed.
+                // This is a success condition, not an error.
+                return { success: false, error: ERR_AUTH_ALREADY_PROCESSED, data: null };
             }
             if (response.status === 401 || response.status === 403) {
                 return { success: false, error: ERR_AUTH_UNAUTHORIZED, data: null };

--- a/app/oauth/consent/actions.ts
+++ b/app/oauth/consent/actions.ts
@@ -129,10 +129,16 @@ export async function getAuthorizationDetailsAction(authorizationId: string): Pr
                 return { success: false, error: ERR_AUTH_EXPIRED, data: null };
             }
             if (response.status === 400) {
+                const responseText = await response.text();
                 // 400 "authorization request cannot be processed" means the authorization
                 // was already consumed — the auto_approved redirect already completed.
                 // This is a success condition, not an error.
-                return { success: false, error: ERR_AUTH_ALREADY_PROCESSED, data: null };
+                if (responseText.toLowerCase().includes('cannot be processed') || responseText.toLowerCase().includes('already_consumed')) {
+                    return { success: false, error: ERR_AUTH_ALREADY_PROCESSED, data: null };
+                }
+                // If it's another 400 error, fall through to generic error handling
+                const msg = parseSupabaseAuthError(responseText, `Failed to fetch details: ${response.status}`);
+                return { success: false, error: msg, data: null };
             }
             if (response.status === 401 || response.status === 403) {
                 return { success: false, error: ERR_AUTH_UNAUTHORIZED, data: null };

--- a/app/oauth/consent/constants.ts
+++ b/app/oauth/consent/constants.ts
@@ -1,0 +1,4 @@
+/** Returned when Supabase returns 400 "authorization request cannot be processed" —
+ *  the authorization was already consumed (e.g. auto_approved redirect already worked). */
+export const ERR_AUTH_ALREADY_PROCESSED =
+    'Diese Autorisierung wurde bereits verarbeitet. Die Verbindung wurde erfolgreich hergestellt.';

--- a/app/oauth/consent/constants.ts
+++ b/app/oauth/consent/constants.ts
@@ -1,4 +1,3 @@
-/** Returned when Supabase returns 400 "authorization request cannot be processed" —
+/** Stable identifier returned when Supabase returns 400 "authorization request cannot be processed" —
  *  the authorization was already consumed (e.g. auto_approved redirect already worked). */
-export const ERR_AUTH_ALREADY_PROCESSED =
-    'Diese Autorisierung wurde bereits verarbeitet. Die Verbindung wurde erfolgreich hergestellt.';
+export const ERR_AUTH_ALREADY_PROCESSED = 'ERR_AUTH_ALREADY_PROCESSED';

--- a/app/oauth/consent/constants.ts
+++ b/app/oauth/consent/constants.ts
@@ -1,3 +1,0 @@
-/** Stable identifier returned when Supabase returns 400 "authorization request cannot be processed" —
- *  the authorization was already consumed (e.g. auto_approved redirect already worked). */
-export const ERR_AUTH_ALREADY_PROCESSED = 'ERR_AUTH_ALREADY_PROCESSED';

--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import ConsentUI from './ConsentUI';
 import { getAuthorizationDetailsAction } from './actions';
+import { ERR_AUTH_ALREADY_PROCESSED } from './constants';
 import { safeServerRedirect } from '@/lib/oauth-utils';
 
 export const runtime = 'edge';
@@ -83,6 +84,13 @@ export default async function ConsentPage({ searchParams }: PageProps) {
         // auto_approved but no redirect_to — redirect to a user-friendly error page
         // instead of silently rendering the consent UI which would cause a 405 on approve.
         redirect(`/oauth/consent?error=true&message=${encodeURIComponent('Automatische Autorisierung fehlgeschlagen: Kein Weiterleitungs-Link gefunden.')}`);
+    }
+
+    // When the authorization was already consumed (400 from Supabase), it means
+    // the auto_approved redirect already completed the OAuth flow successfully.
+    // Show a success screen instead of an error.
+    if (!success && fetchError === ERR_AUTH_ALREADY_PROCESSED) {
+        return <ConsentUI type="success" />;
     }
 
     return (

--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -3,7 +3,6 @@ import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import ConsentUI from './ConsentUI';
 import { getAuthorizationDetailsAction } from './actions';
-import { ERR_AUTH_ALREADY_PROCESSED } from './constants';
 import { safeServerRedirect } from '@/lib/oauth-utils';
 
 export const runtime = 'edge';
@@ -67,7 +66,14 @@ export default async function ConsentPage({ searchParams }: PageProps) {
     // When Supabase has already auto-approved the app, it returns auto_approved: true
     // along with a redirect_to URL. We must NOT POST a decision in this case —
     // Supabase returns 405 Method Not Allowed. Instead, redirect directly.
-    const { success, data, error: fetchError } = await getAuthorizationDetailsAction(authorizationId);
+    const { success, data, error: fetchError, alreadyProcessed } = await getAuthorizationDetailsAction(authorizationId);
+
+    // When the authorization was already consumed (400 from Supabase), it means
+    // the auto_approved redirect already completed the OAuth flow successfully.
+    // Show a success screen instead of an error.
+    if (alreadyProcessed) {
+        return <ConsentUI type="success" />;
+    }
 
     if (success && data?.auto_approved) {
         const autoRedirectUrl = data.redirect_to || data.redirect_url;
@@ -84,13 +90,6 @@ export default async function ConsentPage({ searchParams }: PageProps) {
         // auto_approved but no redirect_to — redirect to a user-friendly error page
         // instead of silently rendering the consent UI which would cause a 405 on approve.
         redirect(`/oauth/consent?error=true&message=${encodeURIComponent('Automatische Autorisierung fehlgeschlagen: Kein Weiterleitungs-Link gefunden.')}`);
-    }
-
-    // When the authorization was already consumed (400 from Supabase), it means
-    // the auto_approved redirect already completed the OAuth flow successfully.
-    // Show a success screen instead of an error.
-    if (!success && fetchError === ERR_AUTH_ALREADY_PROCESSED) {
-        return <ConsentUI type="success" />;
     }
 
     return (


### PR DESCRIPTION
## Description

Shows a success screen when an OAuth authorization was already processed (400) instead of the misleading ERR_AUTH_EXPIRED error.

Supabase returns 400 'authorization request cannot be processed' when an auto_approved authorization has already been consumed by the SSR redirect. This is NOT an error — it means the OAuth flow completed successfully. Previously this showed ERR_AUTH_EXPIRED which confused users.

## Summary of Changes

- actions.ts returns ERR_AUTH_ALREADY_PROCESSED (exported) for 400s
- page.tsx detects this and renders ConsentUI type='success'
- ConsentUI shows a green checkmark 'Verbindung hergestellt' screen
- Client-side safeRedirect also accepts Supabase-internal URLs