### PR TITLE
fix(auth): resolve session refresh in Server Components and optimize parallel fetching

### DIFF
--- a/app/(dashboard)/betriebskosten/page.tsx
+++ b/app/(dashboard)/betriebskosten/page.tsx
@@ -5,7 +5,7 @@ export const dynamic = 'force-dynamic';
 
 import { fetchHaeuser as fetchHaeuserServer } from "../../../lib/data-fetching";
 import { fetchNebenkostenListOptimized } from "@/app/betriebskosten-actions";
-import { createClient } from "@/utils/supabase/server";
+import { requireAuthenticatedUser } from "@/lib/server/route-access";
 import BetriebskostenClientView from "./client-wrapper"; // Import the default export
 // Types are still needed for data fetching
 import { Haus } from "../../../lib/data-fetching";
@@ -13,8 +13,7 @@ import { OptimizedNebenkosten } from "@/types/optimized-betriebskosten";
 // Server actions are fine to be imported by Server Components if needed, but not directly by client-wrapper
 
 export default async function BetriebskostenPage() {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { supabase, user } = await requireAuthenticatedUser();
   
   // Use optimized function that eliminates individual getHausGesamtFlaeche calls
   const nebenkostenResult = await fetchNebenkostenListOptimized();

--- a/app/(dashboard)/dateien/page.tsx
+++ b/app/(dashboard)/dateien/page.tsx
@@ -1,7 +1,6 @@
 import { Suspense } from 'react'
 import { CloudStorage } from "@/components/cloud-storage/cloud-storage"
-import { createClient } from "@/utils/supabase/server"
-import { redirect } from "next/navigation"
+import { requireAuthenticatedUser } from "@/lib/server/route-access"
 import { getFolderContents } from "./actions"
 import DateienLoading from './loading'
 
@@ -29,14 +28,7 @@ async function CloudStorageContent({ userId }: { userId: string }) {
 }
 
 export default async function DateienPage() {
-    const supabase = await createClient()
-
-    // Get user on server side
-    const { data: { user }, error } = await supabase.auth.getUser()
-
-    if (error || !user) {
-        redirect('/auth/login')
-    }
+    const { user } = await requireAuthenticatedUser()
 
     return (
         <Suspense fallback={<DateienLoading />}>

--- a/app/(dashboard)/finanzen/page.tsx
+++ b/app/(dashboard)/finanzen/page.tsx
@@ -3,11 +3,12 @@ export const dynamic = 'force-dynamic';
 
 import FinanzenClientWrapper from "./client-wrapper";
 import { requireAuthenticatedUser } from "@/lib/server/route-access";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
 
 import { PAGINATION } from "@/constants";
 
-async function getSummaryData(supabase: any, year: number) {
+async function getSummaryData(supabase: SupabaseClient, year: number) {
   try {
     // Use the optimized Supabase function that handles pagination internally
     const { data, error } = await supabase.rpc('get_financial_year_summary', {
@@ -34,7 +35,7 @@ async function getSummaryData(supabase: any, year: number) {
   }
 }
 
-async function getSummaryDataFallback(supabase: any, year: number) {
+async function getSummaryDataFallback(supabase: SupabaseClient, year: number) {
   try {
     // Fallback: Use the function that returns all transactions for the year
     const { data, error } = await supabase.rpc('get_financial_summary_data', {
@@ -55,7 +56,7 @@ async function getSummaryDataFallback(supabase: any, year: number) {
   }
 }
 
-async function getAvailableYears(supabase: any) {
+async function getAvailableYears(supabase: SupabaseClient) {
   const { fetchAvailableFinanceYears } = await import("@/utils/financeCalculations");
   return await fetchAvailableFinanceYears(supabase);
 }

--- a/app/(dashboard)/finanzen/page.tsx
+++ b/app/(dashboard)/finanzen/page.tsx
@@ -2,14 +2,12 @@ export const runtime = 'edge';
 export const dynamic = 'force-dynamic';
 
 import FinanzenClientWrapper from "./client-wrapper";
-import { createClient } from "@/utils/supabase/server";
+import { requireAuthenticatedUser } from "@/lib/server/route-access";
 
 
 import { PAGINATION } from "@/constants";
 
-async function getSummaryData(year: number) {
-  const supabase = await createClient();
-
+async function getSummaryData(supabase: any, year: number) {
   try {
     // Use the optimized Supabase function that handles pagination internally
     const { data, error } = await supabase.rpc('get_financial_year_summary', {
@@ -19,7 +17,7 @@ async function getSummaryData(year: number) {
     if (error) {
       console.error('Error fetching summary data with RPC:', error);
       // Fallback to the function that returns raw data for client-side calculation
-      return await getSummaryDataFallback(year);
+      return await getSummaryDataFallback(supabase, year);
     }
 
     if (!data || data.length === 0) {
@@ -32,13 +30,11 @@ async function getSummaryData(year: number) {
     return processRpcFinancialSummary(data[0], year);
   } catch (error) {
     console.error('Error in getSummaryData:', error);
-    return await getSummaryDataFallback(year);
+    return await getSummaryDataFallback(supabase, year);
   }
 }
 
-async function getSummaryDataFallback(year: number) {
-  const supabase = await createClient();
-
+async function getSummaryDataFallback(supabase: any, year: number) {
   try {
     // Fallback: Use the function that returns all transactions for the year
     const { data, error } = await supabase.rpc('get_financial_summary_data', {
@@ -59,8 +55,7 @@ async function getSummaryDataFallback(year: number) {
   }
 }
 
-async function getAvailableYears() {
-  const supabase = await createClient();
+async function getAvailableYears(supabase: any) {
   const { fetchAvailableFinanceYears } = await import("@/utils/financeCalculations");
   return await fetchAvailableFinanceYears(supabase);
 }
@@ -96,7 +91,7 @@ function determineInitialYear(
 }
 
 export default async function FinanzenPage() {
-  const supabase = await createClient();
+  const { supabase } = await requireAuthenticatedUser();
 
   const currentYear = new Date().getFullYear();
 
@@ -118,13 +113,13 @@ export default async function FinanzenPage() {
       .range(0, PAGINATION.DEFAULT_PAGE_SIZE - 1),
 
     // Available years laden (needed for fallback logic)
-    getAvailableYears().catch((error) => {
+    getAvailableYears(supabase).catch((error) => {
       console.error('Failed to fetch available years:', error);
       return []; // Fallback to an empty array to prevent page crash.
     }),
 
     // Summary-Daten für das aktuelle Jahr laden
-    getSummaryData(currentYear)
+    getSummaryData(supabase, currentYear)
   ]);
 
   if (wohnungenResult.error) {
@@ -144,7 +139,7 @@ export default async function FinanzenPage() {
 
   // If we're falling back to a previous year, load that year's summary data
   if (initialYear !== currentYear) {
-    summaryData = await getSummaryData(initialYear);
+    summaryData = await getSummaryData(supabase, initialYear);
   }
 
   return <FinanzenClientWrapper

--- a/app/(dashboard)/haeuser/page.tsx
+++ b/app/(dashboard)/haeuser/page.tsx
@@ -1,13 +1,13 @@
 // "use client" directive removed. This file is now a pure Server Component.
 
 export const runtime = 'edge';
-import { createClient } from "@/utils/supabase/server"; // For server-side data fetching
+import { requireAuthenticatedUser } from "@/lib/server/route-access";
 import HaeuserClientView from "./client-wrapper"; // Import the default export client view
 import { formatNumber } from "@/utils/format";
 import { House } from "@/components/tables/house-table"; // Type for enrichedHaeuser
 
 export default async function HaeuserPage() {
-  const supabase = await createClient();
+  const { supabase } = await requireAuthenticatedUser();
 
   // Load data in parallel
   const [

--- a/app/(dashboard)/mails/page.tsx
+++ b/app/(dashboard)/mails/page.tsx
@@ -2,22 +2,14 @@
 export const dynamic = 'force-dynamic';
 export const runtime = 'edge';
 
-import { createClient } from '@/utils/supabase/server';
-import { redirect } from 'next/navigation';
+import { requireAuthenticatedUser } from "@/lib/server/route-access";
 import MailsClientView from "./client-wrapper";
 import type { LegacyMail } from "@/types/Mail";
 import { convertToLegacyMail } from "@/types/Mail";
 import type { Mail } from "@/types/Mail";
 
 export default async function MailsPage() {
-  const supabase = await createClient();
-
-  // Get current user
-  const { data: { user }, error: userError } = await supabase.auth.getUser();
-
-  if (userError || !user) {
-    redirect('/auth/login');
-  }
+  const { supabase, user } = await requireAuthenticatedUser();
 
   // Fetch initial page of emails from database
   const { data: emails, error: emailsError, count } = await supabase

--- a/app/(dashboard)/mieter/page.tsx
+++ b/app/(dashboard)/mieter/page.tsx
@@ -3,7 +3,7 @@
 export const dynamic = 'force-dynamic';
 export const runtime = 'edge';
 
-import { createClient as createSupabaseServerClient } from "@/utils/supabase/server";
+import { requireAuthenticatedUser } from "@/lib/server/route-access";
 import { handleSubmit as mieterServerAction } from "../../../app/mieter-actions";
 import MieterClientView from "./client-wrapper"; // Import the default export
 
@@ -11,13 +11,18 @@ import type { Tenant } from "@/types/Tenant";
 import type { Wohnung } from "@/types/Wohnung";
 
 export default async function MieterPage() {
-  const supabase = await createSupabaseServerClient();
-  const { data: rawWohnungen, error: wohnungenError } = await supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id,Haeuser(name)');
-  if (wohnungenError) console.error('Fehler beim Laden der Wohnungen:', wohnungenError);
+  const { supabase } = await requireAuthenticatedUser();
 
-  const { data: rawMieter, error: mieterError } = await supabase
-    .from('Mieter')
-    .select('id,wohnung_id,einzug,auszug,name,nebenkosten,email,telefonnummer,notiz,kaution,status,bewerbung_score,bewerbung_metadaten,bewerbung_mail_id');
+  // Load data in parallel to eliminate waterfalls
+  const [
+    { data: rawWohnungen, error: wohnungenError },
+    { data: rawMieter, error: mieterError }
+  ] = await Promise.all([
+    supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id,Haeuser(name)'),
+    supabase.from('Mieter').select('id,wohnung_id,einzug,auszug,name,nebenkosten,email,telefonnummer,notiz,kaution,status,bewerbung_score,bewerbung_metadaten,bewerbung_mail_id')
+  ]);
+
+  if (wohnungenError) console.error('Fehler beim Laden der Wohnungen:', wohnungenError);
   if (mieterError) console.error('Fehler beim Laden der Mieter:', mieterError);
 
   const today = new Date();

--- a/app/(dashboard)/todos/page.tsx
+++ b/app/(dashboard)/todos/page.tsx
@@ -2,10 +2,10 @@ export const runtime = 'edge';
 export const dynamic = 'force-dynamic';
 
 import TodosClientWrapper from "./client-wrapper";
-import { createClient } from "@/utils/supabase/server";
+import { requireAuthenticatedUser } from "@/lib/server/route-access";
 
 export default async function TodosPage() {
-  const supabase = await createClient();
+  const { supabase } = await requireAuthenticatedUser();
   const { data: tasksData } = await supabase.from('Aufgaben').select('*');
   const tasks = tasksData ?? [];
 

--- a/app/(dashboard)/wohnungen/page.tsx
+++ b/app/(dashboard)/wohnungen/page.tsx
@@ -4,8 +4,7 @@
 export const runtime = 'edge';
 export const dynamic = 'force-dynamic';
 
-// Removed Card, CardContent etc. as they are used in ClientView
-import { createClient as createSupabaseClient } from '@/utils/supabase/server';
+import { requireAuthenticatedUser } from "@/lib/server/route-access";
 import { fetchUserProfile } from '@/lib/data-fetching';
 
 import { getPlanDetails } from '@/lib/stripe-server';
@@ -15,71 +14,84 @@ import type { Wohnung } from "@/types/Wohnung";
 
 // Server Component: Fetches data and passes it to the Client Component
 export default async function WohnungenPage() {
-  const supabase = await createSupabaseClient();
-
-  const { data: { user } } = await supabase.auth.getUser();
+  const { supabase, user } = await requireAuthenticatedUser();
 
   let apartmentCount = 0;
   let userIsEligibleToAdd = false;
   let effectiveApartmentLimit: number | typeof Infinity = 0;
   let limitReason: 'trial' | 'subscription' | 'none' = 'none';
 
-  if (user) {
-    const userProfile = await fetchUserProfile();
-    if (userProfile) {
-      const isStripeTrial = userProfile.stripe_subscription_status === 'trialing';
-      const isEffectivelyInTrial = isStripeTrial;
-      const isPaidActiveSub = userProfile.stripe_subscription_status === 'active' && !!userProfile.stripe_price_id;
+  // Load profile and main data in parallel to eliminate waterfalls
+  const [
+    userProfile,
+    countResult,
+    rawApartmentsResult,
+    tenantsResult,
+    housesResult
+  ] = await Promise.all([
+    fetchUserProfile(),
+    supabase.from('Wohnungen').select('*', { count: 'exact', head: true }).eq('user_id', user.id),
+    supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id,Haeuser(name)'),
+    supabase.from('Mieter').select('id,wohnung_id,einzug,auszug,name'),
+    supabase.from('Haeuser').select('id,name')
+  ]);
 
+  if (userProfile) {
+    const isStripeTrial = userProfile.stripe_subscription_status === 'trialing';
+    const isEffectivelyInTrial = isStripeTrial;
+    const isPaidActiveSub = userProfile.stripe_subscription_status === 'active' && !!userProfile.stripe_price_id;
 
-
-      if (isEffectivelyInTrial) {
-        userIsEligibleToAdd = true;
-        effectiveApartmentLimit = 5;
-        limitReason = 'trial';
-        if (isPaidActiveSub && userProfile.stripe_price_id) {
-          try {
-            const planDetails = await getPlanDetails(userProfile.stripe_price_id);
-            if (planDetails) {
-              if (planDetails.limit_wohnungen === null) effectiveApartmentLimit = Infinity;
-              else if (typeof planDetails.limit_wohnungen === 'number' && planDetails.limit_wohnungen > effectiveApartmentLimit) {
-                effectiveApartmentLimit = planDetails.limit_wohnungen;
-              }
-              if (effectiveApartmentLimit !== 5 || planDetails.limit_wohnungen === null) limitReason = 'subscription';
-            }
-          } catch (error) { console.error('WohnungenPage: Error fetching plan details for active sub during trial:', error); }
-        }
-      } else if (isPaidActiveSub && userProfile.stripe_price_id) {
-        userIsEligibleToAdd = true;
-        limitReason = 'subscription';
+    if (isEffectivelyInTrial) {
+      userIsEligibleToAdd = true;
+      effectiveApartmentLimit = 5;
+      limitReason = 'trial';
+      if (isPaidActiveSub && userProfile.stripe_price_id) {
         try {
           const planDetails = await getPlanDetails(userProfile.stripe_price_id);
           if (planDetails) {
-            if (typeof planDetails.limit_wohnungen === 'number' && planDetails.limit_wohnungen > 0) effectiveApartmentLimit = planDetails.limit_wohnungen;
-            else if (planDetails.limit_wohnungen === null) effectiveApartmentLimit = Infinity;
-            else { userIsEligibleToAdd = false; effectiveApartmentLimit = 0; limitReason = 'none'; }
-          } else { userIsEligibleToAdd = false; effectiveApartmentLimit = 0; limitReason = 'none'; }
-        } catch (error) { console.error('WohnungenPage: Error fetching plan details:', error); userIsEligibleToAdd = false; effectiveApartmentLimit = 0; limitReason = 'none'; }
-      } else { userIsEligibleToAdd = false; effectiveApartmentLimit = 0; limitReason = 'none'; }
-    } else { userIsEligibleToAdd = false; effectiveApartmentLimit = 0; limitReason = 'none'; }
-
-    // Bypass limits for E2E tests in CI environment
-    if (isTestEnv()) {
+            if (planDetails.limit_wohnungen === null) effectiveApartmentLimit = Infinity;
+            else if (typeof planDetails.limit_wohnungen === 'number' && planDetails.limit_wohnungen > effectiveApartmentLimit) {
+              effectiveApartmentLimit = planDetails.limit_wohnungen;
+            }
+            if (effectiveApartmentLimit !== 5 || planDetails.limit_wohnungen === null) limitReason = 'subscription';
+          }
+        } catch (error) { console.error('WohnungenPage: Error fetching plan details for active sub during trial:', error); }
+      }
+    } else if (isPaidActiveSub && userProfile.stripe_price_id) {
       userIsEligibleToAdd = true;
-      effectiveApartmentLimit = 100;
       limitReason = 'subscription';
-    }
+      try {
+        const planDetails = await getPlanDetails(userProfile.stripe_price_id);
+        if (planDetails) {
+          if (typeof planDetails.limit_wohnungen === 'number' && planDetails.limit_wohnungen > 0) effectiveApartmentLimit = planDetails.limit_wohnungen;
+          else if (planDetails.limit_wohnungen === null) effectiveApartmentLimit = Infinity;
+          else { userIsEligibleToAdd = false; effectiveApartmentLimit = 0; limitReason = 'none'; }
+        } else { userIsEligibleToAdd = false; effectiveApartmentLimit = 0; limitReason = 'none'; }
+      } catch (error) { console.error('WohnungenPage: Error fetching plan details:', error); userIsEligibleToAdd = false; effectiveApartmentLimit = 0; limitReason = 'none'; }
+    } else { userIsEligibleToAdd = false; effectiveApartmentLimit = 0; limitReason = 'none'; }
+  } else { userIsEligibleToAdd = false; effectiveApartmentLimit = 0; limitReason = 'none'; }
 
-    const { count, error: countError } = await supabase.from('Wohnungen').select('*', { count: 'exact', head: true }).eq('user_id', user.id);
-    if (countError) console.error('Error fetching apartment count:', countError.message);
-    else apartmentCount = count || 0;
+  // Bypass limits for E2E tests in CI environment
+  if (isTestEnv()) {
+    userIsEligibleToAdd = true;
+    effectiveApartmentLimit = 100;
+    limitReason = 'subscription';
   }
 
-  const { data: rawApartments, error: apartmentsError } = await supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id,Haeuser(name)');
+  // Handle count result
+  if (countResult.error) console.error('Error fetching apartment count:', countResult.error.message);
+  else apartmentCount = countResult.count || 0;
+
+  // Handle data results
+  const { data: rawApartments, error: apartmentsError } = rawApartmentsResult;
   if (apartmentsError) console.error('Fehler beim Laden der Wohnungen:', apartmentsError);
 
-  const { data: tenants, error: tenantsError } = await supabase.from('Mieter').select('id,wohnung_id,einzug,auszug,name');
+  const { data: tenants, error: tenantsError } = tenantsResult;
   if (tenantsError) console.error('Fehler beim Laden der Mieter:', tenantsError);
+
+  const { data: housesData, error: housesError } = housesResult;
+  if (housesError) console.error('Fehler beim Laden der Häuser:', housesError);
+  const houses = housesData || [];
 
   const today = new Date();
 
@@ -104,10 +116,6 @@ export default async function WohnungenPage() {
       tenant: tenant ? { id: tenant.id, name: tenant.name, einzug: tenant.einzug as string, auszug: tenant.auszug as string } : undefined,
     } as Wohnung; // Ensure the mapped object conforms to Wohnung type
   }) : [];
-
-  const { data: housesData, error: housesError } = await supabase.from('Haeuser').select('id,name');
-  if (housesError) console.error('Fehler beim Laden der Häuser:', housesError);
-  const houses = housesData || [];
 
   return (
     <WohnungenClientView

--- a/middleware.ts
+++ b/middleware.ts
@@ -36,9 +36,6 @@ export async function middleware(request: NextRequest) {
   const nonce = needsManagedHeaders ? crypto.randomUUID() : null
 
   // Content Security Policy
-  // Note: We use 'unsafe-inline' without a nonce for scripts because Next.js 
-  // root-level hydration scripts don't support nonces in a static-root architecture.
-  // This is the standard way to support Next.js on Cloudflare Pages without breaking hydration.
   const scriptSrc = `script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.supabase.co https://*.stripe.com https://*.posthog.com`
 
   const csp = [
@@ -55,21 +52,21 @@ export async function middleware(request: NextRequest) {
     "frame-ancestors 'self'",
   ].join('; ');
 
-  // Clone request headers so layouts and server components can read request context
-  const requestHeaders = new Headers(request.headers)
+  // Update request headers directly so they are passed downstream
   if (nonce) {
-    requestHeaders.set('x-nonce', nonce)
+    request.headers.set('x-nonce', nonce)
   }
   if (needsManagedHeaders) {
-    requestHeaders.set('x-current-pathname', pathname)
-    requestHeaders.set('x-current-search', request.nextUrl.search)
+    request.headers.set('x-current-pathname', pathname)
+    request.headers.set('x-current-search', request.nextUrl.search)
   }
+  
   // Pre-emptively clear any potentially spoofed user data headers from external client requests
-  requestHeaders.delete('x-user-data')
-  requestHeaders.delete('x-user-signature')
+  request.headers.delete('x-user-data')
+  request.headers.delete('x-user-signature')
 
   // Set CSP on request headers so Server Components can read it (e.g., for nonces)
-  requestHeaders.set('Content-Security-Policy', csp)
+  request.headers.set('Content-Security-Policy', csp)
 
   // Initialize empty response to collect cookie mutations from updateSession
   let response = NextResponse.next()
@@ -104,54 +101,59 @@ export async function middleware(request: NextRequest) {
           .map(b => b.toString(16).padStart(2, '0'))
           .join('')
 
-        requestHeaders.set('x-user-data', btoa(encodeURIComponent(userData)))
-        requestHeaders.set('x-user-signature', signature)
+        request.headers.set('x-user-data', btoa(encodeURIComponent(userData)))
+        request.headers.set('x-user-signature', signature)
       } else {
         // Fallback to unsigned if secret is missing (only for development/testing safety)
-        requestHeaders.set('x-user-data', btoa(encodeURIComponent(userData)))
+        request.headers.set('x-user-data', btoa(encodeURIComponent(userData)))
       }
     }
   }
 
-  // Re-initialize final response with the mutated requestHeaders payload
+  // Create final response from modified request
   const finalResponse = NextResponse.next({
-    request: {
-      headers: requestHeaders,
-    },
+    request,
   })
 
   // Transfer all accrued cookie mutations into the final response
-  // We strictly only transfer Set-Cookie to prevent header duplication issues
   for (const [key, value] of response.headers.entries()) {
     if (key.toLowerCase() === 'set-cookie') {
       finalResponse.headers.append(key, value)
     }
   }
-  response = finalResponse
 
-  // Add security headers
-  response.headers.set('X-Frame-Options', 'DENY')
-  response.headers.set('X-Content-Type-Options', 'nosniff')
-  response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
-  response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=(), interest-cohort=()')
-  response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
+  // Add security headers to the response sent to the browser
+  finalResponse.headers.set('X-Frame-Options', 'DENY')
+  finalResponse.headers.set('X-Content-Type-Options', 'nosniff')
+  finalResponse.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
+  finalResponse.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=(), interest-cohort=()')
+  finalResponse.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
   // Set CSP on response headers so the browser enforces it
-  response.headers.set('Content-Security-Policy', csp);
+  finalResponse.headers.set('Content-Security-Policy', csp);
 
-  return response
+  return finalResponse
 }
 
 export const config = {
   matcher: [
     "/auth/:path*",
+    "/dashboard",
     "/dashboard/:path*",
+    "/betriebskosten",
     "/betriebskosten/:path*",
+    "/finanzen",
     "/finanzen/:path*",
+    "/haeuser",
     "/haeuser/:path*",
+    "/wohnungen",
     "/wohnungen/:path*",
+    "/mieter",
     "/mieter/:path*",
+    "/todos",
     "/todos/:path*",
+    "/mails",
     "/mails/:path*",
+    "/dateien",
     "/dateien/:path*",
     "/checkout/success",
     "/oauth/:path*",

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -13,9 +13,11 @@ export async function updateSession(request: NextRequest, response: NextResponse
           return request.cookies.get(name)?.value
         },
         set(name: string, value: string, options: CookieOptions) {
+          request.cookies.set(name, value)
           response.cookies.set(name, value, options)
         },
         remove(name: string, options: CookieOptions) {
+          request.cookies.set(name, "")
           response.cookies.set(name, "", options)
         },
       },

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -9,16 +9,14 @@ export async function updateSession(request: NextRequest, response: NextResponse
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        get(name: string) {
-          return request.cookies.get(name)?.value
+        getAll() {
+          return request.cookies.getAll()
         },
-        set(name: string, value: string, options: CookieOptions) {
-          request.cookies.set(name, value)
-          response.cookies.set(name, value, options)
-        },
-        remove(name: string, options: CookieOptions) {
-          request.cookies.set(name, "")
-          response.cookies.set(name, "", options)
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            request.cookies.set(name, value)
+            response.cookies.set(name, value, options)
+          })
         },
       },
     },

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -2,21 +2,23 @@ import { createServerClient } from "@supabase/ssr"
 import { cookies } from "next/headers"
 
 export async function createClient() {
-  const cookieStore = cookies()
+  const cookieStore = await cookies()
 
   return createServerClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, {
     cookies: {
-      async get(name: string) {
-        const store = await cookieStore;
-        return store.get(name)?.value;
+      getAll() {
+        return cookieStore.getAll()
       },
-      async set(name: string, value: string, options: any) {
-        const store = await cookieStore;
-        store.set({ name, value, ...options });
-      },
-      async remove(name: string, options: any) {
-        const store = await cookieStore;
-        store.set({ name, value: "", ...options });
+      setAll(cookiesToSet) {
+        try {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            cookieStore.set(name, value, options)
+          )
+        } catch {
+          // The `setAll` method was called from a Server Component.
+          // This can be ignored if you have middleware refreshing
+          // user sessions.
+        }
       },
     },
   })


### PR DESCRIPTION
## Description

Resolves session refresh in Server Components and optimizes parallel data fetching on the dashboard pages.

## Summary of Changes

- All dashboard pages (betriebskosten, dateien, finanzen, haeuser, mails, mieter, todos, wohnungen) now authenticate via the shared `requireAuthenticatedUser()` helper instead of ad-hoc `createClient` + `getUser` + redirect
- `utils/supabase/server.ts`: migrated to the async `cookies()` API and the `getAll`/`setAll` cookie interface (Next.js 15)
- `utils/supabase/middleware.ts`: same `getAll`/`setAll` migration
- `middleware.ts`: request headers are mutated directly instead of cloning into a new Headers object; matcher extended with exact route paths
- Wohnungen/Mieter pages: independent queries run in `Promise.all` to eliminate waterfalls