### PR TITLE
fix(navigation): resolve landing page sign out cache and mobile drawe…

### DIFF
--- a/app/modern/components/navigation.test.tsx
+++ b/app/modern/components/navigation.test.tsx
@@ -6,8 +6,16 @@ import Navigation from './navigation';
 import { createClient } from '@/utils/supabase/client';
 
 // Mock dependencies
+const mockRouter = {
+  push: jest.fn(),
+  replace: jest.fn(),
+  prefetch: jest.fn(),
+  refresh: jest.fn(),
+};
+
 jest.mock('next/navigation', () => ({
   usePathname: jest.fn(),
+  useRouter: () => mockRouter,
 }));
 
 jest.mock('@/utils/supabase/client');
@@ -47,8 +55,8 @@ jest.mock('@/components/ui/pill-container', () => ({
 jest.mock('@/components/ui/dropdown-menu', () => ({
   DropdownMenu: ({ children }: any) => <div>{children}</div>,
   DropdownMenuContent: ({ children }: any) => <div>{children}</div>,
-  DropdownMenuItem: ({ children, onSelect }: any) => (
-    <button onClick={onSelect}>{children}</button>
+  DropdownMenuItem: ({ children, onSelect, onClick }: any) => (
+    <button onClick={onSelect || onClick}>{children}</button>
   ),
   DropdownMenuTrigger: ({ children }: any) => <div>{children}</div>,
   DropdownMenuSeparator: () => <hr />,

--- a/app/modern/components/navigation.test.tsx
+++ b/app/modern/components/navigation.test.tsx
@@ -94,10 +94,6 @@ describe('Navigation - Jetzt loslegen Feature', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (useIsOverflowing as jest.Mock).mockReturnValue({
-      ref: { current: null },
-      isOverflowing: false,
-    });
     setMobile(false); // Default to desktop
     (usePathname as jest.Mock).mockReturnValue('/');
     (createClient as jest.Mock).mockReturnValue(mockSupabaseClient);
@@ -140,46 +136,12 @@ describe('Navigation - Jetzt loslegen Feature', () => {
       render(<Navigation onLogin={mockOnLogin} />);
 
       await waitFor(() => {
-        expect(screen.getByAltText('User avatar')).toBeInTheDocument();
+        expect(screen.getAllByAltText('test@example.com')[0]).toBeInTheDocument();
       });
     });
   });
 
   describe('Login Button Behavior', () => {
-    it('clears auth intent when login button is clicked', async () => {
-      const user = userEvent.setup();
-      render(<Navigation onLogin={mockOnLogin} />);
-
-      await waitFor(() => {
-        const loginButton = screen.getByText('Anmelden');
-        return user.click(loginButton);
-      });
-
-      expect(window.sessionStorage.removeItem).toHaveBeenCalledWith('authIntent');
-      expect(mockOnLogin).toHaveBeenCalled();
-    });
-
-    it('handles sessionStorage errors when clearing auth intent', async () => {
-      const user = userEvent.setup();
-      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
-      
-      (window.sessionStorage.removeItem as jest.Mock).mockImplementation(() => {
-        throw new Error('SessionStorage not available');
-      });
-
-      render(<Navigation onLogin={mockOnLogin} />);
-
-      await waitFor(() => {
-        const loginButton = screen.getByText('Anmelden');
-        return user.click(loginButton);
-      });
-
-      expect(consoleSpy).toHaveBeenCalledWith('SessionStorage not available');
-      expect(mockOnLogin).toHaveBeenCalled();
-      
-      consoleSpy.mockRestore();
-    });
-
     it('calls onLogin prop when provided', async () => {
       const user = userEvent.setup();
       render(<Navigation onLogin={mockOnLogin} />);
@@ -192,7 +154,7 @@ describe('Navigation - Jetzt loslegen Feature', () => {
       expect(mockOnLogin).toHaveBeenCalled();
     });
 
-    it('works without onLogin prop', async () => {
+    it('routes to /auth/login when onLogin prop is not provided', async () => {
       const user = userEvent.setup();
       render(<Navigation />);
 
@@ -201,23 +163,23 @@ describe('Navigation - Jetzt loslegen Feature', () => {
         return user.click(loginButton);
       });
 
-      // Should not throw error
-      expect(window.sessionStorage.removeItem).toHaveBeenCalledWith('authIntent');
+      expect(mockRouter.push).toHaveBeenCalledWith('/auth/login');
+    });
+
+    it('routes to /auth/register when register button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<Navigation />);
+
+      await waitFor(() => {
+        const registerButton = screen.getByText('Kostenlos testen');
+        return user.click(registerButton);
+      });
+
+      expect(mockRouter.push).toHaveBeenCalledWith('/auth/register');
     });
   });
 
   describe('Logout Functionality', () => {
-    let originalLocation: any;
-
-    beforeEach(() => {
-      originalLocation = window.location;
-      delete (window as any).location;
-      window.location = { ...originalLocation, replace: jest.fn(), href: '' };
-    });
-
-    afterEach(() => {
-      window.location = originalLocation;
-    });
 
     it('handles logout successfully and redirects using replace', async () => {
       const user = userEvent.setup();
@@ -285,37 +247,16 @@ describe('Navigation - Jetzt loslegen Feature', () => {
       (usePathname as jest.Mock).mockReturnValue('/');
       render(<Navigation onLogin={mockOnLogin} />);
 
-      expect(screen.getByText(/Funktionen/)).toBeInTheDocument();
-      expect(screen.getByText(/Preise/)).toBeInTheDocument();
-    });
-
-    it('renders home link on other pages', () => {
-      (usePathname as jest.Mock).mockReturnValue('/other-page');
-      render(<Navigation onLogin={mockOnLogin} />);
-
-      expect(screen.getByText('Startseite')).toBeInTheDocument();
-    });
-
-    it('handles navigation clicks with smooth scroll', async () => {
-      const user = userEvent.setup();
-      const mockScrollIntoView = jest.fn();
-      
-      // Mock querySelector and scrollIntoView
-      const mockElement = { scrollIntoView: mockScrollIntoView };
-      jest.spyOn(document, 'querySelector').mockReturnValue(mockElement as any);
-
-      (usePathname as jest.Mock).mockReturnValue('/');
-      render(<Navigation onLogin={mockOnLogin} />);
-
-      const featuresButton = screen.getByText('Funktionen');
-      await user.click(featuresButton);
-
-      expect(document.querySelector).toHaveBeenCalledWith('#features');
-      expect(mockScrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+      expect(screen.getAllByText(/Funktionen/)[0]).toBeInTheDocument();
+      expect(screen.getAllByText(/Preise/)[0]).toBeInTheDocument();
     });
   });
 
   describe('Mobile Navigation', () => {
+    beforeEach(() => {
+      setMobile(true);
+    });
+
     it('opens mobile menu when menu button is clicked', async () => {
       const user = userEvent.setup();
       render(<Navigation onLogin={mockOnLogin} />);
@@ -373,13 +314,15 @@ describe('Navigation - Jetzt loslegen Feature', () => {
 
   describe('Responsive Behavior', () => {
     it('renders desktop navigation elements', () => {
+      setMobile(false);
       render(<Navigation onLogin={mockOnLogin} />);
 
-      // Desktop elements should be present (mobile menu, desktop logo, nav, auth)
-      expect(screen.getAllByTestId('pill-container')).toHaveLength(4);
+      // Desktop elements should be present (desktop nav has 1 wrapper)
+      expect(screen.getAllByTestId('pill-container')).toHaveLength(1);
     });
 
     it('renders mobile navigation elements', () => {
+      setMobile(true);
       render(<Navigation onLogin={mockOnLogin} />);
 
       // Mobile menu button should be present

--- a/app/modern/components/navigation.test.tsx
+++ b/app/modern/components/navigation.test.tsx
@@ -5,6 +5,8 @@ import { usePathname } from 'next/navigation';
 import Navigation from './navigation';
 import { createClient } from '@/utils/supabase/client';
 
+import { useIsOverflowing } from '@/hooks/use-responsive';
+
 // Mock dependencies
 const mockRouter = {
   push: jest.fn(),
@@ -19,6 +21,10 @@ jest.mock('next/navigation', () => ({
 }));
 
 jest.mock('@/utils/supabase/client');
+
+jest.mock('@/hooks/use-responsive', () => ({
+  useIsOverflowing: jest.fn(),
+}));
 
 jest.mock('next/link', () => {
   return function MockLink({ href, children, ...props }: any) {
@@ -56,7 +62,7 @@ jest.mock('@/components/ui/dropdown-menu', () => ({
   DropdownMenu: ({ children }: any) => <div>{children}</div>,
   DropdownMenuContent: ({ children }: any) => <div>{children}</div>,
   DropdownMenuItem: ({ children, onSelect, onClick }: any) => (
-    <button onClick={onSelect || onClick}>{children}</button>
+    <div onClick={onSelect || onClick} role="menuitem" tabIndex={0}>{children}</div>
   ),
   DropdownMenuTrigger: ({ children }: any) => <div>{children}</div>,
   DropdownMenuSeparator: () => <hr />,
@@ -73,8 +79,26 @@ const mockSupabaseClient = {
 describe('Navigation - Jetzt loslegen Feature', () => {
   const mockOnLogin = jest.fn();
 
+  const setMobile = (isMobile: boolean) => {
+    (useIsOverflowing as jest.Mock).mockReturnValue({
+      ref: { current: null },
+      isOverflowing: isMobile,
+    });
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: isMobile ? 500 : 1024,
+    });
+    window.dispatchEvent(new Event('resize'));
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
+    (useIsOverflowing as jest.Mock).mockReturnValue({
+      ref: { current: null },
+      isOverflowing: false,
+    });
+    setMobile(false); // Default to desktop
     (usePathname as jest.Mock).mockReturnValue('/');
     (createClient as jest.Mock).mockReturnValue(mockSupabaseClient);
     
@@ -183,7 +207,19 @@ describe('Navigation - Jetzt loslegen Feature', () => {
   });
 
   describe('Logout Functionality', () => {
-    it('handles logout successfully', async () => {
+    let originalLocation: any;
+
+    beforeEach(() => {
+      originalLocation = window.location;
+      delete (window as any).location;
+      window.location = { ...originalLocation, replace: jest.fn(), href: '' };
+    });
+
+    afterEach(() => {
+      window.location = originalLocation;
+    });
+
+    it('handles logout successfully and redirects using replace', async () => {
       const user = userEvent.setup();
       const mockUser = { 
         id: '123', 
@@ -197,16 +233,21 @@ describe('Navigation - Jetzt loslegen Feature', () => {
       render(<Navigation onLogin={mockOnLogin} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Abmelden')).toBeInTheDocument();
+        expect(screen.getByText('Mein Konto')).toBeInTheDocument();
       });
+
+      // Open the dropdown first
+      const accountButton = screen.getByText('Mein Konto');
+      await user.click(accountButton);
 
       const logoutButton = screen.getByText('Abmelden');
       await user.click(logoutButton);
 
       expect(mockSupabaseClient.auth.signOut).toHaveBeenCalled();
+      expect(window.location.replace).toHaveBeenCalledWith('/');
     });
 
-    it('handles logout errors', async () => {
+    it('handles logout errors and still redirects using replace', async () => {
       const user = userEvent.setup();
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
       const mockUser = { 
@@ -223,25 +264,29 @@ describe('Navigation - Jetzt loslegen Feature', () => {
       render(<Navigation onLogin={mockOnLogin} />);
 
       await waitFor(() => {
-        expect(screen.getByText('Abmelden')).toBeInTheDocument();
+        expect(screen.getByText('Mein Konto')).toBeInTheDocument();
       });
+
+      // Open the dropdown first
+      const accountButton = screen.getByText('Mein Konto');
+      await user.click(accountButton);
 
       const logoutButton = screen.getByText('Abmelden');
       await user.click(logoutButton);
 
       expect(consoleSpy).toHaveBeenCalledWith('Error logging out:', 'Logout failed');
+      expect(window.location.replace).toHaveBeenCalledWith('/');
       consoleSpy.mockRestore();
     });
   });
 
   describe('Navigation Items', () => {
-    it('renders navigation items on homepage', () => {
+    it('renders navigation items', () => {
       (usePathname as jest.Mock).mockReturnValue('/');
       render(<Navigation onLogin={mockOnLogin} />);
 
-      expect(screen.getByText('Startseite')).toBeInTheDocument();
-      expect(screen.getByText('Funktionen')).toBeInTheDocument();
-      expect(screen.getByText('Preise')).toBeInTheDocument();
+      expect(screen.getByText(/Funktionen/)).toBeInTheDocument();
+      expect(screen.getByText(/Preise/)).toBeInTheDocument();
     });
 
     it('renders home link on other pages', () => {
@@ -313,8 +358,8 @@ describe('Navigation - Jetzt loslegen Feature', () => {
     it('renders brand logo with correct text', () => {
       render(<Navigation onLogin={mockOnLogin} />);
 
-      expect(screen.getAllByText('Immobilien')).toHaveLength(2); // Mobile and desktop versions
-      expect(screen.getAllByText('Verwalter')).toHaveLength(2); // Mobile and desktop versions
+      expect(screen.getAllByText('Miet')).toHaveLength(1);
+      expect(screen.getAllByText('evo')).toHaveLength(1);
     });
 
     it('renders brand logo as link to home', () => {

--- a/app/modern/components/navigation.tsx
+++ b/app/modern/components/navigation.tsx
@@ -100,12 +100,11 @@ export default function Navigation({ onLogin }: NavigationProps) {
 
   useEffect(() => {
     const supabase = createClient();
-    const fetchUser = async () => {
-      const { data: { user } } = await supabase.auth.getUser();
-      // react-doctor-disable-next-line react-doctor/no-initialize-state
+    
+    // Set initial user synchronously if possible, otherwise use onAuthStateChange
+    supabase.auth.getUser().then(({ data: { user } }) => {
       setCurrentUser(user);
-    };
-    fetchUser();
+    });
 
     const { data: authListener } = supabase.auth.onAuthStateChange((event, session) => {
       setCurrentUser(session?.user ?? null);
@@ -278,17 +277,17 @@ export default function Navigation({ onLogin }: NavigationProps) {
                   {showProdukte && (
                     <DropdownMenu onOpenChange={(open) => open && trackNavDropdownOpened('produkte')}>
                       <DropdownMenuTrigger asChild>
-                        <button className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-1 whitespace-nowrap cursor-pointer">
-                          <Package className="w-4 h-4" />
+                        <button type="button" className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-1 whitespace-nowrap cursor-pointer">
+                          <Package className="size-4" />
                           <span>Produkte</span>
-                          <ChevronDown className="w-3 h-3" />
+                          <ChevronDown className="size-3" />
                         </button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="start" className="w-72">
                         {produkteItems.map((item) => (
                           <DropdownMenuItem key={item.name} asChild>
                             <Link href={item.href} onClick={() => trackNavLinkClicked(item.name, item.href, 'produkte')}>
-                              <item.icon className="w-4 h-4 shrink-0" />
+                              <item.icon className="size-4 shrink-0" />
                               <div className="flex flex-col items-start gap-0.5">
                                 <span className="font-medium">{item.name}</span>
                                 <span className="text-xs text-muted-foreground">{item.description}</span>
@@ -303,10 +302,10 @@ export default function Navigation({ onLogin }: NavigationProps) {
                   {/* Funktionen Dropdown */}
                   <DropdownMenu onOpenChange={(open) => open && trackNavDropdownOpened('funktionen')}>
                     <DropdownMenuTrigger asChild>
-                      <button className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-1 whitespace-nowrap cursor-pointer">
-                        <Wrench className="w-4 h-4" />
+                      <button type="button" className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-1 whitespace-nowrap cursor-pointer">
+                        <Wrench className="size-4" />
                         <span>Funktionen</span>
-                        <ChevronDown className="w-3 h-3" />
+                        <ChevronDown className="size-3" />
                       </button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="start" className="w-[600px] p-0">
@@ -315,7 +314,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                           {funktionenItems.map((item) => (
                             <DropdownMenuItem key={item.name} asChild>
                               <Link href={item.href} onClick={() => trackNavLinkClicked(item.name, item.href, 'funktionen')}>
-                                <item.icon className="w-4 h-4 shrink-0" />
+                                <item.icon className="size-4 shrink-0" />
                                 <div className="flex flex-col items-start gap-0.5">
                                   <span className="font-medium">{item.name}</span>
                                   <span className="text-xs text-muted-foreground">{item.description}</span>
@@ -361,17 +360,17 @@ export default function Navigation({ onLogin }: NavigationProps) {
                   {showLoesungen && (
                     <DropdownMenu onOpenChange={(open) => open && trackNavDropdownOpened('loesungen')}>
                       <DropdownMenuTrigger asChild>
-                        <button className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-1 whitespace-nowrap cursor-pointer">
-                          <Lightbulb className="w-4 h-4" />
+                        <button type="button" className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-1 whitespace-nowrap cursor-pointer">
+                          <Lightbulb className="size-4" />
                           <span>Lösungen</span>
-                          <ChevronDown className="w-3 h-3" />
+                          <ChevronDown className="size-3" />
                         </button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="start" className="w-72">
                         {loesungenItems.map((item) => (
                           <DropdownMenuItem key={item.name} asChild>
                             <Link href={item.href} onClick={() => trackNavLinkClicked(item.name, item.href, 'loesungen')}>
-                              <item.icon className="w-4 h-4 shrink-0" />
+                              <item.icon className="size-4 shrink-0" />
                               <div className="flex flex-col items-start gap-0.5">
                                 <span className="font-medium">{item.name}</span>
                                 <span className="text-xs text-muted-foreground">{item.description}</span>
@@ -389,17 +388,17 @@ export default function Navigation({ onLogin }: NavigationProps) {
                     onClick={() => trackNavLinkClicked('Preise', '/preise')}
                     className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-1 whitespace-nowrap cursor-pointer"
                   >
-                    <DollarSign className="w-4 h-4" />
+                    <DollarSign className="size-4" />
                     <span>Preise</span>
                   </Link>
 
                   {/* Hilfe Dropdown */}
                   <DropdownMenu onOpenChange={(open) => open && trackNavDropdownOpened('hilfe')}>
                     <DropdownMenuTrigger asChild>
-                      <button className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-1 whitespace-nowrap cursor-pointer">
-                        <HelpCircle className="w-4 h-4" />
+                      <button type="button" className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-1 whitespace-nowrap cursor-pointer">
+                        <HelpCircle className="size-4" />
                         <span>Hilfe</span>
-                        <ChevronDown className="w-3 h-3" />
+                        <ChevronDown className="size-3" />
                       </button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="start" className="w-72">
@@ -411,7 +410,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                             rel={item.rel}
                             onClick={() => trackNavLinkClicked(item.name, item.href, 'hilfe')}
                           >
-                            <item.icon className="w-4 h-4 shrink-0" />
+                            <item.icon className="size-4 shrink-0" />
                             <div className="flex flex-col items-start gap-0.5">
                               <span className="font-medium">{item.name}</span>
                               <span className="text-xs text-muted-foreground">{item.description}</span>
@@ -431,7 +430,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                   {currentUser ? (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <button className="p-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-2 cursor-pointer">
+                        <button type="button" className="p-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-2 cursor-pointer">
                           <Avatar className="h-6 w-6">
                             <AvatarImage src={currentUser.user_metadata?.avatar_url} alt={currentUser.email || 'User'} />
                             <AvatarFallback className="text-xs">
@@ -439,7 +438,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                             </AvatarFallback>
                           </Avatar>
                           <span className="whitespace-nowrap">Mein Konto</span>
-                          <ChevronDown className="w-3 h-3" />
+                          <ChevronDown className="size-3" />
                         </button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end" className="w-60 p-2">
@@ -462,7 +461,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                         <DropdownMenuSeparator className="my-2" />
                         <DropdownMenuItem asChild className="px-3 py-2 rounded-xl group">
                           <Link href={ROUTES.HOME} className="w-full hover:bg-primary hover:text-primary-foreground dark:hover:bg-primary/90">
-                            <LayoutDashboard className="w-4 h-4 mr-3 text-muted-foreground group-hover:text-white" />
+                            <LayoutDashboard className="size-4 mr-3 text-muted-foreground group-hover:text-white" />
                             <span>Dashboard</span>
                           </Link>
                         </DropdownMenuItem>
@@ -473,7 +472,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                             window.location.href = ROUTES.HOME;
                           }}
                         >
-                          <Settings className="w-4 h-4 mr-3 text-muted-foreground group-hover:text-white" />
+                          <Settings className="size-4 mr-3 text-muted-foreground group-hover:text-white" />
                           <span>Einstellungen</span>
                         </DropdownMenuItem>
                         <DropdownMenuSeparator className="my-2" />
@@ -481,7 +480,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                           onClick={handleLogout}
                           className="px-3 py-2 rounded-xl group hover:bg-red-600 hover:text-white dark:hover:bg-red-600/90 cursor-pointer"
                         >
-                          <LogOut className="w-4 h-4 mr-3 group-hover:text-white" />
+                          <LogOut className="size-4 mr-3 group-hover:text-white" />
                           <span className="group-hover:text-white">Abmelden</span>
                         </DropdownMenuItem>
                       </DropdownMenuContent>
@@ -537,11 +536,12 @@ export default function Navigation({ onLogin }: NavigationProps) {
                   <div className="flex items-center justify-between">
                     <h3 className="text-lg font-semibold">Navigation</h3>
                     <button
+                      type="button"
                       onClick={() => setIsOpen(false)}
                       className="p-1.5 rounded-full hover:bg-muted transition-colors"
                       aria-label="Menü schließen"
                     >
-                      <X className="w-5 h-5" />
+                      <X className="size-5" />
                     </button>
                   </div>
                 </div>
@@ -582,7 +582,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                       onClick={() => setIsOpen(false)}
                       className="flex items-center w-full text-left px-4 py-3 rounded-lg transition-colors duration-200 hover:bg-muted/50"
                     >
-                      <DollarSign className="w-5 h-5 mr-3" />
+                      <DollarSign className="size-5 mr-3" />
                       <div>
                         <div className="font-medium">Preise</div>
                         <div className="text-sm text-muted-foreground">Unsere Tarife im Überblick</div>
@@ -617,12 +617,12 @@ export default function Navigation({ onLogin }: NavigationProps) {
                       </div>
                       <Button asChild variant="outline" className="w-full">
                         <Link href={ROUTES.HOME}>
-                          <LayoutDashboard className="w-4 h-4 mr-2" />
+                          <LayoutDashboard className="size-4 mr-2" />
                           Dashboard
                         </Link>
                       </Button>
                       <Button variant="outline" className="w-full" onClick={handleLogout}>
-                        <LogOut className="w-4 h-4 mr-2" />
+                        <LogOut className="size-4 mr-2" />
                         Abmelden
                       </Button>
                     </div>

--- a/app/modern/components/navigation.tsx
+++ b/app/modern/components/navigation.tsx
@@ -1,6 +1,7 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useSyncExternalStore } from "react"
+// react-doctor-disable-next-line react-doctor/use-lazy-motion
 import { AnimatePresence, motion } from "framer-motion"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { Menu, X, DollarSign, Home, User as UserIcon, LogIn, LogOut, Check, LayoutDashboard, BookOpen, Package, Wrench, Lightbulb, HelpCircle, FileText, Building2, Users, Calculator, TrendingUp, BarChart3, Shield, Zap, MessageSquare, Phone, Mail, ChevronDown, Settings, ArrowRight, Sparkles, type LucideIcon } from "lucide-react"
@@ -63,23 +64,29 @@ interface NavigationProps {
   onLogin?: () => void;
 }
 
+const emptySubscribe = () => () => {};
+
+const scrollToPricing = () => {
+  const pricingSection = document.getElementById('pricing');
+  if (pricingSection) {
+    pricingSection.scrollIntoView({ behavior: 'smooth' });
+  } else {
+    // If we're not on a page with the pricing section, redirect to home with hash
+    window.location.href = '/#pricing';
+  }
+};
 
 export default function Navigation({ onLogin }: NavigationProps) {
-  const [hasMounted, setHasMounted] = useState(false);
+  const hasMounted = useSyncExternalStore(emptySubscribe, () => true, () => false);
   const [isOpen, setIsOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const pathname = usePathname();
   const router = useRouter();
   const [currentUser, setCurrentUser] = useState<User | null>(null);
-  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const { userName } = useUserProfile();
   const { ref: navRef, isOverflowing } = useIsOverflowing();
   const showProdukte = useFeatureFlagEnabled('show-produkte-dropdown');
   const showLoesungen = useFeatureFlagEnabled('show-loesungen-dropdown');
-
-  useEffect(() => {
-    setHasMounted(true);
-  }, []);
 
   const checkIfMobile = useCallback(() => {
     if (typeof window === 'undefined' || !hasMounted) return;
@@ -105,6 +112,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
     const supabase = createClient();
     const fetchUser = async () => {
       const { data: { user } } = await supabase.auth.getUser();
+      // react-doctor-disable-next-line react-doctor/no-initialize-state
       setCurrentUser(user);
     };
     fetchUser();
@@ -132,15 +140,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
     }
   };
 
-  const scrollToPricing = () => {
-    const pricingSection = document.getElementById('pricing');
-    if (pricingSection) {
-      pricingSection.scrollIntoView({ behavior: 'smooth' });
-    } else {
-      // If we're not on a page with the pricing section, redirect to home with hash
-      window.location.href = '/#pricing';
-    }
-  };
+
 
   const handleOpenLoginModal = () => {
     trackNavLoginClicked();
@@ -161,6 +161,22 @@ export default function Navigation({ onLogin }: NavigationProps) {
       }
     } catch (error) {
       console.error("Error logging out:", error);
+    }
+
+    try {
+      // Perform cleanup API calls
+      await Promise.allSettled([
+        fetch('/api/auth/logout', {
+          method: 'POST',
+          credentials: 'same-origin'
+        }),
+        fetch('/api/auth/clear-auth-cookie', {
+          method: 'POST',
+          credentials: 'same-origin'
+        })
+      ]);
+    } catch (error) {
+      console.error("Error clearing session:", error);
     } finally {
       setCurrentUser(null);
       setIsOpen(false);
@@ -207,20 +223,20 @@ export default function Navigation({ onLogin }: NavigationProps) {
       <div className="max-w-7xl mx-auto">
         {/* Mobile Header with Menu Button and Logo */}
         {(isMobile || isOverflowing) && (
-          <div className="flex items-center space-x-2">
+          <div className="flex items-center gap-2">
             <PillContainer>
               <button
                 onClick={() => {
                   if (!isOpen) trackNavMobileMenuOpened();
                   setIsOpen(!isOpen);
                 }}
-                className="w-full px-4 py-2 text-left text-sm hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center space-x-2"
+                className="w-full px-4 py-2 text-left text-sm hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-2"
               >
                 <Menu className="w-5 h-5" />
                 <span className="text-sm font-medium">Menü</span>
               </button>
             </PillContainer>
-            <Link href="/" className="flex items-center space-x-1 group">
+            <Link href="/" className="flex items-center gap-1 group">
               <div className="relative w-6 h-6 rounded-full group-hover:scale-110 transition-transform overflow-hidden">
                 <Image
                   src={LOGO_URL}
@@ -243,7 +259,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
             <div className="inline-flex w-auto max-w-full" ref={navRef}>
               <PillContainer className="flex items-center gap-2 w-full">
                 {/* Logo Section */}
-                <Link href="/" className="flex items-center space-x-2 group px-2">
+                <Link href="/" className="flex items-center gap-2 group px-2">
                   <div className="relative w-8 h-8 rounded-full group-hover:scale-110 transition-transform overflow-hidden">
                     <Image
                       src={LOGO_URL}
@@ -267,7 +283,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                   {showProdukte && (
                     <DropdownMenu onOpenChange={(open) => open && trackNavDropdownOpened('produkte')}>
                       <DropdownMenuTrigger asChild>
-                        <button className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center space-x-1 whitespace-nowrap cursor-pointer">
+                        <button className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-1 whitespace-nowrap cursor-pointer">
                           <Package className="w-4 h-4" />
                           <span>Produkte</span>
                           <ChevronDown className="w-3 h-3" />
@@ -292,7 +308,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                   {/* Funktionen Dropdown */}
                   <DropdownMenu onOpenChange={(open) => open && trackNavDropdownOpened('funktionen')}>
                     <DropdownMenuTrigger asChild>
-                      <button className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center space-x-1 whitespace-nowrap cursor-pointer">
+                      <button className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-1 whitespace-nowrap cursor-pointer">
                         <Wrench className="w-4 h-4" />
                         <span>Funktionen</span>
                         <ChevronDown className="w-3 h-3" />
@@ -350,7 +366,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                   {showLoesungen && (
                     <DropdownMenu onOpenChange={(open) => open && trackNavDropdownOpened('loesungen')}>
                       <DropdownMenuTrigger asChild>
-                        <button className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center space-x-1 whitespace-nowrap cursor-pointer">
+                        <button className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-1 whitespace-nowrap cursor-pointer">
                           <Lightbulb className="w-4 h-4" />
                           <span>Lösungen</span>
                           <ChevronDown className="w-3 h-3" />
@@ -376,7 +392,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                   <Link
                     href="/preise"
                     onClick={() => trackNavLinkClicked('Preise', '/preise')}
-                    className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center space-x-1 whitespace-nowrap cursor-pointer"
+                    className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-1 whitespace-nowrap cursor-pointer"
                   >
                     <DollarSign className="w-4 h-4" />
                     <span>Preise</span>
@@ -385,7 +401,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                   {/* Hilfe Dropdown */}
                   <DropdownMenu onOpenChange={(open) => open && trackNavDropdownOpened('hilfe')}>
                     <DropdownMenuTrigger asChild>
-                      <button className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center space-x-1 whitespace-nowrap cursor-pointer">
+                      <button className="px-4 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-1 whitespace-nowrap cursor-pointer">
                         <HelpCircle className="w-4 h-4" />
                         <span>Hilfe</span>
                         <ChevronDown className="w-3 h-3" />
@@ -420,7 +436,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                   {currentUser ? (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <button className="px-2 py-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center space-x-2 cursor-pointer">
+                        <button className="p-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-2 cursor-pointer">
                           <Avatar className="h-6 w-6">
                             <AvatarImage src={currentUser.user_metadata?.avatar_url} alt={currentUser.email || 'User'} />
                             <AvatarFallback className="text-xs">
@@ -432,7 +448,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                         </button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end" className="w-60 p-2">
-                        <div className="flex items-center space-x-3 px-2 py-2">
+                        <div className="flex items-center gap-3 p-2">
                           <Avatar className="h-10 w-10">
                             <AvatarImage src={currentUser.user_metadata?.avatar_url} alt={currentUser.email || 'User'} />
                             <AvatarFallback className="text-sm">
@@ -458,12 +474,8 @@ export default function Navigation({ onLogin }: NavigationProps) {
                         <DropdownMenuItem
                           className="px-3 py-2 rounded-xl group hover:bg-primary hover:text-primary-foreground dark:hover:bg-primary/90 cursor-pointer"
                           onClick={() => {
-                            // Navigate to dashboard first
+                            // Navigate to dashboard
                             window.location.href = ROUTES.HOME;
-                            // Then open settings after a small delay to ensure navigation completes
-                            setTimeout(() => {
-                              setIsSettingsOpen(true);
-                            }, 100);
                           }}
                         >
                           <Settings className="w-4 h-4 mr-3 text-muted-foreground group-hover:text-white" />
@@ -596,7 +608,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                 <div className="p-4 border-t border-border/50">
                   {currentUser ? (
                     <div className="space-y-3">
-                      <div className="flex items-center space-x-3 px-2">
+                      <div className="flex items-center gap-3 px-2">
                         <Avatar className="h-10 w-10">
                           <AvatarImage src={currentUser.user_metadata?.avatar_url} alt={currentUser.email || 'User'} />
                           <AvatarFallback>

--- a/app/modern/components/navigation.tsx
+++ b/app/modern/components/navigation.tsx
@@ -155,10 +155,16 @@ export default function Navigation({ onLogin }: NavigationProps) {
     trackNavLogoutClicked();
     const supabase = createClient();
     try {
-      await supabase.auth.signOut();
-      setCurrentUser(null);
+      const { error } = await supabase.auth.signOut();
+      if (error) {
+        console.error("Error logging out:", error.message);
+      }
     } catch (error) {
       console.error("Error logging out:", error);
+    } finally {
+      setCurrentUser(null);
+      setIsOpen(false);
+      window.location.href = "/";
     }
   };
 

--- a/app/modern/components/navigation.tsx
+++ b/app/modern/components/navigation.tsx
@@ -326,7 +326,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                         <div className="p-2">
                           <div className="h-full w-full rounded-xl bg-linear-to-br from-primary/5 via-muted/20 to-transparent border border-border/50 p-4 flex flex-col justify-between relative overflow-hidden group/card hover:border-primary/20 transition-colors">
                             {/* Abstract shapes/illustration */}
-                            <div className="absolute -right-6 -top-6 w-32 h-32 bg-primary/10 rounded-full blur-3xl group-hover/card:bg-primary/20 transition-colors duration-500" />
+                            <div className="absolute -right-6 -top-6 size-32 bg-primary/10 rounded-full blur-3xl group-hover/card:bg-primary/20 transition-colors duration-500" />
                             <div className="absolute right-2 top-2 opacity-[0.08] group-hover/card:opacity-[0.15] transition-all duration-500 transform group-hover/card:scale-110 group-hover/card:-rotate-6">
                               <Sparkles className="size-20" />
                             </div>
@@ -346,7 +346,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                                   className="w-full group h-8 text-xs"
                                 >
                                   Kostenlos starten
-                                  <ArrowRight className="w-3 h-3 ml-2 transition-transform group-hover:translate-x-1" />
+                                  <ArrowRight className="size-3 ml-2 transition-transform group-hover:translate-x-1" />
                                 </Button>
                               </DropdownMenuItem>
                             </div>
@@ -431,7 +431,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <button type="button" className="p-2 rounded-full text-sm font-medium text-foreground hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-2 cursor-pointer">
-                          <Avatar className="h-6 w-6">
+                          <Avatar className="size-6">
                             <AvatarImage src={currentUser.user_metadata?.avatar_url} alt={currentUser.email || 'User'} />
                             <AvatarFallback className="text-xs">
                               {currentUser.email?.charAt(0).toUpperCase() || 'U'}
@@ -443,7 +443,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end" className="w-60 p-2">
                         <div className="flex items-center gap-3 p-2">
-                          <Avatar className="h-10 w-10">
+                          <Avatar className="size-10">
                             <AvatarImage src={currentUser.user_metadata?.avatar_url} alt={currentUser.email || 'User'} />
                             <AvatarFallback className="text-sm">
                               {currentUser.email?.charAt(0).toUpperCase() || 'U'}
@@ -604,7 +604,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                   {currentUser ? (
                     <div className="space-y-3">
                       <div className="flex items-center gap-3 px-2">
-                        <Avatar className="h-10 w-10">
+                        <Avatar className="size-10">
                           <AvatarImage src={currentUser.user_metadata?.avatar_url} alt={currentUser.email || 'User'} />
                           <AvatarFallback>
                             {currentUser.email?.charAt(0).toUpperCase() || 'U'}
@@ -645,4 +645,3 @@ export default function Navigation({ onLogin }: NavigationProps) {
     </nav>
   )
 }
-

--- a/app/modern/components/navigation.tsx
+++ b/app/modern/components/navigation.tsx
@@ -328,7 +328,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                             {/* Abstract shapes/illustration */}
                             <div className="absolute -right-6 -top-6 w-32 h-32 bg-primary/10 rounded-full blur-3xl group-hover/card:bg-primary/20 transition-colors duration-500" />
                             <div className="absolute right-2 top-2 opacity-[0.08] group-hover/card:opacity-[0.15] transition-all duration-500 transform group-hover/card:scale-110 group-hover/card:-rotate-6">
-                              <Sparkles className="w-20 h-20" />
+                              <Sparkles className="size-20" />
                             </div>
 
                             <div className="relative z-10">
@@ -645,3 +645,4 @@ export default function Navigation({ onLogin }: NavigationProps) {
     </nav>
   )
 }
+

--- a/app/modern/components/navigation.tsx
+++ b/app/modern/components/navigation.tsx
@@ -205,7 +205,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
       }}
       className="flex items-center w-full text-left px-4 py-3 rounded-lg transition-colors duration-200 hover:bg-muted/50"
     >
-      <item.icon className="w-5 h-5 mr-3" />
+      <item.icon className="size-5 mr-3" />
       <div>
         <div className="font-medium">
           {item.name}
@@ -226,22 +226,24 @@ export default function Navigation({ onLogin }: NavigationProps) {
           <div className="flex items-center gap-2">
             <PillContainer>
               <button
+                type="button"
                 onClick={() => {
                   if (!isOpen) trackNavMobileMenuOpened();
                   setIsOpen(!isOpen);
                 }}
                 className="w-full px-4 py-2 text-left text-sm hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover transition-colors duration-200 flex items-center gap-2"
               >
-                <Menu className="w-5 h-5" />
+                <Menu className="size-5" />
                 <span className="text-sm font-medium">Menü</span>
               </button>
             </PillContainer>
             <Link href="/" className="flex items-center gap-1 group">
-              <div className="relative w-6 h-6 rounded-full group-hover:scale-110 transition-transform overflow-hidden">
+              <div className="relative size-6 rounded-full group-hover:scale-110 transition-transform overflow-hidden">
                 <Image
                   src={LOGO_URL}
                   alt="Mietevo Logo"
                   fill
+                  sizes="24px"
                   className="object-cover"
                   unoptimized // Supabase images are stored as pre-optimized .avif
                 />
@@ -260,11 +262,12 @@ export default function Navigation({ onLogin }: NavigationProps) {
               <PillContainer className="flex items-center gap-2 w-full">
                 {/* Logo Section */}
                 <Link href="/" className="flex items-center gap-2 group px-2">
-                  <div className="relative w-8 h-8 rounded-full group-hover:scale-110 transition-transform overflow-hidden">
+                  <div className="relative size-8 rounded-full group-hover:scale-110 transition-transform overflow-hidden">
                     <Image
                       src={LOGO_URL}
                       alt="Mietevo Logo"
                       fill
+                      sizes="32px"
                       className="object-cover"
                       unoptimized // Supabase images are stored as pre-optimized .avif
                     />

--- a/app/modern/components/navigation.tsx
+++ b/app/modern/components/navigation.tsx
@@ -66,16 +66,6 @@ interface NavigationProps {
 
 const emptySubscribe = () => () => {};
 
-const scrollToPricing = () => {
-  const pricingSection = document.getElementById('pricing');
-  if (pricingSection) {
-    pricingSection.scrollIntoView({ behavior: 'smooth' });
-  } else {
-    // If we're not on a page with the pricing section, redirect to home with hash
-    window.location.href = '/#pricing';
-  }
-};
-
 export default function Navigation({ onLogin }: NavigationProps) {
   const hasMounted = useSyncExternalStore(emptySubscribe, () => true, () => false);
   const [isOpen, setIsOpen] = useState(false);
@@ -168,11 +158,13 @@ export default function Navigation({ onLogin }: NavigationProps) {
       await Promise.allSettled([
         fetch('/api/auth/logout', {
           method: 'POST',
-          credentials: 'same-origin'
+          credentials: 'same-origin',
+          keepalive: true
         }),
         fetch('/api/auth/clear-auth-cookie', {
           method: 'POST',
-          credentials: 'same-origin'
+          credentials: 'same-origin',
+          keepalive: true
         })
       ]);
     } catch (error) {

--- a/app/modern/components/navigation.tsx
+++ b/app/modern/components/navigation.tsx
@@ -164,7 +164,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
     } finally {
       setCurrentUser(null);
       setIsOpen(false);
-      window.location.href = "/";
+      window.location.replace("/");
     }
   };
 

--- a/components/common/user-settings.tsx
+++ b/components/common/user-settings.tsx
@@ -93,7 +93,7 @@ export function UserSettings({
       setIsLoadingLogout(false);
 
       // Redirect to home
-      window.location.href = '/';
+      window.location.replace('/');
     }
   }
 

--- a/components/common/user-settings.tsx
+++ b/components/common/user-settings.tsx
@@ -6,6 +6,7 @@ import { LogOut, Settings, FileText } from "lucide-react"
 import { createClient } from "@/utils/supabase/client"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { cn } from "@/lib/utils"
+// react-doctor-disable-next-line react-doctor/use-lazy-motion
 import { motion } from "framer-motion"
 import { trackLogout } from "@/lib/posthog-auth-events"
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,6 +1,7 @@
 // jest.setup.js
 import '@testing-library/jest-dom'
 import 'jest-axe/extend-expect'
+import 'jest-location-mock'
 
 // Add TextEncoder/TextDecoder polyfills for Node.js environment
 const { TextEncoder, TextDecoder } = require('util');
@@ -74,6 +75,12 @@ global.Headers = class Headers extends Map {
     }
   }
 };
+
+global.fetch = jest.fn(() =>
+  Promise.resolve(
+    Response.json({ success: true })
+  )
+);
 
 jest.mock('@supabase/ssr', () => {
   return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,6 +111,7 @@
         "jest": "30.2.0",
         "jest-axe": "10.0.0",
         "jest-environment-jsdom": "30.2.0",
+        "jest-location-mock": "^3.0.0",
         "postcss": "8.5.14",
         "tailwindcss": "^4.3.0",
         "ts-jest": "29.4.9",
@@ -1610,6 +1611,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@jedmao/location": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@jedmao/location/-/location-3.0.0.tgz",
+      "integrity": "sha512-p7mzNlgJbCioUYLUEKds3cQG4CHONVFJNYqMe6ocEtENCL/jYmMo1Q3ApwsMmU+L0ZkaDJEyv4HokaByLoPwlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jest/console": {
       "version": "30.2.0",
@@ -10723,6 +10731,22 @@
       "version": "18.3.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jest-location-mock": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jest-location-mock/-/jest-location-mock-3.0.0.tgz",
+      "integrity": "sha512-BGDXjHBPHgRz6LFxuzWFb87MwjWgS4TYIbnAz81CInfw9jG23cYx4ldmk6tK4h4cYWWBq964rdkcvfQKyTy+eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jedmao/location": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@jest/globals": "^30.0.0"
+      }
     },
     "node_modules/jest-matcher-utils": {
       "version": "30.2.0",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "jest": "30.2.0",
     "jest-axe": "10.0.0",
     "jest-environment-jsdom": "30.2.0",
+    "jest-location-mock": "^3.0.0",
     "postcss": "8.5.14",
     "tailwindcss": "^4.3.0",
     "ts-jest": "29.4.9",


### PR DESCRIPTION
## Description

Fixes sign-out on the landing page leaving stale cache state, and improves the mobile drawer menu.

## Summary of Changes

- `navigation.tsx`: logout now also calls `/api/auth/logout` and `/api/auth/clear-auth-cookie` (keepalive) and hard-redirects via `window.location.replace('/')`, so no cached session survives
- Mounted check via `useSyncExternalStore` instead of effect state (no hydration flicker); unused settings/smooth-scroll code removed
- `user-settings.tsx`: redirect via `window.location.replace` as well
- Tests: `navigation.test.tsx` rewritten around router/logout behavior; `jest-location-mock` added and fetch mocked in `jest.setup.js`