### PR TITLE
fix(worker): Intercept GET requests to stop logging false errors

### DIFF
--- a/workers/mietevo-backend/src/index.test.ts
+++ b/workers/mietevo-backend/src/index.test.ts
@@ -151,6 +151,26 @@ describe('Backend Worker Tests', () => {
     });
 
     describe('Main Router (fetch)', () => {
+        it('should handle GET / correctly (health check)', async () => {
+            const request = new Request('https://worker.com/', {
+                method: 'GET'
+            });
+
+            const response = await (await import('./index')).default.fetch(request, mockEnv as unknown as Env, mockCtx as unknown as ExecutionContext);
+            expect(response.status).toBe(200);
+            expect(await response.text()).toBe('OK');
+        });
+
+        it('should handle GET /health correctly (health check)', async () => {
+            const request = new Request('https://worker.com/health', {
+                method: 'GET'
+            });
+
+            const response = await (await import('./index')).default.fetch(request, mockEnv as unknown as Env, mockCtx as unknown as ExecutionContext);
+            expect(response.status).toBe(200);
+            expect(await response.text()).toBe('OK');
+        });
+
         it('should route to /ai correctly', async () => {
             // Mocking handleAIRequest indirectly by checking the response or using spies
             // Since we export 'default', we can test that.

--- a/workers/mietevo-backend/src/index.ts
+++ b/workers/mietevo-backend/src/index.ts
@@ -1380,6 +1380,15 @@ export default {
         try {
             // Route based on URL path first (more robust)
             let response: Response;
+
+            // Handle simple GET requests (health checks, root)
+            if (request.method === 'GET') {
+                if (url.pathname === '/' || url.pathname === '/health') {
+                    response = new Response('OK', { status: 200 });
+                } else {
+                    response = new Response('Not Found', { status: 404 });
+                }
+            } else
             if (url.pathname === '/ai') {
                 response = await handleAIRequest(request, env, ctx);
             } else if (url.pathname === '/process-queue') {

--- a/workers/mietevo-backend/src/index.ts
+++ b/workers/mietevo-backend/src/index.ts
@@ -1381,15 +1381,14 @@ export default {
             // Route based on URL path first (more robust)
             let response: Response;
 
-            // Handle simple GET requests (health checks, root)
-            if (request.method === 'GET') {
+            // Handle simple GET/HEAD requests (health checks, root)
+            if (request.method === 'GET' || request.method === 'HEAD') {
                 if (url.pathname === '/' || url.pathname === '/health') {
                     response = new Response('OK', { status: 200 });
                 } else {
                     response = new Response('Not Found', { status: 404 });
                 }
-            } else
-            if (url.pathname === '/ai') {
+            } else if (url.pathname === '/ai') {
                 response = await handleAIRequest(request, env, ctx);
             } else if (url.pathname === '/process-queue') {
                 response = await processQueue(request, env, ctx);


### PR DESCRIPTION
The backend worker acts as a catch-all in its router, routing unrecognized 
endpoints to \`handleFileGeneration\`. When external monitors or users visit 
the worker via \`GET /\` or \`GET /health\`, the router fell back to this function. 
Since \`GET\` requests have no body, the \`type\` field was undefined, which 
triggered noisy 'Unknown file generation type' error logs.

This change explicitly intercepts \`GET\` requests before the fallback, answering
with \`200 OK\` for root and health paths, and \`404 Not Found\` for other paths,
which stops the logging.

---
*PR created automatically by Jules for task [14007091867416402567](https://jules.google.com/task/14007091867416402567) started by @NtFelix*