### PR TITLE
fix(posthog): expose posthog on global window object for toolbar support

### DIFF
--- a/components/providers/posthog-provider.tsx
+++ b/components/providers/posthog-provider.tsx
@@ -84,9 +84,12 @@ async function initializePostHog(nonce?: string) {
       distinctID: undefined, // Will be set when user is identified
     },
     // Ensure feature flags are loaded
-    loaded: function (posthog: any) {
+    loaded: function (ph: any) {
       console.log('PostHog loaded successfully, reloading feature flags...');
-      posthog.reloadFeatureFlags?.();
+      if (typeof window !== 'undefined') {
+        (window as any).posthog = ph;
+      }
+      ph.reloadFeatureFlags?.();
     }
   } as any);
 

--- a/components/providers/posthog-provider.tsx
+++ b/components/providers/posthog-provider.tsx
@@ -86,10 +86,10 @@ async function initializePostHog(nonce?: string) {
     // Ensure feature flags are loaded
     loaded: function (ph: any) {
       console.log('PostHog loaded successfully, reloading feature flags...');
-      if (typeof window !== 'undefined') {
+      if (ph) {
         (window as any).posthog = ph;
+        ph.reloadFeatureFlags?.();
       }
-      ph.reloadFeatureFlags?.();
     }
   } as any);
 


### PR DESCRIPTION
## Description

Exposes the initialized PostHog instance on the global `window` object so the PostHog toolbar can attach to it.

## Summary of Changes

- `posthog-provider.tsx`: in the `loaded` callback the instance is now assigned to `window.posthog` before feature flags are reloaded