### PR TITLE
fix: resolve betriebskosten loading issue by fixing RPC types and per…

### DIFF
--- a/app/betriebskosten-actions.ts
+++ b/app/betriebskosten-actions.ts
@@ -1066,6 +1066,7 @@ export async function fetchNebenkostenListOptimized(): Promise<OptimizedActionRe
     const transformedData = (result.data || []).map(item => ({
       ...item,
       // Map database function fields to expected format for compatibility
+      user_id: (item as any).user_id_field,
       Haeuser: { name: item.haus_name },
       gesamtFlaeche: item.gesamt_flaeche,
       anzahlWohnungen: item.anzahl_wohnungen,

--- a/app/betriebskosten-actions.ts
+++ b/app/betriebskosten-actions.ts
@@ -1066,7 +1066,6 @@ export async function fetchNebenkostenListOptimized(): Promise<OptimizedActionRe
     const transformedData = (result.data || []).map(item => ({
       ...item,
       // Map database function fields to expected format for compatibility
-      user_id: (item as any).user_id_field,
       Haeuser: { name: item.haus_name },
       gesamtFlaeche: item.gesamt_flaeche,
       anzahlWohnungen: item.anzahl_wohnungen,

--- a/supabase/migrations/20260513000001_fix_nebenkosten_rpc_types.sql
+++ b/supabase/migrations/20260513000001_fix_nebenkosten_rpc_types.sql
@@ -1,0 +1,87 @@
+-- Fix the return types for get_nebenkosten_with_metrics and rename user_id_field back to user_id
+-- Previous migration changed array types to singular text/numeric types which caused PostgreSQL errors
+-- Additionally user_id was aliased to user_id_field which broke the frontend expectation.
+
+DROP FUNCTION IF EXISTS public.get_nebenkosten_with_metrics();
+
+CREATE OR REPLACE FUNCTION public.get_nebenkosten_with_metrics()
+RETURNS TABLE (
+    id uuid,
+    startdatum date,
+    enddatum date,
+    nebenkostenart text[],
+    betrag numeric[],
+    berechnungsart text[],
+    zaehlerkosten jsonb,
+    zaehlerverbrauch jsonb,
+    haeuser_id uuid,
+    user_id_field uuid,
+    vorauszahlungs_art text,
+    haus_name text,
+    gesamt_flaeche numeric,
+    anzahl_wohnungen integer,
+    anzahl_mieter integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  RETURN QUERY
+  WITH house_metrics AS (
+      SELECT 
+          h.id as house_id,
+          h.name as house_name,
+          COALESCE(h.groesse, (SELECT SUM(groesse) FROM public."Wohnungen" WHERE haus_id = h.id AND user_id = v_uid)) as total_area,
+          COUNT(w.id)::INTEGER as apartment_count
+      FROM public."Haeuser" h
+      LEFT JOIN public."Wohnungen" w ON h.id = w.haus_id AND w.user_id = v_uid
+      WHERE h.user_id = v_uid
+      GROUP BY h.id, h.name, h.groesse
+  ),
+  tenant_counts AS (
+      SELECT 
+          n.id as nebenkosten_id,
+          COUNT(DISTINCT m.id)::INTEGER as tenant_count
+      FROM public."Nebenkosten" n
+      LEFT JOIN public."Wohnungen" w ON n.haeuser_id = w.haus_id AND w.user_id = v_uid
+      LEFT JOIN public."Mieter" m ON w.id = m.wohnung_id 
+          AND m.user_id = v_uid
+          AND COALESCE(m.einzug, '1900-01-01'::DATE) <= n.enddatum
+          AND COALESCE(m.auszug, '9999-12-31'::DATE) >= n.startdatum
+      WHERE n.user_id = v_uid
+      GROUP BY n.id
+  )
+  SELECT 
+      n.id,
+      n.startdatum,
+      n.enddatum,
+      n.nebenkostenart,
+      n.betrag,
+      n.berechnungsart,
+      n.zaehlerkosten,
+      n.zaehlerverbrauch,
+      n.haeuser_id,
+      n.user_id as user_id_field,
+      n.vorauszahlungs_art,
+      COALESCE(hm.house_name, 'Unbekanntes Haus') as haus_name,
+      COALESCE(hm.total_area, 0) as gesamt_flaeche,
+      COALESCE(hm.apartment_count, 0) as anzahl_wohnungen,
+      COALESCE(tc.tenant_count, 0) as anzahl_mieter
+  FROM public."Nebenkosten" n
+  LEFT JOIN house_metrics hm ON n.haeuser_id = hm.house_id
+  LEFT JOIN tenant_counts tc ON n.id = tc.nebenkosten_id
+  WHERE n.user_id = v_uid
+  ORDER BY n.startdatum DESC;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_nebenkosten_with_metrics() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_nebenkosten_with_metrics() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_nebenkosten_with_metrics() TO service_role;

--- a/supabase/migrations/20260513000002_fix_ambiguous_user_id.sql
+++ b/supabase/migrations/20260513000002_fix_ambiguous_user_id.sql
@@ -1,0 +1,86 @@
+-- Fix ambiguous column reference error by reverting user_id back to user_id_field in RETURNS TABLE
+-- and explicitly qualifying all user_id references in the query.
+
+DROP FUNCTION IF EXISTS public.get_nebenkosten_with_metrics();
+
+CREATE OR REPLACE FUNCTION public.get_nebenkosten_with_metrics()
+RETURNS TABLE (
+    id uuid,
+    startdatum date,
+    enddatum date,
+    nebenkostenart text[],
+    betrag numeric[],
+    berechnungsart text[],
+    zaehlerkosten jsonb,
+    zaehlerverbrauch jsonb,
+    haeuser_id uuid,
+    user_id_field uuid,
+    vorauszahlungs_art text,
+    haus_name text,
+    gesamt_flaeche numeric,
+    anzahl_wohnungen integer,
+    anzahl_mieter integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  RETURN QUERY
+  WITH house_metrics AS (
+      SELECT 
+          h.id as house_id,
+          h.name as house_name,
+          COALESCE(h.groesse, (SELECT SUM(w_inner.groesse) FROM public."Wohnungen" w_inner WHERE w_inner.haus_id = h.id AND w_inner.user_id = v_uid)) as total_area,
+          COUNT(w.id)::INTEGER as apartment_count
+      FROM public."Haeuser" h
+      LEFT JOIN public."Wohnungen" w ON h.id = w.haus_id AND w.user_id = v_uid
+      WHERE h.user_id = v_uid
+      GROUP BY h.id, h.name, h.groesse
+  ),
+  tenant_counts AS (
+      SELECT 
+          n.id as nebenkosten_id,
+          COUNT(DISTINCT m.id)::INTEGER as tenant_count
+      FROM public."Nebenkosten" n
+      LEFT JOIN public."Wohnungen" w ON n.haeuser_id = w.haus_id AND w.user_id = v_uid
+      LEFT JOIN public."Mieter" m ON w.id = m.wohnung_id 
+          AND m.user_id = v_uid
+          AND COALESCE(m.einzug, '1900-01-01'::DATE) <= n.enddatum
+          AND COALESCE(m.auszug, '9999-12-31'::DATE) >= n.startdatum
+      WHERE n.user_id = v_uid
+      GROUP BY n.id
+  )
+  SELECT 
+      n.id,
+      n.startdatum,
+      n.enddatum,
+      n.nebenkostenart,
+      n.betrag,
+      n.berechnungsart,
+      n.zaehlerkosten,
+      n.zaehlerverbrauch,
+      n.haeuser_id,
+      n.user_id as user_id_field,
+      n.vorauszahlungs_art,
+      COALESCE(hm.house_name, 'Unbekanntes Haus') as haus_name,
+      COALESCE(hm.total_area, 0) as gesamt_flaeche,
+      COALESCE(hm.apartment_count, 0) as anzahl_wohnungen,
+      COALESCE(tc.tenant_count, 0) as anzahl_mieter
+  FROM public."Nebenkosten" n
+  LEFT JOIN house_metrics hm ON n.haeuser_id = hm.house_id
+  LEFT JOIN tenant_counts tc ON n.id = tc.nebenkosten_id
+  WHERE n.user_id = v_uid
+  ORDER BY n.startdatum DESC;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_nebenkosten_with_metrics() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_nebenkosten_with_metrics() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_nebenkosten_with_metrics() TO service_role;

--- a/supabase/migrations/20260513000003_optimized_consistent_nebenkosten_rpc.sql
+++ b/supabase/migrations/20260513000003_optimized_consistent_nebenkosten_rpc.sql
@@ -1,0 +1,88 @@
+-- Optimized and Consistent RPC for Nebenkosten
+-- 1. Renames user_id_field back to user_id for frontend consistency.
+-- 2. Optimizes total_area calculation by using aggregate SUM instead of correlated subquery.
+-- 3. Resolves ambiguity by strictly qualifying all table columns.
+
+DROP FUNCTION IF EXISTS public.get_nebenkosten_with_metrics();
+
+CREATE OR REPLACE FUNCTION public.get_nebenkosten_with_metrics()
+RETURNS TABLE (
+    id uuid,
+    startdatum date,
+    enddatum date,
+    nebenkostenart text[],
+    betrag numeric[],
+    berechnungsart text[],
+    zaehlerkosten jsonb,
+    zaehlerverbrauch jsonb,
+    haeuser_id uuid,
+    user_id uuid,
+    vorauszahlungs_art text,
+    haus_name text,
+    gesamt_flaeche numeric,
+    anzahl_wohnungen integer,
+    anzahl_mieter integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  RETURN QUERY
+  WITH house_metrics AS (
+      SELECT 
+          h.id as house_id,
+          h.name as house_name,
+          COALESCE(h.groesse, SUM(w.groesse)) as total_area,
+          COUNT(w.id)::INTEGER as apartment_count
+      FROM public."Haeuser" h
+      LEFT JOIN public."Wohnungen" w ON h.id = w.haus_id AND w.user_id = v_uid
+      WHERE h.user_id = v_uid
+      GROUP BY h.id, h.name, h.groesse
+  ),
+  tenant_counts AS (
+      SELECT 
+          n.id as nebenkosten_id,
+          COUNT(DISTINCT m.id)::INTEGER as tenant_count
+      FROM public."Nebenkosten" n
+      LEFT JOIN public."Wohnungen" w ON n.haeuser_id = w.haus_id AND w.user_id = v_uid
+      LEFT JOIN public."Mieter" m ON w.id = m.wohnung_id 
+          AND m.user_id = v_uid
+          AND COALESCE(m.einzug, '1900-01-01'::DATE) <= n.enddatum
+          AND COALESCE(m.auszug, '9999-12-31'::DATE) >= n.startdatum
+      WHERE n.user_id = v_uid
+      GROUP BY n.id
+  )
+  SELECT 
+      n.id,
+      n.startdatum,
+      n.enddatum,
+      n.nebenkostenart,
+      n.betrag,
+      n.berechnungsart,
+      n.zaehlerkosten,
+      n.zaehlerverbrauch,
+      n.haeuser_id,
+      n.user_id,
+      n.vorauszahlungs_art,
+      COALESCE(hm.house_name, 'Unbekanntes Haus') as haus_name,
+      COALESCE(hm.total_area, 0) as gesamt_flaeche,
+      COALESCE(hm.apartment_count, 0) as anzahl_wohnungen,
+      COALESCE(tc.tenant_count, 0) as anzahl_mieter
+  FROM public."Nebenkosten" n
+  LEFT JOIN house_metrics hm ON n.haeuser_id = hm.house_id
+  LEFT JOIN tenant_counts tc ON n.id = tc.nebenkosten_id
+  WHERE n.user_id = v_uid
+  ORDER BY n.startdatum DESC;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_nebenkosten_with_metrics() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_nebenkosten_with_metrics() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_nebenkosten_with_metrics() TO service_role;


### PR DESCRIPTION
## Description

Fixes the Betriebskosten loading issue by correcting the `get_nebenkosten_with_metrics` RPC types and permissions.

## Summary of Changes

- New migration `...000001_fix_nebenkosten_rpc_types.sql`: restores array return types (`text[]`/`numeric[]`) that a previous migration had broken into singular types
- New migration `...000002_fix_ambiguous_user_id.sql`: resolves the ambiguous column reference by qualifying all `user_id` usages
- New migration `...000003_optimized_consistent_nebenkosten_rpc.sql`: renames `user_id_field` back to `user_id` for frontend consistency and replaces the correlated subquery with an aggregate SUM for the total area
- Permissions re-granted to `authenticated` and `service_role`