### PR TITLE
fix(oauth): use data.redirect_url instead of data.redirect_to

### DIFF
--- a/app/oauth/consent/actions.ts
+++ b/app/oauth/consent/actions.ts
@@ -180,14 +180,14 @@ export async function submitDecisionAction(authorizationId: string, decision: 'a
                 console.error('[OAuth] approveAuthorization failed:', error.message);
                 return { success: false, redirect_to: null, error: error.message };
             }
-            return { success: true, redirect_to: data?.redirect_to || null, error: null };
+            return { success: true, redirect_to: data?.redirect_url || data?.redirect_to || null, error: null };
         } else {
             const { data, error } = await (supabase.auth as any).oauth.denyAuthorization(authorizationId);
             if (error) {
                 console.error('[OAuth] denyAuthorization failed:', error.message);
                 return { success: false, redirect_to: null, error: error.message };
             }
-            return { success: true, redirect_to: data?.redirect_to || null, error: null };
+            return { success: true, redirect_to: data?.redirect_url || data?.redirect_to || null, error: null };
         }
     } catch (err: any) {
         console.error('Server Action: submitDecision failed:', err.message);


### PR DESCRIPTION
The Supabase GoTrue docs say that approveAuthorization and denyAuthorization return data.redirect_to, but the `@supabase/gotrue-js` source code actually returns `data.redirect_url`. This mismatch caused the 'No redirect URL returned' error in the Consent UI.