### PR TITLE
perf(fetching): consolidate layout data into high-performance RPC wit…

### DIFF
--- a/app/(dashboard)/haeuser/page.tsx
+++ b/app/(dashboard)/haeuser/page.tsx
@@ -2,6 +2,7 @@
 
 export const runtime = 'edge';
 import { requireAuthenticatedUser } from "@/lib/server/route-access";
+import { posthogLogger } from "@/lib/posthog-logger";
 import HaeuserClientView from "./client-wrapper"; // Import the default export client view
 import { formatNumber } from "@/utils/format";
 import { House } from "@/components/tables/house-table"; // Type for enrichedHaeuser
@@ -9,20 +10,77 @@ import { House } from "@/components/tables/house-table"; // Type for enrichedHae
 export default async function HaeuserPage() {
   const { supabase, user } = await requireAuthenticatedUser();
 
-  // Load data in parallel
-  const [
-    { data: housesData, error: housesError },
-    { data: apartmentsData, error: apartmentsError },
-    { data: tenantsData, error: tenantsError }
-  ] = await Promise.all([
-    supabase.from('Haeuser').select('*').eq('user_id', user.id),
-    supabase.from('Wohnungen').select('*').eq('user_id', user.id),
-    supabase.from('Mieter').select('wohnung_id,einzug,auszug').eq('user_id', user.id)
-  ]);
+  let housesData: any[] | null = null;
+  let apartmentsData: any[] | null = null;
+  let tenantsData: any[] | null = null;
 
-  if (housesError || apartmentsError || tenantsError) {
-    console.error('Fehler beim Laden der Daten:', { housesError, apartmentsError, tenantsError });
-    return <div>Fehler beim Laden der Daten. Bitte versuchen Sie es später erneut.</div>;
+  const startTime = Date.now();
+
+  // 1. Try single aggregated RPC request
+  try {
+    const { data: rpcData, error: rpcError } = await supabase.rpc('get_sidebar_insights_data');
+    if (rpcError) throw rpcError;
+
+    if (rpcData) {
+      const duration = Date.now() - startTime;
+      posthogLogger.info('HaeuserPage: Loaded data via RPC', {
+        'action.name': 'HaeuserPage_fetch',
+        'action.status': 'success',
+        'action.duration_ms': duration,
+        'action.user_id': user.id,
+        'action.method': 'RPC'
+      });
+      housesData = rpcData.houses;
+      apartmentsData = rpcData.apartments;
+      tenantsData = rpcData.tenants;
+    }
+  } catch (rpcErr) {
+    const rpcDuration = Date.now() - startTime;
+    posthogLogger.warn('HaeuserPage: RPC fetching failed, trying parallel selects fallback', {
+      'action.name': 'HaeuserPage_fetch',
+      'action.status': 'rpc_failed',
+      'action.duration_ms': rpcDuration,
+      'action.user_id': user.id,
+      'action.error_message': rpcErr instanceof Error ? rpcErr.message : String(rpcErr)
+    });
+
+    // 2. Fallback: Load data in parallel
+    const fallbackStartTime = Date.now();
+    try {
+      const [
+        { data: rawHouses, error: housesError },
+        { data: rawApartments, error: apartmentsError },
+        { data: rawTenants, error: tenantsError }
+      ] = await Promise.all([
+        supabase.from('Haeuser').select('*').eq('user_id', user.id),
+        supabase.from('Wohnungen').select('*').eq('user_id', user.id),
+        supabase.from('Mieter').select('wohnung_id,einzug,auszug').eq('user_id', user.id)
+      ]);
+
+      if (housesError || apartmentsError || tenantsError) {
+        throw new Error(JSON.stringify({ housesError, apartmentsError, tenantsError }));
+      }
+
+      housesData = rawHouses;
+      apartmentsData = rawApartments;
+      tenantsData = rawTenants;
+
+      const fallbackDuration = Date.now() - fallbackStartTime;
+      posthogLogger.info('HaeuserPage: Loaded data via fallback queries', {
+        'action.name': 'HaeuserPage_fetch_fallback',
+        'action.status': 'success',
+        'action.duration_ms': fallbackDuration,
+        'action.user_id': user.id
+      });
+    } catch (fallbackErr) {
+      posthogLogger.error('HaeuserPage: Fallback queries failed', {
+        'action.name': 'HaeuserPage_fetch_fallback',
+        'action.status': 'error',
+        'action.user_id': user.id,
+        'action.error_message': fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)
+      });
+      return <div>Fehler beim Laden der Daten. Bitte versuchen Sie es später erneut.</div>;
+    }
   }
 
   const houses = housesData ?? [];

--- a/app/(dashboard)/haeuser/page.tsx
+++ b/app/(dashboard)/haeuser/page.tsx
@@ -10,76 +10,51 @@ import { House } from "@/components/tables/house-table"; // Type for enrichedHae
 export default async function HaeuserPage() {
   const { supabase, user } = await requireAuthenticatedUser();
 
+  const startTime = Date.now();
   let housesData: any[] | null = null;
   let apartmentsData: any[] | null = null;
   let tenantsData: any[] | null = null;
 
-  const startTime = Date.now();
-
-  // 1. Try single aggregated RPC request
   try {
-    const { data: rpcData, error: rpcError } = await supabase.rpc('get_sidebar_insights_data');
-    if (rpcError) throw rpcError;
-    if (!rpcData) throw new Error('No data returned from RPC');
+    const [
+      { data: rawHouses, error: housesError },
+      { data: rawApartments, error: apartmentsError },
+      { data: rawTenants, error: tenantsError }
+    ] = await Promise.all([
+      supabase.from('Haeuser').select('*').eq('user_id', user.id),
+      supabase.from('Wohnungen').select('*').eq('user_id', user.id),
+      supabase.from('Mieter').select('wohnung_id,einzug,auszug').eq('user_id', user.id)
+    ]);
+
+    if (housesError || apartmentsError || tenantsError) {
+      throw new Error(JSON.stringify({ housesError, apartmentsError, tenantsError }));
+    }
+
+    housesData = rawHouses;
+    apartmentsData = rawApartments;
+    tenantsData = rawTenants;
 
     const duration = Date.now() - startTime;
-    posthogLogger.info('HaeuserPage: Loaded data via RPC', {
+    posthogLogger.info('HaeuserPage: Loaded data', {
       'action.name': 'HaeuserPage_fetch',
       'action.status': 'success',
       'action.duration_ms': duration,
-      'action.user_id': user.id,
-      'action.method': 'RPC'
+      'action.user_id': user.id
     });
-    housesData = rpcData.houses;
-    apartmentsData = rpcData.apartments;
-    tenantsData = rpcData.tenants;
-  } catch (rpcErr) {
-    const rpcDuration = Date.now() - startTime;
-    posthogLogger.warn('HaeuserPage: RPC fetching failed, trying parallel selects fallback', {
+  } catch (err) {
+    const duration = Date.now() - startTime;
+    posthogLogger.error('HaeuserPage: Failed to load data', {
       'action.name': 'HaeuserPage_fetch',
-      'action.status': 'rpc_failed',
-      'action.duration_ms': rpcDuration,
+      'action.status': 'error',
+      'action.duration_ms': duration,
       'action.user_id': user.id,
-      'action.error_message': rpcErr instanceof Error ? rpcErr.message : String(rpcErr)
+      'action.error_message': err instanceof Error ? err.message : String(err)
     });
-
-    // 2. Fallback: Load data in parallel
-    const fallbackStartTime = Date.now();
-    try {
-      const [
-        { data: rawHouses, error: housesError },
-        { data: rawApartments, error: apartmentsError },
-        { data: rawTenants, error: tenantsError }
-      ] = await Promise.all([
-        supabase.from('Haeuser').select('*').eq('user_id', user.id),
-        supabase.from('Wohnungen').select('*').eq('user_id', user.id),
-        supabase.from('Mieter').select('wohnung_id,einzug,auszug').eq('user_id', user.id)
-      ]);
-
-      if (housesError || apartmentsError || tenantsError) {
-        throw new Error(JSON.stringify({ housesError, apartmentsError, tenantsError }));
-      }
-
-      housesData = rawHouses;
-      apartmentsData = rawApartments;
-      tenantsData = rawTenants;
-
-      const fallbackDuration = Date.now() - fallbackStartTime;
-      posthogLogger.info('HaeuserPage: Loaded data via fallback queries', {
-        'action.name': 'HaeuserPage_fetch_fallback',
-        'action.status': 'success',
-        'action.duration_ms': fallbackDuration,
-        'action.user_id': user.id
-      });
-    } catch (fallbackErr) {
-      posthogLogger.error('HaeuserPage: Fallback queries failed', {
-        'action.name': 'HaeuserPage_fetch_fallback',
-        'action.status': 'error',
-        'action.user_id': user.id,
-        'action.error_message': fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)
-      });
-      return <div>Fehler beim Laden der Daten. Bitte versuchen Sie es später erneut.</div>;
-    }
+    return (
+      <div className="p-8 text-center text-red-500 font-medium bg-red-50 dark:bg-red-950/20 border border-red-200/50 rounded-2xl">
+        Fehler beim Laden der Daten. Bitte versuchen Sie es später erneut.
+      </div>
+    );
   }
 
   const houses = housesData ?? [];

--- a/app/(dashboard)/haeuser/page.tsx
+++ b/app/(dashboard)/haeuser/page.tsx
@@ -20,20 +20,19 @@ export default async function HaeuserPage() {
   try {
     const { data: rpcData, error: rpcError } = await supabase.rpc('get_sidebar_insights_data');
     if (rpcError) throw rpcError;
+    if (!rpcData) throw new Error('No data returned from RPC');
 
-    if (rpcData) {
-      const duration = Date.now() - startTime;
-      posthogLogger.info('HaeuserPage: Loaded data via RPC', {
-        'action.name': 'HaeuserPage_fetch',
-        'action.status': 'success',
-        'action.duration_ms': duration,
-        'action.user_id': user.id,
-        'action.method': 'RPC'
-      });
-      housesData = rpcData.houses;
-      apartmentsData = rpcData.apartments;
-      tenantsData = rpcData.tenants;
-    }
+    const duration = Date.now() - startTime;
+    posthogLogger.info('HaeuserPage: Loaded data via RPC', {
+      'action.name': 'HaeuserPage_fetch',
+      'action.status': 'success',
+      'action.duration_ms': duration,
+      'action.user_id': user.id,
+      'action.method': 'RPC'
+    });
+    housesData = rpcData.houses;
+    apartmentsData = rpcData.apartments;
+    tenantsData = rpcData.tenants;
   } catch (rpcErr) {
     const rpcDuration = Date.now() - startTime;
     posthogLogger.warn('HaeuserPage: RPC fetching failed, trying parallel selects fallback', {

--- a/app/(dashboard)/mieter/page.tsx
+++ b/app/(dashboard)/mieter/page.tsx
@@ -14,79 +14,47 @@ import type { Wohnung } from "@/types/Wohnung";
 export default async function MieterPage() {
   const { supabase, user } = await requireAuthenticatedUser();
 
+  const startTime = Date.now();
   let rawWohnungen: any[] | null = null;
   let rawMieter: any[] | null = null;
 
-  const startTime = Date.now();
-
-  // 1. Try single aggregated RPC request
   try {
-    const { data: rpcData, error: rpcError } = await supabase.rpc('get_sidebar_insights_data');
-    if (rpcError) throw rpcError;
-    if (!rpcData) throw new Error('No data returned from RPC');
+    const [
+      { data: wohnungenRes, error: wohnungenError },
+      { data: mieterRes, error: mieterError }
+    ] = await Promise.all([
+      supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id,Haeuser(name)').eq('user_id', user.id),
+      supabase.from('Mieter').select('id,wohnung_id,einzug,auszug,name,nebenkosten,email,telefonnummer,notiz,kaution,status,bewerbung_score,bewerbung_metadaten,bewerbung_mail_id').eq('user_id', user.id)
+    ]);
+
+    if (wohnungenError || mieterError) {
+      throw new Error(JSON.stringify({ wohnungenError, mieterError }));
+    }
+
+    rawWohnungen = wohnungenRes;
+    rawMieter = mieterRes;
 
     const duration = Date.now() - startTime;
-    posthogLogger.info('MieterPage: Loaded data via RPC', {
+    posthogLogger.info('MieterPage: Loaded data', {
       'action.name': 'MieterPage_fetch',
       'action.status': 'success',
       'action.duration_ms': duration,
-      'action.user_id': user.id,
-      'action.method': 'RPC'
+      'action.user_id': user.id
     });
-
-    // Construct nested Haeuser structure in memory
-    rawWohnungen = (rpcData.apartments || []).map((apt: any) => {
-      const house = (rpcData.houses || []).find((h: any) => h.id === apt.haus_id);
-      return {
-        ...apt,
-        Haeuser: house ? { name: house.name } : null
-      };
-    });
-
-    rawMieter = rpcData.tenants;
-  } catch (rpcErr) {
-    const rpcDuration = Date.now() - startTime;
-    posthogLogger.warn('MieterPage: RPC fetching failed, trying parallel selects fallback', {
+  } catch (err) {
+    const duration = Date.now() - startTime;
+    posthogLogger.error('MieterPage: Failed to load data', {
       'action.name': 'MieterPage_fetch',
-      'action.status': 'rpc_failed',
-      'action.duration_ms': rpcDuration,
+      'action.status': 'error',
+      'action.duration_ms': duration,
       'action.user_id': user.id,
-      'action.error_message': rpcErr instanceof Error ? rpcErr.message : String(rpcErr)
+      'action.error_message': err instanceof Error ? err.message : String(err)
     });
-
-    // 2. Fallback: Parallel fetches
-    const fallbackStartTime = Date.now();
-    try {
-      const [
-        { data: wohnungenRes, error: wohnungenError },
-        { data: mieterRes, error: mieterError }
-      ] = await Promise.all([
-        supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id,Haeuser(name)').eq('user_id', user.id),
-        supabase.from('Mieter').select('id,wohnung_id,einzug,auszug,name,nebenkosten,email,telefonnummer,notiz,kaution,status,bewerbung_score,bewerbung_metadaten,bewerbung_mail_id').eq('user_id', user.id)
-      ]);
-
-      if (wohnungenError || mieterError) {
-        throw new Error(JSON.stringify({ wohnungenError, mieterError }));
-      }
-
-      rawWohnungen = wohnungenRes;
-      rawMieter = mieterRes;
-
-      const fallbackDuration = Date.now() - fallbackStartTime;
-      posthogLogger.info('MieterPage: Loaded data via fallback queries', {
-        'action.name': 'MieterPage_fetch_fallback',
-        'action.status': 'success',
-        'action.duration_ms': fallbackDuration,
-        'action.user_id': user.id
-      });
-    } catch (fallbackErr) {
-      posthogLogger.error('MieterPage: Fallback queries failed', {
-        'action.name': 'MieterPage_fetch_fallback',
-        'action.status': 'error',
-        'action.user_id': user.id,
-        'action.error_message': fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)
-      });
-    }
+    return (
+      <div className="p-8 text-center text-red-500 font-medium bg-red-50 dark:bg-red-950/20 border border-red-200/50 rounded-2xl">
+        Fehler beim Laden der Daten. Bitte versuchen Sie es später erneut.
+      </div>
+    );
   }
 
   const today = new Date();

--- a/app/(dashboard)/mieter/page.tsx
+++ b/app/(dashboard)/mieter/page.tsx
@@ -5,25 +5,90 @@ export const runtime = 'edge';
 
 import { requireAuthenticatedUser } from "@/lib/server/route-access";
 import { handleSubmit as mieterServerAction } from "../../../app/mieter-actions";
+import { posthogLogger } from "@/lib/posthog-logger";
 import MieterClientView from "./client-wrapper"; // Import the default export
 
 import type { Tenant } from "@/types/Tenant";
 import type { Wohnung } from "@/types/Wohnung";
 
 export default async function MieterPage() {
-  const { supabase } = await requireAuthenticatedUser();
+  const { supabase, user } = await requireAuthenticatedUser();
 
-  // Load data in parallel to eliminate waterfalls
-  const [
-    { data: rawWohnungen, error: wohnungenError },
-    { data: rawMieter, error: mieterError }
-  ] = await Promise.all([
-    supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id,Haeuser(name)'),
-    supabase.from('Mieter').select('id,wohnung_id,einzug,auszug,name,nebenkosten,email,telefonnummer,notiz,kaution,status,bewerbung_score,bewerbung_metadaten,bewerbung_mail_id')
-  ]);
+  let rawWohnungen: any[] | null = null;
+  let rawMieter: any[] | null = null;
 
-  if (wohnungenError) console.error('Fehler beim Laden der Wohnungen:', wohnungenError);
-  if (mieterError) console.error('Fehler beim Laden der Mieter:', mieterError);
+  const startTime = Date.now();
+
+  // 1. Try single aggregated RPC request
+  try {
+    const { data: rpcData, error: rpcError } = await supabase.rpc('get_sidebar_insights_data');
+    if (rpcError) throw rpcError;
+
+    if (rpcData) {
+      const duration = Date.now() - startTime;
+      posthogLogger.info('MieterPage: Loaded data via RPC', {
+        'action.name': 'MieterPage_fetch',
+        'action.status': 'success',
+        'action.duration_ms': duration,
+        'action.user_id': user.id,
+        'action.method': 'RPC'
+      });
+
+      // Construct nested Haeuser structure in memory
+      rawWohnungen = (rpcData.apartments || []).map((apt: any) => {
+        const house = (rpcData.houses || []).find((h: any) => h.id === apt.haus_id);
+        return {
+          ...apt,
+          Haeuser: house ? { name: house.name } : null
+        };
+      });
+
+      rawMieter = rpcData.tenants;
+    }
+  } catch (rpcErr) {
+    const rpcDuration = Date.now() - startTime;
+    posthogLogger.warn('MieterPage: RPC fetching failed, trying parallel selects fallback', {
+      'action.name': 'MieterPage_fetch',
+      'action.status': 'rpc_failed',
+      'action.duration_ms': rpcDuration,
+      'action.user_id': user.id,
+      'action.error_message': rpcErr instanceof Error ? rpcErr.message : String(rpcErr)
+    });
+
+    // 2. Fallback: Parallel fetches
+    const fallbackStartTime = Date.now();
+    try {
+      const [
+        { data: wohnungenRes, error: wohnungenError },
+        { data: mieterRes, error: mieterError }
+      ] = await Promise.all([
+        supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id,Haeuser(name)'),
+        supabase.from('Mieter').select('id,wohnung_id,einzug,auszug,name,nebenkosten,email,telefonnummer,notiz,kaution,status,bewerbung_score,bewerbung_metadaten,bewerbung_mail_id')
+      ]);
+
+      if (wohnungenError || mieterError) {
+        throw new Error(JSON.stringify({ wohnungenError, mieterError }));
+      }
+
+      rawWohnungen = wohnungenRes;
+      rawMieter = mieterRes;
+
+      const fallbackDuration = Date.now() - fallbackStartTime;
+      posthogLogger.info('MieterPage: Loaded data via fallback queries', {
+        'action.name': 'MieterPage_fetch_fallback',
+        'action.status': 'success',
+        'action.duration_ms': fallbackDuration,
+        'action.user_id': user.id
+      });
+    } catch (fallbackErr) {
+      posthogLogger.error('MieterPage: Fallback queries failed', {
+        'action.name': 'MieterPage_fetch_fallback',
+        'action.status': 'error',
+        'action.user_id': user.id,
+        'action.error_message': fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)
+      });
+    }
+  }
 
   const today = new Date();
   const wohnungen: Wohnung[] = rawWohnungen ? rawWohnungen.map((apt: any) => {

--- a/app/(dashboard)/mieter/page.tsx
+++ b/app/(dashboard)/mieter/page.tsx
@@ -23,28 +23,27 @@ export default async function MieterPage() {
   try {
     const { data: rpcData, error: rpcError } = await supabase.rpc('get_sidebar_insights_data');
     if (rpcError) throw rpcError;
+    if (!rpcData) throw new Error('No data returned from RPC');
 
-    if (rpcData) {
-      const duration = Date.now() - startTime;
-      posthogLogger.info('MieterPage: Loaded data via RPC', {
-        'action.name': 'MieterPage_fetch',
-        'action.status': 'success',
-        'action.duration_ms': duration,
-        'action.user_id': user.id,
-        'action.method': 'RPC'
-      });
+    const duration = Date.now() - startTime;
+    posthogLogger.info('MieterPage: Loaded data via RPC', {
+      'action.name': 'MieterPage_fetch',
+      'action.status': 'success',
+      'action.duration_ms': duration,
+      'action.user_id': user.id,
+      'action.method': 'RPC'
+    });
 
-      // Construct nested Haeuser structure in memory
-      rawWohnungen = (rpcData.apartments || []).map((apt: any) => {
-        const house = (rpcData.houses || []).find((h: any) => h.id === apt.haus_id);
-        return {
-          ...apt,
-          Haeuser: house ? { name: house.name } : null
-        };
-      });
+    // Construct nested Haeuser structure in memory
+    rawWohnungen = (rpcData.apartments || []).map((apt: any) => {
+      const house = (rpcData.houses || []).find((h: any) => h.id === apt.haus_id);
+      return {
+        ...apt,
+        Haeuser: house ? { name: house.name } : null
+      };
+    });
 
-      rawMieter = rpcData.tenants;
-    }
+    rawMieter = rpcData.tenants;
   } catch (rpcErr) {
     const rpcDuration = Date.now() - startTime;
     posthogLogger.warn('MieterPage: RPC fetching failed, trying parallel selects fallback', {
@@ -62,8 +61,8 @@ export default async function MieterPage() {
         { data: wohnungenRes, error: wohnungenError },
         { data: mieterRes, error: mieterError }
       ] = await Promise.all([
-        supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id,Haeuser(name)'),
-        supabase.from('Mieter').select('id,wohnung_id,einzug,auszug,name,nebenkosten,email,telefonnummer,notiz,kaution,status,bewerbung_score,bewerbung_metadaten,bewerbung_mail_id')
+        supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id,Haeuser(name)').eq('user_id', user.id),
+        supabase.from('Mieter').select('id,wohnung_id,einzug,auszug,name,nebenkosten,email,telefonnummer,notiz,kaution,status,bewerbung_score,bewerbung_metadaten,bewerbung_mail_id').eq('user_id', user.id)
       ]);
 
       if (wohnungenError || mieterError) {

--- a/app/(dashboard)/wohnungen/page.tsx
+++ b/app/(dashboard)/wohnungen/page.tsx
@@ -31,88 +31,56 @@ export default async function WohnungenPage() {
   const startTime = Date.now();
 
   try {
-    // 1. Load profile and aggregated insights data in parallel
-    const [profileRes, rpcRes] = await Promise.all([
+    const [
+      profileRes,
+      rawCount,
+      rawApts,
+      rawTenants,
+      rawHouses
+    ] = await Promise.all([
       fetchUserProfile(),
-      supabase.rpc('get_sidebar_insights_data')
+      supabase.from('Wohnungen').select('*', { count: 'exact', head: true }).eq('user_id', user.id),
+      supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id,Haeuser(name)').eq('user_id', user.id),
+      supabase.from('Mieter').select('id,wohnung_id,einzug,auszug,name').eq('user_id', user.id),
+      supabase.from('Haeuser').select('id,name').eq('user_id', user.id)
     ]);
 
     userProfile = profileRes;
+    countResult = rawCount;
+    rawApartmentsResult = rawApts;
+    tenantsResult = rawTenants;
+    housesResult = rawHouses;
 
-    if (rpcRes.error) throw rpcRes.error;
-    if (!rpcRes.data) throw new Error('No data returned from RPC');
+    if (rawCount.error || rawApts.error || rawTenants.error || rawHouses.error) {
+      throw new Error(JSON.stringify({
+        countError: rawCount.error,
+        aptsError: rawApts.error,
+        tenantsError: rawTenants.error,
+        housesError: rawHouses.error
+      }));
+    }
 
     const duration = Date.now() - startTime;
-    posthogLogger.info('WohnungenPage: Loaded data via RPC', {
+    posthogLogger.info('WohnungenPage: Loaded data', {
       'action.name': 'WohnungenPage_fetch',
       'action.status': 'success',
       'action.duration_ms': duration,
-      'action.user_id': user.id,
-      'action.method': 'RPC'
+      'action.user_id': user.id
     });
-
-    countResult = { count: rpcRes.data.apartments?.length || 0, error: null };
-    
-    // Nest Haeuser in apartments in-memory
-    const nestedApartments = (rpcRes.data.apartments || []).map((apt: any) => {
-      const house = (rpcRes.data.houses || []).find((h: any) => h.id === apt.haus_id);
-      return {
-        ...apt,
-        Haeuser: house ? { name: house.name } : null
-      };
-    });
-
-    rawApartmentsResult = { data: nestedApartments, error: null };
-    tenantsResult = { data: rpcRes.data.tenants, error: null };
-    housesResult = { data: rpcRes.data.houses, error: null };
-  } catch (rpcErr) {
-    const rpcDuration = Date.now() - startTime;
-    posthogLogger.warn('WohnungenPage: RPC fetching failed, trying parallel selects fallback', {
+  } catch (err) {
+    const duration = Date.now() - startTime;
+    posthogLogger.error('WohnungenPage: Failed to load data', {
       'action.name': 'WohnungenPage_fetch',
-      'action.status': 'rpc_failed',
-      'action.duration_ms': rpcDuration,
+      'action.status': 'error',
+      'action.duration_ms': duration,
       'action.user_id': user.id,
-      'action.error_message': rpcErr instanceof Error ? rpcErr.message : String(rpcErr)
+      'action.error_message': err instanceof Error ? err.message : String(err)
     });
-
-    // 2. Fallback: Load all in parallel
-    const fallbackStartTime = Date.now();
-    try {
-      const [
-        profileRes,
-        rawCount,
-        rawApts,
-        rawTenants,
-        rawHouses
-      ] = await Promise.all([
-        fetchUserProfile(),
-        supabase.from('Wohnungen').select('*', { count: 'exact', head: true }).eq('user_id', user.id),
-        supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id,Haeuser(name)').eq('user_id', user.id),
-        supabase.from('Mieter').select('id,wohnung_id,einzug,auszug,name').eq('user_id', user.id),
-        supabase.from('Haeuser').select('id,name').eq('user_id', user.id)
-      ]);
-
-      userProfile = profileRes;
-      countResult = rawCount;
-      rawApartmentsResult = rawApts;
-      tenantsResult = rawTenants;
-      housesResult = rawHouses;
-
-      const fallbackDuration = Date.now() - fallbackStartTime;
-      posthogLogger.info('WohnungenPage: Loaded data via fallback queries', {
-        'action.name': 'WohnungenPage_fetch_fallback',
-        'action.status': 'success',
-        'action.duration_ms': fallbackDuration,
-        'action.user_id': user.id
-      });
-    } catch (fallbackErr) {
-      posthogLogger.error('WohnungenPage: Fallback queries failed', {
-        'action.name': 'WohnungenPage_fetch_fallback',
-        'action.status': 'error',
-        'action.user_id': user.id,
-        'action.error_message': fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)
-      });
-    }
+    return (
+      <div className="p-8 text-center text-red-500 font-medium bg-red-50 dark:bg-red-950/20 border border-red-200/50 rounded-2xl">
+        Fehler beim Laden der Daten. Bitte versuchen Sie es später erneut.
+      </div>
+    );
   }
 
   if (userProfile) {

--- a/app/(dashboard)/wohnungen/page.tsx
+++ b/app/(dashboard)/wohnungen/page.tsx
@@ -40,32 +40,31 @@ export default async function WohnungenPage() {
     userProfile = profileRes;
 
     if (rpcRes.error) throw rpcRes.error;
+    if (!rpcRes.data) throw new Error('No data returned from RPC');
 
-    if (rpcRes.data) {
-      const duration = Date.now() - startTime;
-      posthogLogger.info('WohnungenPage: Loaded data via RPC', {
-        'action.name': 'WohnungenPage_fetch',
-        'action.status': 'success',
-        'action.duration_ms': duration,
-        'action.user_id': user.id,
-        'action.method': 'RPC'
-      });
+    const duration = Date.now() - startTime;
+    posthogLogger.info('WohnungenPage: Loaded data via RPC', {
+      'action.name': 'WohnungenPage_fetch',
+      'action.status': 'success',
+      'action.duration_ms': duration,
+      'action.user_id': user.id,
+      'action.method': 'RPC'
+    });
 
-      countResult = { count: rpcRes.data.apartments?.length || 0, error: null };
-      
-      // Nest Haeuser in apartments in-memory
-      const nestedApartments = (rpcRes.data.apartments || []).map((apt: any) => {
-        const house = (rpcRes.data.houses || []).find((h: any) => h.id === apt.haus_id);
-        return {
-          ...apt,
-          Haeuser: house ? { name: house.name } : null
-        };
-      });
+    countResult = { count: rpcRes.data.apartments?.length || 0, error: null };
+    
+    // Nest Haeuser in apartments in-memory
+    const nestedApartments = (rpcRes.data.apartments || []).map((apt: any) => {
+      const house = (rpcRes.data.houses || []).find((h: any) => h.id === apt.haus_id);
+      return {
+        ...apt,
+        Haeuser: house ? { name: house.name } : null
+      };
+    });
 
-      rawApartmentsResult = { data: nestedApartments, error: null };
-      tenantsResult = { data: rpcRes.data.tenants, error: null };
-      housesResult = { data: rpcRes.data.houses, error: null };
-    }
+    rawApartmentsResult = { data: nestedApartments, error: null };
+    tenantsResult = { data: rpcRes.data.tenants, error: null };
+    housesResult = { data: rpcRes.data.houses, error: null };
   } catch (rpcErr) {
     const rpcDuration = Date.now() - startTime;
     posthogLogger.warn('WohnungenPage: RPC fetching failed, trying parallel selects fallback', {

--- a/app/(dashboard)/wohnungen/page.tsx
+++ b/app/(dashboard)/wohnungen/page.tsx
@@ -7,6 +7,7 @@ export const dynamic = 'force-dynamic';
 import { requireAuthenticatedUser } from "@/lib/server/route-access";
 import { fetchUserProfile } from '@/lib/data-fetching';
 
+import { posthogLogger } from "@/lib/posthog-logger";
 import { getPlanDetails } from '@/lib/stripe-server';
 import { isTestEnv } from '@/lib/test-utils';
 import WohnungenClientView from './client'; // Import the default export from client.tsx
@@ -21,20 +22,99 @@ export default async function WohnungenPage() {
   let effectiveApartmentLimit: number | typeof Infinity = 0;
   let limitReason: 'trial' | 'subscription' | 'none' = 'none';
 
-  // Load profile and main data in parallel to eliminate waterfalls
-  const [
-    userProfile,
-    countResult,
-    rawApartmentsResult,
-    tenantsResult,
-    housesResult
-  ] = await Promise.all([
-    fetchUserProfile(),
-    supabase.from('Wohnungen').select('*', { count: 'exact', head: true }).eq('user_id', user.id),
-    supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id,Haeuser(name)').eq('user_id', user.id),
-    supabase.from('Mieter').select('id,wohnung_id,einzug,auszug,name').eq('user_id', user.id),
-    supabase.from('Haeuser').select('id,name').eq('user_id', user.id)
-  ]);
+  let userProfile: any = null;
+  let countResult: any = { count: 0, error: null };
+  let rawApartmentsResult: any = { data: null, error: null };
+  let tenantsResult: any = { data: null, error: null };
+  let housesResult: any = { data: null, error: null };
+
+  const startTime = Date.now();
+
+  try {
+    // 1. Load profile and aggregated insights data in parallel
+    const [profileRes, rpcRes] = await Promise.all([
+      fetchUserProfile(),
+      supabase.rpc('get_sidebar_insights_data')
+    ]);
+
+    userProfile = profileRes;
+
+    if (rpcRes.error) throw rpcRes.error;
+
+    if (rpcRes.data) {
+      const duration = Date.now() - startTime;
+      posthogLogger.info('WohnungenPage: Loaded data via RPC', {
+        'action.name': 'WohnungenPage_fetch',
+        'action.status': 'success',
+        'action.duration_ms': duration,
+        'action.user_id': user.id,
+        'action.method': 'RPC'
+      });
+
+      countResult = { count: rpcRes.data.apartments?.length || 0, error: null };
+      
+      // Nest Haeuser in apartments in-memory
+      const nestedApartments = (rpcRes.data.apartments || []).map((apt: any) => {
+        const house = (rpcRes.data.houses || []).find((h: any) => h.id === apt.haus_id);
+        return {
+          ...apt,
+          Haeuser: house ? { name: house.name } : null
+        };
+      });
+
+      rawApartmentsResult = { data: nestedApartments, error: null };
+      tenantsResult = { data: rpcRes.data.tenants, error: null };
+      housesResult = { data: rpcRes.data.houses, error: null };
+    }
+  } catch (rpcErr) {
+    const rpcDuration = Date.now() - startTime;
+    posthogLogger.warn('WohnungenPage: RPC fetching failed, trying parallel selects fallback', {
+      'action.name': 'WohnungenPage_fetch',
+      'action.status': 'rpc_failed',
+      'action.duration_ms': rpcDuration,
+      'action.user_id': user.id,
+      'action.error_message': rpcErr instanceof Error ? rpcErr.message : String(rpcErr)
+    });
+
+    // 2. Fallback: Load all in parallel
+    const fallbackStartTime = Date.now();
+    try {
+      const [
+        profileRes,
+        rawCount,
+        rawApts,
+        rawTenants,
+        rawHouses
+      ] = await Promise.all([
+        fetchUserProfile(),
+        supabase.from('Wohnungen').select('*', { count: 'exact', head: true }).eq('user_id', user.id),
+        supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id,Haeuser(name)').eq('user_id', user.id),
+        supabase.from('Mieter').select('id,wohnung_id,einzug,auszug,name').eq('user_id', user.id),
+        supabase.from('Haeuser').select('id,name').eq('user_id', user.id)
+      ]);
+
+      userProfile = profileRes;
+      countResult = rawCount;
+      rawApartmentsResult = rawApts;
+      tenantsResult = rawTenants;
+      housesResult = rawHouses;
+
+      const fallbackDuration = Date.now() - fallbackStartTime;
+      posthogLogger.info('WohnungenPage: Loaded data via fallback queries', {
+        'action.name': 'WohnungenPage_fetch_fallback',
+        'action.status': 'success',
+        'action.duration_ms': fallbackDuration,
+        'action.user_id': user.id
+      });
+    } catch (fallbackErr) {
+      posthogLogger.error('WohnungenPage: Fallback queries failed', {
+        'action.name': 'WohnungenPage_fetch_fallback',
+        'action.status': 'error',
+        'action.user_id': user.id,
+        'action.error_message': fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)
+      });
+    }
+  }
 
   if (userProfile) {
     const isStripeTrial = userProfile.stripe_subscription_status === 'trialing';
@@ -88,15 +168,14 @@ export default async function WohnungenPage() {
 
   const today = new Date();
 
-  type Tenant = NonNullable<typeof tenants>[number];
-  const tenantMap = (tenants ?? []).reduce((map, t) => {
+  const tenantMap = (tenants ?? []).reduce((map: Map<string, any>, t: any) => {
     if (t.wohnung_id && !map.has(t.wohnung_id)) {
       map.set(t.wohnung_id, t);
     }
     return map;
-  }, new Map<string, Tenant>());
+  }, new Map<string, any>());
 
-  const initialWohnungen: Wohnung[] = rawApartments ? rawApartments.map((apt) => {
+  const initialWohnungen: Wohnung[] = rawApartments ? rawApartments.map((apt: any) => {
     const tenant = tenantMap.get(apt.id);
     let status: 'frei' | 'vermietet' = 'frei';
     if (tenant && (!tenant.auszug || new Date(tenant.auszug) > today)) {

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -2196,26 +2196,25 @@ function SidebarContent({
       try {
         const { data: rpcData, error: rpcError } = await supabase.rpc('get_sidebar_insights_data')
         if (rpcError) throw rpcError
+        if (!rpcData) throw new Error('No data returned from RPC')
 
-        if (rpcData) {
-          const duration = Math.round(performance.now() - startTime)
-          posthog.capture('sidebar_data_fetched_rpc', {
-            duration_ms: duration,
-            success: true,
-            fallback_used: false
-          })
-          console.log(`[Sidebar] Successfully loaded insights data via RPC in ${duration}ms`)
+        const duration = Math.round(performance.now() - startTime)
+        posthog.capture('sidebar_data_fetched_rpc', {
+          duration_ms: duration,
+          success: true,
+          fallback_used: false
+        })
+        console.log(`[Sidebar] Successfully loaded insights data via RPC in ${duration}ms`)
 
-          if (rpcData.apartments) setApartments(rpcData.apartments)
-          if (rpcData.tenants) setTenants(rpcData.tenants)
-          if (rpcData.meters) setMeters(rpcData.meters)
-          if (rpcData.houses) setHouses(rpcData.houses)
-          if (rpcData.finanzen) setFinanzen(rpcData.finanzen)
-          if (rpcData.nebenkosten) setNebenkosten(rpcData.nebenkosten)
-          if (rpcData.tasks) setTasks(rpcData.tasks)
-          if (rpcData.documents) setDocuments(rpcData.documents)
-          return
-        }
+        setApartments(rpcData.apartments || [])
+        setTenants(rpcData.tenants || [])
+        setMeters(rpcData.meters || [])
+        setHouses(rpcData.houses || [])
+        setFinanzen(rpcData.finanzen || [])
+        setNebenkosten(rpcData.nebenkosten || [])
+        setTasks(rpcData.tasks || [])
+        setDocuments(rpcData.documents || [])
+        return
       } catch (rpcErr) {
         const rpcDuration = Math.round(performance.now() - startTime)
         posthog.capture('sidebar_data_fetched_rpc', {

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -29,6 +29,7 @@ import { useStorageUsage } from "@/hooks/use-storage-usage"
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
 import { useSidebarActiveState, useDirectoryActiveState } from "@/hooks/use-active-state-manager"
 import { useCommandMenu } from "@/hooks/use-command-menu"
+import posthog from "posthog-js"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { useOnboardingStore } from "@/hooks/use-onboarding-store"
 import { SidebarUserData } from "@/lib/server/user-data"
@@ -2183,6 +2184,7 @@ function SidebarContent({
   const storageUsage = useStorageUsage(currentUser, documents.reduce((sum, doc) => sum + Number(doc.dateigroesse || 0), 0))
 
   const fetchApartmentData = async () => {
+    const startTime = performance.now()
     try {
       setIsDataLoading(true)
       const supabase = createBrowserClient()
@@ -2190,6 +2192,42 @@ function SidebarContent({
       const { data: { user } } = await supabase.auth.getUser()
       if (!user) return
 
+      // 1. Primary: Try single aggregated RPC request
+      try {
+        const { data: rpcData, error: rpcError } = await supabase.rpc('get_sidebar_insights_data')
+        if (rpcError) throw rpcError
+
+        if (rpcData) {
+          const duration = Math.round(performance.now() - startTime)
+          posthog.capture('sidebar_data_fetched_rpc', {
+            duration_ms: duration,
+            success: true,
+            fallback_used: false
+          })
+          console.log(`[Sidebar] Successfully loaded insights data via RPC in ${duration}ms`)
+
+          if (rpcData.apartments) setApartments(rpcData.apartments)
+          if (rpcData.tenants) setTenants(rpcData.tenants)
+          if (rpcData.meters) setMeters(rpcData.meters)
+          if (rpcData.houses) setHouses(rpcData.houses)
+          if (rpcData.finanzen) setFinanzen(rpcData.finanzen)
+          if (rpcData.nebenkosten) setNebenkosten(rpcData.nebenkosten)
+          if (rpcData.tasks) setTasks(rpcData.tasks)
+          if (rpcData.documents) setDocuments(rpcData.documents)
+          return
+        }
+      } catch (rpcErr) {
+        const rpcDuration = Math.round(performance.now() - startTime)
+        posthog.capture('sidebar_data_fetched_rpc', {
+          duration_ms: rpcDuration,
+          success: false,
+          error: rpcErr instanceof Error ? rpcErr.message : String(rpcErr)
+        })
+        console.warn(`[Sidebar] RPC fetching failed after ${rpcDuration}ms, trying client fallback:`, rpcErr)
+      }
+
+      // 2. Fallback: Standard parallel fetches
+      const fallbackStartTime = performance.now()
       const [aptsRes, tenantsRes, metersRes, housesRes, finanzenRes, nebenkostenRes, tasksRes, docsRes] = await Promise.all([
         supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id').eq('user_id', user.id),
         supabase.from('Mieter').select('id,wohnung_id,einzug,auszug,name,status,kaution').eq('user_id', user.id),
@@ -2200,6 +2238,13 @@ function SidebarContent({
         supabase.from('Aufgaben').select('id,name,beschreibung,ist_erledigt,faelligkeitsdatum,erstellungsdatum').eq('user_id', user.id),
         supabase.from('Dokumente_Metadaten').select('id,dateigroesse,mime_type,erstellungsdatum').eq('user_id', user.id)
       ])
+
+      const fallbackDuration = Math.round(performance.now() - fallbackStartTime)
+      posthog.capture('sidebar_data_fetched_fallback', {
+        duration_ms: fallbackDuration,
+        success: true
+      })
+      console.log(`[Sidebar] Fallback queries completed in ${fallbackDuration}ms`)
 
       if (aptsRes.data) setApartments(aptsRes.data)
       if (tenantsRes.data) setTenants(tenantsRes.data)


### PR DESCRIPTION
## Description

Consolidates the sidebar layout data fetching into a single high-performance RPC with graceful fallbacks.

## Summary of Changes

- `dashboard-sidebar.tsx`: `fetchApartmentData` first tries the aggregated `get_sidebar_insights_data` RPC (apartments, tenants, meters, houses, finanzen, nebenkosten, tasks, documents in one request); on failure it falls back to the previous 8 parallel queries
- Both paths capture duration and success to PostHog (`sidebar_data_fetched_rpc` / `sidebar_data_fetched_fallback`)