### PR TITLE
fix(ci): remove conflicting paths-ignore from run-tests workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,8 +10,6 @@ on:
       - '**/*.jsx'
       - '**/package.json'
       - '**/package-lock.json'
-    paths-ignore:
-      - 'playwright/snapshots.yml'
   pull_request:
     branches: [main, develop]
     paths-ignore:
@@ -428,7 +426,7 @@ jobs:
   install-playwright:
     name: Install Playwright Browsers
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     outputs:
       playwright-cache-key: ${{ steps.playwright-key.outputs.key }}
     


### PR DESCRIPTION
## Description

Removes the conflicting `paths-ignore` from the run-tests workflow and gives Playwright browser installation more time.

## Summary of Changes

- `run-tests.yml`: drop the `paths-ignore: playwright/snapshots.yml` entry that conflicted with the path filters
- `install-playwright` job timeout raised from 10 to 20 minutes