### PR TITLE
ci: improve PR comment workflow for backend ci

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -15,12 +15,48 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 defaults:
   run:
     working-directory: workers/mietevo-backend
 
 jobs:
+  comment-start:
+    name: Comment Start
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Comment Backend CI Started
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const prNumber = context.issue.number;
+            const marker = '<!-- backend-ci-comment -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existingComment = comments.find(c => c.body.includes(marker));
+            const body = `${marker}\n⏳ **Backend CI Started...** Running tests, lint, and type checks.`;
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body
+              });
+            }
+
   type-check:
     name: Type Check
     runs-on: ubuntu-latest
@@ -105,6 +141,67 @@ jobs:
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+  comment-end:
+    name: Comment End
+    runs-on: ubuntu-latest
+    needs: [type-check, lint, test, build]
+    if: always() && github.event_name == 'pull_request'
+    steps:
+      - name: Generate PR comment
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          TYPE_CHECK_RESULT: ${{ needs.type-check.result }}
+          LINT_RESULT: ${{ needs.lint.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+        with:
+          script: |
+            const getEmoji = (status) => {
+              if (status === 'success') return '🟢';
+              if (status === 'failure') return '🔴';
+              if (status === 'cancelled') return '⚪';
+              return '🟡';
+            };
+
+            const prNumber = context.issue.number;
+            const marker = '<!-- backend-ci-comment -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existingComment = comments.find(c => c.body.includes(marker));
+
+            const comment = [
+              marker,
+              '## ⚡ Backend CI Results',
+              '',
+              '| Job | Status |',
+              '|---|---|',
+              `| Type Check | ${getEmoji(process.env.TYPE_CHECK_RESULT)} ${process.env.TYPE_CHECK_RESULT} |`,
+              `| Lint | ${getEmoji(process.env.LINT_RESULT)} ${process.env.LINT_RESULT} |`,
+              `| Test | ${getEmoji(process.env.TEST_RESULT)} ${process.env.TEST_RESULT} |`,
+              `| Build / Dry-run Deploy | ${getEmoji(process.env.BUILD_RESULT)} ${process.env.BUILD_RESULT} |`,
+              '',
+              `[View detailed logs](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID})`
+            ].join('\n');
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: comment
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: comment
+              });
+            }
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -6,11 +6,13 @@ on:
       - main
     paths:
       - 'workers/mietevo-backend/**'
+      - '.github/workflows/backend-ci.yml'
   pull_request:
     branches:
       - main
     paths:
       - 'workers/mietevo-backend/**'
+      - '.github/workflows/backend-ci.yml'
   workflow_dispatch:
 
 permissions:
@@ -25,9 +27,9 @@ jobs:
   comment-start:
     name: Comment Start
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     steps:
       - name: Comment Backend CI Started
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
@@ -60,6 +62,7 @@ jobs:
   type-check:
     name: Type Check
     runs-on: ubuntu-latest
+    needs: comment-start
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -80,6 +83,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: comment-start
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -100,6 +104,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: comment-start
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -120,7 +125,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [type-check, lint, test]
+    needs: [comment-start, type-check, lint, test]
     if: always()
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Updates the backend CI pipeline to leave a single, continuously updated comment on Pull Requests. This prevents commit spam while accurately tracking the status of type-check, lint, test, and build/deploy steps using an HTML marker to uniquely identify and mutate the comment over time.

---
*PR created automatically by Jules for task [12316136827594625578](https://jules.google.com/task/12316136827594625578) started by @NtFelix*