### PR TITLE
fix(actions): use unstable_rethrow for nextjs redirect in try-catch

### DIFF
--- a/app/(dashboard)/dateien/actions.ts
+++ b/app/(dashboard)/dateien/actions.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { createClient } from '@/utils/supabase/server'
-import { redirect } from 'next/navigation'
+import { redirect, unstable_rethrow } from 'next/navigation'
 
 /**
  * Unified Document Navigation Actions
@@ -178,6 +178,8 @@ export async function getFolderContents(userId: string, path?: string): Promise<
         }
 
     } catch (error) {
+        unstable_rethrow(error)
+
         await logRpcCall('get_folder_contents', targetPath, startTime, false, {
             error: error instanceof Error ? error.message : 'Unknown error'
         })


### PR DESCRIPTION
## Description

Uses `unstable_rethrow` in the dateien server action so Next.js navigation throws (redirect) are not swallowed by the try-catch.

## Summary of Changes

- `dateien/actions.ts`: `unstable_rethrow(error)` at the top of the catch block in `getFolderContents`, letting framework-internal errors propagate while still logging real RPC failures