### PR TITLE
fix(config): disable experimental inlineCss to resolve 404 stylesheet…

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -70,7 +70,6 @@ const nextConfig = {
     ],
   },
   experimental: {
-    inlineCss: true,
     scrollRestoration: true,
     optimizePackageImports: [
       'recharts',


### PR DESCRIPTION
## Description

Disables the experimental `inlineCss` option to resolve 404 stylesheet prefetch warnings.

## Summary of Changes

- `next.config.mjs`: removes `experimental.inlineCss: true`