### PR TITLE
Feat/oauth settings dashboard

### DIFF
--- a/supabase/migrations/20260308220748_add_oauth_integrations_management.sql
+++ b/supabase/migrations/20260308220748_add_oauth_integrations_management.sql
@@ -38,11 +38,15 @@ BEGIN
   WHERE id = auth_id AND user_id = auth.uid();
 
   IF v_client_id IS NOT NULL THEN
-    -- 2. Delete the consent record so they have to re-authorize again next time
+    -- 2. Terminate all active sessions connected to this OAuth client
+    DELETE FROM auth.sessions
+    WHERE oauth_client_id = v_client_id AND user_id = auth.uid();
+
+    -- 3. Delete the consent record so they have to re-authorize again next time
     DELETE FROM auth.oauth_consents
     WHERE id = auth_id AND user_id = auth.uid();
       
-    -- 3. Delete authorization records
+    -- 4. Delete lingering authorization records
     DELETE FROM auth.oauth_authorizations
     WHERE client_id = v_client_id AND user_id = auth.uid();
   END IF;

--- a/supabase/migrations/20260308220748_add_oauth_integrations_management.sql
+++ b/supabase/migrations/20260308220748_add_oauth_integrations_management.sql
@@ -12,14 +12,14 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
   SELECT 
-    a.id as authorization_id,
-    c.client_name,
-    c.logo_uri as client_logo,
-    a.scope as scopes,
-    a.created_at
-  FROM auth.oauth_authorizations a
-  JOIN auth.oauth_clients c ON a.client_id = c.id
-  WHERE a.user_id = auth.uid();
+    c.id as authorization_id,
+    app.client_name,
+    app.logo_uri as client_logo,
+    c.scopes,
+    c.granted_at as created_at
+  FROM auth.oauth_consents c
+  JOIN auth.oauth_clients app ON c.client_id = app.id
+  WHERE c.user_id = auth.uid();
 $$;
 
 -- Allow users to revoke an integration by auth_id
@@ -32,20 +32,19 @@ AS $$
 DECLARE
   v_client_id UUID;
 BEGIN
-  -- 1. Find the client_id for this authorization
+  -- 1. Find the client_id for this authorization consent
   SELECT client_id INTO v_client_id
-  FROM auth.oauth_authorizations
+  FROM auth.oauth_consents
   WHERE id = auth_id AND user_id = auth.uid();
 
   IF v_client_id IS NOT NULL THEN
     -- 2. Delete the consent record so they have to re-authorize again next time
     DELETE FROM auth.oauth_consents
-    WHERE user_id = auth.uid() 
-      AND client_id = v_client_id;
+    WHERE id = auth_id AND user_id = auth.uid();
       
     -- 3. Delete authorization records
     DELETE FROM auth.oauth_authorizations
-    WHERE id = auth_id AND user_id = auth.uid();
+    WHERE client_id = v_client_id AND user_id = auth.uid();
   END IF;
 END;
 $$;

--- a/supabase/migrations/20260308220748_add_oauth_integrations_management.sql
+++ b/supabase/migrations/20260308220748_add_oauth_integrations_management.sql
@@ -1,0 +1,51 @@
+-- Return the authorized apps. Uses the authorization_id.
+CREATE OR REPLACE FUNCTION public.get_authorized_apps()
+RETURNS TABLE (
+  authorization_id UUID,
+  client_name TEXT,
+  client_logo TEXT,
+  scopes TEXT,
+  created_at TIMESTAMPTZ
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT 
+    a.id as authorization_id,
+    c.client_name,
+    c.logo_uri as client_logo,
+    a.scopes,
+    a.created_at
+  FROM auth.oauth_authorizations a
+  JOIN auth.oauth_clients c ON a.client_id = c.id
+  WHERE a.user_id = auth.uid();
+$$;
+
+-- Allow users to revoke an integration by auth_id
+CREATE OR REPLACE FUNCTION public.revoke_app_access(auth_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_client_id UUID;
+BEGIN
+  -- 1. Find the client_id for this authorization
+  SELECT client_id INTO v_client_id
+  FROM auth.oauth_authorizations
+  WHERE id = auth_id AND user_id = auth.uid();
+
+  IF v_client_id IS NOT NULL THEN
+    -- 2. Delete the consent record so they have to re-authorize again next time
+    DELETE FROM auth.oauth_consents
+    WHERE user_id = auth.uid() 
+      AND client_id = v_client_id;
+      
+    -- 3. Delete authorization records
+    DELETE FROM auth.oauth_authorizations
+    WHERE id = auth_id AND user_id = auth.uid();
+  END IF;
+END;
+$$;

--- a/supabase/migrations/20260308220748_add_oauth_integrations_management.sql
+++ b/supabase/migrations/20260308220748_add_oauth_integrations_management.sql
@@ -15,7 +15,7 @@ AS $$
     c.id as authorization_id,
     app.client_name,
     app.logo_uri as client_logo,
-    c.scopes,
+    c.scopes::TEXT,
     c.granted_at as created_at
   FROM auth.oauth_consents c
   JOIN auth.oauth_clients app ON c.client_id = app.id
@@ -24,7 +24,7 @@ $$;
 
 -- Allow users to revoke an integration by auth_id
 CREATE OR REPLACE FUNCTION public.revoke_app_access(auth_id UUID)
-RETURNS void
+RETURNS BOOLEAN
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = ''
@@ -37,18 +37,26 @@ BEGIN
   FROM auth.oauth_consents
   WHERE id = auth_id AND user_id = auth.uid();
 
-  IF v_client_id IS NOT NULL THEN
-    -- 2. Terminate all active sessions connected to this OAuth client
-    DELETE FROM auth.sessions
-    WHERE oauth_client_id = v_client_id AND user_id = auth.uid();
-
-    -- 3. Delete the consent record so they have to re-authorize again next time
-    DELETE FROM auth.oauth_consents
-    WHERE id = auth_id AND user_id = auth.uid();
-      
-    -- 4. Delete lingering authorization records
-    DELETE FROM auth.oauth_authorizations
-    WHERE client_id = v_client_id AND user_id = auth.uid();
+  IF v_client_id IS NULL THEN
+    RETURN FALSE; -- Consent not found or access denied
   END IF;
+
+  -- 2. Terminate all active sessions connected to this OAuth client
+  DELETE FROM auth.sessions
+  WHERE oauth_client_id = v_client_id AND user_id = auth.uid();
+
+  -- 3. Delete the consent record so they have to re-authorize again next time
+  DELETE FROM auth.oauth_consents
+  WHERE id = auth_id AND user_id = auth.uid();
+    
+  -- 4. Delete lingering authorization records
+  DELETE FROM auth.oauth_authorizations
+  WHERE client_id = v_client_id AND user_id = auth.uid();
+
+  RETURN TRUE;
 END;
 $$;
+
+-- Grant execute permissions to authenticated users
+GRANT EXECUTE ON FUNCTION public.get_authorized_apps() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.revoke_app_access(UUID) TO authenticated;

--- a/supabase/migrations/20260308220748_add_oauth_integrations_management.sql
+++ b/supabase/migrations/20260308220748_add_oauth_integrations_management.sql
@@ -23,6 +23,7 @@ AS $$
 $$;
 
 -- Allow users to revoke an integration by auth_id
+DROP FUNCTION IF EXISTS public.revoke_app_access(UUID);
 CREATE OR REPLACE FUNCTION public.revoke_app_access(auth_id UUID)
 RETURNS BOOLEAN
 LANGUAGE plpgsql

--- a/supabase/migrations/20260308220748_add_oauth_integrations_management.sql
+++ b/supabase/migrations/20260308220748_add_oauth_integrations_management.sql
@@ -15,7 +15,7 @@ AS $$
     a.id as authorization_id,
     c.client_name,
     c.logo_uri as client_logo,
-    a.scopes,
+    a.scope as scopes,
     a.created_at
   FROM auth.oauth_authorizations a
   JOIN auth.oauth_clients c ON a.client_id = c.id


### PR DESCRIPTION
## Description

Adds the database foundation for the OAuth settings dashboard: list and revoke authorized apps.

## Summary of Changes

- New migration `add_oauth_integrations_management.sql`
- `get_authorized_apps()`: returns the current user's OAuth consents joined with client name/logo/scopes/grant date, scoped to `auth.uid()`
- `revoke_app_access(auth_id)`: ownership-checked revocation — terminates all sessions of the OAuth client, deletes the consent record and lingering authorizations
- Execute granted to `authenticated`