### PR TITLE
fix(oauth): correctly detect auto_approved payload from GoTrue

### DIFF
--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -81,8 +81,8 @@ function safeRedirect(url: string | undefined | null): void {
  * Reusable layout wrapper for all full-screen states (loading, error, success, consent).
  * Handles the ambient background effects and centered container.
  */
-function FullScreenLayout({ 
-    children, 
+function FullScreenLayout({
+    children,
     className = "",
     showGlow = false,
     motionProps = {
@@ -90,8 +90,8 @@ function FullScreenLayout({
         animate: { opacity: 1, y: 0 },
         transition: { duration: 0.5 }
     }
-}: { 
-    children: React.ReactNode; 
+}: {
+    children: React.ReactNode;
     className?: string;
     showGlow?: boolean;
     motionProps?: HTMLMotionProps<"div">;
@@ -99,7 +99,7 @@ function FullScreenLayout({
     return (
         <div className={cn("min-h-screen flex items-center justify-center bg-background p-4 md:p-8 relative overflow-hidden font-sans", className)}>
             <div className="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--muted-foreground)/0.15)_1px,transparent_1px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_80%_50%_at_50%_50%,black_40%,transparent_100%)]" />
-            
+
             {showGlow && (
                 <motion.div
                     initial={{ opacity: 0, scale: 0.8 }}
@@ -299,8 +299,11 @@ export default function ConsentUI({
         try {
             // For auto-approved authorizations, Supabase has already granted access.
             // POSTing a decision to the endpoint returns 405 Method Not Allowed.
-            // Instead, use the redirect_to from the initial GET details response directly.
-            if (authDetails?.auto_approved) {
+            // Instead, use the redirect_url from the initial GET details response directly.
+            const autoRedirectUrl = (authDetails as any)?.redirect_url || (authDetails as any)?.redirect_to;
+            const isAutoApproved = autoRedirectUrl && !authDetails?.client;
+
+            if (isAutoApproved) {
                 if (decision === 'deny') {
                     // For auto-approved, the access is already granted. Denying now would face the same
                     // 405 constraint, so we gracefully abort and inform the user.
@@ -309,8 +312,6 @@ export default function ConsentUI({
                     return;
                 }
 
-                // redirect_to is set by Supabase on auto-approved flows; redirect_url is the registered fallback
-                const autoRedirectUrl = authDetails.redirect_to || authDetails.redirect_url;
                 if (!autoRedirectUrl) {
                     setProcessError('Automatically approved authorization has no redirect URL. Please try again.');
                     setIsProcessing(false);
@@ -420,8 +421,8 @@ export default function ConsentUI({
 
     // Consent form
     return (
-        <FullScreenLayout 
-            showGlow 
+        <FullScreenLayout
+            showGlow
             motionProps={{
                 initial: { opacity: 0, y: 30, scale: 0.95 },
                 animate: { opacity: 1, y: 0, scale: 1 },

--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -62,33 +62,38 @@ export default async function ConsentPage({ searchParams }: PageProps) {
         redirect(`/login?redirect=/oauth/consent?authorization_id=${authorizationId}`);
     }
 
-    // Fetch authorization details server-side to handle auto_approved flows.
-    // When Supabase has already auto-approved the app, it returns auto_approved: true
-    // along with a redirect_to URL. We must NOT POST a decision in this case —
-    // Supabase returns 405 Method Not Allowed. Instead, redirect directly.
+    // When Supabase has already auto-approved the app, it responds with a ConsentResponse
+    // (which includes redirect_url) instead of an AuthorizationDetailsResponse.
+    // It does NOT include an `auto_approved` property in the JSON, nor does it include `client`.
+    // We must NOT POST a decision in this case — Supabase returns 405 Method Not Allowed
+    // or 400 Validation Failed. Instead, redirect directly.
     const { success, data, error: fetchError, alreadyProcessed } = await getAuthorizationDetailsAction(authorizationId);
 
-    // When the authorization was already consumed (400 from Supabase), it means
+    // When the authorization was already consumed (400 from Supabase or already processed), it means
     // the auto_approved redirect already completed the OAuth flow successfully.
     // Show a success screen instead of an error.
     if (alreadyProcessed) {
         return <ConsentUI type="success" />;
     }
 
-    if (success && data?.auto_approved) {
-        const autoRedirectUrl = data.redirect_to || data.redirect_url;
+    // Detect auto-approval: The response has a redirect URL but no client details
+    const autoRedirectUrl = data?.redirect_url || data?.redirect_to;
+    const isAutoApproved = success && autoRedirectUrl && !data?.client;
+
+    if (isAutoApproved) {
         console.info('[OAuth SSR] auto_approved detected', {
             authorizationId,
-            redirect_to: data.redirect_to,
-            redirect_url: data.redirect_url,
+            redirect_to: data?.redirect_to,
+            redirect_url: data?.redirect_url,
             resolved: autoRedirectUrl,
         });
+
         if (autoRedirectUrl) {
-            safeServerRedirect(autoRedirectUrl);
+            safeServerRedirect(autoRedirectUrl as string);
         }
 
-        // auto_approved but no redirect_to — redirect to a user-friendly error page
-        // instead of silently rendering the consent UI which would cause a 405 on approve.
+        // auto_approved but no redirect url — redirect to a user-friendly error page
+        // instead of silently rendering the consent UI which would cause a 400 on approve.
         redirect(`/oauth/consent?error=true&message=${encodeURIComponent('Automatische Autorisierung fehlgeschlagen: Kein Weiterleitungs-Link gefunden.')}`);
     }
 


### PR DESCRIPTION
ROOT CAUSE:
When an authorization is automatically approved, Supabase GoTrue does NOT return an `auto_approved: true` flag in the GET response JSON. Instead, it internally changes the authorization status to `approved` and returns a minimal response: `{ redirect_url: "..." }`.

Because our code checked for the non-existent `auto_approved` property, it failed to auto-redirect. Instead, it rendered the ConsentUI. If the user clicked 'Approve', it sent a POST to approve an authorization that was NO LONGER PENDING, which caused GoTrue to throw: `400 authorization request cannot be processed`.

Fix:
Detect auto-approved requests by checking for the presence of `redirect_url` and the absence of a `client` payload. Then redirect immediately instead of rendering the Consent UI.