### PR TITLE
fix(security): remediate workflow command injection and insecure cook…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1753,14 +1753,23 @@ jobs:
       - name: Create PostHog Visual Review run
         if: always()
         id: vr-run
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          POSTHOG_VR_TOKEN: ${{ secrets.POSTHOG_VR_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
+          PR_ARG=""
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            PR_ARG="--pr $PR_NUMBER"
+          fi
           RUN_ID=$(npx tsx /tmp/posthog/products/visual_review/cli/src/index.ts run create \
             --type playwright \
             --baseline playwright/snapshots.yml \
-            --token ${{ secrets.POSTHOG_VR_TOKEN }} \
-            --branch ${{ github.event.pull_request.head.ref || github.ref_name }} \
+            --token "$POSTHOG_VR_TOKEN" \
+            --branch "$BRANCH_NAME" \
             --commit $(git rev-parse HEAD) \
-            ${{ github.event_name == 'pull_request' && format('--pr {0}', github.event.pull_request.number) || '' }})
+            $PR_ARG)
           echo "run-id=$RUN_ID" >> $GITHUB_OUTPUT
           echo "Created PostHog VR run: $RUN_ID"
 

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -30,16 +30,20 @@ jobs:
 
       - name: Remove Preview and Merged Branch Tags
         if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BRANCH_REF: ${{ github.event.pull_request.head.ref }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
         run: |
-          PR_TAG="pr-${{ github.event.pull_request.number }}"
-          BRANCH_TAG=$(printf '%s' "branch-${{ github.event.pull_request.head.ref }}" \
+          PR_TAG="pr-$PR_NUMBER"
+          BRANCH_TAG=$(printf '%s' "branch-$BRANCH_REF" \
             | tr '[:upper:]' '[:lower:]' \
             | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g' \
             | cut -c1-63 \
             | sed -E 's/-+$//')
 
           TAGS=("$PR_TAG")
-          if [ "${{ github.event.pull_request.merged }}" = "true" ] && [ -n "$BRANCH_TAG" ]; then
+          if [ "$PR_MERGED" = "true" ] && [ -n "$BRANCH_TAG" ]; then
             TAGS+=("$BRANCH_TAG")
           fi
 

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -14,8 +14,16 @@ export async function updateSession(request: NextRequest, response: NextResponse
         },
         setAll(cookiesToSet) {
           cookiesToSet.forEach(({ name, value, options }) => {
-            request.cookies.set(name, value)
-            response.cookies.set(name, value, options)
+            request.cookies.set({
+              name,
+              value,
+              ...options,
+              sameSite: "lax",
+            })
+            response.cookies.set(name, value, {
+              ...options,
+              sameSite: "lax",
+            })
           })
           
           // Force update the Cookie header for downstream Server Actions/Components

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -14,12 +14,7 @@ export async function updateSession(request: NextRequest, response: NextResponse
         },
         setAll(cookiesToSet) {
           cookiesToSet.forEach(({ name, value, options }) => {
-            request.cookies.set({
-              name,
-              value,
-              ...options,
-              sameSite: "lax",
-            })
+            request.cookies.set(name, value)
             response.cookies.set(name, value, {
               ...options,
               sameSite: "lax",


### PR DESCRIPTION
## Description

Remediates workflow command-injection vectors and insecure cookie flags.

## Summary of Changes

- `ci.yml` (PostHog Visual Review) and `preview-cleanup.yml`: GitHub context values (branch name, PR number, merge state, tokens) are now passed through `env:` variables instead of being interpolated directly into `run` scripts — prevents shell injection via crafted branch names
- `utils/supabase/middleware.ts`: session cookies are re-set with `sameSite: 'lax'` explicitly