### PR TITLE
chore: remove unused @notionhq/client dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^3.10.0",
-        "@notionhq/client": "^5.6.0",
         "@opentelemetry/api-logs": "^0.217.0",
         "@opentelemetry/exporter-logs-otlp-http": "^0.217.0",
         "@opentelemetry/resources": "^2.7.1",
@@ -2230,13 +2229,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
-      }
-    },
-    "node_modules/@notionhq/client": {
-      "version": "5.6.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@opentelemetry/api": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^3.10.0",
-    "@notionhq/client": "^5.6.0",
     "@opentelemetry/api-logs": "^0.217.0",
     "@opentelemetry/exporter-logs-otlp-http": "^0.217.0",
     "@opentelemetry/resources": "^2.7.1",


### PR DESCRIPTION
## Description

Removes the unused `@notionhq/client` dependency.

## Summary of Changes

- `package.json` / `package-lock.json`: `@notionhq/client` dropped from dependencies