### PR TITLE
fix(oauth): broaden 400 response detection for already-processed auth…

### DIFF
--- a/app/oauth/consent/actions.ts
+++ b/app/oauth/consent/actions.ts
@@ -131,13 +131,19 @@ export async function getAuthorizationDetailsAction(authorizationId: string): Pr
             }
             if (response.status === 400) {
                 const responseText = await response.text();
-                // 400 "authorization request cannot be processed" means the authorization
-                // was already consumed — the auto_approved redirect already completed.
-                // This is a success condition, not an error.
-                if (responseText.toLowerCase().includes('cannot be processed')) {
+                const lowerText = responseText.toLowerCase();
+                console.warn('[OAuth] GET authorization returned 400, body:', responseText);
+                // Supabase returns 400 with error_code "validation_failed" when the
+                // authorization was already consumed (auto_approved redirect completed).
+                // The response body format varies — check for known indicators.
+                if (
+                    lowerText.includes('validation_failed') ||
+                    lowerText.includes('cannot be processed') ||
+                    lowerText.includes('already')
+                ) {
                     return { success: true, alreadyProcessed: true, error: null, data: null };
                 }
-                // If it's another 400 error, fall through to generic error handling
+                // If it's a truly unexpected 400, fall through to generic error handling
                 const msg = parseSupabaseAuthError(responseText, `Failed to fetch details: ${response.status}`);
                 return { success: false, error: msg, data: null };
             }

--- a/components/finance/operating-costs-overview-modal.tsx
+++ b/components/finance/operating-costs-overview-modal.tsx
@@ -58,7 +58,6 @@ export function OperatingCostsOverviewModal({
     }
   }, [isOpen, nebenkosten?.id])
 
-  if (!nebenkosten) return null
 
   // Helper function to format currency
   const formatCurrency = (value: number | null | undefined) => {
@@ -175,6 +174,9 @@ export function OperatingCostsOverviewModal({
       mode
     );
   }, [abrechnungData, nebenkosten]);
+
+  // Early return must come AFTER all hooks to satisfy Rules of Hooks
+  if (!nebenkosten) return null;
 
   const totalBalance = totalCosts - (summaryTotals?.totalVorauszahlungen || 0);
   const isNachzahlung = totalBalance >= 0;


### PR DESCRIPTION
## Description

Broadens the 400-response detection for already-processed OAuth authorizations to cover all possible Supabase response formats.

The 'cannot be processed' string match was too fragile — it only appears in the Supabase internal server log, not necessarily in the HTTP response body. The actual response uses error_code 'validation_failed'. Now checks for 'validation_failed', 'cannot be processed', or 'already', and adds console.warn to log the actual 400 body for debugging.

Also fixes a pre-existing Rules of Hooks violation in operating-costs-overview-modal.tsx (useMemo called after early return) that was blocking production builds.