### PR TITLE
test(e2e): fix brittle locators in auth and business flows tests

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -39,8 +39,8 @@ test.describe('Authentication Flows', () => {
 
     // Verify we are on the dashboard
     // Check for common dashboard elements using more specific locators
-    await expect(page.locator('#sidebar-nav-dashboard, a[href="/dashboard"]').first()).toBeVisible({ timeout: 10000 });
-    await expect(page.locator('#sidebar-nav-haeuser, a[href="/haeuser"]').first()).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('#sidebar-nav-dashboard, a[href="/dashboard"]').filter({ visible: true }).first()).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('#sidebar-nav-haeuser, a[href="/haeuser"]').filter({ visible: true }).first()).toBeVisible({ timeout: 10000 });
   });
 
   test('Should be able to log out', async ({ page }) => {

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -39,8 +39,8 @@ test.describe('Authentication Flows', () => {
 
     // Verify we are on the dashboard
     // Check for common dashboard elements using more specific locators
-    await expect(page.getByRole('link', { name: 'Dashboard' }).first()).toBeVisible({ timeout: 10000 });
-    await expect(page.getByRole('link', { name: /Häuser|Objekte/i }).first()).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('#sidebar-nav-dashboard, a[href="/dashboard"]').first()).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('#sidebar-nav-haeuser, a[href="/haeuser"]').first()).toBeVisible({ timeout: 10000 });
   });
 
   test('Should be able to log out', async ({ page }) => {

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -4,7 +4,7 @@ import { login, hasTestCredentials, acceptCookieConsent } from './utils';
 test.describe('Authentication Flows', () => {
 
   test('Login page should render correctly', async ({ page }) => {
-    await page.goto('/auth/login', { waitUntil: 'networkidle' });
+    await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
     // Wait for animation/loading
     await expect(page.getByRole('heading', { name: /ANMELDEN/i })).toBeVisible({ timeout: 10000 });
 
@@ -16,7 +16,7 @@ test.describe('Authentication Flows', () => {
   });
 
   test('Registration page should render correctly', async ({ page }) => {
-    await page.goto('/auth/register', { waitUntil: 'networkidle' });
+    await page.goto('/auth/register', { waitUntil: 'domcontentloaded' });
     // Wait for potential animation/loading
     await expect(page.getByRole('heading', { name: /REGISTRIEREN/i })).toBeVisible({ timeout: 10000 });
 

--- a/e2e/business-flows.spec.ts
+++ b/e2e/business-flows.spec.ts
@@ -155,7 +155,8 @@ test.describe('Business Logic Flows', () => {
     await page.waitForTimeout(300);
 
     // Type to search
-    await page.keyboard.type(houseName);
+    const houseSearchbox = page.getByRole('searchbox').first();
+    await houseSearchbox.fill(houseName);
     await page.waitForTimeout(500);
 
     // Select option
@@ -230,7 +231,8 @@ test.describe('Business Logic Flows', () => {
     await combobox.click();
     await page.waitForTimeout(300);
 
-    await page.keyboard.type(aptName);
+    const aptSearchbox = page.getByRole('searchbox').first();
+    await aptSearchbox.fill(aptName);
     await page.waitForTimeout(500);
 
     const option = page.getByRole('option', { name: aptName }).first();
@@ -239,6 +241,8 @@ test.describe('Business Logic Flows', () => {
       await expect(option).toBeVisible({ timeout: 5000 });
     } catch (e) {
       await page.locator('button[role="combobox"]').first().click({ force: true });
+      await expect(page.getByRole('searchbox').first()).toBeVisible({ timeout: 5000 });
+      await page.getByRole('searchbox').first().fill(aptName);
       await expect(option).toBeVisible({ timeout: 10000 });
     }
     await option.scrollIntoViewIfNeeded().catch(() => {});

--- a/e2e/business-flows.spec.ts
+++ b/e2e/business-flows.spec.ts
@@ -155,7 +155,7 @@ test.describe('Business Logic Flows', () => {
     await page.waitForTimeout(300);
 
     // Type to search
-    const houseSearchbox = page.getByRole('searchbox').first();
+    const houseSearchbox = page.locator('[data-combobox-dropdown]').getByRole('searchbox').first();
     await houseSearchbox.fill(houseName);
     await page.waitForTimeout(500);
 
@@ -230,7 +230,7 @@ test.describe('Business Logic Flows', () => {
     await combobox.click();
     await page.waitForTimeout(300);
 
-    const aptSearchbox = page.getByRole('searchbox').first();
+    const aptSearchbox = page.locator('[data-combobox-dropdown]').getByRole('searchbox').first();
     await aptSearchbox.fill(aptName);
     await page.waitForTimeout(500);
 
@@ -240,8 +240,8 @@ test.describe('Business Logic Flows', () => {
       await expect(option).toBeVisible({ timeout: 5000 });
     } catch (e) {
       await modal.locator('#wohnung_id').first().click({ force: true });
-      await expect(page.getByRole('searchbox').first()).toBeVisible({ timeout: 5000 });
-      await page.getByRole('searchbox').first().fill(aptName);
+      await expect(aptSearchbox).toBeVisible({ timeout: 5000 });
+      await aptSearchbox.fill(aptName);
       await expect(option).toBeVisible({ timeout: 10000 });
     }
     await option.scrollIntoViewIfNeeded().catch(() => {});

--- a/e2e/business-flows.spec.ts
+++ b/e2e/business-flows.spec.ts
@@ -304,7 +304,7 @@ test.describe('Business Logic Flows', () => {
       for (const entity of entities) {
         try {
           console.log(`[Cleanup] Processing ${entity.label}: ${entity.name}`);
-          await safeNavigate(page, entity.path, 'networkidle');
+          await safeNavigate(page, entity.path, 'domcontentloaded');
 
           // Strategy 1: Search for the specific entity name
           let foundAndDeleted = false;

--- a/e2e/business-flows.spec.ts
+++ b/e2e/business-flows.spec.ts
@@ -224,9 +224,8 @@ test.describe('Business Logic Flows', () => {
     await page.waitForTimeout(300);
 
     // Select Apartment
-    // It's a CustomCombobox. ID might be on the hidden input, not the trigger.
-    // We look for the combobox trigger again.
-    const combobox = modal.getByRole('combobox').first();
+    // It's a CustomCombobox with id="wohnung_id" on the button trigger.
+    const combobox = modal.locator('#wohnung_id').first();
     await expect(combobox).toBeVisible({ timeout: 10000 });
     await combobox.click();
     await page.waitForTimeout(300);
@@ -240,7 +239,7 @@ test.describe('Business Logic Flows', () => {
     try {
       await expect(option).toBeVisible({ timeout: 5000 });
     } catch (e) {
-      await page.locator('button[role="combobox"]').first().click({ force: true });
+      await modal.locator('#wohnung_id').first().click({ force: true });
       await expect(page.getByRole('searchbox').first()).toBeVisible({ timeout: 5000 });
       await page.getByRole('searchbox').first().fill(aptName);
       await expect(option).toBeVisible({ timeout: 10000 });

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -21,7 +21,12 @@ export const login = async (page: Page) => {
     throw new Error('Cannot log in: TEST_EMAIL or TEST_PASSWORD not set');
   }
 
-  await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
+  await page.goto('/auth/login', { waitUntil: 'load' });
+
+  // Wait for Next.js hydration to be complete.
+  // The social login buttons are only rendered client-side after component mount/hydration.
+  const socialBtn = page.getByRole('button', { name: /Google|Microsoft/i }).first();
+  await expect(socialBtn).toBeVisible({ timeout: 15000 });
 
   // Wait for the form to be ready
   await expect(page.locator('form')).toBeVisible({ timeout: 30000 });
@@ -34,7 +39,7 @@ export const login = async (page: Page) => {
   // Ensure button is ready to receive clicks
   const loginBtn = page.getByRole('button', { name: /anmelden/i }).first();
   await expect(loginBtn).toBeEnabled();
-  await loginBtn.click({ force: true });
+  await loginBtn.click();
 
   // Wait for navigation to dashboard or check for errors
   try {

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -21,7 +21,7 @@ export const login = async (page: Page) => {
     throw new Error('Cannot log in: TEST_EMAIL or TEST_PASSWORD not set');
   }
 
-  await page.goto('/auth/login', { waitUntil: 'networkidle' });
+  await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
 
   // Wait for the form to be ready
   await expect(page.locator('form')).toBeVisible({ timeout: 30000 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3290,6 +3290,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@posthog/cli/node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "extraneous": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/@posthog/cli/node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",


### PR DESCRIPTION
- Replaced text-based `getByRole` link locators in `auth.spec.ts` with robust `href` and `id` locators to fix failures caused by `DashboardSidebar` responsive logic and Framer Motion animations.
- Fixed `CustomCombobox` search input interaction in `business-flows.spec.ts` by explicitly selecting `getByRole('searchbox')` and using `.fill()`, replacing the flaky `page.keyboard.type()` method. Also improved the fallback logic to properly re-fill the search box.

---
*PR created automatically by Jules for task [55703542613122485](https://jules.google.com/task/55703542613122485) started by @NtFelix*