### PR TITLE
refactor: expand NO_CACHE_HEADERS to all sensitive API routes

### DIFF
--- a/app/api/apartments/[apartmentId]/details/route.ts
+++ b/app/api/apartments/[apartmentId]/details/route.ts
@@ -2,6 +2,7 @@ export const runtime = 'edge';
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 import { createRequestLogger } from "@/utils/logger";
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
 
 export async function GET(
   request: Request,
@@ -12,7 +13,7 @@ export async function GET(
     const { apartmentId } = await params;
 
     if (!apartmentId) {
-      return NextResponse.json({ error: "Apartment ID ist erforderlich." }, { status: 400 });
+      return NextResponse.json({ error: "Apartment ID ist erforderlich." }, { status: 400, headers: NO_CACHE_HEADERS });
     }
 
     // Fetch apartment details with house information
@@ -40,12 +41,12 @@ export async function GET(
       if (apartmentError.code === 'PGRST116' || apartmentError.message?.includes('No rows returned')) {
         return NextResponse.json(
           { error: "Wohnung nicht gefunden." }, 
-          { status: 404 }
+          { status: 404, headers: NO_CACHE_HEADERS }
         );
       }
       return NextResponse.json(
         { error: "Fehler beim Laden der Wohnungsdaten." }, 
-        { status: 500 }
+        { status: 500, headers: NO_CACHE_HEADERS }
       );
     }
 
@@ -104,15 +105,15 @@ export async function GET(
       } : undefined,
     };
 
-    return NextResponse.json(response, { status: 200 });
-  } catch (error) {
+    return NextResponse.json(response, { status: 200, headers: NO_CACHE_HEADERS });
+    } catch (error) {
     const logger = createRequestLogger(request);
     logger.error("Unexpected error in GET /api/apartments/[apartmentId]/details", error instanceof Error ? error : new Error(String(error)), {
       apartmentId: (await params).apartmentId
     });
     return NextResponse.json(
       { error: "Serverfehler beim Laden der Details." }, 
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     );
-  }
-}
+    }
+    }

--- a/app/api/apartments/[apartmentId]/tenant/[tenantId]/details/route.ts
+++ b/app/api/apartments/[apartmentId]/tenant/[tenantId]/details/route.ts
@@ -2,6 +2,7 @@ export const runtime = 'edge';
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 import { createRequestLogger } from "@/utils/logger";
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
 
 interface ApartmentTenantDetailsResponse {
   apartment: {
@@ -66,7 +67,7 @@ export async function GET(
     if (!apartmentId || !tenantId) {
       return NextResponse.json(
         { error: "Apartment ID und Tenant ID sind erforderlich." }, 
-        { status: 400 }
+        { status: 400, headers: NO_CACHE_HEADERS }
       );
     }
 
@@ -75,7 +76,7 @@ export async function GET(
     if (!uuidRegex.test(apartmentId) || !uuidRegex.test(tenantId)) {
       return NextResponse.json(
         { error: "Ungültige ID-Formate." }, 
-        { status: 400 }
+        { status: 400, headers: NO_CACHE_HEADERS }
       );
     }
 
@@ -108,12 +109,12 @@ export async function GET(
       if (apartmentError.code === 'PGRST116') {
         return NextResponse.json(
           { error: "Wohnung nicht gefunden." }, 
-          { status: 404 }
+          { status: 404, headers: NO_CACHE_HEADERS }
         );
       }
       return NextResponse.json(
         { error: "Fehler beim Laden der Wohnungsdaten." }, 
-        { status: 500 }
+        { status: 500, headers: NO_CACHE_HEADERS }
       );
     }
 
@@ -137,12 +138,12 @@ export async function GET(
       if (tenantError.code === 'PGRST116') {
         return NextResponse.json(
           { error: "Mieter nicht gefunden oder nicht dieser Wohnung zugeordnet." }, 
-          { status: 404 }
+          { status: 404, headers: NO_CACHE_HEADERS }
         );
       }
       return NextResponse.json(
         { error: "Fehler beim Laden der Mieterdaten." }, 
-        { status: 500 }
+        { status: 500, headers: NO_CACHE_HEADERS }
       );
     }
 
@@ -235,9 +236,9 @@ export async function GET(
       },
     };
 
-    return NextResponse.json(response, { status: 200 });
+    return NextResponse.json(response, { status: 200, headers: NO_CACHE_HEADERS });
 
-  } catch (error) {
+    } catch (error) {
     const logger = createRequestLogger(request);
     const errorContext: Record<string, any> = {
       error: error instanceof Error ? error.message : 'Unknown error',
@@ -245,15 +246,15 @@ export async function GET(
       ...(apartmentId && { apartmentId }),
       ...(tenantId && { tenantId })
     };
-    
+
     logger.error("Failed to fetch apartment/tenant details", 
       error instanceof Error ? error : new Error(String(error)),
       errorContext
     );
-    
+
     return NextResponse.json(
       { error: "Serverfehler beim Laden der Details." }, 
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     );
-  }
-}
+    }
+    }

--- a/app/api/apartments/bulk-delete/route.ts
+++ b/app/api/apartments/bulk-delete/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
+import { NO_CACHE_HEADERS } from "@/lib/constants/http"
 
 export const runtime = 'edge';
 
@@ -11,7 +12,7 @@ export async function POST(request: Request) {
     if (!ids || !Array.isArray(ids) || ids.length === 0) {
       return NextResponse.json(
         { error: "Mindestens eine Wohnungs-ID ist erforderlich." },
-        { status: 400 }
+        { status: 400, headers: NO_CACHE_HEADERS }
       )
     }
 
@@ -25,19 +26,19 @@ export async function POST(request: Request) {
       console.error("Supabase Bulk Delete Error:", error)
       return NextResponse.json(
         { error: error.message },
-        { status: 500 }
+        { status: 500, headers: NO_CACHE_HEADERS }
       )
     }
 
     return NextResponse.json(
       { successCount: data?.length || 0 },
-      { status: 200 }
+      { status: 200, headers: NO_CACHE_HEADERS }
     )
   } catch (e) {
     console.error("POST /api/apartments/bulk-delete error:", e)
     return NextResponse.json(
       { error: "Serverfehler beim Löschen der Wohnungen." },
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     )
   }
 }

--- a/app/api/apartments/bulk-update/route.ts
+++ b/app/api/apartments/bulk-update/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
+import { NO_CACHE_HEADERS } from "@/lib/constants/http"
 
 export const runtime = 'edge';
 
@@ -18,14 +19,14 @@ export async function PATCH(request: Request) {
     if (!ids || !Array.isArray(ids) || ids.length === 0) {
       return NextResponse.json(
         { error: "Mindestens eine Wohnungs-ID ist erforderlich." },
-        { status: 400 }
+        { status: 400, headers: NO_CACHE_HEADERS }
       )
     }
 
     if (!updates || typeof updates !== 'object' || Object.keys(updates).length === 0) {
       return NextResponse.json(
         { error: "Keine Aktualisierungen angegeben." },
-        { status: 400 }
+        { status: 400, headers: NO_CACHE_HEADERS }
       )
     }
 
@@ -44,19 +45,19 @@ export async function PATCH(request: Request) {
       console.error("Supabase Bulk Update Error:", error)
       return NextResponse.json(
         { error: error.message },
-        { status: 500 }
+        { status: 500, headers: NO_CACHE_HEADERS }
       )
     }
 
     return NextResponse.json(
       { successCount: data?.length || 0 },
-      { status: 200 }
+      { status: 200, headers: NO_CACHE_HEADERS }
     )
   } catch (e) {
     console.error("PATCH /api/apartments/bulk-update error:", e)
     return NextResponse.json(
       { error: "Serverfehler beim Aktualisieren der Wohnungen." },
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     )
   }
 }

--- a/app/api/auth/check-verification/route.ts
+++ b/app/api/auth/check-verification/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@supabase/supabase-js"
 import { NextResponse } from "next/server"
+import { NO_CACHE_HEADERS } from "@/lib/constants/http"
 
 export const runtime = 'edge'
 
@@ -13,7 +14,7 @@ export async function GET(request: Request) {
 
     if (!id) {
         // Return 400 if ID is missing (we strictly require it now)
-        return NextResponse.json({ confirmed: false, error: 'User ID is required' }, { status: 400 })
+        return NextResponse.json({ confirmed: false, error: 'User ID is required' }, { status: 400, headers: NO_CACHE_HEADERS })
     }
 
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -21,7 +22,7 @@ export async function GET(request: Request) {
 
     if (!supabaseUrl || !serviceRoleKey) {
         console.error('Missing SUPABASE_SERVICE_ROLE_KEY')
-        return NextResponse.json({ confirmed: false, error: 'Server config error' }, { status: 500 })
+        return NextResponse.json({ confirmed: false, error: 'Server config error' }, { status: 500, headers: NO_CACHE_HEADERS })
     }
 
     try {
@@ -37,22 +38,22 @@ export async function GET(request: Request) {
             if (error.status !== 404) {
                 console.error('Admin getUserById error:', error)
             }
-            return NextResponse.json({ confirmed: false })
+            return NextResponse.json({ confirmed: false }, { headers: NO_CACHE_HEADERS })
         }
 
         const user = data.user
 
         if (!user) {
             // User not found (double check): Return same structure as unverified
-            return NextResponse.json({ confirmed: false })
+            return NextResponse.json({ confirmed: false }, { headers: NO_CACHE_HEADERS })
         }
 
         return NextResponse.json({
             confirmed: !!user.email_confirmed_at,
             email_confirmed_at: user.email_confirmed_at || null
-        })
+        }, { headers: NO_CACHE_HEADERS })
     } catch (error) {
         console.error('Check verification error:', error)
-        return NextResponse.json({ confirmed: false, error: 'An unexpected error occurred' }, { status: 500 })
+        return NextResponse.json({ confirmed: false, error: 'An unexpected error occurred' }, { status: 500, headers: NO_CACHE_HEADERS })
     }
 }

--- a/app/api/auth/clear-auth-cookie/route.ts
+++ b/app/api/auth/clear-auth-cookie/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
 
 export const runtime = 'edge';
 
 export async function POST() {
   // Dummy clear-auth-cookie route for E2E tests and client consistency
-  return NextResponse.json({ success: true });
+  return NextResponse.json({ success: true }, { headers: NO_CACHE_HEADERS });
 }

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
 
 export const runtime = 'edge';
 
 export async function POST() {
   // Dummy logout route for E2E tests and client consistency
-  return NextResponse.json({ success: true });
+  return NextResponse.json({ success: true }, { headers: NO_CACHE_HEADERS });
 }

--- a/app/api/auth/outlook/disconnect/route.ts
+++ b/app/api/auth/outlook/disconnect/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
+import { NO_CACHE_HEADERS } from "@/lib/constants/http"
 
 export const runtime = 'edge';
 
@@ -12,7 +13,7 @@ export async function POST() {
     if (authError || !user) {
       return NextResponse.json(
         { error: "Unauthorized" },
-        { status: 401 }
+        { status: 401, headers: NO_CACHE_HEADERS }
       )
     }
 
@@ -35,16 +36,16 @@ export async function POST() {
       console.error("Error disconnecting Outlook:", error)
       return NextResponse.json(
         { error: "Failed to disconnect Outlook account" },
-        { status: 500 }
+        { status: 500, headers: NO_CACHE_HEADERS }
       )
     }
 
-    return NextResponse.json({ success: true })
+    return NextResponse.json({ success: true }, { headers: NO_CACHE_HEADERS })
   } catch (error) {
     console.error("Outlook disconnect error:", error)
     return NextResponse.json(
       { error: "Internal server error" },
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     )
   }
 }

--- a/app/api/auth/outlook/route.ts
+++ b/app/api/auth/outlook/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
 import { ROUTES } from "@/lib/constants"
+import { NO_CACHE_HEADERS } from "@/lib/constants/http"
 
 export const runtime = 'edge';
 
@@ -20,7 +21,7 @@ export async function GET(request: NextRequest) {
   if (!clientId || !tenantId) {
     return NextResponse.json(
       { error: "Outlook OAuth configuration missing" },
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     )
   }
 

--- a/app/api/auth/outlook/status/route.ts
+++ b/app/api/auth/outlook/status/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
+import { NO_CACHE_HEADERS } from "@/lib/constants/http"
 
 export const runtime = 'edge';
 
@@ -12,7 +13,7 @@ export async function GET() {
     if (authError || !user) {
       return NextResponse.json(
         { connected: false },
-        { status: 200 }
+        { status: 200, headers: NO_CACHE_HEADERS }
       )
     }
 
@@ -27,7 +28,7 @@ export async function GET() {
     if (accountError || !account) {
       return NextResponse.json(
         { connected: false },
-        { status: 200 }
+        { status: 200, headers: NO_CACHE_HEADERS }
       )
     }
 
@@ -51,12 +52,12 @@ export async function GET() {
         token_expires_in_hours: expiresInHours,
         needs_reauth: !account.sync_enabled || isExpired,
       }
-    })
+    }, { headers: NO_CACHE_HEADERS })
   } catch (error) {
     console.error("Outlook status error:", error)
     return NextResponse.json(
       { connected: false },
-      { status: 200 }
+      { status: 200, headers: NO_CACHE_HEADERS }
     )
   }
 }

--- a/app/api/export/route.ts
+++ b/app/api/export/route.ts
@@ -1,6 +1,7 @@
 export const runtime = 'edge';
 import { NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
+import { NO_CACHE_HEADERS } from '@/lib/constants/http';
 
 // Define the tables and columns to export based on the LATEST provided schema.
 // Exclude ALL ID columns (primary and foreign keys) as requested.
@@ -50,24 +51,38 @@ export async function GET() {
 
     if (Object.keys(exportData).length === 0) {
       console.error('No data could be exported. All table queries might have failed or returned no data.');
-      return new NextResponse(JSON.stringify({ error: 'Keine Daten exportiert.', details: 'Möglicherweise sind alle Tabellen leer oder es gab Fehler beim Datenabruf für alle Tabellen.' }), {
+      return NextResponse.json({ 
+        error: 'Keine Daten exportiert.', 
+        details: 'Möglicherweise sind alle Tabellen leer oder es gab Fehler beim Datenabruf für alle Tabellen.' 
+      }, {
         status: 500,
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: NO_CACHE_HEADERS
       });
     }
 
     // Offload ZIP generation to Worker
     const { generateZIP } = await import('@/lib/worker-client');
-    return await generateZIP(exportData, 'datenexport.zip');
+    const zipResponse = await generateZIP(exportData, 'datenexport.zip');
+    
+    // Add no-cache headers to the ZIP response
+    const headers = new Headers(zipResponse.headers);
+    Object.entries(NO_CACHE_HEADERS).forEach(([key, value]) => {
+        headers.set(key, value);
+    });
+    
+    return new NextResponse(zipResponse.body, {
+        status: zipResponse.status,
+        statusText: zipResponse.statusText,
+        headers
+    });
   } catch (error) {
     console.error('Error during data export process:', error);
-    return new NextResponse(JSON.stringify({ error: 'Fehler beim Exportieren der Daten.', details: (error as Error).message }), {
+    return NextResponse.json({ 
+        error: 'Fehler beim Exportieren der Daten.', 
+        details: (error as Error).message 
+    }, {
       status: 500,
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: NO_CACHE_HEADERS
     });
   }
 }

--- a/app/api/files/contents/route.ts
+++ b/app/api/files/contents/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@/utils/supabase/server'
 import { NextRequest, NextResponse } from 'next/server'
 import { logRpcCall, type FolderContentsResult } from '@/app/(dashboard)/dateien/actions'
+import { NO_CACHE_HEADERS } from '@/lib/constants/http'
 
 export const runtime = 'edge'
 
@@ -20,7 +21,7 @@ export async function GET(request: NextRequest) {
     if (!path) {
         return NextResponse.json(
             { error: 'Missing path parameter' },
-            { status: 400 }
+            { status: 400, headers: NO_CACHE_HEADERS }
         )
     }
 
@@ -33,7 +34,7 @@ export async function GET(request: NextRequest) {
         if (authError || !user) {
             return NextResponse.json(
                 { error: 'Nicht authentifiziert' },
-                { status: 401 }
+                { status: 401, headers: NO_CACHE_HEADERS }
             )
         }
 
@@ -42,7 +43,7 @@ export async function GET(request: NextRequest) {
         if (!path.startsWith(expectedPrefix)) {
             return NextResponse.json(
                 { error: 'Ungültiger Pfad' },
-                { status: 403 }
+                { status: 403, headers: NO_CACHE_HEADERS }
             )
         }
 
@@ -62,7 +63,7 @@ export async function GET(request: NextRequest) {
                     totalSize: 0,
                     error: `Fehler beim Laden: ${error.message}`
                 },
-                { status: 500 }
+                { status: 500, headers: NO_CACHE_HEADERS }
             )
         }
 
@@ -85,7 +86,7 @@ export async function GET(request: NextRequest) {
                     totalSize: 0,
                     error: result.error
                 },
-                { status: 200 }
+                { status: 200, headers: NO_CACHE_HEADERS }
             )
         }
 
@@ -94,7 +95,7 @@ export async function GET(request: NextRequest) {
             folders: result.folders || [],
             breadcrumbs: result.breadcrumbs || [{ name: 'Cloud Storage', path: expectedPrefix, type: 'root' }],
             totalSize: result.totalSize || 0
-        })
+        }, { headers: NO_CACHE_HEADERS })
 
     } catch (error) {
         const duration = Math.round(performance.now() - startTime)
@@ -104,7 +105,7 @@ export async function GET(request: NextRequest) {
             {
                 error: error instanceof Error ? error.message : 'Unerwarteter Fehler'
             },
-            { status: 500 }
+            { status: 500, headers: NO_CACHE_HEADERS }
         )
     }
 }

--- a/app/api/finanzen/years/route.ts
+++ b/app/api/finanzen/years/route.ts
@@ -2,14 +2,15 @@ export const runtime = 'edge';
 import { NextResponse } from "next/server";
 import { createClient } from "../../../../utils/supabase/server";
 import { fetchAvailableFinanceYears } from "../../../../utils/financeCalculations";
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
 
 export async function GET() {
   try {
     const supabase = await createClient();
     const years = await fetchAvailableFinanceYears(supabase);
-    return NextResponse.json(years, { status: 200 });
+    return NextResponse.json(years, { status: 200, headers: NO_CACHE_HEADERS });
   } catch (e) {
     console.error('Server error GET /api/finanzen/years:', e);
-    return NextResponse.json({ error: 'Serverfehler bei Jahren-Abfrage.' }, { status: 500 });
+    return NextResponse.json({ error: 'Serverfehler bei Jahren-Abfrage.' }, { status: 500, headers: NO_CACHE_HEADERS });
   }
 }

--- a/app/api/haeuser/bulk-delete/route.ts
+++ b/app/api/haeuser/bulk-delete/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
+import { NO_CACHE_HEADERS } from "@/lib/constants/http"
 
 export const runtime = 'edge';
 
@@ -11,7 +12,7 @@ export async function POST(request: Request) {
     if (!ids || !Array.isArray(ids) || ids.length === 0) {
       return NextResponse.json(
         { error: "Mindestens eine Haus-ID ist erforderlich." },
-        { status: 400 }
+        { status: 400, headers: NO_CACHE_HEADERS }
       )
     }
 
@@ -25,19 +26,19 @@ export async function POST(request: Request) {
       console.error("Supabase Bulk Delete Error:", error)
       return NextResponse.json(
         { error: error.message },
-        { status: 500 }
+        { status: 500, headers: NO_CACHE_HEADERS }
       )
     }
 
     return NextResponse.json(
       { successCount: data?.length || 0 },
-      { status: 200 }
+      { status: 200, headers: NO_CACHE_HEADERS }
     )
   } catch (e) {
     console.error("POST /api/haeuser/bulk-delete error:", e)
     return NextResponse.json(
       { error: "Serverfehler beim Löschen der Häuser." },
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     )
   }
 }

--- a/app/api/mail/outlook/sync/route.ts
+++ b/app/api/mail/outlook/sync/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
+import { NO_CACHE_HEADERS } from "@/lib/constants/http"
 
 export const runtime = 'edge';
 
@@ -12,7 +13,7 @@ export async function POST() {
     if (authError || !user) {
       return NextResponse.json(
         { error: "Unauthorized" },
-        { status: 401 }
+        { status: 401, headers: NO_CACHE_HEADERS }
       )
     }
 
@@ -32,7 +33,7 @@ export async function POST() {
           error: "No Outlook account connected",
           details: accountError?.message
         },
-        { status: 404 }
+        { status: 404, headers: NO_CACHE_HEADERS }
       )
     }
 
@@ -57,7 +58,7 @@ export async function POST() {
           details: error.message || error.toString(),
           data: data
         },
-        { status: 500 }
+        { status: 500, headers: NO_CACHE_HEADERS }
       )
     }
 
@@ -70,7 +71,7 @@ export async function POST() {
           details: data.details,
           requiresReauth: data.requiresReauth || false
         },
-        { status: data.requiresReauth ? 401 : 500 }
+        { status: data.requiresReauth ? 401 : 500, headers: NO_CACHE_HEADERS }
       )
     }
 
@@ -82,12 +83,12 @@ export async function POST() {
       message: data?.message || "Email import started",
       queueId: data?.queueId,
       syncedAt: data?.syncedAt,
-    })
+    }, { headers: NO_CACHE_HEADERS })
   } catch (error) {
     console.error("Outlook sync error:", error)
     return NextResponse.json(
       { error: "Internal server error" },
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     )
   }
 }

--- a/app/api/mail/queue/process/route.ts
+++ b/app/api/mail/queue/process/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
+import { NO_CACHE_HEADERS } from "@/lib/constants/http"
 
 export const runtime = 'edge';
 
@@ -12,7 +13,7 @@ export async function POST() {
     if (authError || !user) {
       return NextResponse.json(
         { error: "Unauthorized" },
-        { status: 401 }
+        { status: 401, headers: NO_CACHE_HEADERS }
       )
     }
 
@@ -23,7 +24,7 @@ export async function POST() {
       console.error("Error triggering queue processor:", error)
       return NextResponse.json(
         { error: "Failed to trigger queue processor" },
-        { status: 500 }
+        { status: 500, headers: NO_CACHE_HEADERS }
       )
     }
 
@@ -36,12 +37,12 @@ export async function POST() {
       message: result.pending_count > 0 
         ? `Processing ${result.pending_count} pending items` 
         : 'No pending items in queue',
-    })
+    }, { headers: NO_CACHE_HEADERS })
   } catch (error) {
     console.error("Queue process error:", error)
     return NextResponse.json(
       { error: "Internal server error" },
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     )
   }
 }

--- a/app/api/mail/queue/retry/route.ts
+++ b/app/api/mail/queue/retry/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
+import { NO_CACHE_HEADERS } from "@/lib/constants/http"
 
 export const runtime = 'edge';
 
@@ -12,7 +13,7 @@ export async function POST() {
     if (authError || !user) {
       return NextResponse.json(
         { error: "Unauthorized" },
-        { status: 401 }
+        { status: 401, headers: NO_CACHE_HEADERS }
       )
     }
 
@@ -25,7 +26,7 @@ export async function POST() {
       console.error("Error retrying failed items:", error)
       return NextResponse.json(
         { error: "Failed to retry queue items" },
-        { status: 500 }
+        { status: 500, headers: NO_CACHE_HEADERS }
       )
     }
 
@@ -37,12 +38,12 @@ export async function POST() {
       message: retriedCount > 0 
         ? `Retrying ${retriedCount} failed items` 
         : 'No failed items to retry',
-    })
+    }, { headers: NO_CACHE_HEADERS })
   } catch (error) {
     console.error("Queue retry error:", error)
     return NextResponse.json(
       { error: "Internal server error" },
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     )
   }
 }

--- a/app/api/mail/queue/status/route.ts
+++ b/app/api/mail/queue/status/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
+import { NO_CACHE_HEADERS } from "@/lib/constants/http"
 
 export const runtime = 'edge';
 
@@ -12,7 +13,7 @@ export async function GET() {
     if (authError || !user) {
       return NextResponse.json(
         { error: "Unauthorized" },
-        { status: 401 }
+        { status: 401, headers: NO_CACHE_HEADERS }
       )
     }
 
@@ -24,7 +25,7 @@ export async function GET() {
       console.error("Error fetching queue stats:", statsError)
       return NextResponse.json(
         { error: "Failed to fetch queue statistics" },
-        { status: 500 }
+        { status: 500, headers: NO_CACHE_HEADERS }
       )
     }
 
@@ -38,12 +39,12 @@ export async function GET() {
         failed_items: 0,
         total_messages_imported: 0,
       },
-    })
+    }, { headers: NO_CACHE_HEADERS })
   } catch (error) {
     console.error("Queue status error:", error)
     return NextResponse.json(
       { error: "Internal server error" },
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     )
   }
 }

--- a/app/api/mieter/[id]/route.ts
+++ b/app/api/mieter/[id]/route.ts
@@ -1,6 +1,7 @@
 export const runtime = 'edge';
 import { createClient } from "@/utils/supabase/server";
 import { NextRequest, NextResponse } from "next/server";
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
 
 // GET specific tenant by ID
 export async function GET(
@@ -20,15 +21,15 @@ export async function GET(
         if (error) {
             console.error(`GET /api/mieter/${id} error:`, error);
             if (error.code === 'PGRST116') {
-                return NextResponse.json({ error: 'Mieter nicht gefunden.' }, { status: 404 });
+                return NextResponse.json({ error: 'Mieter nicht gefunden.' }, { status: 404, headers: NO_CACHE_HEADERS });
             }
-            return NextResponse.json({ error: error.message }, { status: 500 });
+            return NextResponse.json({ error: error.message }, { status: 500, headers: NO_CACHE_HEADERS });
         }
 
-        return NextResponse.json(data, { status: 200 });
+        return NextResponse.json(data, { status: 200, headers: NO_CACHE_HEADERS });
     } catch (e) {
         console.error('Server error GET /api/mieter/[id]:', e);
-        return NextResponse.json({ error: 'Serverfehler bei Mieter-Abfrage.' }, { status: 500 });
+        return NextResponse.json({ error: 'Serverfehler bei Mieter-Abfrage.' }, { status: 500, headers: NO_CACHE_HEADERS });
     }
 }
 
@@ -50,17 +51,17 @@ export async function PATCH(
 
         if (error) {
             console.error(`PATCH /api/mieter/${id} error:`, error);
-            return NextResponse.json({ error: error.message }, { status: 400 });
+            return NextResponse.json({ error: error.message }, { status: 400, headers: NO_CACHE_HEADERS });
         }
 
         if (!data || data.length === 0) {
-            return NextResponse.json({ error: 'Mieter nicht gefunden.' }, { status: 404 });
+            return NextResponse.json({ error: 'Mieter nicht gefunden.' }, { status: 404, headers: NO_CACHE_HEADERS });
         }
 
-        return NextResponse.json(data[0], { status: 200 });
+        return NextResponse.json(data[0], { status: 200, headers: NO_CACHE_HEADERS });
     } catch (e) {
         console.error('Server error PATCH /api/mieter/[id]:', e);
-        return NextResponse.json({ error: 'Serverfehler beim Aktualisieren des Mieters.' }, { status: 500 });
+        return NextResponse.json({ error: 'Serverfehler beim Aktualisieren des Mieters.' }, { status: 500, headers: NO_CACHE_HEADERS });
     }
 }
 
@@ -83,12 +84,12 @@ export async function DELETE(
 
         if (error) {
             console.error(`DELETE /api/mieter/${id} error:`, error);
-            return NextResponse.json({ error: error.message }, { status: 500 });
+            return NextResponse.json({ error: error.message }, { status: 500, headers: NO_CACHE_HEADERS });
         }
 
-        return NextResponse.json({ message: 'Mieter gelöscht' }, { status: 200 });
+        return NextResponse.json({ message: 'Mieter gelöscht' }, { status: 200, headers: NO_CACHE_HEADERS });
     } catch (e) {
         console.error('Server error DELETE /api/mieter/[id]:', e);
-        return NextResponse.json({ error: 'Serverfehler beim Löschen des Mieters.' }, { status: 500 });
+        return NextResponse.json({ error: 'Serverfehler beim Löschen des Mieters.' }, { status: 500, headers: NO_CACHE_HEADERS });
     }
 }

--- a/app/api/mieter/bulk-delete/route.ts
+++ b/app/api/mieter/bulk-delete/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
+import { NO_CACHE_HEADERS } from "@/lib/constants/http"
 
 export const runtime = 'edge';
 
@@ -11,7 +12,7 @@ export async function POST(request: Request) {
     if (!ids || !Array.isArray(ids) || ids.length === 0) {
       return NextResponse.json(
         { error: "Mindestens eine Mieter-ID ist erforderlich." },
-        { status: 400 }
+        { status: 400, headers: NO_CACHE_HEADERS }
       )
     }
 
@@ -25,19 +26,19 @@ export async function POST(request: Request) {
       console.error("Supabase Bulk Delete Error:", error)
       return NextResponse.json(
         { error: error.message },
-        { status: 500 }
+        { status: 500, headers: NO_CACHE_HEADERS }
       )
     }
 
     return NextResponse.json(
       { successCount: data?.length || 0 },
-      { status: 200 }
+      { status: 200, headers: NO_CACHE_HEADERS }
     )
   } catch (e) {
     console.error("POST /api/mieter/bulk-delete error:", e)
     return NextResponse.json(
       { error: "Serverfehler beim Löschen der Mieter." },
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     )
   }
 }

--- a/app/api/mieter/bulk-update/route.ts
+++ b/app/api/mieter/bulk-update/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
+import { NO_CACHE_HEADERS } from "@/lib/constants/http"
 
 export const runtime = 'edge';
 
@@ -18,14 +19,14 @@ export async function PATCH(request: Request) {
     if (!ids || !Array.isArray(ids) || ids.length === 0) {
       return NextResponse.json(
         { error: "Mindestens eine Mieter-ID ist erforderlich." },
-        { status: 400 }
+        { status: 400, headers: NO_CACHE_HEADERS }
       )
     }
 
     if (Object.keys(updates).length === 0) {
       return NextResponse.json(
         { error: "Keine Aktualisierungen angegeben." },
-        { status: 400 }
+        { status: 400, headers: NO_CACHE_HEADERS }
       )
     }
 
@@ -39,19 +40,19 @@ export async function PATCH(request: Request) {
       console.error("Supabase Bulk Update Error:", error)
       return NextResponse.json(
         { error: error.message },
-        { status: 500 }
+        { status: 500, headers: NO_CACHE_HEADERS }
       )
     }
 
     return NextResponse.json(
       { successCount: data?.length || 0 },
-      { status: 200 }
+      { status: 200, headers: NO_CACHE_HEADERS }
     )
   } catch (e) {
     console.error("PATCH /api/mieter/bulk-update error:", e)
     return NextResponse.json(
       { error: "Serverfehler beim Aktualisieren der Mieter." },
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     )
   }
 }

--- a/app/api/oauth/approve/route.ts
+++ b/app/api/oauth/approve/route.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
+import { NO_CACHE_HEADERS } from '@/lib/constants/http';
 
 export const runtime = 'edge';
 
@@ -10,7 +11,7 @@ export async function GET(request: NextRequest) {
     const baseUrl = new URL(request.url).origin;
 
     if (!authorizationId) {
-        return NextResponse.json({ error: 'Missing authorization_id' }, { status: 400 });
+        return NextResponse.json({ error: 'Missing authorization_id' }, { status: 400, headers: NO_CACHE_HEADERS });
     }
 
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -18,7 +19,7 @@ export async function GET(request: NextRequest) {
 
     if (!supabaseUrl || !anonKey) {
         console.error('Missing Supabase environment variables');
-        return NextResponse.json({ error: 'Configuration error' }, { status: 500 });
+        return NextResponse.json({ error: 'Configuration error' }, { status: 500, headers: NO_CACHE_HEADERS });
     }
 
     try {

--- a/app/api/oauth/decision/route.ts
+++ b/app/api/oauth/decision/route.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+import { NO_CACHE_HEADERS } from '@/lib/constants/http';
 
 export const runtime = 'edge';
 
@@ -10,7 +11,7 @@ export async function POST(request: Request) {
     const authorizationId = formData.get('authorization_id') as string;
 
     if (!authorizationId) {
-        return NextResponse.json({ error: 'Missing authorization_id' }, { status: 400 });
+        return NextResponse.json({ error: 'Missing authorization_id' }, { status: 400, headers: NO_CACHE_HEADERS });
     }
 
     if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
@@ -36,7 +37,7 @@ export async function POST(request: Request) {
 
         if (error) {
             console.error('Approval error:', error);
-            return NextResponse.json({ error: error.message }, { status: 400 });
+            return NextResponse.json({ error: error.message }, { status: 400, headers: NO_CACHE_HEADERS });
         }
 
         // Redirect back to the client with authorization code
@@ -46,7 +47,7 @@ export async function POST(request: Request) {
 
         if (error) {
             console.error('Denial error:', error);
-            return NextResponse.json({ error: error.message }, { status: 400 });
+            return NextResponse.json({ error: error.message }, { status: 400, headers: NO_CACHE_HEADERS });
         }
 
         // Redirect back to the client with error

--- a/app/api/oauth/token/route.ts
+++ b/app/api/oauth/token/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { NO_CACHE_HEADERS } from '@/lib/constants/http';
 
 export const runtime = 'edge';
 
@@ -43,7 +44,7 @@ export async function POST(request: NextRequest) {
         if (!grant_type || !code || !client_id || !redirect_uri) {
             return NextResponse.json(
                 { error: 'invalid_request', error_description: 'Missing required parameters' },
-                { status: 400 }
+                { status: 400, headers: NO_CACHE_HEADERS }
             );
         }
 
@@ -59,15 +60,15 @@ export async function POST(request: NextRequest) {
 
         if (isStrictValidation) {
             if (!ALLOWED_CLIENTS.hasOwnProperty(client_id)) {
-                return NextResponse.json({ error: 'invalid_client', error_description: 'Unknown client_id' }, { status: 401 });
+                return NextResponse.json({ error: 'invalid_client', error_description: 'Unknown client_id' }, { status: 401, headers: NO_CACHE_HEADERS });
             }
             const expectedSecret = ALLOWED_CLIENTS[client_id];
             if (expectedSecret && expectedSecret !== client_secret) {
-                return NextResponse.json({ error: 'invalid_client', error_description: 'Invalid client_secret' }, { status: 401 });
+                return NextResponse.json({ error: 'invalid_client', error_description: 'Invalid client_secret' }, { status: 401, headers: NO_CACHE_HEADERS });
             }
         } else {
             console.error('CRITICAL: No OAuth clients configured. Rejecting request. Please configure ALLOWED_CLIENTS in app/api/oauth/token/route.ts or set OAUTH_CLIENT_ID env var.');
-            return NextResponse.json({ error: 'invalid_client', error_description: 'Client authentication failed: server not configured.' }, { status: 500 });
+            return NextResponse.json({ error: 'invalid_client', error_description: 'Client authentication failed: server not configured.' }, { status: 500, headers: NO_CACHE_HEADERS });
         }
 
         // Proxy to Supabase's token endpoint
@@ -106,7 +107,7 @@ export async function POST(request: NextRequest) {
                     error: errorData.error || 'token_exchange_failed',
                     error_description: errorData.error_description || errorData.message || `Token exchange failed: ${tokenResponse.status}`
                 },
-                { status: tokenResponse.status }
+                { status: tokenResponse.status, headers: NO_CACHE_HEADERS }
             );
         }
 
@@ -119,13 +120,13 @@ export async function POST(request: NextRequest) {
             expires_in: tokenData.expires_in,
             refresh_token: tokenData.refresh_token,
             scope: tokenData.scope || 'email',
-        });
+        }, { headers: NO_CACHE_HEADERS });
 
     } catch (err: any) {
         console.error('Token exchange error:', err);
         return NextResponse.json(
             { error: 'server_error', error_description: err.message || 'Internal server error' },
-            { status: 500 }
+            { status: 500, headers: NO_CACHE_HEADERS }
         );
     }
 }

--- a/app/api/posthog-config/route.ts
+++ b/app/api/posthog-config/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import posthogProxyConfig from '@/lib/posthog-proxy'
+import { NO_CACHE_HEADERS } from '@/lib/constants/http'
 
 export const runtime = 'edge'
 
@@ -17,8 +18,8 @@ export async function GET() {
 
   // Only return config if we have a valid key
   if (!config.key || config.key === 'phc_placeholder_key') {
-    return NextResponse.json({ error: 'PostHog not configured' }, { status: 404 })
+    return NextResponse.json({ error: 'PostHog not configured' }, { status: 404, headers: NO_CACHE_HEADERS })
   }
 
-  return NextResponse.json(config)
+  return NextResponse.json(config, { headers: NO_CACHE_HEADERS })
 }

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,6 +1,7 @@
 export const runtime = 'edge';
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
 import type {
   SearchResponse,
   SearchResult as FrontendSearchResult
@@ -154,20 +155,20 @@ export async function GET(request: Request) {
     if (!query || query.trim().length === 0) {
       return NextResponse.json({ 
         error: 'Search query is required' 
-      }, { status: 400 });
+      }, { status: 400, headers: NO_CACHE_HEADERS });
     }
     
     if (query.length > 100) {
       return NextResponse.json({ 
         error: 'Search query too long' 
-      }, { status: 400 });
+      }, { status: 400, headers: NO_CACHE_HEADERS });
     }
     
     // Validate limit
     if (limit < 1 || limit > 20) {
       return NextResponse.json({ 
         error: 'Limit must be between 1 and 20' 
-      }, { status: 400 });
+      }, { status: 400, headers: NO_CACHE_HEADERS });
     }
     
     const supabase = await createClient();
@@ -680,7 +681,7 @@ export async function GET(request: Request) {
     // Add warning header if some searches failed but we have partial results
     const headers = new Headers({
       'Content-Type': 'application/json',
-      'Cache-Control': 'public, max-age=60', // Cache for 1 minute
+      ...NO_CACHE_HEADERS,
     });
     
     if (failedSearches > 0 && successfulSearches > 0) {
@@ -732,7 +733,7 @@ export async function GET(request: Request) {
       }
     }
     
-    const responseHeaders: Record<string, string> = {};
+    const responseHeaders: Record<string, string> = { ...NO_CACHE_HEADERS };
     if (statusCode === 503) {
       responseHeaders['Retry-After'] = '30'; // Suggest retry after 30 seconds for service unavailable
     }

--- a/app/api/stripe/plans/[priceId]/route.ts
+++ b/app/api/stripe/plans/[priceId]/route.ts
@@ -1,6 +1,7 @@
 export const runtime = 'edge';
 import { NextResponse } from 'next/server';
 import { getPlanDetails } from '@/lib/stripe-server';
+import { NO_CACHE_HEADERS } from '@/lib/constants/http';
 
 export async function GET(
     request: Request,
@@ -11,6 +12,7 @@ export async function GET(
     if (!priceId) {
         return NextResponse.json({ error: 'Price ID is required' }, {
             status: 400,
+            headers: NO_CACHE_HEADERS
         });
     }
 
@@ -20,16 +22,18 @@ export async function GET(
         if (!plan) {
             return NextResponse.json({ error: 'Plan not found' }, {
                 status: 404,
+                headers: NO_CACHE_HEADERS
             });
         }
 
-        return NextResponse.json(plan);
+        return NextResponse.json(plan, { headers: NO_CACHE_HEADERS });
     } catch (error) {
         console.error(`Error fetching plan details for ${priceId}:`, error);
         return NextResponse.json(
             { error: 'Failed to fetch plan details' },
             {
                 status: 500,
+                headers: NO_CACHE_HEADERS
             }
         );
     }

--- a/app/api/stripe/plans/route.ts
+++ b/app/api/stripe/plans/route.ts
@@ -4,6 +4,7 @@ import Stripe from 'stripe';
 import { STRIPE_CONFIG } from '@/lib/constants/stripe';
 import { StripePlan } from '@/types/stripe';
 import { parseStorageString } from '@/lib/stripe-server';
+import { NO_CACHE_HEADERS } from '@/lib/constants/http';
 
 import { isTestEnv, isStripeMocked } from '@/lib/test-utils';
 
@@ -50,6 +51,7 @@ export async function GET() {
 
     return NextResponse.json({ error: 'Stripe secret key not configured.' }, {
       status: 500,
+      headers: NO_CACHE_HEADERS
     });
   }
 
@@ -133,7 +135,7 @@ export async function GET() {
       return 0;
     });
 
-    return NextResponse.json(plans);
+    return NextResponse.json(plans, { headers: NO_CACHE_HEADERS });
 
   } catch (error) {
     let errorMessage = 'An unknown error occurred while fetching plans.';
@@ -156,6 +158,7 @@ export async function GET() {
     }
     return NextResponse.json({ error: 'Failed to fetch plans from Stripe.', details: errorMessage }, {
       status: 500,
+      headers: NO_CACHE_HEADERS
     });
   }
 }

--- a/app/api/tenants/[tenantId]/missed-payments/route.ts
+++ b/app/api/tenants/[tenantId]/missed-payments/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 import { calculateMissedPayments } from "@/utils/tenant-payment-calculations";
 import { logger } from "@/utils/logger";
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
 
 export async function GET(
     request: Request,
@@ -13,7 +14,7 @@ export async function GET(
         const { tenantId } = await params;
 
         if (!tenantId) {
-            return NextResponse.json({ error: "Tenant ID is required." }, { status: 400 });
+            return NextResponse.json({ error: "Tenant ID is required." }, { status: 400, headers: NO_CACHE_HEADERS });
         }
 
         // Fetch tenant with apartment details
@@ -33,7 +34,7 @@ export async function GET(
             .single();
 
         if (tenantError || !tenant) {
-            return NextResponse.json({ error: "Tenant not found." }, { status: 404 });
+            return NextResponse.json({ error: "Tenant not found." }, { status: 404, headers: NO_CACHE_HEADERS });
         }
 
         // Fetch finances for this tenant's apartment
@@ -41,7 +42,7 @@ export async function GET(
         // We fetch all finances since the start of the move-in month to be safe
         if (!tenant.einzug) {
             logger.error("Cannot calculate missed payments for tenant without move-in date.", undefined, { tenantId });
-            return NextResponse.json({ error: "Tenant move-in date is missing." }, { status: 400 });
+            return NextResponse.json({ error: "Tenant move-in date is missing." }, { status: 400, headers: NO_CACHE_HEADERS });
         }
         const moveInDate = new Date(tenant.einzug);
         // Reset to the first day of the month to ensure we catch payments made on the 1st
@@ -57,7 +58,7 @@ export async function GET(
             .order('datum', { ascending: true });
 
         if (financesError) {
-            return NextResponse.json({ error: "Failed to fetch finances." }, { status: 500 });
+            return NextResponse.json({ error: "Failed to fetch finances." }, { status: 500, headers: NO_CACHE_HEADERS });
         }
 
         const missedPayments = calculateMissedPayments(tenant, finances || [], true);
@@ -65,10 +66,10 @@ export async function GET(
         return NextResponse.json({
             missedPayments,
             hasMissingPayments: missedPayments.totalAmount > 0
-        });
+        }, { headers: NO_CACHE_HEADERS });
 
     } catch (error) {
         logger.error("Error in missed payments API:", error as Error);
-        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+        return NextResponse.json({ error: "Internal server error" }, { status: 500, headers: NO_CACHE_HEADERS });
     }
 }

--- a/app/api/todos/[id]/route.ts
+++ b/app/api/todos/[id]/route.ts
@@ -1,6 +1,7 @@
 export const runtime = 'edge';
 import { NextRequest, NextResponse } from "next/server"
 import { createSupabaseServerClient } from "@/lib/supabase-server"
+import { NO_CACHE_HEADERS } from "@/lib/constants/http"
 
 // GET specific todo by ID
 export async function GET(
@@ -20,12 +21,12 @@ export async function GET(
     
     if (error) throw error
     
-    return NextResponse.json(data)
+    return NextResponse.json(data, { headers: NO_CACHE_HEADERS })
   } catch (error) {
     console.error("Error fetching todo:", error)
     return NextResponse.json(
       { error: "Fehler beim Laden der Aufgabe" },
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     )
   }
 }
@@ -45,7 +46,7 @@ export async function PUT(
     if (!name || !beschreibung) {
       return NextResponse.json(
         { error: "Name und Beschreibung sind erforderlich" },
-        { status: 400 }
+        { status: 400, headers: NO_CACHE_HEADERS }
       )
     }
     
@@ -62,12 +63,12 @@ export async function PUT(
     
     if (error) throw error
     
-    return NextResponse.json(data[0])
+    return NextResponse.json(data[0], { headers: NO_CACHE_HEADERS })
   } catch (error) {
     console.error("Error updating todo:", error)
     return NextResponse.json(
       { error: "Fehler beim Aktualisieren der Aufgabe" },
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     )
   }
 }
@@ -89,12 +90,12 @@ export async function DELETE(
     
     if (error) throw error
     
-    return NextResponse.json({ success: true })
+    return NextResponse.json({ success: true }, { headers: NO_CACHE_HEADERS })
   } catch (error) {
     console.error("Error deleting todo:", error)
     return NextResponse.json(
       { error: "Fehler beim Löschen der Aufgabe" },
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     )
   }
 }

--- a/app/api/todos/route.ts
+++ b/app/api/todos/route.ts
@@ -1,6 +1,7 @@
 export const runtime = 'edge';
 import { NextRequest, NextResponse } from "next/server"
 import { createSupabaseServerClient } from "@/lib/supabase-server"
+import { NO_CACHE_HEADERS } from "@/lib/constants/http"
 
 // GET todos
 export async function GET(request: NextRequest) {
@@ -14,12 +15,12 @@ export async function GET(request: NextRequest) {
     
     if (error) throw error
     
-    return NextResponse.json(data)
+    return NextResponse.json(data, { headers: NO_CACHE_HEADERS })
   } catch (error) {
     console.error("Error fetching todos:", error)
     return NextResponse.json(
       { error: "Fehler beim Laden der Aufgaben" },
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     )
   }
 }
@@ -35,7 +36,7 @@ export async function POST(request: NextRequest) {
     if (!name || !beschreibung) {
       return NextResponse.json(
         { error: "Name und Beschreibung sind erforderlich" },
-        { status: 400 }
+        { status: 400, headers: NO_CACHE_HEADERS }
       )
     }
     
@@ -52,12 +53,12 @@ export async function POST(request: NextRequest) {
     
     if (error) throw error
     
-    return NextResponse.json(data[0])
+    return NextResponse.json(data[0], { headers: NO_CACHE_HEADERS })
   } catch (error) {
     console.error("Error creating todo:", error)
     return NextResponse.json(
       { error: "Fehler beim Erstellen der Aufgabe" },
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     )
   }
 }
@@ -73,7 +74,7 @@ export async function PATCH(request: NextRequest) {
     if (!id) {
       return NextResponse.json(
         { error: "ID ist erforderlich" },
-        { status: 400 }
+        { status: 400, headers: NO_CACHE_HEADERS }
       )
     }
     
@@ -88,12 +89,12 @@ export async function PATCH(request: NextRequest) {
     
     if (error) throw error
     
-    return NextResponse.json(data[0])
+    return NextResponse.json(data[0], { headers: NO_CACHE_HEADERS })
   } catch (error) {
     console.error("Error updating todo:", error)
     return NextResponse.json(
       { error: "Fehler beim Aktualisieren der Aufgabe" },
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     )
   }
 }

--- a/app/api/wohnungen/[id]/overview/route.ts
+++ b/app/api/wohnungen/[id]/overview/route.ts
@@ -2,6 +2,7 @@ export const runtime = 'edge';
 import { NextResponse } from "next/server";
 import { createClient } from "@/utils/supabase/server";
 import { createRequestLogger } from "@/utils/logger";
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
 
 interface WohnungWithMieter {
   id: string;
@@ -45,7 +46,7 @@ export async function GET(
     if (!wohnungId || wohnungId.trim() === '') {
       return NextResponse.json(
         { error: "Wohnungs-ID ist erforderlich." },
-        { status: 400 }
+        { status: 400, headers: NO_CACHE_HEADERS }
       );
     }
 
@@ -54,7 +55,7 @@ export async function GET(
     if (!uuidRegex.test(wohnungId)) {
       return NextResponse.json(
         { error: "Ungültige Wohnungs-ID Format." },
-        { status: 400 }
+        { status: 400, headers: NO_CACHE_HEADERS }
       );
     }
 
@@ -79,16 +80,16 @@ export async function GET(
         errorCode: wohnungError.code,
         details: wohnungError.details
       });
-      
+
       if (wohnungError.code === 'PGRST116') {
         return NextResponse.json(
           { error: "Wohnung nicht gefunden." },
-          { status: 404 }
+          { status: 404, headers: NO_CACHE_HEADERS }
         );
       }
       return NextResponse.json(
         { error: "Fehler beim Laden der Wohnungsdaten." },
-        { status: 500 }
+        { status: 500, headers: NO_CACHE_HEADERS }
       );
     }
 
@@ -106,10 +107,10 @@ export async function GET(
         errorCode: mieterError.code,
         details: mieterError.details
       });
-      
+
       return NextResponse.json(
         { error: "Fehler beim Laden der Mieterdaten." },
-        { status: 500 }
+        { status: 500, headers: NO_CACHE_HEADERS }
       );
     }
 
@@ -166,7 +167,7 @@ export async function GET(
       mieter
     };
 
-    return NextResponse.json(response, { status: 200 });
+    return NextResponse.json(response, { status: 200, headers: NO_CACHE_HEADERS });
 
   } catch (error) {
     const logger = createRequestLogger(request);
@@ -176,7 +177,7 @@ export async function GET(
     
     return NextResponse.json(
       { error: "Serverfehler beim Laden der Wohnungsübersicht." },
-      { status: 500 }
+      { status: 500, headers: NO_CACHE_HEADERS }
     );
   }
 }

--- a/app/api/wohnungen/[id]/rent/route.ts
+++ b/app/api/wohnungen/[id]/rent/route.ts
@@ -2,6 +2,7 @@ export const runtime = 'edge';
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 import { fetchUserProfile } from "@/lib/data-fetching";
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
 
 export async function GET(
   request: Request,
@@ -13,7 +14,7 @@ export async function GET(
     // Verify user authentication
     const userProfile = await fetchUserProfile();
     if (!userProfile) {
-      return NextResponse.json({ error: "Benutzer nicht authentifiziert." }, { status: 401 });
+      return NextResponse.json({ error: "Benutzer nicht authentifiziert." }, { status: 401, headers: NO_CACHE_HEADERS });
     }
 
     const { id: wohnungId } = await params;
@@ -28,16 +29,16 @@ export async function GET(
 
     if (error) {
       console.error("Supabase Select Error (Wohnung rent):", error);
-      return NextResponse.json({ error: "Wohnung nicht gefunden." }, { status: 404 });
+      return NextResponse.json({ error: "Wohnung nicht gefunden." }, { status: 404, headers: NO_CACHE_HEADERS });
     }
 
     if (!apartment) {
-      return NextResponse.json({ error: "Wohnung nicht gefunden." }, { status: 404 });
+      return NextResponse.json({ error: "Wohnung nicht gefunden." }, { status: 404, headers: NO_CACHE_HEADERS });
     }
 
-    return NextResponse.json({ miete: apartment.miete }, { status: 200 });
+    return NextResponse.json({ miete: apartment.miete }, { status: 200, headers: NO_CACHE_HEADERS });
   } catch (e) {
     console.error("GET /api/wohnungen/[id]/rent error:", e);
-    return NextResponse.json({ error: "Serverfehler beim Abrufen der Mietdaten." }, { status: 500 });
+    return NextResponse.json({ error: "Serverfehler beim Abrufen der Mietdaten." }, { status: 500, headers: NO_CACHE_HEADERS });
   }
 }

--- a/app/api/worker/route.ts
+++ b/app/api/worker/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { NO_CACHE_HEADERS } from '@/lib/constants/http';
 export const runtime = 'edge';
 
 const MAX_RETRIES = 3;
@@ -56,7 +57,10 @@ export async function POST(request: Request) {
         if (!response.ok) {
             const errorText = await response.text();
             console.error('[WorkerProxy] Backend error:', response.status, errorText);
-            return new NextResponse(errorText, { status: response.status });
+            return new NextResponse(errorText, { 
+                status: response.status,
+                headers: NO_CACHE_HEADERS
+            });
         }
 
         // Forward the binary response from the worker
@@ -74,6 +78,11 @@ export async function POST(request: Request) {
         // Expose headers for the frontend
         responseHeaders.set('Access-Control-Expose-Headers', 'X-PDF-Page-Count, X-PDF-Generation-Time');
 
+        // Apply NO_CACHE_HEADERS
+        Object.entries(NO_CACHE_HEADERS).forEach(([key, value]) => {
+            responseHeaders.set(key, value);
+        });
+
         return new NextResponse(response.body, {
             status: response.status,
             headers: responseHeaders,
@@ -81,13 +90,13 @@ export async function POST(request: Request) {
     } catch (err: unknown) {
         const error = err instanceof Error ? err : new Error(String(err));
         console.error('[WorkerProxy] Proxy failed:', error);
-        return new NextResponse(JSON.stringify({
+        return NextResponse.json({
             error: 'Proxy failed',
             details: error.message,
             name: error.name
-        }), {
+        }, {
             status: 500,
-            headers: { 'Content-Type': 'application/json' },
+            headers: NO_CACHE_HEADERS,
         });
     }
 }

--- a/lib/constants/http.ts
+++ b/lib/constants/http.ts
@@ -4,8 +4,9 @@
 
 // Cache-control headers to prevent CDN caching of user-specific responses
 // Private directive ensures shared caches (CDNs) don't store authenticated responses
+// 'no-store' is the primary directive to ensure data is never written to disk/memory in any cache
 export const NO_CACHE_HEADERS = {
-    'Cache-Control': 'private, no-cache, no-store, must-revalidate',
+    'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0',
     'Pragma': 'no-cache',
     'Expires': '0',
 };


### PR DESCRIPTION
## Description

Expands the `NO_CACHE_HEADERS` coverage to all sensitive API routes so authenticated/user-specific responses are never cached by CDNs or browsers.

## Summary of Changes

- ~30 API routes now return `NO_CACHE_HEADERS` on every response (apartments/tenant details, bulk operations, auth + outlook routes, export, files/contents, finanzen years, haeuser/mieter CRUD + bulk, mail queue, oauth approve/decision, todos, wohnungen, worker proxy)
- `lib/constants/http.ts`: Cache-Control strengthened to `no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0` (plus Pragma/Expires)
- Export + worker proxy: headers are also applied to streamed/binary responses