### PR TITLE
fix: prevent Cloudflare caching of setup and onboarding status

### DIFF
--- a/app/api/user/onboarding/route.ts
+++ b/app/api/user/onboarding/route.ts
@@ -1,14 +1,8 @@
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
 
 export const runtime = 'edge';
-
-// Cache-control headers to prevent CDN caching of user-specific responses
-const NO_CACHE_HEADERS = {
-    'Cache-Control': 'no-cache, no-store, must-revalidate',
-    'Pragma': 'no-cache',
-    'Expires': '0',
-};
 
 export async function POST() {
     const supabase = await createClient();

--- a/app/api/user/setup/route.ts
+++ b/app/api/user/setup/route.ts
@@ -3,15 +3,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { updateBillingAddress, getBillingAddress } from "@/app/user-billing-actions";
 import { requireAuthenticatedUserForApi } from "@/lib/server/route-access";
 import { z } from "zod";
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
 
 export const runtime = 'edge';
-
-// Cache-control headers to prevent CDN caching of user-specific responses
-const NO_CACHE_HEADERS = {
-    'Cache-Control': 'no-cache, no-store, must-revalidate',
-    'Pragma': 'no-cache',
-    'Expires': '0',
-};
 
 // Zod schema for request body validation with conditional validation
 const setupBodySchema = z.object({

--- a/lib/constants/http.ts
+++ b/lib/constants/http.ts
@@ -1,0 +1,11 @@
+/**
+ * HTTP-related constants for consistent caching and security headers
+ */
+
+// Cache-control headers to prevent CDN caching of user-specific responses
+// Private directive ensures shared caches (CDNs) don't store authenticated responses
+export const NO_CACHE_HEADERS = {
+    'Cache-Control': 'private, no-cache, no-store, must-revalidate',
+    'Pragma': 'no-cache',
+    'Expires': '0',
+};

--- a/lib/server/route-access.ts
+++ b/lib/server/route-access.ts
@@ -5,6 +5,7 @@ import type { User, SupabaseClient } from "@supabase/supabase-js"
 import { ROUTES } from "@/lib/constants"
 import { createClient } from "@/utils/supabase/server"
 import { isTestEnv } from "@/lib/test-utils"
+import { NO_CACHE_HEADERS } from "@/lib/constants/http"
 
 function buildLoginRedirect(pathname: string | null, search: string | null) {
   if (!pathname) {
@@ -194,7 +195,10 @@ export async function requireAuthenticatedUserForApi(): Promise<
   const { user, error } = await getAuthenticatedUser(supabase)
   
   if (error || !user) {
-    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+    return NextResponse.json(
+      { error: 'Not authenticated' }, 
+      { status: 401, headers: NO_CACHE_HEADERS }
+    )
   }
   return { supabase, user }
 }


### PR DESCRIPTION
- Add Cache-Control headers to /api/user/setup route
- Add Cache-Control headers to /api/user/onboarding route
- Prevents stale cached responses causing setup wizard to show for users who already completed setup on mietevo.de
- Fixes issue where preview domain worked but main domain didn't

Fixes setup wizard appearing for user cus_T7SlxvE0NRhBQX