### PR TITLE
chore(ci): update deployment comment to use Europe/Berlin timezone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1905,7 +1905,15 @@ jobs:
             });
             const existingComment = comments.find(c => c.body.includes(marker));
 
-            const timestamp = endTime.toISOString().replace('T', ' ').split('.')[0] + ' UTC';
+            const timestamp = endTime.toLocaleString('de-DE', {
+              timeZone: 'Europe/Berlin',
+              year: 'numeric',
+              month: '2-digit',
+              day: '2-digit',
+              hour: '2-digit',
+              minute: '2-digit',
+              second: '2-digit'
+            }) + ' (Berlin Time)';
             const body = `${marker}\n✅ **New version is live!**\n\n🔗 **[Preview #${prNumber}](${process.env.DEPLOY_URL})**\n\n🕒 **Deployed at:** ${timestamp}\n⏱️ **Duration:** ${durationStr} (Build + Deploy)`;
 
             if (existingComment) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1905,15 +1905,31 @@ jobs:
             });
             const existingComment = comments.find(c => c.body.includes(marker));
 
-            const timestamp = endTime.toLocaleString('de-DE', {
-              timeZone: 'Europe/Berlin',
+            const options = {
               year: 'numeric',
               month: '2-digit',
               day: '2-digit',
               hour: '2-digit',
               minute: '2-digit',
               second: '2-digit'
-            }) + ' (Berlin Time)';
+            };
+            const formatter = new Intl.DateTimeFormat('en-US', {
+              timeZone: 'Europe/Berlin',
+              timeZoneName: 'short'
+            });
+            const parts = formatter.formatToParts(endTime);
+            const tzPart = parts.find(part => part.type === 'timeZoneName');
+            const tzName = tzPart ? tzPart.value : 'GMT+2';
+
+            const berlinTime = endTime.toLocaleString('de-DE', {
+              ...options,
+              timeZone: 'Europe/Berlin'
+            });
+            const utcTime = endTime.toLocaleString('de-DE', {
+              ...options,
+              timeZone: 'UTC'
+            });
+            const timestamp = `${berlinTime} (${tzName}) / ${utcTime} UTC`;
             const body = `${marker}\n✅ **New version is live!**\n\n🔗 **[Preview #${prNumber}](${process.env.DEPLOY_URL})**\n\n🕒 **Deployed at:** ${timestamp}\n⏱️ **Duration:** ${durationStr} (Build + Deploy)`;
 
             if (existingComment) {


### PR DESCRIPTION
## Description

Updates the CI deployment comment to display the timestamp in the Europe/Berlin timezone (with UTC alongside).

## Summary of Changes

- `ci.yml`: the "New version is live!" comment now formats the deploy time via `Intl.DateTimeFormat` in `Europe/Berlin` (incl. CEST/CET abbreviation) followed by the UTC time, instead of a plain ISO UTC string