### PR TITLE
refactor(skeletons): align loading skeletons with new main container

### DIFF
--- a/app/(dashboard)/betriebskosten/loading.tsx
+++ b/app/(dashboard)/betriebskosten/loading.tsx
@@ -3,6 +3,7 @@ import { PageSkeleton } from "@/components/skeletons/page-skeleton"
 export default function Loading() {
   return (
     <PageSkeleton
+      tabCount={2}
       buttonWidth="w-60 sm:w-[280px]"
       showInstructionGuide={true}
     />

--- a/app/(dashboard)/finanzen/loading.tsx
+++ b/app/(dashboard)/finanzen/loading.tsx
@@ -5,6 +5,12 @@ import { ArrowUpCircle, ArrowDownCircle, BarChart3, Wallet } from "lucide-react"
 export default function Loading() {
   return (
     <div className="flex flex-col gap-6 sm:gap-8 p-4 sm:p-8">
+      {/* Tab Toggle Skeleton */}
+      <div className="flex items-center gap-1 bg-zinc-100/80 dark:bg-zinc-900/80 border border-zinc-200/30 dark:border-zinc-800/30 p-1 rounded-full relative w-full sm:w-fit max-w-[400px]">
+        <Skeleton className="h-9 w-28 rounded-full" />
+        <Skeleton className="h-9 w-28 rounded-full" />
+      </div>
+
       {/* Summary Cards */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl animate-pulse" style={{ animationDelay: '0ms' }}>

--- a/app/(dashboard)/finanzen/loading.tsx
+++ b/app/(dashboard)/finanzen/loading.tsx
@@ -13,8 +13,8 @@ export default function Loading() {
 
       {/* Summary Cards */}
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl animate-pulse" style={{ animationDelay: '0ms' }}>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem] animate-pulse" style={{ animationDelay: '0ms' }}>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium">Ø Monatliche Einnahmen</CardTitle>
             <div className="p-2 bg-muted rounded-lg">
               <ArrowUpCircle className="size-4 text-green-500" />
@@ -24,8 +24,8 @@ export default function Loading() {
             <Skeleton className="h-8 w-24 mb-2" />
           </CardContent>
         </Card>
-        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl animate-pulse" style={{ animationDelay: '100ms' }}>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem] animate-pulse" style={{ animationDelay: '100ms' }}>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium">Ø Monatliche Ausgaben</CardTitle>
             <div className="p-2 bg-muted rounded-lg">
               <ArrowDownCircle className="size-4 text-red-500" />
@@ -35,8 +35,8 @@ export default function Loading() {
             <Skeleton className="h-8 w-24 mb-2" />
           </CardContent>
         </Card>
-        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl animate-pulse" style={{ animationDelay: '200ms' }}>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem] animate-pulse" style={{ animationDelay: '200ms' }}>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium">Ø Monatlicher Cashflow</CardTitle>
             <div className="p-2 bg-muted rounded-lg">
               <Wallet className="size-4 text-muted-foreground" />
@@ -46,8 +46,8 @@ export default function Loading() {
             <Skeleton className="h-8 w-24 mb-2" />
           </CardContent>
         </Card>
-        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl animate-pulse" style={{ animationDelay: '300ms' }}>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem] animate-pulse" style={{ animationDelay: '300ms' }}>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
             <CardTitle className="text-sm font-medium">Jahresprognose</CardTitle>
             <div className="p-2 bg-muted rounded-lg">
               <BarChart3 className="size-4 text-muted-foreground" />

--- a/app/(dashboard)/haeuser/loading.tsx
+++ b/app/(dashboard)/haeuser/loading.tsx
@@ -3,48 +3,54 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Building, Home, Key } from "lucide-react"
 import { PageSkeleton } from "@/components/skeletons/page-skeleton"
 
+function HaeuserStats() {
+  return (
+    <div className="flex flex-wrap gap-4">
+      <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <CardTitle className="text-sm font-medium">Häuser gesamt</CardTitle>
+          <div className="p-2 bg-muted rounded-lg">
+            <Building className="size-4 text-muted-foreground" />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-8 w-16 mb-2" />
+        </CardContent>
+      </Card>
+      <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <CardTitle className="text-sm font-medium">Wohnungen gesamt</CardTitle>
+          <div className="p-2 bg-muted rounded-lg">
+            <Home className="size-4 text-muted-foreground" />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-8 w-16 mb-2" />
+        </CardContent>
+      </Card>
+      <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <CardTitle className="text-sm font-medium">Freie Wohnungen</CardTitle>
+          <div className="p-2 bg-muted rounded-lg">
+            <Key className="size-4 text-muted-foreground" />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-8 w-16 mb-2" />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
 export default function Loading() {
   return (
     <PageSkeleton
+      tabCount={2}
       headerTitleWidth="w-40"
       headerDescriptionWidth="w-64"
-      statsCards={
-        <div className="flex flex-wrap gap-4">
-          <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Häuser gesamt</CardTitle>
-              <div className="p-2 bg-muted rounded-lg">
-                <Building className="h-4 w-4 text-muted-foreground" />
-              </div>
-            </CardHeader>
-            <CardContent>
-              <Skeleton className="h-8 w-16 mb-2" />
-            </CardContent>
-          </Card>
-          <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Wohnungen gesamt</CardTitle>
-              <div className="p-2 bg-muted rounded-lg">
-                <Home className="h-4 w-4 text-muted-foreground" />
-              </div>
-            </CardHeader>
-            <CardContent>
-              <Skeleton className="h-8 w-16 mb-2" />
-            </CardContent>
-          </Card>
-          <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Freie Wohnungen</CardTitle>
-              <div className="p-2 bg-muted rounded-lg">
-                <Key className="h-4 w-4 text-muted-foreground" />
-              </div>
-            </CardHeader>
-            <CardContent>
-              <Skeleton className="h-8 w-16 mb-2" />
-            </CardContent>
-          </Card>
-        </div>
-      }
-    />
+    >
+      <HaeuserStats />
+    </PageSkeleton>
   )
 }

--- a/app/(dashboard)/loading.tsx
+++ b/app/(dashboard)/loading.tsx
@@ -7,7 +7,7 @@ export default function Loading() {
     <div className="flex flex-col gap-8 p-8">
       <div className="grid gap-4 grid-cols-1 auto-rows-auto md:grid-cols-6 md:auto-rows-[140px]">
         {/* Row 1: Three summary cards + Tenant Payment List */}
-        <Card className="col-span-1 row-span-1 md:col-span-1 md:row-span-1 min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
+        <Card className="col-span-1 row-span-1 md:col-span-1 md:row-span-1 min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
           <CardHeader className="flex flex-row items-center justify-between gap-0 pb-2">
             <CardTitle className="text-sm font-medium">Häuser</CardTitle>
             <div className="p-2 bg-muted rounded-lg">
@@ -20,7 +20,7 @@ export default function Loading() {
           </CardContent>
         </Card>
 
-        <Card className="col-span-1 row-span-1 md:col-span-2 md:row-span-1 min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
+        <Card className="col-span-1 row-span-1 md:col-span-2 md:row-span-1 min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
           <CardHeader className="flex flex-row items-center justify-between gap-0 pb-2">
             <CardTitle className="text-sm font-medium">Wohnungen</CardTitle>
             <div className="p-2 bg-muted rounded-lg">
@@ -33,7 +33,7 @@ export default function Loading() {
           </CardContent>
         </Card>
 
-        <Card className="col-span-1 row-span-1 md:col-span-1 md:row-span-1 min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
+        <Card className="col-span-1 row-span-1 md:col-span-1 md:row-span-1 min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
           <CardHeader className="flex flex-row items-center justify-between gap-0 pb-2">
             <CardTitle className="text-sm font-medium">Mieter</CardTitle>
             <div className="p-2 bg-muted rounded-lg">
@@ -47,7 +47,7 @@ export default function Loading() {
         </Card>
 
         {/* Tenant Payment List Skeleton */}
-        <Card className="col-span-1 row-span-1 md:col-span-2 md:row-span-4 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
+        <Card className="col-span-1 row-span-1 md:col-span-2 md:row-span-4 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
           <CardHeader className="pb-3">
             <Skeleton className="h-5 w-40 mb-2" />
             <Skeleton className="h-4 w-56" />
@@ -69,7 +69,7 @@ export default function Loading() {
         </Card>
 
         {/* Row 2: Occupancy Chart */}
-        <Card className="col-span-1 row-span-1 md:col-span-4 md:row-span-3 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
+        <Card className="col-span-1 row-span-1 md:col-span-4 md:row-span-3 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
           <CardHeader>
             <Skeleton className="h-5 w-32 mb-2" />
             <Skeleton className="h-4 w-48" />
@@ -80,7 +80,7 @@ export default function Loading() {
         </Card>
 
         {/* Row 5: Revenue Chart + Stacked Cards */}
-        <Card className="col-span-1 row-span-1 md:col-span-4 md:row-span-3 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
+        <Card className="col-span-1 row-span-1 md:col-span-4 md:row-span-3 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
           <CardHeader>
             <Skeleton className="h-5 w-40 mb-2" />
             <Skeleton className="h-4 w-56" />
@@ -91,7 +91,7 @@ export default function Loading() {
         </Card>
 
         {/* Mobile: Individual cards, Desktop: Stacked container */}
-        <Card className="col-span-1 row-span-1 md:hidden min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
+        <Card className="col-span-1 row-span-1 md:hidden min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
           <CardHeader className="flex flex-row items-center justify-between gap-0 pb-2">
             <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
             <div className="p-2 bg-muted rounded-lg">
@@ -104,7 +104,7 @@ export default function Loading() {
           </CardContent>
         </Card>
 
-        <Card className="col-span-1 row-span-1 md:hidden min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
+        <Card className="col-span-1 row-span-1 md:hidden min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
           <CardHeader className="flex flex-row items-center justify-between gap-0 pb-2">
             <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
             <div className="p-2 bg-muted rounded-lg">
@@ -117,7 +117,7 @@ export default function Loading() {
           </CardContent>
         </Card>
 
-        <Card className="col-span-1 row-span-1 md:hidden min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
+        <Card className="col-span-1 row-span-1 md:hidden min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
           <CardHeader className="flex flex-row items-center justify-between gap-0 pb-2">
             <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
             <div className="p-2 bg-muted rounded-lg">
@@ -133,7 +133,7 @@ export default function Loading() {
         {/* Desktop: Stacked container */}
         <div className="hidden md:block md:col-span-2 md:row-span-3">
           <div className="h-full flex flex-col gap-4">
-            <Card className="flex-1 overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
+            <Card className="flex-1 overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
               <CardHeader className="flex flex-row items-center justify-between gap-0 pb-2">
                 <CardTitle className="text-sm font-medium">Aufgaben</CardTitle>
                 <div className="p-2 bg-muted rounded-lg">
@@ -146,7 +146,7 @@ export default function Loading() {
               </CardContent>
             </Card>
 
-            <Card className="flex-1 overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
+            <Card className="flex-1 overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
               <CardHeader className="flex flex-row items-center justify-between gap-0 pb-2">
                 <CardTitle className="text-sm font-medium">Einnahmen</CardTitle>
                 <div className="p-2 bg-muted rounded-lg">
@@ -159,7 +159,7 @@ export default function Loading() {
               </CardContent>
             </Card>
 
-            <Card className="flex-1 overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
+            <Card className="flex-1 overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
               <CardHeader className="flex flex-row items-center justify-between gap-0 pb-2">
                 <CardTitle className="text-sm font-medium">Betriebskosten</CardTitle>
                 <div className="p-2 bg-muted rounded-lg">
@@ -175,7 +175,7 @@ export default function Loading() {
         </div>
 
         {/* Row 8: Last Transactions + Maintenance Chart */}
-        <Card className="col-span-1 row-span-1 md:col-span-3 md:row-span-3 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
+        <Card className="col-span-1 row-span-1 md:col-span-3 md:row-span-3 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
           <CardHeader>
             <Skeleton className="h-5 w-36 mb-2" />
             <Skeleton className="h-4 w-48" />
@@ -193,7 +193,7 @@ export default function Loading() {
           </CardContent>
         </Card>
 
-        <Card className="col-span-1 row-span-1 md:col-span-3 md:row-span-3 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
+        <Card className="col-span-1 row-span-1 md:col-span-3 md:row-span-3 h-[300px] md:h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
           <CardHeader>
             <Skeleton className="h-5 w-32 mb-2" />
             <Skeleton className="h-4 w-48" />

--- a/app/(dashboard)/loading.tsx
+++ b/app/(dashboard)/loading.tsx
@@ -4,7 +4,7 @@ import { Building2, Home, Users, Wallet, FileSpreadsheet, CheckSquare } from "lu
 
 export default function Loading() {
   return (
-    <div className="flex flex-col gap-8 p-8 rounded-[2rem] md:rounded-[2.5rem] relative overflow-hidden">
+    <div className="flex flex-col gap-8 p-8">
       <div className="grid gap-4 grid-cols-1 auto-rows-auto md:grid-cols-6 md:auto-rows-[140px]">
         {/* Row 1: Three summary cards + Tenant Payment List */}
         <Card className="col-span-1 row-span-1 md:col-span-1 md:row-span-1 min-h-[120px] h-full overflow-hidden bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">

--- a/app/(dashboard)/mieter/loading.tsx
+++ b/app/(dashboard)/mieter/loading.tsx
@@ -9,6 +9,8 @@ export default function Loading() {
       headerTitleWidth="w-40"
       headerDescriptionWidth="w-64"
       buttonWidth="w-44"
+      tabCount={3}
+      tabWidth="w-28"
       statsCards={
         <div className="flex flex-wrap gap-4">
           <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">

--- a/app/(dashboard)/mieter/loading.tsx
+++ b/app/(dashboard)/mieter/loading.tsx
@@ -3,6 +3,46 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Users, BadgeCheck, Euro } from "lucide-react"
 import { PageSkeleton } from "@/components/skeletons/page-skeleton"
 
+function MieterStats() {
+  return (
+    <div className="flex flex-wrap gap-4">
+      <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <CardTitle className="text-sm font-medium">Mieter gesamt</CardTitle>
+          <div className="p-2 bg-muted rounded-lg">
+            <Users className="size-4 text-muted-foreground" />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-8 w-16 mb-2" />
+        </CardContent>
+      </Card>
+      <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <CardTitle className="text-sm font-medium">Aktiv / Ehemalig</CardTitle>
+          <div className="p-2 bg-muted rounded-lg">
+            <BadgeCheck className="size-4 text-muted-foreground" />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-8 w-24 mb-2" />
+        </CardContent>
+      </Card>
+      <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <CardTitle className="text-sm font-medium">Ø Nebenkosten</CardTitle>
+          <div className="p-2 bg-muted rounded-lg">
+            <Euro className="size-4 text-muted-foreground" />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-8 w-20 mb-2" />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
 export default function Loading() {
   return (
     <PageSkeleton
@@ -11,43 +51,9 @@ export default function Loading() {
       buttonWidth="w-44"
       tabCount={3}
       tabWidth="w-28"
-      statsCards={
-        <div className="flex flex-wrap gap-4">
-          <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Mieter gesamt</CardTitle>
-              <div className="p-2 bg-muted rounded-lg">
-                <Users className="h-4 w-4 text-muted-foreground" />
-              </div>
-            </CardHeader>
-            <CardContent>
-              <Skeleton className="h-8 w-16 mb-2" />
-            </CardContent>
-          </Card>
-          <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Aktiv / Ehemalig</CardTitle>
-              <div className="p-2 bg-muted rounded-lg">
-                <BadgeCheck className="h-4 w-4 text-muted-foreground" />
-              </div>
-            </CardHeader>
-            <CardContent>
-              <Skeleton className="h-8 w-24 mb-2" />
-            </CardContent>
-          </Card>
-          <Card className="flex-1 min-w-[200px] bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Ø Nebenkosten</CardTitle>
-              <div className="p-2 bg-muted rounded-lg">
-                <Euro className="h-4 w-4 text-muted-foreground" />
-              </div>
-            </CardHeader>
-            <CardContent>
-              <Skeleton className="h-8 w-20 mb-2" />
-            </CardContent>
-          </Card>
-        </div>
-      }
-    />
+      tabContainerWidth="sm:w-[380px]"
+    >
+      <MieterStats />
+    </PageSkeleton>
   )
 }

--- a/app/(dashboard)/wohnungen/loading.tsx
+++ b/app/(dashboard)/wohnungen/loading.tsx
@@ -3,58 +3,64 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Home, Key, Euro, Ruler } from "lucide-react"
 import { PageSkeleton } from "@/components/skeletons/page-skeleton"
 
+function WohnungenStats() {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <CardTitle className="text-sm font-medium">Wohnungen gesamt</CardTitle>
+          <div className="p-2 bg-muted rounded-lg">
+            <Home className="size-4 text-muted-foreground" />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-8 w-16 mb-2" />
+        </CardContent>
+      </Card>
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <CardTitle className="text-sm font-medium">Frei / Vermietet</CardTitle>
+          <div className="p-2 bg-muted rounded-lg">
+            <Key className="size-4 text-muted-foreground" />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-8 w-24 mb-2" />
+        </CardContent>
+      </Card>
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <CardTitle className="text-sm font-medium">Ø Miete</CardTitle>
+          <div className="p-2 bg-muted rounded-lg">
+            <Euro className="size-4 text-muted-foreground" />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-8 w-20 mb-2" />
+        </CardContent>
+      </Card>
+      <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <CardTitle className="text-sm font-medium">Ø Preis pro m²</CardTitle>
+          <div className="p-2 bg-muted rounded-lg">
+            <Ruler className="size-4 text-muted-foreground" />
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-8 w-20 mb-2" />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
 export default function Loading() {
   return (
     <PageSkeleton
+      tabCount={2}
       buttonWidth="w-48"
-      statsCards={
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-          <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Wohnungen gesamt</CardTitle>
-              <div className="p-2 bg-muted rounded-lg">
-                <Home className="h-4 w-4 text-muted-foreground" />
-              </div>
-            </CardHeader>
-            <CardContent>
-              <Skeleton className="h-8 w-16 mb-2" />
-            </CardContent>
-          </Card>
-          <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Frei / Vermietet</CardTitle>
-              <div className="p-2 bg-muted rounded-lg">
-                <Key className="h-4 w-4 text-muted-foreground" />
-              </div>
-            </CardHeader>
-            <CardContent>
-              <Skeleton className="h-8 w-24 mb-2" />
-            </CardContent>
-          </Card>
-          <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Ø Miete</CardTitle>
-              <div className="p-2 bg-muted rounded-lg">
-                <Euro className="h-4 w-4 text-muted-foreground" />
-              </div>
-            </CardHeader>
-            <CardContent>
-              <Skeleton className="h-8 w-20 mb-2" />
-            </CardContent>
-          </Card>
-          <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-3xl">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-sm font-medium">Ø Preis pro m²</CardTitle>
-              <div className="p-2 bg-muted rounded-lg">
-                <Ruler className="h-4 w-4 text-muted-foreground" />
-              </div>
-            </CardHeader>
-            <CardContent>
-              <Skeleton className="h-8 w-20 mb-2" />
-            </CardContent>
-          </Card>
-        </div>
-      }
-    />
+    >
+      <WohnungenStats />
+    </PageSkeleton>
   )
 }

--- a/components/skeletons/page-skeleton.tsx
+++ b/components/skeletons/page-skeleton.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { ReactNode } from "react"
 
 interface PageSkeletonProps {
-  statsCards?: ReactNode
+  children?: ReactNode
   headerTitleWidth?: string
   headerDescriptionWidth?: string
   buttonWidth?: string
@@ -12,31 +12,34 @@ interface PageSkeletonProps {
   showInstructionGuide?: boolean
   tabCount?: number
   tabWidth?: string
+  tabContainerWidth?: string
 }
 
 export function PageSkeleton({
-  statsCards,
-  headerTitleWidth = "w-48",
-  headerDescriptionWidth = "w-72",
-  buttonWidth = "w-40",
+  children,
+  headerTitleWidth = "w-32",
+  headerDescriptionWidth = "w-48",
+  buttonWidth = "w-32",
   filterCount = 3,
   tableRowCount = 5,
   showInstructionGuide = false,
-  tabCount = 2,
+  tabCount = 0,
   tabWidth = "w-24",
+  tabContainerWidth,
 }: PageSkeletonProps) {
   const isFullWidthTabs = tabCount >= 3
 
   return (
-    <div className="flex flex-col gap-6 sm:gap-8 p-4 sm:p-8">
-      {/* Tab Toggle Skeleton */}
+    <div className="flex flex-col gap-6 sm:gap-8 p-4 sm:p-8 animate-in fade-in duration-500">
       {tabCount > 0 && (
         <div
-          className={
-            isFullWidthTabs
-              ? "flex items-center gap-1 bg-zinc-100/80 dark:bg-zinc-900/80 border border-zinc-200/30 dark:border-zinc-800/30 p-1 rounded-full relative w-full sm:w-[300px] overflow-hidden"
-              : "flex items-center gap-1 bg-zinc-100/80 dark:bg-zinc-900/80 border border-zinc-200/30 dark:border-zinc-800/30 p-1 rounded-full relative w-full sm:w-fit max-w-[400px]"
-          }
+          className={`flex items-center gap-1 bg-zinc-100/80 dark:bg-zinc-900/80 border border-zinc-200/30 dark:border-zinc-800/30 p-1 rounded-full relative w-full ${
+            tabContainerWidth 
+              ? tabContainerWidth
+              : isFullWidthTabs
+                ? "sm:w-[300px] overflow-hidden"
+                : "sm:w-fit max-w-[400px]"
+          }`}
         >
           {Array.from({ length: tabCount }).map((_, i) =>
             isFullWidthTabs ? (
@@ -48,8 +51,8 @@ export function PageSkeleton({
         </div>
       )}
 
-      {/* Stats Cards (optional) */}
-      {statsCards}
+      {/* Children (e.g., Stats Cards) */}
+      {children}
 
       {/* Instruction Guide Skeleton (optional) */}
       {showInstructionGuide && (

--- a/components/skeletons/page-skeleton.tsx
+++ b/components/skeletons/page-skeleton.tsx
@@ -10,6 +10,8 @@ interface PageSkeletonProps {
   filterCount?: number
   tableRowCount?: number
   showInstructionGuide?: boolean
+  tabCount?: number
+  tabWidth?: string
 }
 
 export function PageSkeleton({
@@ -20,10 +22,31 @@ export function PageSkeleton({
   filterCount = 3,
   tableRowCount = 5,
   showInstructionGuide = false,
+  tabCount = 2,
+  tabWidth = "w-24",
 }: PageSkeletonProps) {
-  return (
-    <div className="flex flex-col gap-8 p-8 rounded-[2rem] md:rounded-[2.5rem] relative overflow-hidden">
+  const isFullWidthTabs = tabCount >= 3
 
+  return (
+    <div className="flex flex-col gap-6 sm:gap-8 p-4 sm:p-8">
+      {/* Tab Toggle Skeleton */}
+      {tabCount > 0 && (
+        <div
+          className={
+            isFullWidthTabs
+              ? "flex items-center gap-1 bg-zinc-100/80 dark:bg-zinc-900/80 border border-zinc-200/30 dark:border-zinc-800/30 p-1 rounded-full relative w-full sm:w-[300px] overflow-hidden"
+              : "flex items-center gap-1 bg-zinc-100/80 dark:bg-zinc-900/80 border border-zinc-200/30 dark:border-zinc-800/30 p-1 rounded-full relative w-full sm:w-fit max-w-[400px]"
+          }
+        >
+          {Array.from({ length: tabCount }).map((_, i) =>
+            isFullWidthTabs ? (
+              <Skeleton key={i} className="h-9 flex-1 rounded-full" />
+            ) : (
+              <Skeleton key={i} className={`h-9 ${tabWidth} rounded-full`} />
+            )
+          )}
+        </div>
+      )}
 
       {/* Stats Cards (optional) */}
       {statsCards}
@@ -32,12 +55,12 @@ export function PageSkeleton({
       {showInstructionGuide && (
         <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
           <CardHeader className="pb-4">
-            <div className="flex items-start justify-between">
-              <div className="flex-1">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex-1 min-w-0">
                 <Skeleton className="h-6 w-64 mb-2" />
-                <Skeleton className="h-4 w-96" />
+                <Skeleton className="h-4 w-96 max-w-full" />
               </div>
-              <Skeleton className="h-8 w-24 rounded-lg" />
+              <Skeleton className="h-8 w-24 rounded-lg shrink-0" />
             </div>
           </CardHeader>
           <CardContent>
@@ -45,16 +68,16 @@ export function PageSkeleton({
               {Array.from({ length: 5 }).map((_, i) => (
                 <div key={i} className="flex gap-4">
                   <Skeleton className="shrink-0 size-8 rounded-full" />
-                  <div className="flex-1 flex flex-col gap-2">
+                  <div className="flex-1 flex flex-col gap-2 min-w-0">
                     <Skeleton className="h-4 w-48" />
                     <Skeleton className="h-3 w-full" />
                   </div>
                 </div>
               ))}
             </div>
-            <div className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700 flex gap-3">
+            <div className="mt-6 pt-4 border-t border-gray-200 dark:border-gray-700 flex flex-col gap-2 sm:flex-row sm:gap-3">
               <Skeleton className="h-10 flex-1 rounded-full" />
-              <Skeleton className="h-10 w-40 rounded-full" />
+              <Skeleton className="h-10 flex-1 sm:w-40 rounded-full" />
             </div>
           </CardContent>
         </Card>
@@ -63,12 +86,12 @@ export function PageSkeleton({
       {/* Main Card Structure Skeleton */}
       <Card className="bg-gray-50 dark:bg-[#22272e] border border-gray-200 dark:border-[#3C4251] shadow-xs rounded-[2rem]">
         <CardHeader>
-          <div className="flex flex-row items-start justify-between">
-            <div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0">
               <Skeleton className={`h-6 ${headerTitleWidth} mb-2`} />
               <Skeleton className={`h-4 ${headerDescriptionWidth}`} />
             </div>
-            <Skeleton className={`h-10 ${buttonWidth} rounded-full`} />
+            <Skeleton className={`h-10 ${buttonWidth} rounded-full shrink-0`} />
           </div>
         </CardHeader>
         <div className="px-6">
@@ -76,21 +99,25 @@ export function PageSkeleton({
         </div>
         <CardContent className="flex flex-col gap-6">
           {/* Filters Skeleton */}
-          <div className="flex flex-col gap-4 mt-6">
-            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-col gap-4 mt-4 sm:mt-6">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex flex-wrap gap-2">
                 {Array.from({ length: filterCount }).map((_, i) => (
-                  <Skeleton key={i} className="h-9 w-32 rounded-full" />
+                  <Skeleton key={i} className="h-9 w-24 sm:w-28 rounded-full" />
                 ))}
               </div>
-              <Skeleton className="h-10 w-full sm:w-[300px] rounded-full" />
+              <Skeleton className="h-10 w-full sm:w-[280px] rounded-full" />
             </div>
           </div>
 
           {/* Table Skeleton */}
           <div className="flex flex-col gap-3">
             {Array.from({ length: tableRowCount }).map((_, i) => (
-              <Skeleton key={i} className="h-16 w-full rounded-lg" />
+              <Skeleton
+                key={i}
+                className="h-16 w-full rounded-lg"
+                style={{ animationDelay: `${i * 50}ms` }}
+              />
             ))}
           </div>
         </CardContent>


### PR DESCRIPTION
- Dashboard loading: drop duplicate rounded/overflow wrappers (provided by layout)
- Mieter loading: set tabCount=3 to match Mieter/Bewerber/Übersicht tabs
- Finanzen loading: add missing tab toggle skeleton (Finanzen/Übersicht)
- PageSkeleton: add tabCount/tabWidth props, drop duplicate container styling, and improve responsive layout (gap/padding/min-w-0)