### PR TITLE
fix(stripe): move stripe client to a singleton in lib to avoid shared…

### DIFF
--- a/app/user-billing-actions.ts
+++ b/app/user-billing-actions.ts
@@ -3,18 +3,7 @@
 import Stripe from 'stripe';
 import { STRIPE_CONFIG } from '@/lib/constants/stripe';
 import { isTestEnv, isStripeMocked } from '@/lib/test-utils';
-
-let stripeClient: Stripe | null = null;
-function getStripe(): Stripe {
-  // Note: On Cloudflare Workers, module scope is not shared across requests.
-  // This singleton only benefits Node.js environments.
-  if (!stripeClient) {
-    const key = process.env.STRIPE_SECRET_KEY;
-    if (!key) throw new Error("STRIPE_SECRET_KEY is not configured");
-    stripeClient = new Stripe(key, STRIPE_CONFIG);
-  }
-  return stripeClient;
-}
+import { getStripeClient as getStripe } from '@/lib/stripe';
 
 type BillingAddressError = {
   error: string;

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -1,0 +1,13 @@
+import Stripe from 'stripe';
+import { STRIPE_CONFIG } from './constants/stripe';
+
+let stripeClient: Stripe | null = null;
+
+export function getStripeClient(): Stripe {
+  if (!stripeClient) {
+    const key = process.env.STRIPE_SECRET_KEY;
+    if (!key) throw new Error("STRIPE_SECRET_KEY is not configured");
+    stripeClient = new Stripe(key, STRIPE_CONFIG);
+  }
+  return stripeClient;
+}


### PR DESCRIPTION
## Description

Moves the Stripe client into a shared singleton in `lib/` to avoid shared mutable state scattered across server actions.

## Summary of Changes

- New `lib/stripe.ts`: `getStripeClient()` singleton (lazy init from `STRIPE_SECRET_KEY` with `STRIPE_CONFIG`)
- `user-billing-actions.ts`: uses the shared client instead of its own module-level singleton