### PR TITLE
fix(telemetry): fallback to NEXT_PUBLIC_POSTHOG_KEY for log ingestion if POSTHOG_API_KEY is a personal key

### DIFF
--- a/lib/otlp-utils.ts
+++ b/lib/otlp-utils.ts
@@ -14,7 +14,13 @@ export interface LogAttributes {
 import resolvePostHogHost from './posthog-host';
 
 export const SERVICE_NAME = 'mietevo';
-export const POSTHOG_API_KEY = process.env.POSTHOG_API_KEY;
+export const POSTHOG_API_KEY = (() => {
+    const key = process.env.POSTHOG_API_KEY;
+    if (key?.startsWith('phx_')) {
+        return process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    }
+    return key || process.env.NEXT_PUBLIC_POSTHOG_KEY;
+})();
 export const POSTHOG_HOST = resolvePostHogHost();
 
 /**

--- a/lib/otlp-utils.ts
+++ b/lib/otlp-utils.ts
@@ -16,10 +16,10 @@ import resolvePostHogHost from './posthog-host';
 export const SERVICE_NAME = 'mietevo';
 export const POSTHOG_API_KEY = (() => {
     const key = process.env.POSTHOG_API_KEY;
-    if (key?.startsWith('phx_')) {
-        return process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    if (key && !key.startsWith('phx_')) {
+        return key;
     }
-    return key || process.env.NEXT_PUBLIC_POSTHOG_KEY;
+    return process.env.NEXT_PUBLIC_POSTHOG_KEY;
 })();
 export const POSTHOG_HOST = resolvePostHogHost();
 

--- a/lib/posthog-logger.ts
+++ b/lib/posthog-logger.ts
@@ -34,7 +34,7 @@ const IS_TEST = process.env.NODE_ENV === 'test';
 const DEBUG_MODE = process.env.POSTHOG_LOGS_DEBUG === 'true';
 
 // Always send logs to PostHog when API key is configured (both dev and production)
-const SHOULD_SEND_TO_POSTHOG = true; // Use real API key logic inside flushLogs
+const SHOULD_SEND_TO_POSTHOG = !!POSTHOG_API_KEY;
 
 // Suppress noisy logs in CI/test environments
 const QUIET_MODE = IS_CI || IS_TEST;
@@ -76,7 +76,7 @@ async function flushLogs(): Promise<void> {
         return;
     }
 
-    if (!POSTHOG_API_KEY) {
+    if (!SHOULD_SEND_TO_POSTHOG) {
         debugLog('Skipping flush - POSTHOG_API_KEY not configured');
         logBatch = [];
         return;
@@ -213,7 +213,7 @@ function log(
     }
 
     // Queue for sending to PostHog if configured
-    if (POSTHOG_API_KEY) {
+    if (SHOULD_SEND_TO_POSTHOG) {
         logBatch.push({
             timestamp,
             severityText,

--- a/lib/posthog-logger.ts
+++ b/lib/posthog-logger.ts
@@ -34,7 +34,7 @@ const IS_TEST = process.env.NODE_ENV === 'test';
 const DEBUG_MODE = process.env.POSTHOG_LOGS_DEBUG === 'true';
 
 // Always send logs to PostHog when API key is configured (both dev and production)
-const SHOULD_SEND_TO_POSTHOG = !!POSTHOG_API_KEY;
+const SHOULD_SEND_TO_POSTHOG = true; // Use real API key logic inside flushLogs
 
 // Suppress noisy logs in CI/test environments
 const QUIET_MODE = IS_CI || IS_TEST;
@@ -76,7 +76,7 @@ async function flushLogs(): Promise<void> {
         return;
     }
 
-    if (!SHOULD_SEND_TO_POSTHOG) {
+    if (!POSTHOG_API_KEY) {
         debugLog('Skipping flush - POSTHOG_API_KEY not configured');
         logBatch = [];
         return;
@@ -213,7 +213,7 @@ function log(
     }
 
     // Queue for sending to PostHog if configured
-    if (SHOULD_SEND_TO_POSTHOG) {
+    if (POSTHOG_API_KEY) {
         logBatch.push({
             timestamp,
             severityText,

--- a/workers/mietevo-backend/src/index.ts
+++ b/workers/mietevo-backend/src/index.ts
@@ -963,7 +963,7 @@ export async function processQueue(request: Request, env: Env, ctx: ExecutionCon
         // Initialize PostHog only if we have work
         let posthogKey = env.POSTHOG_API_KEY;
         if (posthogKey && posthogKey.startsWith('phx_')) {
-            posthogKey = env.NEXT_PUBLIC_POSTHOG_KEY || posthogKey;
+            posthogKey = env.NEXT_PUBLIC_POSTHOG_KEY;
         }
 
         if (posthogKey) {

--- a/workers/mietevo-backend/src/index.ts
+++ b/workers/mietevo-backend/src/index.ts
@@ -4,7 +4,7 @@ import JSZip from 'jszip';
 import Papa from 'papaparse';
 import { GoogleGenAI } from '@google/genai';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import { WorkerLogger, ExecutionContext } from './logger';
+import { WorkerLogger, ExecutionContext, getPostHogApiKey } from './logger';
 import pako from 'pako';
 import { PostHog } from 'posthog-node';
 
@@ -961,10 +961,7 @@ export async function processQueue(request: Request, env: Env, ctx: ExecutionCon
         }
 
         // Initialize PostHog only if we have work
-        let posthogKey = env.POSTHOG_API_KEY;
-        if (posthogKey && posthogKey.startsWith('phx_')) {
-            posthogKey = env.NEXT_PUBLIC_POSTHOG_KEY;
-        }
+        const posthogKey = getPostHogApiKey(env);
 
         if (posthogKey) {
             posthog = new PostHog(posthogKey, {

--- a/workers/mietevo-backend/src/index.ts
+++ b/workers/mietevo-backend/src/index.ts
@@ -15,6 +15,7 @@ export interface Env {
     SUPABASE_URL: string;
     SUPABASE_SERVICE_ROLE_KEY: string;
     POSTHOG_API_KEY?: string;
+    NEXT_PUBLIC_POSTHOG_KEY?: string;
     POSTHOG_HOST?: string;
     RATE_LIMITER: unknown; // Using 'unknown' instead of 'any'
     WORKER_AUTH_KEY?: string;
@@ -960,8 +961,13 @@ export async function processQueue(request: Request, env: Env, ctx: ExecutionCon
         }
 
         // Initialize PostHog only if we have work
-        if (env.POSTHOG_API_KEY) {
-            posthog = new PostHog(env.POSTHOG_API_KEY, {
+        let posthogKey = env.POSTHOG_API_KEY;
+        if (posthogKey && posthogKey.startsWith('phx_')) {
+            posthogKey = env.NEXT_PUBLIC_POSTHOG_KEY || posthogKey;
+        }
+
+        if (posthogKey) {
+            posthog = new PostHog(posthogKey, {
                 host: env.POSTHOG_HOST || 'https://eu.i.posthog.com',
                 flushAt: 1,
                 flushInterval: 0,

--- a/workers/mietevo-backend/src/logger.ts
+++ b/workers/mietevo-backend/src/logger.ts
@@ -83,7 +83,7 @@ export class WorkerLogger {
         const envApiKey = this.env.POSTHOG_API_KEY;
         let apiKey = envApiKey;
         if (envApiKey && envApiKey.startsWith('phx_')) {
-            apiKey = this.env.NEXT_PUBLIC_POSTHOG_KEY || envApiKey;
+            apiKey = this.env.NEXT_PUBLIC_POSTHOG_KEY;
         }
         if (!apiKey) return;
 
@@ -121,7 +121,7 @@ export class WorkerLogger {
         const envApiKey2 = this.env.POSTHOG_API_KEY;
         let apiKey = envApiKey2;
         if (envApiKey2 && envApiKey2.startsWith('phx_')) {
-            apiKey = this.env.NEXT_PUBLIC_POSTHOG_KEY || envApiKey2;
+            apiKey = this.env.NEXT_PUBLIC_POSTHOG_KEY;
         }
         const host = this.env.POSTHOG_HOST || 'https://eu.i.posthog.com';
         const endpoint = `${host.replace(/\/$/, '')}/i/v1/logs`;

--- a/workers/mietevo-backend/src/logger.ts
+++ b/workers/mietevo-backend/src/logger.ts
@@ -7,6 +7,7 @@
 
 export interface Env {
     POSTHOG_API_KEY?: string;
+    NEXT_PUBLIC_POSTHOG_KEY?: string;
     POSTHOG_HOST?: string;
     [key: string]: unknown;
 }
@@ -79,7 +80,11 @@ export class WorkerLogger {
         // Console log for local debugging / real-time logs in dashboard
         console.log(`[${severity.toUpperCase()}] ${message}`, JSON.stringify(attributes));
 
-        const apiKey = this.env.POSTHOG_API_KEY;
+        const envApiKey = this.env.POSTHOG_API_KEY;
+        let apiKey = envApiKey;
+        if (envApiKey && envApiKey.startsWith('phx_')) {
+            apiKey = this.env.NEXT_PUBLIC_POSTHOG_KEY || envApiKey;
+        }
         if (!apiKey) return;
 
         const timestamp = new Date().toISOString();
@@ -113,7 +118,11 @@ export class WorkerLogger {
     async flush() {
         if (this.logs.length === 0) return;
 
-        const apiKey = this.env.POSTHOG_API_KEY;
+        const envApiKey2 = this.env.POSTHOG_API_KEY;
+        let apiKey = envApiKey2;
+        if (envApiKey2 && envApiKey2.startsWith('phx_')) {
+            apiKey = this.env.NEXT_PUBLIC_POSTHOG_KEY || envApiKey2;
+        }
         const host = this.env.POSTHOG_HOST || 'https://eu.i.posthog.com';
         const endpoint = `${host.replace(/\/$/, '')}/i/v1/logs`;
 

--- a/workers/mietevo-backend/src/logger.ts
+++ b/workers/mietevo-backend/src/logger.ts
@@ -12,6 +12,14 @@ export interface Env {
     [key: string]: unknown;
 }
 
+export function getPostHogApiKey(env: Env): string | undefined {
+    const key = env.POSTHOG_API_KEY;
+    if (key && !key.startsWith('phx_')) {
+        return key;
+    }
+    return env.NEXT_PUBLIC_POSTHOG_KEY;
+}
+
 export interface LogAttributes {
     [key: string]: string | number | boolean | string[] | number[] | null | undefined;
 }
@@ -63,7 +71,7 @@ export class WorkerLogger {
     constructor(env: Env, ctx: ExecutionContext) {
         this.env = env;
         this.ctx = ctx;
-        if (!this.env.POSTHOG_API_KEY) {
+        if (!getPostHogApiKey(this.env)) {
             console.warn('[WorkerLogger] POSTHOG_API_KEY not set. Logs will not be sent to PostHog.');
         }
     }
@@ -80,11 +88,7 @@ export class WorkerLogger {
         // Console log for local debugging / real-time logs in dashboard
         console.log(`[${severity.toUpperCase()}] ${message}`, JSON.stringify(attributes));
 
-        const envApiKey = this.env.POSTHOG_API_KEY;
-        let apiKey = envApiKey;
-        if (envApiKey && envApiKey.startsWith('phx_')) {
-            apiKey = this.env.NEXT_PUBLIC_POSTHOG_KEY;
-        }
+        const apiKey = getPostHogApiKey(this.env);
         if (!apiKey) return;
 
         const timestamp = new Date().toISOString();
@@ -118,11 +122,7 @@ export class WorkerLogger {
     async flush() {
         if (this.logs.length === 0) return;
 
-        const envApiKey2 = this.env.POSTHOG_API_KEY;
-        let apiKey = envApiKey2;
-        if (envApiKey2 && envApiKey2.startsWith('phx_')) {
-            apiKey = this.env.NEXT_PUBLIC_POSTHOG_KEY;
-        }
+        const apiKey = getPostHogApiKey(this.env);
         const host = this.env.POSTHOG_HOST || 'https://eu.i.posthog.com';
         const endpoint = `${host.replace(/\/$/, '')}/i/v1/logs`;
 


### PR DESCRIPTION
When `POSTHOG_API_KEY` starts with `phx_` (a personal API key), PostHog log ingestion silently fails because it requires a project key (typically starting with `phc_`).

This commit adds a fallback mechanism across the Next.js server (`lib/otlp-utils.ts`, `lib/posthog-logger.ts`) and Cloudflare Worker (`workers/mietevo-backend`) to check if `POSTHOG_API_KEY` is either missing or begins with `phx_`. If so, it falls back to the client-safe `NEXT_PUBLIC_POSTHOG_KEY`, ensuring telemetry and OTLP logs are successfully ingested.

---
*PR created automatically by Jules for task [11578117543736730034](https://jules.google.com/task/11578117543736730034) started by @NtFelix*