### PR TITLE
Move meter import parsing to worker

### DIFF
--- a/app/api/meter-import/execute/route.ts
+++ b/app/api/meter-import/execute/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/utils/supabase/server';
+
+export const runtime = 'edge';
+
+const WORKER_URL = (process.env.MIETEVO_BACKEND_URL || process.env.WORKER_URL || 'https://backend.mietevo.de').trim();
+const WORKER_AUTH_KEY = process.env.WORKER_AUTH_KEY;
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Nicht authentifiziert' }, { status: 401 });
+  }
+
+  if (!WORKER_AUTH_KEY) {
+    return NextResponse.json({ error: 'Worker authentication key not configured' }, { status: 500 });
+  }
+
+  const body = await request.json();
+
+  const response = await fetch(`${WORKER_URL}/meter-import/execute`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-worker-auth': WORKER_AUTH_KEY,
+    },
+    body: JSON.stringify({
+      ...body,
+      userId: user.id,
+    }),
+  });
+
+  const responseBody = await response.text();
+  return new NextResponse(responseBody, {
+    status: response.status,
+    headers: { 'Content-Type': response.headers.get('Content-Type') || 'application/json' },
+  });
+}

--- a/app/api/meter-import/preview/route.ts
+++ b/app/api/meter-import/preview/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/utils/supabase/server';
+
+export const runtime = 'edge';
+
+const WORKER_URL = (process.env.MIETEVO_BACKEND_URL || process.env.WORKER_URL || 'https://backend.mietevo.de').trim();
+const WORKER_AUTH_KEY = process.env.WORKER_AUTH_KEY;
+
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Nicht authentifiziert' }, { status: 401 });
+  }
+
+  if (!WORKER_AUTH_KEY) {
+    return NextResponse.json({ error: 'Worker authentication key not configured' }, { status: 500 });
+  }
+
+  const contentType = request.headers.get('content-type') || '';
+
+  if (contentType.includes('multipart/form-data')) {
+    const formData = await request.formData();
+    const file = formData.get('file');
+
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: 'Keine gültige Datei hochgeladen' }, { status: 400 });
+    }
+
+    const forwardForm = new FormData();
+    forwardForm.append('file', file);
+    forwardForm.append('user_id', user.id);
+
+    const response = await fetch(`${WORKER_URL}/meter-import/preview`, {
+      method: 'POST',
+      headers: {
+        'x-worker-auth': WORKER_AUTH_KEY,
+      },
+      body: forwardForm,
+    });
+
+    const responseBody = await response.text();
+    return new NextResponse(responseBody, {
+      status: response.status,
+      headers: { 'Content-Type': response.headers.get('Content-Type') || 'application/json' },
+    });
+  }
+
+  const body = await request.json();
+  const response = await fetch(`${WORKER_URL}/meter-import/preview`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-worker-auth': WORKER_AUTH_KEY,
+    },
+    body: JSON.stringify({
+      ...body,
+      userId: user.id,
+    }),
+  });
+
+  const responseBody = await response.text();
+  return new NextResponse(responseBody, {
+    status: response.status,
+    headers: { 'Content-Type': response.headers.get('Content-Type') || 'application/json' },
+  });
+}

--- a/components/water-meters/meter-import-modal.tsx
+++ b/components/water-meters/meter-import-modal.tsx
@@ -9,9 +9,8 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useToast } from "@/hooks/use-toast";
 import { Upload, Check, AlertTriangle, X, FileSpreadsheet, Loader2, Hash, Calendar, Gauge, Droplets } from "lucide-react";
 import type { Zaehler as SharedMeter, ZaehlerAblesung } from "@/lib/types";
-import { bulkCreateAblesungen } from "@/app/meter-actions";
 import { isoToGermanDate } from "@/utils/date-calculations";
-import { formatNumber, roundToDecimals } from "@/utils/format";
+import { formatNumber } from "@/utils/format";
 import { StatCard } from "@/components/common/stat-card";
 
 interface MeterImportModalProps {
@@ -23,10 +22,6 @@ interface MeterImportModalProps {
 }
 
 type ImportStep = "upload" | "mapping" | "preview";
-
-interface ParsedRow {
-  [key: string]: string | number | null;
-}
 
 interface ColumnMapping {
   custom_id: string;
@@ -41,9 +36,9 @@ interface ProcessedReading {
   ablese_datum: string;
   zaehlerstand: number;
   verbrauch: number;
-  original_row: ParsedRow;
   status: "valid" | "duplicate" | "missing_meter" | "invalid_date" | "invalid_value";
   message?: string;
+  rowIndex?: number;
 }
 
 export function MeterImportModal({
@@ -54,11 +49,17 @@ export function MeterImportModal({
   readings,
 }: MeterImportModalProps) {
   const [step, setStep] = useState<ImportStep>("upload");
-  const [file, setFile] = useState<File | null>(null);
-  const [parsedData, setParsedData] = useState<ParsedRow[]>([]);
+  const [jobId, setJobId] = useState<string | null>(null);
   const [columns, setColumns] = useState<string[]>([]);
   const [mapping, setMapping] = useState<ColumnMapping>({ custom_id: "", ablese_datum: "", zaehlerstand: "", verbrauch: "" });
   const [processedData, setProcessedData] = useState<ProcessedReading[]>([]);
+  const [totalRowCount, setTotalRowCount] = useState(0);
+  const [counts, setCounts] = useState({
+    validCount: 0,
+    duplicateCount: 0,
+    missingCount: 0,
+    invalidCount: 0,
+  });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { toast } = useToast();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -66,55 +67,38 @@ export function MeterImportModal({
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFile = e.target.files?.[0];
     if (!selectedFile) return;
-    setFile(selectedFile);
-    await parseFile(selectedFile);
-  };
+    setIsSubmitting(true);
+    setProcessedData([]);
+    setCounts({ validCount: 0, duplicateCount: 0, missingCount: 0, invalidCount: 0 });
 
-  const parseFile = async (file: File) => {
-    const fileExtension = file.name.split(".").pop()?.toLowerCase();
+    try {
+      const formData = new FormData();
+      formData.append("file", selectedFile);
 
-    if (fileExtension === "csv") {
-      const Papa = (await import("papaparse")).default;
-      Papa.parse(file, {
-        header: true,
-        skipEmptyLines: true,
-        complete: (results) => {
-          if (results.data && results.data.length > 0) {
-            setParsedData(results.data as ParsedRow[]);
-            setColumns(Object.keys(results.data[0] as object));
-            setStep("mapping");
-          } else {
-            toast({ title: "Fehler", description: "Die CSV-Datei ist leer oder ungültig.", variant: "destructive" });
-          }
-        },
-        error: (error: any) => {
-          toast({ title: "Fehler", description: `Fehler beim Parsen der CSV: ${error.message}`, variant: "destructive" });
-        },
+      const response = await fetch("/api/meter-import/preview", {
+        method: "POST",
+        body: formData,
       });
-    } else if (fileExtension === "xlsx" || fileExtension === "xls") {
-      const XLSX = await import("xlsx");
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        try {
-          const data = e.target?.result;
-          const workbook = XLSX.read(data, { type: "binary" });
-          const sheetName = workbook.SheetNames[0];
-          const sheet = workbook.Sheets[sheetName];
-          const jsonData = XLSX.utils.sheet_to_json(sheet);
-          if (jsonData && jsonData.length > 0) {
-            setParsedData(jsonData as ParsedRow[]);
-            setColumns(Object.keys(jsonData[0] as object));
-            setStep("mapping");
-          } else {
-            toast({ title: "Fehler", description: "Die Excel-Datei ist leer.", variant: "destructive" });
-          }
-        } catch (error) {
-          toast({ title: "Fehler", description: "Fehler beim Parsen der Excel-Datei.", variant: "destructive" });
-        }
-      };
-      reader.readAsBinaryString(file);
-    } else {
-      toast({ title: "Fehler", description: "Nicht unterstütztes Dateiformat.", variant: "destructive" });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data?.error || "Datei konnte nicht verarbeitet werden.");
+      }
+
+      setJobId(data.jobId);
+      setColumns(data.columns || []);
+      setTotalRowCount(data.totalRowCount || 0);
+      setMapping({ custom_id: "", ablese_datum: "", zaehlerstand: "", verbrauch: "" });
+      setStep("mapping");
+    } catch (error: unknown) {
+      toast({
+        title: "Fehler",
+        description: error instanceof Error ? error.message : "Datei konnte nicht verarbeitet werden.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -124,61 +108,14 @@ export function MeterImportModal({
 
   const columnOptions = columns.map(col => ({ value: col, label: col }));
 
-  const parseDateString = (value: string | number | Date): string | null => {
-    if (!value) return null;
-
-    // Handle Excel serial dates
-    if (typeof value === 'number') {
-      const date = new Date((value - 25569) * 86400 * 1000);
-      return date.toISOString().split('T')[0];
-    }
-
-    if (value instanceof Date) {
-      return value.toISOString().split('T')[0];
-    }
-
-    const strVal = String(value).trim();
-
-    // German format: DD.MM.YYYY
-    const germanMatch = strVal.match(/^(\d{1,2})\.(\d{1,2})\.(\d{4})/);
-    if (germanMatch) {
-      const day = germanMatch[1].padStart(2, '0');
-      const month = germanMatch[2].padStart(2, '0');
-      const year = germanMatch[3];
-      return `${year}-${month}-${day}`;
-    }
-
-    // Try standard parsing (handles ISO YYYY-MM-DD)
-    const date = new Date(strVal);
-    if (!isNaN(date.getTime())) {
-      return date.toISOString().split('T')[0];
-    }
-
-    return null;
-  };
-
-
-  const parseGermanNumber = (value: string | number): number => {
-    let parsed: number;
-
-    if (typeof value === 'number') {
-      parsed = value;
-    } else if (!value) {
-      parsed = 0;
-    } else {
-      let strVal = String(value).trim();
-
-      if (strVal.includes(',')) {
-        strVal = strVal.replace(/\./g, '');
-        strVal = strVal.replace(',', '.');
-      }
-
-      parsed = parseFloat(strVal);
-      if (isNaN(parsed)) parsed = 0;
-    }
-
-    // Round to 3 decimal places
-    return roundToDecimals(parsed);
+  const resetToUpload = () => {
+    setJobId(null);
+    setColumns([]);
+    setProcessedData([]);
+    setTotalRowCount(0);
+    setCounts({ validCount: 0, duplicateCount: 0, missingCount: 0, invalidCount: 0 });
+    setMapping({ custom_id: "", ablese_datum: "", zaehlerstand: "", verbrauch: "" });
+    setStep("upload");
   };
 
   const validateAndProcessData = async () => {
@@ -187,197 +124,53 @@ export function MeterImportModal({
       return;
     }
 
+    if (!jobId) {
+      toast({ title: "Fehler", description: "Bitte laden Sie die Datei erneut hoch.", variant: "destructive" });
+      resetToUpload();
+      return;
+    }
+
     setIsSubmitting(true);
 
     try {
-      // Create efficient lookup map
-      const metersByCustomId = new Map(meters.map(m => [m.custom_id?.toLowerCase(), m]));
-
-      // 1. Identify relevant meters from the parsed data
-      const meterIdsToFetch = new Set<string>();
-
-      parsedData.forEach(row => {
-        const customIdRaw = row[mapping.custom_id];
-        const customId = customIdRaw ? String(customIdRaw).trim() : "";
-        if (customId) {
-          const meter = metersByCustomId.get(customId.toLowerCase());
-          if (meter) {
-            meterIdsToFetch.add(meter.id);
-          }
-        }
+      const response = await fetch("/api/meter-import/preview", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jobId, mapping }),
       });
 
-      // 2. Fetch LATEST readings for these meters from the server
-      // This ensures we don't think a deleted reading still exists
-      let freshReadings = [...readings]; // Start with props as fallback
-      if (meterIdsToFetch.size > 0) {
-        const { getReadingsForMetersAction } = await import("@/app/meter-actions");
-        const result = await getReadingsForMetersAction(Array.from(meterIdsToFetch));
+      const data = await response.json();
 
-        if (result.success && result.data) {
-          freshReadings = result.data as ZaehlerAblesung[];
-        } else {
-          console.warn("Could not fetch fresh readings, falling back to props data. Error:", result.message);
-        }
+      if (data?.error === "job_expired") {
+        toast({
+          title: "Datei abgelaufen",
+          description: "Die Datei ist abgelaufen, bitte erneut hochladen.",
+          variant: "destructive",
+        });
+        resetToUpload();
+        return;
       }
 
-      // 3. Phase 1: Parse and perform basic validation (Pre-Check)
-      let processed: ProcessedReading[] = parsedData.map((row) => {
-        const customIdRaw = row[mapping.custom_id];
-        const customId = customIdRaw ? String(customIdRaw).trim() : "";
-        const dateRaw = row[mapping.ablese_datum];
-        const valueRaw = row[mapping.zaehlerstand];
+      if (!response.ok) {
+        throw new Error(data?.error || "Fehler bei der Vorschau.");
+      }
 
-        const ableseDatum = parseDateString(dateRaw as string | number | Date);
-        const zaehlerstand = parseGermanNumber(valueRaw as string | number);
-
-        if (!customId) {
-          return {
-            zaehler_id: "",
-            custom_id: "",
-            ablese_datum: ableseDatum || "",
-            zaehlerstand: zaehlerstand,
-            verbrauch: 0,
-            original_row: row,
-            status: "missing_meter",
-            message: "Keine Zähler-ID",
-          };
-        }
-
-        const meter = metersByCustomId.get(customId.toLowerCase());
-
-        if (!meter) {
-          return {
-            zaehler_id: "",
-            custom_id: customId,
-            ablese_datum: ableseDatum || "",
-            zaehlerstand: zaehlerstand,
-            verbrauch: 0,
-            original_row: row,
-            status: "missing_meter",
-            message: `Zähler '${customId}' nicht gefunden`
-          };
-        }
-
-        if (!ableseDatum) {
-          return {
-            zaehler_id: meter.id,
-            custom_id: customId,
-            ablese_datum: "",
-            zaehlerstand: zaehlerstand,
-            verbrauch: 0,
-            original_row: row,
-            status: "invalid_date",
-            message: "Ungültiges Datum"
-          };
-        }
-
-        if (isNaN(zaehlerstand)) {
-          return {
-            zaehler_id: meter.id,
-            custom_id: customId,
-            ablese_datum: ableseDatum,
-            zaehlerstand: 0,
-            verbrauch: 0,
-            original_row: row,
-            status: "invalid_value",
-            message: "Ungültiger Zählerstand"
-          };
-        }
-
-        // Duplicate check (against DB only for now)
-        const isDuplicate = freshReadings.some(
-          (r) => r.zaehler_id === meter.id && r.ablese_datum === ableseDatum
-        );
-
-        if (isDuplicate) {
-          return {
-            zaehler_id: meter.id,
-            custom_id: customId,
-            ablese_datum: ableseDatum,
-            zaehlerstand,
-            verbrauch: 0,
-            original_row: row,
-            status: "duplicate",
-            message: "Ablesung existiert bereits"
-          };
-        }
-
-        // Init usage
-        let verbrauch = 0;
-        if (mapping.verbrauch && row[mapping.verbrauch]) {
-          verbrauch = parseGermanNumber(row[mapping.verbrauch] as string | number);
-        }
-
-        return {
-          zaehler_id: meter.id,
-          custom_id: customId,
-          ablese_datum: ableseDatum,
-          zaehlerstand,
-          verbrauch,
-          original_row: row,
-          status: "valid",
-        };
+      setProcessedData(data.previewRows || []);
+      setTotalRowCount(data.totalRowCount || (data.previewRows?.length || 0));
+      setCounts({
+        validCount: data.validCount ?? 0,
+        duplicateCount: data.duplicateCount ?? 0,
+        missingCount: data.missingCount ?? 0,
+        invalidCount: data.invalidCount ?? 0,
       });
-
-      // 4. Phase 2: Calculate Usage (Inter-row + DB)
-      processed = processed.map(item => {
-        if (item.status !== "valid") return item;
-
-        // If user explicitly mapped consumption and it has a value, we trust it or use it.
-        // But if they just mapped the column and it's empty, we might want to calculate?
-        // Current logic: if usage was found in the row (non-zero or zero but present), we keep it.
-        // Actually, previous logic set verbrauch=0 if not found.
-        // Let's refine: if the mapped value was present in the row, we use it.
-        if (mapping.verbrauch && item.original_row[mapping.verbrauch]) {
-          return item;
-        }
-
-        const currentMeterId = item.zaehler_id;
-        const currentJsDate = new Date(item.ablese_datum).getTime();
-
-        // 1. DB candidates (normalized)
-        const dbCandidates = freshReadings
-          .filter(r => r.zaehler_id === currentMeterId)
-          .map(r => ({
-            date: new Date(r.ablese_datum).getTime(),
-            value: r.zaehlerstand
-          }));
-
-        // 2. File candidates (other valid rows in this batch) -- enable chaining!
-        const fileCandidates = processed
-          .filter(r => r.status === 'valid' && r.zaehler_id === currentMeterId && r !== item)
-          .map(r => ({
-            date: new Date(r.ablese_datum).getTime(),
-            value: r.zaehlerstand
-          }));
-
-        const allCandidates = [...dbCandidates, ...fileCandidates];
-
-        // Find predecessors (Strictly before current date)
-        const predecessors = allCandidates.filter(c => c.date < currentJsDate);
-
-        // Sort by date DESC (closest previous date first)
-        predecessors.sort((a, b) => b.date - a.date);
-
-        const prev = predecessors[0];
-
-        let calculatedUsage = 0;
-        if (prev) {
-          calculatedUsage = Math.max(0, item.zaehlerstand - prev.value);
-        }
-
-        // Round calculated usage to 3 decimal places
-        calculatedUsage = roundToDecimals(calculatedUsage);
-
-        return { ...item, verbrauch: calculatedUsage };
-      });
-
-      setProcessedData(processed);
       setStep("preview");
     } catch (error: unknown) {
       console.error("Error validating data:", error);
-      toast({ title: "Fehler", description: error instanceof Error ? error.message : "Fehler bei der Validierung der Daten.", variant: "destructive" });
+      toast({
+        title: "Fehler",
+        description: error instanceof Error ? error.message : "Fehler bei der Validierung der Daten.",
+        variant: "destructive",
+      });
     } finally {
       setIsSubmitting(false);
     }
@@ -385,46 +178,72 @@ export function MeterImportModal({
 
   const handleSubmit = async () => {
     setIsSubmitting(true);
-    const rowsToImport = processedData.filter(row => row.status === "valid");
+    if (!jobId) {
+      toast({ title: "Fehler", description: "Bitte laden Sie die Datei erneut hoch.", variant: "destructive" });
+      resetToUpload();
+      setIsSubmitting(false);
+      return;
+    }
 
-    if (rowsToImport.length === 0) {
+    if (counts.validCount === 0) {
       toast({ title: "Info", description: "Keine gültigen Datensätze zum Importieren.", variant: "default" });
       setIsSubmitting(false);
       return;
     }
 
-    const payload = rowsToImport.map(row => ({
-      zaehler_id: row.zaehler_id,
-      ablese_datum: row.ablese_datum,
-      zaehlerstand: row.zaehlerstand,
-      verbrauch: row.verbrauch,
-      kommentar: "Importiert"
-    }));
-
-    const result = await bulkCreateAblesungen(payload);
-
-    if (result.success) {
-      toast({
-        title: "Import erfolgreich",
-        description: `${payload.length} Ablesungen wurden importiert.`,
-        variant: "success"
+    try {
+      const response = await fetch("/api/meter-import/execute", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jobId, mapping }),
       });
+
+      const data = await response.json();
+
+      if (data?.error === "job_expired") {
+        toast({
+          title: "Datei abgelaufen",
+          description: "Die Datei ist abgelaufen, bitte erneut hochladen.",
+          variant: "destructive",
+        });
+        resetToUpload();
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error(data?.error || "Fehler beim Import.");
+      }
+
+      if (data.success) {
+        toast({
+          title: "Import erfolgreich",
+          description: `${data.importedCount ?? 0} Ablesungen wurden importiert.`,
+          variant: "success",
+        });
+      } else {
+        toast({
+          title: "Import abgeschlossen",
+          description: `${data.importedCount ?? 0} Ablesungen importiert, ${data.errorCount ?? 0} Fehler.`,
+          variant: "default",
+        });
+      }
+
       onSuccess();
       onClose();
-    } else {
+    } catch (error: unknown) {
       toast({
         title: "Fehler beim Import",
-        description: result.message || "Unbekannter Fehler",
-        variant: "destructive"
+        description: error instanceof Error ? error.message : "Unbekannter Fehler",
+        variant: "destructive",
       });
+    } finally {
+      setIsSubmitting(false);
     }
-    setIsSubmitting(false);
   };
 
-  const validCount = processedData.filter(d => d.status === "valid").length;
-  const duplicateCount = processedData.filter(d => d.status === "duplicate").length;
-  const missingCount = processedData.filter(d => d.status === "missing_meter").length;
-  const errorCount = processedData.filter(d => d.status === "invalid_date" || d.status === "invalid_value").length;
+  const { validCount, duplicateCount, missingCount, invalidCount } = counts;
+  const errorCount = invalidCount;
+  const remainingRows = Math.max(0, totalRowCount - processedData.length);
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -593,10 +412,10 @@ export function MeterImportModal({
                         <TableCell className="text-xs text-muted-foreground">{row.message}</TableCell>
                       </TableRow>
                     ))}
-                    {processedData.length > 100 && (
+                    {remainingRows > 0 && (
                       <TableRow>
                         <TableCell colSpan={6} className="text-center text-muted-foreground">
-                          ... {processedData.length - 100} weitere Zeilen
+                          ... {remainingRows} weitere Zeilen
                         </TableCell>
                       </TableRow>
                     )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,6 @@
         "use-sync-external-store": "^1.6.0",
         "vaul": "^1.1.2",
         "ws": "^8.19.0",
-        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
         "zod": "^3.24.1",
         "zustand": "^5.0.11"
       },
@@ -15171,18 +15170,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/xlsx": {
-      "version": "0.20.2",
-      "resolved": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
-      "integrity": "sha512-+nKZ39+nvK7Qq6i0PvWWRA4j/EkfWOtkP/YhMtupm+lJIiHxUrgTr1CcKv1nBk1rHtkRRQ3O2+Ih/q/sA+FXZA==",
-      "license": "Apache-2.0",
-      "bin": {
-        "xlsx": "bin/xlsx.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "use-sync-external-store": "^1.6.0",
     "vaul": "^1.1.2",
     "ws": "^8.19.0",
-    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
     "zod": "^3.24.1",
     "zustand": "^5.0.11"
   },

--- a/supabase/functions/cleanup-import-jobs/index.ts
+++ b/supabase/functions/cleanup-import-jobs/index.ts
@@ -1,0 +1,68 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.8'
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+const supabaseServiceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+
+Deno.serve(async () => {
+  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey)
+  const nowIso = new Date().toISOString()
+
+  const { data: jobs, error: jobsError } = await supabase
+    .from('import_jobs')
+    .select('id, storage_path')
+    .lt('expires_at', nowIso)
+    .limit(1000)
+
+  if (jobsError) {
+    return new Response(JSON.stringify({ error: jobsError.message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const jobIds = (jobs || []).map((job) => job.id)
+  const paths = (jobs || [])
+    .map((job) => job.storage_path)
+    .filter((path): path is string => !!path)
+
+  let removedFiles = 0
+  if (paths.length > 0) {
+    const { data: removed, error: removeError } = await supabase.storage
+      .from('file-processing')
+      .remove(paths)
+
+    if (removeError) {
+      return new Response(JSON.stringify({ error: removeError.message }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    removedFiles = removed?.length || 0
+  }
+
+  let deletedJobs = 0
+  if (jobIds.length > 0) {
+    const { error: deleteError, count } = await supabase
+      .from('import_jobs')
+      .delete({ count: 'exact' })
+      .in('id', jobIds)
+
+    if (deleteError) {
+      return new Response(JSON.stringify({ error: deleteError.message }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    deletedJobs = count || jobIds.length
+  }
+
+  return new Response(
+    JSON.stringify({
+      deletedJobs,
+      removedFiles,
+    }),
+    { headers: { 'Content-Type': 'application/json' } }
+  )
+})

--- a/supabase/migrations/20260316090000_create_import_jobs_and_file_processing.sql
+++ b/supabase/migrations/20260316090000_create_import_jobs_and_file_processing.sql
@@ -1,0 +1,90 @@
+-- Create import_jobs table and file-processing storage policies
+
+-- Ensure storage bucket exists (private)
+insert into storage.buckets (id, name, public)
+values ('file-processing', 'file-processing', false)
+on conflict (id) do nothing;
+
+-- Import jobs table
+create table if not exists public.import_jobs (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users,
+  storage_path text not null,
+  original_filename text not null,
+  status text not null default 'pending'
+    check (status in ('pending', 'processing', 'completed', 'failed')),
+  preview_columns jsonb,
+  preview_rows jsonb,
+  total_row_count integer,
+  mapping jsonb,
+  imported_count integer,
+  error_count integer,
+  error_summary jsonb,
+  expires_at timestamptz not null default (now() + interval '24 hours'),
+  created_at timestamptz not null default now(),
+  completed_at timestamptz
+);
+
+create index if not exists import_jobs_user_id_idx on public.import_jobs (user_id);
+create index if not exists import_jobs_expires_at_idx on public.import_jobs (expires_at);
+
+alter table public.import_jobs enable row level security;
+alter table public.import_jobs force row level security;
+
+create policy "import_jobs_select_own"
+  on public.import_jobs for select
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+create policy "import_jobs_insert_own"
+  on public.import_jobs for insert
+  to authenticated
+  with check ((select auth.uid()) = user_id);
+
+create policy "import_jobs_update_own"
+  on public.import_jobs for update
+  to authenticated
+  using ((select auth.uid()) = user_id)
+  with check ((select auth.uid()) = user_id);
+
+create policy "import_jobs_delete_own"
+  on public.import_jobs for delete
+  to authenticated
+  using ((select auth.uid()) = user_id);
+
+-- Storage policies for file-processing bucket
+create policy "file_processing_select_own"
+  on storage.objects for select
+  to authenticated
+  using (
+    bucket_id = 'file-processing'
+    and name like ('user_' || auth.uid())::text || '/%'
+  );
+
+create policy "file_processing_insert_own"
+  on storage.objects for insert
+  to authenticated
+  with check (
+    bucket_id = 'file-processing'
+    and name like ('user_' || auth.uid())::text || '/%'
+  );
+
+create policy "file_processing_update_own"
+  on storage.objects for update
+  to authenticated
+  using (
+    bucket_id = 'file-processing'
+    and name like ('user_' || auth.uid())::text || '/%'
+  )
+  with check (
+    bucket_id = 'file-processing'
+    and name like ('user_' || auth.uid())::text || '/%'
+  );
+
+create policy "file_processing_delete_own"
+  on storage.objects for delete
+  to authenticated
+  using (
+    bucket_id = 'file-processing'
+    and name like ('user_' || auth.uid())::text || '/%'
+  );

--- a/workers/mietevo-backend/package-lock.json
+++ b/workers/mietevo-backend/package-lock.json
@@ -15,7 +15,8 @@
                 "jszip": "^3.10.1",
                 "pako": "^2.1.0",
                 "papaparse": "^5.4.1",
-                "posthog-node": "^5.26.0"
+                "posthog-node": "^5.26.0",
+                "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
             },
             "devDependencies": {
                 "@cloudflare/vitest-pool-workers": "^0.12.12",
@@ -5592,6 +5593,18 @@
                 "utf-8-validate": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/xlsx": {
+            "version": "0.20.2",
+            "resolved": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
+            "integrity": "sha512-+nKZ39+nvK7Qq6i0PvWWRA4j/EkfWOtkP/YhMtupm+lJIiHxUrgTr1CcKv1nBk1rHtkRRQ3O2+Ih/q/sA+FXZA==",
+            "license": "Apache-2.0",
+            "bin": {
+                "xlsx": "bin/xlsx.njs"
+            },
+            "engines": {
+                "node": ">=0.8"
             }
         },
         "node_modules/yocto-queue": {

--- a/workers/mietevo-backend/package.json
+++ b/workers/mietevo-backend/package.json
@@ -32,6 +32,7 @@
         "jszip": "^3.10.1",
         "pako": "^2.1.0",
         "papaparse": "^5.4.1",
-        "posthog-node": "^5.26.0"
+    "posthog-node": "^5.26.0",
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
     }
 }

--- a/workers/mietevo-backend/src/index.ts
+++ b/workers/mietevo-backend/src/index.ts
@@ -2,6 +2,7 @@ import { jsPDF } from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import JSZip from 'jszip';
 import Papa from 'papaparse';
+import * as XLSX from 'xlsx';
 import { GoogleGenAI } from '@google/genai';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { WorkerLogger, ExecutionContext } from './logger';
@@ -45,6 +46,365 @@ import { formatCurrency, isoToGermanDate, roundToNearest5 } from './utils';
 
 // --- Constants ---
 const QUEUE_VISIBILITY_TIMEOUT = 60;
+
+const MAX_IMPORT_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+const PREVIEW_ROW_LIMIT = 100;
+
+type ImportStatus = 'pending' | 'processing' | 'completed' | 'failed';
+
+interface ColumnMapping {
+    custom_id: string;
+    ablese_datum: string;
+    zaehlerstand: string;
+    verbrauch?: string;
+}
+
+interface ParsedRow {
+    [key: string]: string | number | null;
+}
+
+interface ProcessedReading {
+    zaehler_id: string;
+    custom_id: string;
+    ablese_datum: string;
+    zaehlerstand: number;
+    verbrauch: number;
+    status: 'valid' | 'duplicate' | 'missing_meter' | 'invalid_date' | 'invalid_value';
+    message?: string;
+    rowIndex: number;
+}
+
+interface ImportCounts {
+    validCount: number;
+    duplicateCount: number;
+    missingCount: number;
+    invalidCount: number;
+    errorCount: number;
+}
+
+interface ImportErrorSummary {
+    row: number;
+    field: string;
+    message: string;
+}
+
+function isAuthorized(request: Request, env: Env, logger: WorkerLogger): boolean {
+    const authHeader = request.headers.get('x-worker-auth');
+    if (!env.WORKER_AUTH_KEY) {
+        logger.error('WORKER_AUTH_KEY not configured');
+        return false;
+    }
+    if (authHeader !== env.WORKER_AUTH_KEY) {
+        logger.error('Unauthorized access attempt', { workerAuthKeyConfigured: !!env.WORKER_AUTH_KEY });
+        return false;
+    }
+    return true;
+}
+
+function getFileExtension(filename: string): string {
+    const parts = filename.split('.');
+    return parts.length > 1 ? parts[parts.length - 1].toLowerCase() : '';
+}
+
+function parseDateString(value: string | number | Date): string | null {
+    if (!value) return null;
+
+    if (typeof value === 'number') {
+        const date = new Date((value - 25569) * 86400 * 1000);
+        return date.toISOString().split('T')[0];
+    }
+
+    if (value instanceof Date) {
+        return value.toISOString().split('T')[0];
+    }
+
+    const strVal = String(value).trim();
+    const germanMatch = strVal.match(/^(\d{1,2})\.(\d{1,2})\.(\d{4})/);
+    if (germanMatch) {
+        const day = germanMatch[1].padStart(2, '0');
+        const month = germanMatch[2].padStart(2, '0');
+        const year = germanMatch[3];
+        return `${year}-${month}-${day}`;
+    }
+
+    const date = new Date(strVal);
+    if (!isNaN(date.getTime())) {
+        return date.toISOString().split('T')[0];
+    }
+
+    return null;
+}
+
+function roundToDecimals(value: number, decimals = 3): number {
+    const factor = Math.pow(10, decimals);
+    return Math.round(value * factor) / factor;
+}
+
+function parseGermanNumber(value: string | number): number {
+    let parsed: number;
+
+    if (typeof value === 'number') {
+        parsed = value;
+    } else if (!value) {
+        parsed = 0;
+    } else {
+        let strVal = String(value).trim();
+        if (strVal.includes(',')) {
+            strVal = strVal.replace(/\./g, '');
+            strVal = strVal.replace(',', '.');
+        }
+        parsed = parseFloat(strVal);
+        if (isNaN(parsed)) parsed = 0;
+    }
+
+    return roundToDecimals(parsed);
+}
+
+function buildErrorSummary(
+    rows: ProcessedReading[],
+    rowOffset: number
+): ImportErrorSummary[] {
+    return rows
+        .map((row) => {
+            if (row.status === 'valid') return null;
+
+            let field = 'ablese_datum';
+            if (row.status === 'missing_meter') field = 'custom_id';
+            if (row.status === 'invalid_value') field = 'zaehlerstand';
+            if (row.status === 'invalid_date') field = 'ablese_datum';
+
+            return {
+                row: row.rowIndex + rowOffset,
+                field,
+                message: row.message || 'Ungültiger Datensatz',
+            };
+        })
+        .filter((entry): entry is ImportErrorSummary => !!entry);
+}
+
+async function parseSpreadsheet(
+    buffer: ArrayBuffer,
+    extension: string
+): Promise<{ rows: ParsedRow[]; columns: string[]; totalRowCount: number }> {
+    if (extension === 'csv') {
+        const text = new TextDecoder().decode(buffer);
+        const results = Papa.parse(text, {
+            header: true,
+            skipEmptyLines: true,
+        });
+        const rows = (results.data || []) as ParsedRow[];
+        const columns = (results.meta.fields || Object.keys(rows[0] || {})) as string[];
+        return { rows, columns, totalRowCount: rows.length };
+    }
+
+    if (extension === 'xlsx' || extension === 'xls') {
+        const workbook = XLSX.read(buffer, { type: 'array' });
+        const sheetName = workbook.SheetNames[0];
+        const sheet = workbook.Sheets[sheetName];
+        const rows = XLSX.utils.sheet_to_json(sheet, { defval: null }) as ParsedRow[];
+        const columns = Object.keys(rows[0] || {});
+        return { rows, columns, totalRowCount: rows.length };
+    }
+
+    throw new Error('Unsupported file type');
+}
+
+async function validateImportRows(
+    supabase: SupabaseClient,
+    userId: string,
+    rows: ParsedRow[],
+    mapping: ColumnMapping
+): Promise<{
+    processed: ProcessedReading[];
+    counts: ImportCounts;
+    errorSummary: ImportErrorSummary[];
+}> {
+    const { data: meters, error: metersError } = await supabase
+        .from('Zaehler')
+        .select('id, custom_id')
+        .eq('user_id', userId);
+
+    if (metersError) {
+        throw new Error(metersError.message);
+    }
+
+    const metersByCustomId = new Map(
+        (meters || [])
+            .filter((meter) => meter.custom_id)
+            .map((meter) => [String(meter.custom_id).toLowerCase(), meter])
+    );
+
+    const meterIdsToFetch = new Set<string>();
+    rows.forEach((row) => {
+        const customIdRaw = row[mapping.custom_id];
+        const customId = customIdRaw ? String(customIdRaw).trim() : '';
+        const meter = metersByCustomId.get(customId.toLowerCase());
+        if (meter?.id) {
+            meterIdsToFetch.add(meter.id);
+        }
+    });
+
+    let freshReadings: { zaehler_id: string; ablese_datum: string; zaehlerstand: number }[] = [];
+    if (meterIdsToFetch.size > 0) {
+        const { data: readings, error: readingsError } = await supabase
+            .from('Zaehler_Ablesungen')
+            .select('zaehler_id, ablese_datum, zaehlerstand')
+            .in('zaehler_id', Array.from(meterIdsToFetch))
+            .eq('user_id', userId);
+
+        if (readingsError) {
+            throw new Error(readingsError.message);
+        }
+
+        freshReadings = readings || [];
+    }
+
+    let processed: ProcessedReading[] = rows.map((row, rowIndex) => {
+        const customIdRaw = row[mapping.custom_id];
+        const customId = customIdRaw ? String(customIdRaw).trim() : '';
+        const dateRaw = row[mapping.ablese_datum];
+        const valueRaw = row[mapping.zaehlerstand];
+
+        const ableseDatum = parseDateString(dateRaw as string | number | Date);
+        const zaehlerstand = parseGermanNumber(valueRaw as string | number);
+
+        if (!customId) {
+            return {
+                zaehler_id: '',
+                custom_id: '',
+                ablese_datum: ableseDatum || '',
+                zaehlerstand,
+                verbrauch: 0,
+                status: 'missing_meter',
+                message: 'Keine Zähler-ID',
+                rowIndex,
+            };
+        }
+
+        const meter = metersByCustomId.get(customId.toLowerCase());
+        if (!meter) {
+            return {
+                zaehler_id: '',
+                custom_id: customId,
+                ablese_datum: ableseDatum || '',
+                zaehlerstand,
+                verbrauch: 0,
+                status: 'missing_meter',
+                message: `Zähler '${customId}' nicht gefunden`,
+                rowIndex,
+            };
+        }
+
+        if (!ableseDatum) {
+            return {
+                zaehler_id: meter.id,
+                custom_id: customId,
+                ablese_datum: '',
+                zaehlerstand,
+                verbrauch: 0,
+                status: 'invalid_date',
+                message: 'Ungültiges Datum',
+                rowIndex,
+            };
+        }
+
+        if (isNaN(zaehlerstand)) {
+            return {
+                zaehler_id: meter.id,
+                custom_id: customId,
+                ablese_datum: ableseDatum,
+                zaehlerstand: 0,
+                verbrauch: 0,
+                status: 'invalid_value',
+                message: 'Ungültiger Zählerstand',
+                rowIndex,
+            };
+        }
+
+        const isDuplicate = freshReadings.some(
+            (reading) => reading.zaehler_id === meter.id && reading.ablese_datum === ableseDatum
+        );
+
+        if (isDuplicate) {
+            return {
+                zaehler_id: meter.id,
+                custom_id: customId,
+                ablese_datum: ableseDatum,
+                zaehlerstand,
+                verbrauch: 0,
+                status: 'duplicate',
+                message: 'Ablesung existiert bereits',
+                rowIndex,
+            };
+        }
+
+        let verbrauch = 0;
+        if (mapping.verbrauch && row[mapping.verbrauch]) {
+            verbrauch = parseGermanNumber(row[mapping.verbrauch] as string | number);
+        }
+
+        return {
+            zaehler_id: meter.id,
+            custom_id: customId,
+            ablese_datum: ableseDatum,
+            zaehlerstand,
+            verbrauch,
+            status: 'valid',
+            rowIndex,
+        };
+    });
+
+    processed = processed.map((item) => {
+        if (item.status !== 'valid') return item;
+
+        if (mapping.verbrauch && rows[item.rowIndex]?.[mapping.verbrauch]) {
+            return item;
+        }
+
+        const currentMeterId = item.zaehler_id;
+        const currentJsDate = new Date(item.ablese_datum).getTime();
+
+        const dbCandidates = freshReadings
+            .filter((reading) => reading.zaehler_id === currentMeterId)
+            .map((reading) => ({
+                date: new Date(reading.ablese_datum).getTime(),
+                value: reading.zaehlerstand,
+            }));
+
+        const fileCandidates = processed
+            .filter((row) => row.status === 'valid' && row.zaehler_id === currentMeterId && row !== item)
+            .map((row) => ({
+                date: new Date(row.ablese_datum).getTime(),
+                value: row.zaehlerstand,
+            }));
+
+        const allCandidates = [...dbCandidates, ...fileCandidates];
+        const predecessors = allCandidates.filter((candidate) => candidate.date < currentJsDate);
+        predecessors.sort((a, b) => b.date - a.date);
+
+        const prev = predecessors[0];
+        let calculatedUsage = 0;
+        if (prev) {
+            calculatedUsage = Math.max(0, item.zaehlerstand - prev.value);
+        }
+
+        return { ...item, verbrauch: roundToDecimals(calculatedUsage) };
+    });
+
+    const counts: ImportCounts = {
+        validCount: processed.filter((row) => row.status === 'valid').length,
+        duplicateCount: processed.filter((row) => row.status === 'duplicate').length,
+        missingCount: processed.filter((row) => row.status === 'missing_meter').length,
+        invalidCount: processed.filter(
+            (row) => row.status === 'invalid_date' || row.status === 'invalid_value'
+        ).length,
+        errorCount: processed.filter((row) => row.status !== 'valid').length,
+    };
+
+    const errorSummary = buildErrorSummary(processed, 2);
+
+    return { processed, counts, errorSummary };
+}
 
 // --- PDF Generation Functions (Preserved) ---
 
@@ -677,6 +1037,349 @@ export async function handleAIRequest(request: Request, env: Env, ctx: Execution
                 'Access-Control-Allow-Origin': '*',
                 'Content-Type': 'application/json'
             }
+        });
+    }
+}
+
+async function handleMeterImportPreview(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const logger = new WorkerLogger(env, ctx);
+
+    if (!isAuthorized(request, env, logger)) {
+        logger.flush();
+        return new Response('Unauthorized', { status: 401 });
+    }
+
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
+    const contentType = request.headers.get('content-type') || '';
+
+    try {
+        if (contentType.includes('multipart/form-data')) {
+            const formData = await request.formData();
+            const file = formData.get('file');
+            const userId = formData.get('user_id');
+
+            if (!(file instanceof File) || typeof userId !== 'string' || !userId) {
+                return new Response(JSON.stringify({ error: 'Invalid upload request' }), {
+                    status: 400,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+
+            if (file.size > MAX_IMPORT_FILE_SIZE_BYTES) {
+                return new Response(JSON.stringify({ error: 'File too large' }), {
+                    status: 400,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+
+            const extension = getFileExtension(file.name);
+            if (!['csv', 'xlsx', 'xls'].includes(extension)) {
+                return new Response(JSON.stringify({ error: 'Unsupported file type' }), {
+                    status: 400,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+
+            const jobId = crypto.randomUUID();
+            const storagePath = `user_${userId}/imports/${jobId}.${extension}`;
+
+            const { error: insertError } = await supabase
+                .from('import_jobs')
+                .insert({
+                    id: jobId,
+                    user_id: userId,
+                    storage_path: storagePath,
+                    original_filename: file.name,
+                    status: 'pending' as ImportStatus,
+                });
+
+            if (insertError) {
+                return new Response(JSON.stringify({ error: insertError.message }), {
+                    status: 500,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+
+            const { error: uploadError } = await supabase.storage
+                .from('file-processing')
+                .upload(storagePath, file, {
+                    contentType: file.type || 'application/octet-stream',
+                    upsert: false,
+                });
+
+            if (uploadError) {
+                return new Response(JSON.stringify({ error: uploadError.message }), {
+                    status: 500,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+
+            const buffer = await file.arrayBuffer();
+            const parsed = await parseSpreadsheet(buffer, extension);
+
+            await supabase
+                .from('import_jobs')
+                .update({
+                    preview_columns: parsed.columns,
+                    total_row_count: parsed.totalRowCount,
+                })
+                .eq('id', jobId);
+
+            return new Response(
+                JSON.stringify({
+                    jobId,
+                    columns: parsed.columns,
+                    previewRows: [],
+                    totalRowCount: parsed.totalRowCount,
+                }),
+                { headers: { 'Content-Type': 'application/json' } }
+            );
+        }
+
+        const body = (await request.json()) as { jobId?: string; userId?: string; mapping?: ColumnMapping };
+        const { jobId, userId, mapping } = body || {};
+
+        if (!jobId || !userId || !mapping) {
+            return new Response(JSON.stringify({ error: 'Invalid preview request' }), {
+                status: 400,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
+
+        const { data: job, error: jobError } = await supabase
+            .from('import_jobs')
+            .select('id, storage_path, status, expires_at, preview_columns')
+            .eq('id', jobId)
+            .eq('user_id', userId)
+            .single();
+
+        if (jobError || !job) {
+            return new Response(JSON.stringify({ error: 'Job not found' }), {
+                status: 404,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
+
+        if (job.expires_at && new Date(job.expires_at).getTime() < Date.now()) {
+            return new Response(JSON.stringify({ error: 'job_expired' }), {
+                status: 410,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
+
+        const { data: fileBlob, error: downloadError } = await supabase.storage
+            .from('file-processing')
+            .download(job.storage_path);
+
+        if (downloadError || !fileBlob) {
+            return new Response(JSON.stringify({ error: downloadError?.message || 'Download failed' }), {
+                status: 500,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
+
+        const extension = getFileExtension(job.storage_path);
+        const buffer = await fileBlob.arrayBuffer();
+        const parsed = await parseSpreadsheet(buffer, extension);
+
+        if (Array.isArray(job.preview_columns) && job.preview_columns.length > 0) {
+            const mappingFields = [mapping.custom_id, mapping.ablese_datum, mapping.zaehlerstand, mapping.verbrauch]
+                .filter((field): field is string => !!field);
+            const missingFields = mappingFields.filter((field) => !job.preview_columns.includes(field));
+            if (missingFields.length > 0) {
+                return new Response(JSON.stringify({ error: 'mapping_invalid', missingFields }), {
+                    status: 400,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+        }
+
+        const { processed, counts, errorSummary } = await validateImportRows(
+            supabase,
+            userId,
+            parsed.rows,
+            mapping
+        );
+
+        const previewRows = processed.slice(0, PREVIEW_ROW_LIMIT);
+
+        await supabase
+            .from('import_jobs')
+            .update({
+                preview_columns: parsed.columns,
+                preview_rows: previewRows,
+                total_row_count: parsed.totalRowCount,
+                error_count: counts.errorCount,
+                error_summary: errorSummary,
+                status: 'processing' as ImportStatus,
+            })
+            .eq('id', jobId);
+
+        return new Response(
+            JSON.stringify({
+                jobId,
+                columns: parsed.columns,
+                previewRows,
+                totalRowCount: parsed.totalRowCount,
+                ...counts,
+            }),
+            { headers: { 'Content-Type': 'application/json' } }
+        );
+    } catch (error: unknown) {
+        logger.error('Meter import preview failed', { error: (error as Error).message });
+        logger.flush();
+        return new Response(JSON.stringify({ error: (error as Error).message }), {
+            status: 500,
+            headers: { 'Content-Type': 'application/json' },
+        });
+    }
+}
+
+async function handleMeterImportExecute(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const logger = new WorkerLogger(env, ctx);
+
+    if (!isAuthorized(request, env, logger)) {
+        logger.flush();
+        return new Response('Unauthorized', { status: 401 });
+    }
+
+    const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
+
+    try {
+        const body = (await request.json()) as { jobId?: string; userId?: string; mapping?: ColumnMapping };
+        const { jobId, userId, mapping } = body || {};
+
+        if (!jobId || !userId || !mapping) {
+            return new Response(JSON.stringify({ error: 'Invalid execute request' }), {
+                status: 400,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
+
+        const { data: job, error: jobError } = await supabase
+            .from('import_jobs')
+            .select('id, storage_path, status, expires_at, preview_columns')
+            .eq('id', jobId)
+            .eq('user_id', userId)
+            .single();
+
+        if (jobError || !job) {
+            return new Response(JSON.stringify({ error: 'Job not found' }), {
+                status: 404,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
+
+        if (job.expires_at && new Date(job.expires_at).getTime() < Date.now()) {
+            return new Response(JSON.stringify({ error: 'job_expired' }), {
+                status: 410,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
+
+        if (Array.isArray(job.preview_columns) && job.preview_columns.length > 0) {
+            const mappingFields = [mapping.custom_id, mapping.ablese_datum, mapping.zaehlerstand, mapping.verbrauch]
+                .filter((field): field is string => !!field);
+            const missingFields = mappingFields.filter((field) => !job.preview_columns.includes(field));
+            if (missingFields.length > 0) {
+                return new Response(JSON.stringify({ error: 'mapping_invalid', missingFields }), {
+                    status: 400,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+        }
+
+        const { data: fileBlob, error: downloadError } = await supabase.storage
+            .from('file-processing')
+            .download(job.storage_path);
+
+        if (downloadError || !fileBlob) {
+            return new Response(JSON.stringify({ error: downloadError?.message || 'Download failed' }), {
+                status: 500,
+                headers: { 'Content-Type': 'application/json' },
+            });
+        }
+
+        const extension = getFileExtension(job.storage_path);
+        const buffer = await fileBlob.arrayBuffer();
+        const parsed = await parseSpreadsheet(buffer, extension);
+
+        const { processed, counts, errorSummary } = await validateImportRows(
+            supabase,
+            userId,
+            parsed.rows,
+            mapping
+        );
+
+        const validRows = processed.filter((row) => row.status === 'valid');
+        const rowsToInsert = validRows.map((row) => ({
+            zaehler_id: row.zaehler_id,
+            ablese_datum: row.ablese_datum,
+            zaehlerstand: row.zaehlerstand,
+            verbrauch: row.verbrauch,
+            kommentar: 'Importiert',
+            user_id: userId,
+        }));
+
+        let importedCount = 0;
+        const chunkSize = 500;
+        for (let i = 0; i < rowsToInsert.length; i += chunkSize) {
+            const chunk = rowsToInsert.slice(i, i + chunkSize);
+            if (chunk.length === 0) continue;
+
+            const { error: insertError } = await supabase
+                .from('Zaehler_Ablesungen')
+                .insert(chunk);
+
+            if (insertError) {
+                await supabase
+                    .from('import_jobs')
+                    .update({
+                        status: 'failed' as ImportStatus,
+                        mapping,
+                        imported_count: importedCount,
+                        error_count: counts.errorCount,
+                        error_summary: errorSummary,
+                        completed_at: new Date().toISOString(),
+                    })
+                    .eq('id', jobId);
+
+                return new Response(JSON.stringify({ error: insertError.message }), {
+                    status: 500,
+                    headers: { 'Content-Type': 'application/json' },
+                });
+            }
+
+            importedCount += chunk.length;
+        }
+
+        await supabase
+            .from('import_jobs')
+            .update({
+                status: 'completed' as ImportStatus,
+                mapping,
+                imported_count: importedCount,
+                error_count: counts.errorCount,
+                error_summary: errorSummary,
+                completed_at: new Date().toISOString(),
+            })
+            .eq('id', jobId);
+
+        return new Response(
+            JSON.stringify({
+                success: counts.errorCount === 0,
+                importedCount,
+                errorCount: counts.errorCount,
+                errors: errorSummary,
+            }),
+            { headers: { 'Content-Type': 'application/json' } }
+        );
+    } catch (error: unknown) {
+        logger.error('Meter import execute failed', { error: (error as Error).message });
+        logger.flush();
+        return new Response(JSON.stringify({ error: (error as Error).message }), {
+            status: 500,
+            headers: { 'Content-Type': 'application/json' },
         });
     }
 }
@@ -1356,7 +2059,7 @@ export default {
         const corsHeaders: Record<string, string> = {
             'Access-Control-Allow-Origin': origin,
             'Access-Control-Allow-Methods': 'POST, OPTIONS',
-            'Access-Control-Allow-Headers': 'Content-Type',
+            'Access-Control-Allow-Headers': 'Content-Type, x-worker-auth',
             'Access-Control-Allow-Credentials': 'true',
             'Access-Control-Max-Age': '86400',
             'Access-Control-Expose-Headers': 'X-PDF-Page-Count, X-PDF-Generation-Time',
@@ -1380,7 +2083,11 @@ export default {
         try {
             // Route based on URL path first (more robust)
             let response: Response;
-            if (url.pathname === '/ai') {
+            if (url.pathname === '/meter-import/preview') {
+                response = await handleMeterImportPreview(request, env, ctx);
+            } else if (url.pathname === '/meter-import/execute') {
+                response = await handleMeterImportExecute(request, env, ctx);
+            } else if (url.pathname === '/ai') {
                 response = await handleAIRequest(request, env, ctx);
             } else if (url.pathname === '/process-queue') {
                 response = await processQueue(request, env, ctx);


### PR DESCRIPTION
## Description

Moves the meter import parsing from the frontend bundle to the backend worker.

## Summary of Changes

- New API routes `/api/meter-import/preview` and `/api/meter-import/execute`: authenticated proxies that forward the file/mapping to the worker with `x-worker-auth`
- `meter-import-modal.tsx`: ~316 lines of client-side parsing removed — replaced by a job-based flow (upload → jobId → column mapping → server preview → execute), incl. expired-job handling
- Worker: new `handleMeterImportPreview`/`handleMeterImportExecute` (~700 lines) — CSV/XLSX parsing (papaparse + xlsx), row validation with duplicate/missing/invalid detection, consumption chaining, chunked inserts into `Zaehler_Ablesungen`
- New migration: `import_jobs` table with RLS + private `file-processing` storage bucket policies; new edge function `cleanup-import-jobs` for expired jobs
- `xlsx` dependency moved from the frontend bundle to the worker