### PR TITLE
fix(security): resolve samesite cookie flag and log injection vulnera…

### DIFF
--- a/app/api/stripe/customer-portal/route.ts
+++ b/app/api/stripe/customer-portal/route.ts
@@ -33,9 +33,23 @@ export async function POST(request: Request) {
 
     // Get return URL from request body or use default
     const body = await request.json();
-    const origin = request.headers.get('origin') || 'http://localhost:3000';
-    const rawReturnUrl = body.return_url || `${origin}/dashboard`;
-    const returnUrl = typeof rawReturnUrl === 'string' ? rawReturnUrl.replace(/[\r\n]/g, '') : '';
+    const appOrigin = new URL(request.url).origin;
+    const rawReturnUrl = body.return_url || `${appOrigin}/dashboard`;
+    let returnUrl = `${appOrigin}/dashboard`;
+
+    if (typeof rawReturnUrl === 'string') {
+      const sanitized = rawReturnUrl.replace(/[\r\n]/g, '');
+      try {
+        const parsedUrl = new URL(sanitized);
+        if (parsedUrl.origin === appOrigin) {
+          returnUrl = sanitized;
+        }
+      } catch {
+        if (sanitized.startsWith('/')) {
+          returnUrl = appOrigin + sanitized;
+        }
+      }
+    }
     
     if (process.env.NODE_ENV === 'development') {
       console.log('Creating Stripe portal session with return_url:', returnUrl);

--- a/app/api/stripe/customer-portal/route.ts
+++ b/app/api/stripe/customer-portal/route.ts
@@ -34,7 +34,8 @@ export async function POST(request: Request) {
     // Get return URL from request body or use default
     const body = await request.json();
     const origin = request.headers.get('origin') || 'http://localhost:3000';
-    const returnUrl = body.return_url || `${origin}/dashboard`;
+    const rawReturnUrl = body.return_url || `${origin}/dashboard`;
+    const returnUrl = typeof rawReturnUrl === 'string' ? rawReturnUrl.replace(/[\r\n]/g, '') : '';
     
     if (process.env.NODE_ENV === 'development') {
       console.log('Creating Stripe portal session with return_url:', returnUrl);

--- a/app/api/worker/route.ts
+++ b/app/api/worker/route.ts
@@ -58,7 +58,7 @@ export async function POST(request: Request) {
         const backendUrl = backendBaseUrl + subPath + url.search;
         const workerAuthKey = process.env.WORKER_AUTH_KEY;
 
-        console.log('[WorkerProxy] Proxying request to:', backendUrl, 'for user:', user.id);
+        console.log('[WorkerProxy] Proxying request to:', backendUrl.replace(/[\r\n]/g, ''), 'for user:', user.id);
 
         let body;
         try {

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -14,11 +14,11 @@ export async function updateSession(request: NextRequest, response: NextResponse
         },
         setAll(cookiesToSet) {
           cookiesToSet.forEach(({ name, value, options }) => {
+            request.cookies.set(name, value)
             const secureOptions = { ...options }
-            if (secureOptions.sameSite === 'none' || secureOptions.sameSite === 'None') {
+            if (secureOptions.sameSite === 'none') {
               secureOptions.sameSite = 'lax'
             }
-            request.cookies.set(name, value, secureOptions)
             response.cookies.set(name, value, secureOptions)
           })
           

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -14,8 +14,12 @@ export async function updateSession(request: NextRequest, response: NextResponse
         },
         setAll(cookiesToSet) {
           cookiesToSet.forEach(({ name, value, options }) => {
-            request.cookies.set(name, value)
-            response.cookies.set(name, value, options)
+            const secureOptions = { ...options }
+            if (secureOptions.sameSite === 'none' || secureOptions.sameSite === 'None') {
+              secureOptions.sameSite = 'lax'
+            }
+            request.cookies.set(name, value, secureOptions)
+            response.cookies.set(name, value, secureOptions)
           })
           
           // Force update the Cookie header for downstream Server Actions/Components


### PR DESCRIPTION
## Description

Resolves the SameSite cookie flag issue and log-injection vulnerabilities in API routes.

## Summary of Changes

- `stripe/customer-portal/route.ts`: `return_url` is sanitized (CR/LF stripped) and validated — only same-origin absolute URLs or relative paths are accepted, everything else falls back to `/dashboard`
- `api/worker/route.ts`: CR/LF stripped from the backend URL before it is written to logs (log-injection fix)
- `utils/supabase/middleware.ts`: cookies with `sameSite: 'none'` are upgraded to `'lax'` when re-set