### PR TITLE
feat(visual-review): capture per-tab screenshots for multi-tab pages

### DIFF
--- a/playwright/snapshots.yml
+++ b/playwright/snapshots.yml
@@ -20,10 +20,6 @@ snapshots:
         hash: v1.k04ffa068.de05db8b5006de4fee2085090fa9ed227c9a199162e6ba386ca35cfa2f7ffb93.V32W1T6Xeu1Hpp-859XWePdzo-diVRFYUouFby_zL18
     chromium-dashboard-dateien-light:
         hash: v1.k04ffa068.c055a12c171905aecfe7cf89f1afc3559a990450513fd4c0697d8c6fbc43555c.hr87ajdX3XX5Y1p21HYvJ7ctblXg7Zdr5E1nW10ksYg
-    chromium-dashboard-finanzen-dark:
-        hash: v1.k04ffa068.032646d236d7c146f1d508781957092925370436aeb357420ffb33771159e2fb.ucLp_dBVYKTrb9RKQwIEAO48clvoo5e9LM7ikY3muYg
-    chromium-dashboard-finanzen-light:
-        hash: v1.k04ffa068.af10267901653202de14ac6edf0ea387cdc7f3422c9d7bb7275510c9d9c508d4.NPgGFJ3GSWPHuV02E5rDxeWHMJpBR7zSjXR7vjpnHjg
     chromium-dashboard-haeuser-dark:
         hash: v1.k04ffa068.8ed94a9165e3f4c24cb3ee363e3f5e2daacc5e3b6002f1f485b951780dd2e925.1Xs2ktb9emmjsmGfvfWPXXWlZvjfir7oAhnQQ4tKAyw
     chromium-dashboard-haeuser-light:
@@ -32,18 +28,10 @@ snapshots:
         hash: v1.k04ffa068.0aa2e96155016eef488bff8991a9fb96aa122b3b68ec3d907c71382de74efd5e.PVckPuTOhtzxioDkFmH2M90__O5B4352s0gvTVMcbbY
     chromium-dashboard-mails-light:
         hash: v1.k04ffa068.1e1c8d5a297886e52fb03c98bf1e553767a90fac562e1f2373ace691fd5fbe59.vYsGQsVv76XWnPkU-9uqEJa5YwTwSYY81arjoQ6uoYM
-    chromium-dashboard-mieter-dark:
-        hash: v1.k04ffa068.deb0803ea96a85a190137d88416cc5e17ea8576083dcd01d9b328c5556fe1efc.T3Ss3lcwb614cwq09LooJrbmxvYcfufhDWdjjAGRAHM
-    chromium-dashboard-mieter-light:
-        hash: v1.k04ffa068.1b6ffb3d6f844ca610cd8e9b8ad7e773a56e78ed0c2ea3a3ac68e5f0cd2c761b.cT0CYYBFqOwQL_HkvYWYuVRoLvYmEgPJqOWqpI1m158
     chromium-dashboard-todos-dark:
         hash: v1.k04ffa068.d445d882f77272107c26c18daa6d25fc16ff7ab4c11bd7b518dbb4b9f3b39669.ZgRn3njW6KmjuQSeSJYOdg1lC67WaFRZSSyVHUOBNH8
     chromium-dashboard-todos-light:
         hash: v1.k04ffa068.2d3b7df910907a65ebc59ddd4debf6e42cc27e67dadf8ba184976dedca79f84c.vtMGOu74ghRB0dTMqhgxqr-_Zw_W53LetRypZ_ZHl7Q
-    chromium-dashboard-wohnungen-dark:
-        hash: v1.k04ffa068.d66654be093929818f51c0a6c3c150f5543a814af28c4db729081b043f8fa26b.PgGRA8NQrko0KRTNGO_AZJU1NMAjL1y0r_egTpwMIDI
-    chromium-dashboard-wohnungen-light:
-        hash: v1.k04ffa068.3897dfb37907616b5980b2474e25963ca973dd26fb65373e5eef54a3b957c6f5.0_ZMT0_bzkrXIzvx5jE57n1FErGFjSDfv8nC4hXXw5k
     chromium-datenschutz-dark:
         hash: v1.k04ffa068.8ef3761a5f22da87969fa7e478b7ffea6c081c5799a3fc52b8e12270e23b13fc.POeGowJF92jkk5Lu3aPtdylgzAG03gJrXB9f6On1qt0
     chromium-datenschutz-light:

--- a/playwright/visual.spec.ts
+++ b/playwright/visual.spec.ts
@@ -3,10 +3,6 @@ import { login, acceptCookieConsent } from '../e2e/utils';
 import path from 'path';
 import fs from 'fs';
 
-/**
- * Disables all CSS transitions and animations to ensure deterministic screenshots.
- * This prevents "ghosting" diffs caused by capturing a UI mid-transition.
- */
 async function disableAnimations(page: Page) {
   await page.addStyleTag({
     content: `
@@ -19,33 +15,22 @@ async function disableAnimations(page: Page) {
   });
 }
 
-/**
- * Scrolls the page from top to bottom incrementally to trigger lazy-loaded images
- * and scroll-based animations (like Intersection Observers).
- */
 async function triggerScrollAnimations(page: Page) {
   await page.evaluate(async () => {
     const scrollHeight = document.body.scrollHeight;
     const viewportHeight = window.innerHeight;
-    
-    // Scroll down in chunks to ensure all observers fire
+
     for (let i = 0; i < scrollHeight; i += viewportHeight / 2) {
       window.scrollTo(0, i);
-      // Increased delay to let JS execution and observers catch up
       await new Promise(r => setTimeout(r, 100));
     }
-    // Scroll back to the top
     window.scrollTo(0, 0);
-    // Increased settling time
     await new Promise(r => setTimeout(r, 500));
   });
 }
 
-// Ensure snapshot directory exists
 const snapshotDir = path.join(__dirname, '__snapshots__');
 
-
-// Array of public pages to screenshot
 const publicPages = [
   '/',
   '/preise',
@@ -62,7 +47,6 @@ const publicPages = [
   '/warteliste/browser-erweiterung',
 ];
 
-// Array of authenticated dashboard pages to screenshot
 const dashboardPages = [
   '/dashboard',
   '/haeuser',
@@ -75,6 +59,21 @@ const dashboardPages = [
   '/mails',
 ];
 
+const pagesWithTabs: Record<string, Array<{ tabKey: string; tabText: string }>> = {
+  '/finanzen': [
+    { tabKey: 'finanzen', tabText: 'Finanzen' },
+    { tabKey: 'uebersicht', tabText: 'Übersicht' },
+  ],
+  '/mieter': [
+    { tabKey: 'mieter', tabText: 'Mieter' },
+    { tabKey: 'uebersicht', tabText: 'Übersicht' },
+  ],
+  '/wohnungen': [
+    { tabKey: 'wohnungen', tabText: 'Wohnungen' },
+    { tabKey: 'uebersicht', tabText: 'Übersicht' },
+  ],
+};
+
 const themes = ['light', 'dark'] as const;
 
 for (const theme of themes) {
@@ -86,7 +85,6 @@ for (const theme of themes) {
   });
 
   for (const pathStr of publicPages) {
-      // Generate a safe filename based on path and theme
       const baseFilename = pathStr === '/' ? 'landing' : `${pathStr.replace(/^\//, '').replace(/\//g, '-')}`;
       const filename = `${baseFilename}-${theme}.png`;
 
@@ -96,27 +94,16 @@ for (const theme of themes) {
         await acceptCookieConsent(page);
         await disableAnimations(page);
 
-        // Force the theme using classList.toggle
         await page.evaluate((t) => {
           document.documentElement.classList.toggle('dark', t === 'dark');
           document.documentElement.classList.toggle('light', t === 'light');
         }, theme);
 
-        // Small wait to allow theme switch JS to settle
         await page.waitForTimeout(500);
-
-        // Scroll the page to trigger all animations
         await triggerScrollAnimations(page);
-
-        // Wait for the page to be fully settled
         await page.waitForLoadState('networkidle');
-        // Wait for footer as a signal that the long page has rendered
         await page.locator('footer').first().waitFor({ state: 'visible' }).catch(() => {});
 
-
-        // Capture screenshot for PostHog Visual Review
-        // We use page.screenshot instead of expect().toHaveScreenshot to avoid 
-        // baseline mismatch errors in CI, as PostHog handles the comparison.
         await page.screenshot({
           path: path.join(snapshotDir, `${testInfo.project.name}-${filename}`),
           fullPage: true,
@@ -134,42 +121,65 @@ for (const theme of themes) {
     });
 
     for (const pathStr of dashboardPages) {
-      const baseFilename = `dashboard-${pathStr.replace(/^\//, '').replace(/\//g, '-')}`;
-      const filename = `${baseFilename}-${theme}.png`;
+      const tabs = pagesWithTabs[pathStr];
 
-      test(`Dashboard Page: ${pathStr}`, async ({ page }, testInfo) => {
-        await page.goto(pathStr);
-        await page.waitForLoadState('networkidle');
-        await disableAnimations(page);
+      if (tabs) {
+        for (const tabInfo of tabs) {
+          const baseFilename = `dashboard-${pathStr.replace(/^\//, '').replace(/\//g, '-')}-${tabInfo.tabKey}`;
+          const filename = `${baseFilename}-${theme}.png`;
 
-        // Force the theme using classList.toggle
-        await page.evaluate((t) => {
-          document.documentElement.classList.toggle('dark', t === 'dark');
-          document.documentElement.classList.toggle('light', t === 'light');
-        }, theme);
+          test(`Dashboard Page: ${pathStr} - ${tabInfo.tabText}`, async ({ page }, testInfo) => {
+            await page.goto(pathStr);
+            await page.waitForLoadState('networkidle');
+            await disableAnimations(page);
 
-        // Small wait to allow theme switch JS to settle
-        await page.waitForTimeout(500);
+            await page.evaluate((t) => {
+              document.documentElement.classList.toggle('dark', t === 'dark');
+              document.documentElement.classList.toggle('light', t === 'light');
+            }, theme);
 
-        // Scroll the page to trigger all animations
-        await triggerScrollAnimations(page);
+            await page.locator('button').filter({ hasText: tabInfo.tabText }).first().click();
+            await page.waitForTimeout(500);
 
-        await page.waitForLoadState('networkidle');
-        
-        // Instead of a hard timeout, wait for main content or chart containers
-        // This is much faster and more reliable
-        await page.locator('main').waitFor({ state: 'visible' });
-        // Optional: wait for charts if they exist (common in dashboards)
-        await page.locator('.recharts-wrapper, canvas').first().waitFor({ state: 'visible' }).catch(() => {});
+            await triggerScrollAnimations(page);
+            await page.waitForLoadState('networkidle');
 
+            await page.locator('main').waitFor({ state: 'visible' });
+            await page.locator('.recharts-wrapper, canvas').first().waitFor({ state: 'visible' }).catch(() => {});
 
-        // Capture screenshot for PostHog Visual Review
-        await page.screenshot({
-          path: path.join(snapshotDir, `${testInfo.project.name}-${filename}`),
-          fullPage: true,
+            await page.screenshot({
+              path: path.join(snapshotDir, `${testInfo.project.name}-${filename}`),
+              fullPage: true,
+            });
+          });
+        }
+      } else {
+        const baseFilename = `dashboard-${pathStr.replace(/^\//, '').replace(/\//g, '-')}`;
+        const filename = `${baseFilename}-${theme}.png`;
+
+        test(`Dashboard Page: ${pathStr}`, async ({ page }, testInfo) => {
+          await page.goto(pathStr);
+          await page.waitForLoadState('networkidle');
+          await disableAnimations(page);
+
+          await page.evaluate((t) => {
+            document.documentElement.classList.toggle('dark', t === 'dark');
+            document.documentElement.classList.toggle('light', t === 'light');
+          }, theme);
+
+          await page.waitForTimeout(500);
+          await triggerScrollAnimations(page);
+          await page.waitForLoadState('networkidle');
+
+          await page.locator('main').waitFor({ state: 'visible' });
+          await page.locator('.recharts-wrapper, canvas').first().waitFor({ state: 'visible' }).catch(() => {});
+
+          await page.screenshot({
+            path: path.join(snapshotDir, `${testInfo.project.name}-${filename}`),
+            fullPage: true,
+          });
         });
-      });
+      }
     }
   });
 }
-


### PR DESCRIPTION
Generate separate screenshots for each tab on pages with tabs (finanzen, mieter, wohnungen) instead of a single page screenshot.