### PR TITLE
Fix background scroll blocking for finance category dropdown

### DIFF
--- a/components/ui/tag-input.tsx
+++ b/components/ui/tag-input.tsx
@@ -106,7 +106,7 @@ export function TagInput({
     ).filter(cat => cat.tags.length > 0);
 
     return (
-        <Popover open={open} onOpenChange={setOpen}>
+        <Popover open={open} onOpenChange={setOpen} modal={true}>
             <PopoverTrigger asChild>
                 <Button
                     variant="outline"


### PR DESCRIPTION
This PR fixes a UI inconsistency on the Finance page where opening the category selection dropdown (TagInput) did not block background scrolling. By adding `modal={true}` to the underlying Radix UI Popover, the component now correctly traps focus and disables background interactions, matching the behavior of the apartment and year filter dropdowns.

Changes:
- Modified `components/ui/tag-input.tsx` to add `modal={true}` to the `Popover` component.

Fixes #1308

---
*PR created automatically by Jules for task [4715839280029685295](https://jules.google.com/task/4715839280029685295) started by @NtFelix*