### PR TITLE
feat(worker): add authentication check to backend worker proxy

### DIFF
--- a/app/api/worker/route.ts
+++ b/app/api/worker/route.ts
@@ -52,16 +52,34 @@ export async function POST(request: Request) {
             });
         }
 
-        const backendUrl = (process.env.MIETEVO_BACKEND_URL || 'https://backend.mietevo.de').trim();
+        const url = new URL(request.url);
+        const subPath = url.pathname.replace('/api/worker', '');
+        const backendBaseUrl = (process.env.MIETEVO_BACKEND_URL || 'https://backend.mietevo.de').trim().replace(/\/$/, '');
+        const backendUrl = backendBaseUrl + subPath + url.search;
+        const workerAuthKey = process.env.WORKER_AUTH_KEY;
 
         console.log('[WorkerProxy] Proxying request to:', backendUrl, 'for user:', user.id);
 
-        const body = await request.json();
+        let body;
+        try {
+            body = await request.json();
+            // Ensure the request is attributed to the authenticated user
+            if (body && typeof body === 'object') {
+                body.user_id = user.id;
+            }
+        } catch (e) {
+            console.warn('[WorkerProxy] Invalid JSON body:', (e as Error).message);
+            return NextResponse.json({ error: 'Invalid JSON body' }, { 
+                status: 400, 
+                headers: NO_CACHE_HEADERS 
+            });
+        }
 
         const response = await fetchWithRetry(backendUrl, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
+                ...(workerAuthKey ? { 'x-worker-auth': workerAuthKey } : {})
             },
             body: JSON.stringify(body),
         });

--- a/app/api/worker/route.ts
+++ b/app/api/worker/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { createClient } from "@/utils/supabase/server";
 import { NO_CACHE_HEADERS } from '@/lib/constants/http';
 export const runtime = 'edge';
 
@@ -39,11 +40,22 @@ async function fetchWithRetry(url: string, options: RequestInit, retries = MAX_R
 }
 
 export async function POST(request: Request) {
-    const backendUrl = (process.env.MIETEVO_BACKEND_URL || 'https://backend.mietevo.de').trim();
-
-    console.log('[WorkerProxy] Proxying request to:', backendUrl);
-
     try {
+        const supabase = await createClient();
+        const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+        if (authError || !user) {
+            console.error('[WorkerProxy] Authentication failed:', authError?.message || 'No user');
+            return NextResponse.json({ error: 'Unauthorized' }, { 
+                status: 401,
+                headers: NO_CACHE_HEADERS
+            });
+        }
+
+        const backendUrl = (process.env.MIETEVO_BACKEND_URL || 'https://backend.mietevo.de').trim();
+
+        console.log('[WorkerProxy] Proxying request to:', backendUrl, 'for user:', user.id);
+
         const body = await request.json();
 
         const response = await fetchWithRetry(backendUrl, {

--- a/app/api/worker/route.ts
+++ b/app/api/worker/route.ts
@@ -64,7 +64,8 @@ export async function POST(request: Request) {
         try {
             body = await request.json();
             // Ensure the request is attributed to the authenticated user
-            if (body && typeof body === 'object') {
+            // We check !Array.isArray because JSON.stringify ignores custom properties on arrays
+            if (body && typeof body === 'object' && !Array.isArray(body)) {
                 body.user_id = user.id;
             }
         } catch (e) {

--- a/workers/mietevo-backend/src/index.test.ts
+++ b/workers/mietevo-backend/src/index.test.ts
@@ -150,6 +150,50 @@ describe('Backend Worker Tests', () => {
         });
     });
 
+    describe('Main Router (fetch)', () => {
+        it('should route to /ai correctly', async () => {
+            // Mocking handleAIRequest indirectly by checking the response or using spies
+            // Since we export 'default', we can test that.
+            const request = new Request('https://worker.com/ai', {
+                method: 'POST',
+                body: JSON.stringify({ message: 'Hello' })
+            });
+
+            // We expect this to fail with 500 or similar because Gemini key is test-key
+            // but it proves it hit the AI handler rather than file generation.
+            const response = await (await import('./index')).default.fetch(request, mockEnv as unknown as Env, mockCtx as unknown as ExecutionContext);
+            
+            // handleAIRequest returns 500 if Gemini fails, or starts a stream.
+            // File generation would return 400 for this body because 'type' is missing.
+            expect(response.status).not.toBe(400);
+        });
+
+        it('should route to /process-queue correctly', async () => {
+            const request = new Request('https://worker.com/process-queue', {
+                method: 'POST',
+                headers: { 'x-worker-auth': 'test-auth-key' },
+                body: JSON.stringify({ user_id: 'test-user' })
+            });
+
+            const response = await (await import('./index')).default.fetch(request, mockEnv as unknown as Env, mockCtx as unknown as ExecutionContext);
+            
+            // processQueue would hit auth check then fail on Supabase
+            expect(response.status).not.toBe(404);
+            expect(response.status).not.toBe(400);
+        });
+
+        it('should fallback to file generation for other paths', async () => {
+            const request = new Request('https://worker.com/some-random-path', {
+                method: 'POST',
+                body: JSON.stringify({ type: 'csv', data: [] })
+            });
+
+            const response = await (await import('./index')).default.fetch(request, mockEnv as unknown as Env, mockCtx as unknown as ExecutionContext);
+            expect(response.status).toBe(200);
+            expect(response.headers.get('Content-Type')).toBe('text/csv');
+        });
+    });
+
     it('should pass a basic smoke test', () => {
         expect(true).toBe(true);
     });


### PR DESCRIPTION
## Description

Adds an authentication check to the backend worker proxy so only signed-in users can call the mietevo-backend worker.

## Summary of Changes

- `app/api/worker/route.ts`: verifies the Supabase session (401 when unauthenticated), forwards sub-paths to the backend, injects the authenticated `user_id` into the request body, and sends the `x-worker-auth` header when `WORKER_AUTH_KEY` is configured; invalid JSON returns 400
- `workers/mietevo-backend/src/index.test.ts`: new router tests for /ai, /process-queue and the file-generation fallback