### PR TITLE
Feat/organisation management

### DIFF
--- a/app/(dashboard)/organisation/client-wrapper.tsx
+++ b/app/(dashboard)/organisation/client-wrapper.tsx
@@ -640,6 +640,176 @@ function OrganisationMembersTab({
 }
 // End of extracted sub-components
 
+function useOrganisationActions({
+  uiState,
+  dispatch,
+  setMembers,
+  setInvitations,
+  startInviteTransition,
+  startActionTransition,
+  toast: showToast
+}: {
+  uiState: UiState;
+  dispatch: React.Dispatch<UiAction>;
+  setMembers: React.Dispatch<React.SetStateAction<Member[]>>;
+  setInvitations: React.Dispatch<React.SetStateAction<Invitation[]>>;
+  startInviteTransition: (callback: () => void) => void;
+  startActionTransition: (callback: () => void) => void;
+  toast: typeof toast;
+}) {
+  const handleInvite = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!uiState.inviteEmail) return;
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(uiState.inviteEmail)) {
+      showToast({
+        title: "Ungültige E-Mail-Adresse",
+        description: "Bitte geben Sie eine gültige E-Mail-Adresse ein.",
+        variant: "destructive"
+      });
+      return;
+    }
+
+    startInviteTransition(async () => {
+      const res = await createEinladungAction(uiState.inviteEmail, uiState.inviteRole);
+      if (res.success) {
+        showToast({
+          title: "Einladung gesendet",
+          description: `Die Einladung für ${uiState.inviteEmail} wurde erfolgreich erstellt.`,
+          variant: "success"
+        });
+        dispatch({ type: 'CLEAR_INVITE_EMAIL' });
+        if (res.data) {
+          setInvitations(prev => [res.data, ...prev]);
+        }
+      } else {
+        showToast({
+          title: "Einladung fehlgeschlagen",
+          description: res.error?.message || "Ein Fehler ist aufgetreten.",
+          variant: "destructive"
+        });
+      }
+    });
+  };
+
+  const handleRevoke = (id: string, email: string) => {
+    dispatch({
+      type: 'SET_PENDING_CONFIRM',
+      payload: { type: 'revoke', invitationId: id, memberName: email }
+    });
+  };
+
+  const confirmRevoke = () => {
+    if (!uiState.pendingConfirm?.invitationId) return;
+    const { invitationId } = uiState.pendingConfirm;
+
+    startActionTransition(async () => {
+      const res = await revokeEinladungAction(invitationId);
+      if (res.success) {
+        showToast({ title: "Einladung widerrufen", description: "Die Einladung wurde erfolgreich widerrufen.", variant: "success" });
+        setInvitations(prev => prev.filter(i => i.id !== invitationId));
+      } else {
+        showToast({ title: "Fehler", description: res.error?.message || "Die Einladung konnte nicht widerrufen werden.", variant: "destructive" });
+      }
+      dispatch({ type: 'SET_PENDING_CONFIRM', payload: null });
+    });
+  };
+
+  const handleRoleChange = (memberId: string, name: string, newRole: string) => {
+    dispatch({
+      type: 'SET_PENDING_CONFIRM',
+      payload: { type: 'role', memberId, value: newRole, memberName: name }
+    });
+  };
+
+  const confirmRoleChange = () => {
+    if (!uiState.pendingConfirm?.memberId || !uiState.pendingConfirm?.value) return;
+    const { memberId, value: newRole, memberName } = uiState.pendingConfirm;
+
+    startActionTransition(async () => {
+      const res = await setMitgliedRolleAction(memberId, newRole);
+      if (res.success) {
+        showToast({
+          title: "Rolle aktualisiert",
+          description: `Die Rolle von ${memberName} wurde auf ${
+            newRole === 'owner' ? 'Inhaber' : newRole === 'admin' ? 'Administrator' : 'Mitarbeiter'
+          } geändert.`,
+          variant: "success"
+        });
+        setMembers(prev => prev.map(m => m.mitglied_id === memberId ? { ...m, rolle: newRole as Member['rolle'] } : m));
+      } else {
+        showToast({ title: "Fehler beim Ändern der Rolle", description: res.error?.message || "Die Rolle konnte nicht geändert werden.", variant: "destructive" });
+      }
+      dispatch({ type: 'SET_PENDING_CONFIRM', payload: null });
+    });
+  };
+
+  const handleStatusChange = (memberId: string, name: string, newStatus: string) => {
+    dispatch({
+      type: 'SET_PENDING_CONFIRM',
+      payload: { type: 'status', memberId, value: newStatus, memberName: name }
+    });
+  };
+
+  const confirmStatusChange = () => {
+    if (!uiState.pendingConfirm?.memberId || !uiState.pendingConfirm?.value) return;
+    const { memberId, value: newStatus, memberName } = uiState.pendingConfirm;
+
+    startActionTransition(async () => {
+      const res = await setMitgliedStatusAction(memberId, newStatus);
+      if (res.success) {
+        showToast({
+          title: "Status aktualisiert",
+          description: `Der Status von ${memberName} wurde auf ${
+            newStatus === 'aktiv' ? 'Aktiv' : 'Deaktiviert'
+          } geändert.`,
+          variant: "success"
+        });
+        setMembers(prev => prev.map(m => m.mitglied_id === memberId ? { ...m, status: newStatus as Member['status'] } : m));
+      } else {
+        showToast({ title: "Fehler beim Ändern des Status", description: res.error?.message || "Der Status konnte nicht geändert werden.", variant: "destructive" });
+      }
+      dispatch({ type: 'SET_PENDING_CONFIRM', payload: null });
+    });
+  };
+
+  const handleRemove = (memberId: string, name: string) => {
+    dispatch({
+      type: 'SET_PENDING_CONFIRM',
+      payload: { type: 'delete', memberId, memberName: name }
+    });
+  };
+
+  const confirmRemove = () => {
+    if (!uiState.pendingConfirm?.memberId) return;
+    const { memberId, memberName } = uiState.pendingConfirm;
+
+    startActionTransition(async () => {
+      const res = await removeMitgliedAction(memberId);
+      if (res.success) {
+        showToast({ title: "Mitarbeiter entfernt", description: `${memberName} wurde aus der Organisation entfernt.`, variant: "success" });
+        setMembers(prev => prev.filter(m => m.mitglied_id !== memberId));
+      } else {
+        showToast({ title: "Fehler beim Entfernen", description: res.error?.message || "Der Mitarbeiter konnte nicht entfernt werden.", variant: "destructive" });
+      }
+      dispatch({ type: 'SET_PENDING_CONFIRM', payload: null });
+    });
+  };
+
+  return {
+    handleInvite,
+    handleRevoke,
+    handleRoleChange,
+    handleStatusChange,
+    handleRemove,
+    confirmRevoke,
+    confirmRoleChange,
+    confirmStatusChange,
+    confirmRemove
+  };
+}
+
 export default function OrganisationClientView({
   initialMembers,
   initialInvitations,
@@ -670,195 +840,25 @@ export default function OrganisationClientView({
 
   const hasVerwaltenPermission = canManage || isUserOwner;
 
-  // Invite action
-  const handleInvite = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!uiState.inviteEmail) return;
-
-    // Client-side email validation
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(uiState.inviteEmail)) {
-      toast({
-        title: "Ungültige E-Mail-Adresse",
-        description: "Bitte geben Sie eine gültige E-Mail-Adresse ein.",
-        variant: "destructive"
-      });
-      return;
-    }
-
-    startInviteTransition(async () => {
-      const res = await createEinladungAction(uiState.inviteEmail, uiState.inviteRole);
-      if (res.success) {
-        toast({
-          title: "Einladung gesendet",
-          description: `Die Einladung für ${uiState.inviteEmail} wurde erfolgreich erstellt.`,
-          variant: "success"
-        });
-        dispatch({ type: 'CLEAR_INVITE_EMAIL' });
-        // Optimistically add invitation or reload list
-        // Since Next.js action does revalidatePath, reloading the router or updating state:
-        if (res.data) {
-          setInvitations(prev => [res.data, ...prev]);
-        }
-      } else {
-        toast({
-          title: "Einladung fehlgeschlagen",
-          description: res.error?.message || "Ein Fehler ist aufgetreten.",
-          variant: "destructive"
-        });
-      }
-    });
-  };
-
-  // Revoke action
-  const handleRevoke = (id: string, email: string) => {
-    dispatch({
-      type: 'SET_PENDING_CONFIRM',
-      payload: {
-        type: 'revoke',
-        invitationId: id,
-        memberName: email
-      }
-    });
-  };
-
-  const confirmRevoke = () => {
-    if (!uiState.pendingConfirm?.invitationId) return;
-    const { invitationId } = uiState.pendingConfirm;
-
-    startActionTransition(async () => {
-      const res = await revokeEinladungAction(invitationId);
-      if (res.success) {
-        toast({
-          title: "Einladung widerrufen",
-          description: "Die Einladung wurde erfolgreich widerrufen.",
-          variant: "success"
-        });
-        setInvitations(prev => prev.filter(i => i.id !== invitationId));
-      } else {
-        toast({
-          title: "Fehler",
-          description: res.error?.message || "Die Einladung konnte nicht widerrufen werden.",
-          variant: "destructive"
-        });
-      }
-      dispatch({ type: 'SET_PENDING_CONFIRM', payload: null });
-    });
-  };
-
-  // Role change action
-  const handleRoleChange = (memberId: string, name: string, newRole: string) => {
-    dispatch({
-      type: 'SET_PENDING_CONFIRM',
-      payload: {
-        type: 'role',
-        memberId,
-        value: newRole,
-        memberName: name
-      }
-    });
-  };
-
-  const confirmRoleChange = () => {
-    if (!uiState.pendingConfirm?.memberId || !uiState.pendingConfirm?.value) return;
-    const { memberId, value: newRole, memberName } = uiState.pendingConfirm;
-
-    startActionTransition(async () => {
-      const res = await setMitgliedRolleAction(memberId, newRole);
-      if (res.success) {
-        toast({
-          title: "Rolle aktualisiert",
-          description: `Die Rolle von ${memberName} wurde auf ${
-            newRole === 'owner' ? 'Inhaber' : newRole === 'admin' ? 'Administrator' : 'Mitarbeiter'
-          } geändert.`,
-          variant: "success"
-        });
-        setMembers(prev => prev.map(m => m.mitglied_id === memberId ? { ...m, rolle: newRole as Member['rolle'] } : m));
-      } else {
-        toast({
-          title: "Fehler beim Ändern der Rolle",
-          description: res.error?.message || "Die Rolle konnte nicht geändert werden.",
-          variant: "destructive"
-        });
-      }
-      dispatch({ type: 'SET_PENDING_CONFIRM', payload: null });
-    });
-  };
-
-  // Status change action
-  const handleStatusChange = (memberId: string, name: string, newStatus: string) => {
-    dispatch({
-      type: 'SET_PENDING_CONFIRM',
-      payload: {
-        type: 'status',
-        memberId,
-        value: newStatus,
-        memberName: name
-      }
-    });
-  };
-
-  const confirmStatusChange = () => {
-    if (!uiState.pendingConfirm?.memberId || !uiState.pendingConfirm?.value) return;
-    const { memberId, value: newStatus, memberName } = uiState.pendingConfirm;
-
-    startActionTransition(async () => {
-      const res = await setMitgliedStatusAction(memberId, newStatus);
-      if (res.success) {
-        toast({
-          title: "Status aktualisiert",
-          description: `Der Status von ${memberName} wurde auf ${
-            newStatus === 'aktiv' ? 'Aktiv' : 'Deaktiviert'
-          } geändert.`,
-          variant: "success"
-        });
-        setMembers(prev => prev.map(m => m.mitglied_id === memberId ? { ...m, status: newStatus as Member['status'] } : m));
-      } else {
-        toast({
-          title: "Fehler beim Ändern des Status",
-          description: res.error?.message || "Der Status konnte nicht geändert werden.",
-          variant: "destructive"
-        });
-      }
-      dispatch({ type: 'SET_PENDING_CONFIRM', payload: null });
-    });
-  };
-
-  // Delete/Remove action
-  const handleRemove = (memberId: string, name: string) => {
-    dispatch({
-      type: 'SET_PENDING_CONFIRM',
-      payload: {
-        type: 'delete',
-        memberId,
-        memberName: name
-      }
-    });
-  };
-
-  const confirmRemove = () => {
-    if (!uiState.pendingConfirm?.memberId) return;
-    const { memberId, memberName } = uiState.pendingConfirm;
-
-    startActionTransition(async () => {
-      const res = await removeMitgliedAction(memberId);
-      if (res.success) {
-        toast({
-          title: "Mitarbeiter entfernt",
-          description: `${memberName} wurde aus der Organisation entfernt.`,
-          variant: "success"
-        });
-        setMembers(prev => prev.filter(m => m.mitglied_id !== memberId));
-      } else {
-        toast({
-          title: "Fehler beim Entfernen",
-          description: res.error?.message || "Der Mitarbeiter konnte nicht entfernt werden.",
-          variant: "destructive"
-        });
-      }
-      dispatch({ type: 'SET_PENDING_CONFIRM', payload: null });
-    });
-  };
+  const {
+    handleInvite,
+    handleRevoke,
+    handleRoleChange,
+    handleStatusChange,
+    handleRemove,
+    confirmRevoke,
+    confirmRoleChange,
+    confirmStatusChange,
+    confirmRemove
+  } = useOrganisationActions({
+    uiState,
+    dispatch,
+    setMembers,
+    setInvitations,
+    startInviteTransition,
+    startActionTransition,
+    toast
+  });
 
   // Compute stats for overview tab
   const stats = useMemo(() => {

--- a/app/(dashboard)/organisation/client-wrapper.tsx
+++ b/app/(dashboard)/organisation/client-wrapper.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition, useMemo, useCallback } from "react";
+import { useState, useEffect, useReducer, useTransition, useMemo, useCallback } from "react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -10,7 +10,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogAction, AlertDialogCancel } from "@/components/ui/alert-dialog";
 import { StatCard } from "@/components/common/stat-card";
 import { toast } from "@/hooks/use-toast";
-import { motion } from "framer-motion";
+import { LazyMotion, m, domAnimation } from "framer-motion";
 import { cn } from "@/lib/utils";
 import {
   Users,
@@ -84,6 +84,68 @@ interface OrganisationClientViewProps {
   rpcError?: string | null;
 }
 
+type UiState = {
+  currentTab: "overview" | "members";
+  searchQuery: string;
+  roleFilter: string;
+  statusFilter: string;
+  inviteEmail: string;
+  inviteRole: "admin" | "mitarbeiter";
+  pendingConfirm: {
+    type: 'role' | 'status' | 'delete' | 'revoke';
+    memberId?: string;
+    invitationId?: string;
+    value?: string;
+    memberName?: string;
+  } | null;
+};
+
+type UiAction =
+  | { type: 'SET_TAB'; payload: "overview" | "members" }
+  | { type: 'SET_SEARCH_QUERY'; payload: string }
+  | { type: 'SET_ROLE_FILTER'; payload: string }
+  | { type: 'SET_STATUS_FILTER'; payload: string }
+  | { type: 'SET_INVITE_EMAIL'; payload: string }
+  | { type: 'SET_INVITE_ROLE'; payload: "admin" | "mitarbeiter" }
+  | { type: 'SET_PENDING_CONFIRM'; payload: UiState['pendingConfirm'] }
+  | { type: 'CLEAR_INVITE_EMAIL' }
+  | { type: 'RESET_FILTERS' };
+
+const initialUiState: UiState = {
+  currentTab: "overview",
+  searchQuery: "",
+  roleFilter: "all",
+  statusFilter: "all",
+  inviteEmail: "",
+  inviteRole: "mitarbeiter",
+  pendingConfirm: null,
+};
+
+function uiReducer(state: UiState, action: UiAction): UiState {
+  switch (action.type) {
+    case 'SET_TAB':
+      return { ...state, currentTab: action.payload };
+    case 'SET_SEARCH_QUERY':
+      return { ...state, searchQuery: action.payload };
+    case 'SET_ROLE_FILTER':
+      return { ...state, roleFilter: action.payload };
+    case 'SET_STATUS_FILTER':
+      return { ...state, statusFilter: action.payload };
+    case 'SET_INVITE_EMAIL':
+      return { ...state, inviteEmail: action.payload };
+    case 'SET_INVITE_ROLE':
+      return { ...state, inviteRole: action.payload };
+    case 'SET_PENDING_CONFIRM':
+      return { ...state, pendingConfirm: action.payload };
+    case 'CLEAR_INVITE_EMAIL':
+      return { ...state, inviteEmail: "" };
+    case 'RESET_FILTERS':
+      return { ...state, searchQuery: "", roleFilter: "all", statusFilter: "all" };
+    default:
+      return state;
+  }
+}
+
 export default function OrganisationClientView({
   org,
   initialMembers,
@@ -92,29 +154,24 @@ export default function OrganisationClientView({
   canManage = false,
   rpcError = null
 }: OrganisationClientViewProps) {
-  const [currentTab, setCurrentTab] = useState<"overview" | "members">("overview");
+  const [uiState, dispatch] = useReducer(uiReducer, initialUiState);
   const [members, setMembers] = useState<Member[]>(initialMembers);
   const [invitations, setInvitations] = useState<Invitation[]>(initialInvitations);
+  const [expiredInvitationIds, setExpiredInvitationIds] = useState<Set<string>>(new Set());
 
-  // Search & Filter
-  const [searchQuery, setSearchQuery] = useState("");
-  const [roleFilter, setRoleFilter] = useState<string>("all");
-  const [statusFilter, setStatusFilter] = useState<string>("all");
+  useEffect(() => {
+    const now = new Date();
+    const expired = new Set<string>();
+    invitations.forEach(invite => {
+      if (new Date(invite.expires_at) < now) {
+        expired.add(invite.id);
+      }
+    });
+    setExpiredInvitationIds(expired);
+  }, [invitations]);
 
-  // Invite Form
-  const [inviteEmail, setInviteEmail] = useState("");
-  const [inviteRole, setInviteRole] = useState<"admin" | "mitarbeiter">("mitarbeiter");
   const [isInviting, startInviteTransition] = useTransition();
-
-  // Pending action states
   const [isPending, startActionTransition] = useTransition();
-  const [pendingConfirm, setPendingConfirm] = useState<{
-    type: 'role' | 'status' | 'delete' | 'revoke';
-    memberId?: string;
-    invitationId?: string;
-    value?: string;
-    memberName?: string;
-  } | null>(null);
 
   const isUserOwner = useMemo(() => {
     return members.some(m => m.user_id === currentUser?.id && m.rolle === 'owner');
@@ -125,11 +182,11 @@ export default function OrganisationClientView({
   // Invite action
   const handleInvite = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!inviteEmail) return;
+    if (!uiState.inviteEmail) return;
 
     // Client-side email validation
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(inviteEmail)) {
+    if (!emailRegex.test(uiState.inviteEmail)) {
       toast({
         title: "Ungültige E-Mail-Adresse",
         description: "Bitte geben Sie eine gültige E-Mail-Adresse ein.",
@@ -139,14 +196,14 @@ export default function OrganisationClientView({
     }
 
     startInviteTransition(async () => {
-      const res = await createEinladungAction(inviteEmail, inviteRole);
+      const res = await createEinladungAction(uiState.inviteEmail, uiState.inviteRole);
       if (res.success) {
         toast({
           title: "Einladung gesendet",
-          description: `Die Einladung für ${inviteEmail} wurde erfolgreich erstellt.`,
+          description: `Die Einladung für ${uiState.inviteEmail} wurde erfolgreich erstellt.`,
           variant: "success"
         });
-        setInviteEmail("");
+        dispatch({ type: 'CLEAR_INVITE_EMAIL' });
         // Optimistically add invitation or reload list
         // Since Next.js action does revalidatePath, reloading the router or updating state:
         if (res.data) {
@@ -164,16 +221,19 @@ export default function OrganisationClientView({
 
   // Revoke action
   const handleRevoke = (id: string, email: string) => {
-    setPendingConfirm({
-      type: 'revoke',
-      invitationId: id,
-      memberName: email
+    dispatch({
+      type: 'SET_PENDING_CONFIRM',
+      payload: {
+        type: 'revoke',
+        invitationId: id,
+        memberName: email
+      }
     });
   };
 
   const confirmRevoke = () => {
-    if (!pendingConfirm?.invitationId) return;
-    const { invitationId } = pendingConfirm;
+    if (!uiState.pendingConfirm?.invitationId) return;
+    const { invitationId } = uiState.pendingConfirm;
 
     startActionTransition(async () => {
       const res = await revokeEinladungAction(invitationId);
@@ -191,30 +251,33 @@ export default function OrganisationClientView({
           variant: "destructive"
         });
       }
-      setPendingConfirm(null);
+      dispatch({ type: 'SET_PENDING_CONFIRM', payload: null });
     });
   };
 
   // Role change action
   const handleRoleChange = (memberId: string, name: string, newRole: string) => {
-    setPendingConfirm({
-      type: 'role',
-      memberId,
-      value: newRole,
-      memberName: name
+    dispatch({
+      type: 'SET_PENDING_CONFIRM',
+      payload: {
+        type: 'role',
+        memberId,
+        value: newRole,
+        memberName: name
+      }
     });
   };
 
   const confirmRoleChange = () => {
-    if (!pendingConfirm?.memberId || !pendingConfirm?.value) return;
-    const { memberId, value: newRole } = pendingConfirm;
+    if (!uiState.pendingConfirm?.memberId || !uiState.pendingConfirm?.value) return;
+    const { memberId, value: newRole, memberName } = uiState.pendingConfirm;
 
     startActionTransition(async () => {
       const res = await setMitgliedRolleAction(memberId, newRole);
       if (res.success) {
         toast({
           title: "Rolle aktualisiert",
-          description: `Die Rolle von ${pendingConfirm.memberName} wurde auf ${
+          description: `Die Rolle von ${memberName} wurde auf ${
             newRole === 'owner' ? 'Inhaber' : newRole === 'admin' ? 'Administrator' : 'Mitarbeiter'
           } geändert.`,
           variant: "success"
@@ -227,30 +290,33 @@ export default function OrganisationClientView({
           variant: "destructive"
         });
       }
-      setPendingConfirm(null);
+      dispatch({ type: 'SET_PENDING_CONFIRM', payload: null });
     });
   };
 
   // Status change action
   const handleStatusChange = (memberId: string, name: string, newStatus: string) => {
-    setPendingConfirm({
-      type: 'status',
-      memberId,
-      value: newStatus,
-      memberName: name
+    dispatch({
+      type: 'SET_PENDING_CONFIRM',
+      payload: {
+        type: 'status',
+        memberId,
+        value: newStatus,
+        memberName: name
+      }
     });
   };
 
   const confirmStatusChange = () => {
-    if (!pendingConfirm?.memberId || !pendingConfirm?.value) return;
-    const { memberId, value: newStatus } = pendingConfirm;
+    if (!uiState.pendingConfirm?.memberId || !uiState.pendingConfirm?.value) return;
+    const { memberId, value: newStatus, memberName } = uiState.pendingConfirm;
 
     startActionTransition(async () => {
       const res = await setMitgliedStatusAction(memberId, newStatus);
       if (res.success) {
         toast({
           title: "Status aktualisiert",
-          description: `Der Status von ${pendingConfirm.memberName} wurde auf ${
+          description: `Der Status von ${memberName} wurde auf ${
             newStatus === 'aktiv' ? 'Aktiv' : 'Deaktiviert'
           } geändert.`,
           variant: "success"
@@ -263,29 +329,32 @@ export default function OrganisationClientView({
           variant: "destructive"
         });
       }
-      setPendingConfirm(null);
+      dispatch({ type: 'SET_PENDING_CONFIRM', payload: null });
     });
   };
 
   // Delete/Remove action
   const handleRemove = (memberId: string, name: string) => {
-    setPendingConfirm({
-      type: 'delete',
-      memberId,
-      memberName: name
+    dispatch({
+      type: 'SET_PENDING_CONFIRM',
+      payload: {
+        type: 'delete',
+        memberId,
+        memberName: name
+      }
     });
   };
 
   const confirmRemove = () => {
-    if (!pendingConfirm?.memberId) return;
-    const { memberId } = pendingConfirm;
+    if (!uiState.pendingConfirm?.memberId) return;
+    const { memberId, memberName } = uiState.pendingConfirm;
 
     startActionTransition(async () => {
       const res = await removeMitgliedAction(memberId);
       if (res.success) {
         toast({
           title: "Mitarbeiter entfernt",
-          description: `${pendingConfirm.memberName} wurde aus der Organisation entfernt.`,
+          description: `${memberName} wurde aus der Organisation entfernt.`,
           variant: "success"
         });
         setMembers(prev => prev.filter(m => m.mitglied_id !== memberId));
@@ -296,7 +365,7 @@ export default function OrganisationClientView({
           variant: "destructive"
         });
       }
-      setPendingConfirm(null);
+      dispatch({ type: 'SET_PENDING_CONFIRM', payload: null });
     });
   };
 
@@ -315,18 +384,19 @@ export default function OrganisationClientView({
     return members.filter(m => {
       const name = `${m.first_name || ""} ${m.last_name || ""}`.toLowerCase();
       const email = m.email.toLowerCase();
-      const query = searchQuery.toLowerCase();
+      const query = uiState.searchQuery.toLowerCase();
 
       const matchesSearch = name.includes(query) || email.includes(query);
-      const matchesRole = roleFilter === "all" || m.rolle === roleFilter;
-      const matchesStatus = statusFilter === "all" || m.status === statusFilter;
+      const matchesRole = uiState.roleFilter === "all" || m.rolle === uiState.roleFilter;
+      const matchesStatus = uiState.statusFilter === "all" || m.status === uiState.statusFilter;
 
       return matchesSearch && matchesRole && matchesStatus;
     });
-  }, [members, searchQuery, roleFilter, statusFilter]);
+  }, [members, uiState.searchQuery, uiState.roleFilter, uiState.statusFilter]);
 
   return (
-    <div className="flex flex-col gap-6 sm:gap-8 p-4 sm:p-8">
+    <LazyMotion features={domAnimation}>
+      <div className="flex flex-col gap-6 sm:gap-8 p-4 sm:p-8">
       {/* Page Header */}
       <div className="flex flex-col gap-2">
         <h1 className="text-3xl font-bold tracking-tight">Organisation</h1>
@@ -348,17 +418,17 @@ export default function OrganisationClientView({
 
       {/* 2-way sliding toggle */}
       <div className="flex items-center gap-1 bg-zinc-100/80 dark:bg-zinc-900/80 border border-zinc-200/30 dark:border-zinc-800/30 p-1 rounded-full relative w-full sm:w-fit max-w-[400px] select-none z-0">
-        <motion.button
+        <m.button
           layout
           type="button"
-          onClick={() => setCurrentTab("overview")}
+          onClick={() => dispatch({ type: 'SET_TAB', payload: "overview" })}
           className={cn(
             "flex-1 sm:flex-initial flex items-center justify-center gap-2 rounded-full h-9 px-6 relative outline-none cursor-pointer text-sm font-medium transition-colors duration-300",
-            currentTab === "overview" ? "text-gray-900 dark:text-gray-100 font-semibold" : "text-muted-foreground hover:text-foreground"
+            uiState.currentTab === "overview" ? "text-gray-900 dark:text-gray-100 font-semibold" : "text-muted-foreground hover:text-foreground"
           )}
         >
-          {currentTab === "overview" && (
-            <motion.div
+          {uiState.currentTab === "overview" && (
+            <m.div
               layoutId="active-org-tab-pill"
               className="absolute inset-0 bg-white dark:bg-zinc-800 shadow-sm border border-zinc-200/10 dark:border-zinc-700/30 rounded-full -z-10"
               transition={{ type: "spring", stiffness: 380, damping: 30 }}
@@ -366,19 +436,19 @@ export default function OrganisationClientView({
           )}
           <Network className="size-4 shrink-0" />
           <span>Übersicht</span>
-        </motion.button>
+        </m.button>
 
-        <motion.button
+        <m.button
           layout
           type="button"
-          onClick={() => setCurrentTab("members")}
+          onClick={() => dispatch({ type: 'SET_TAB', payload: "members" })}
           className={cn(
             "flex-1 sm:flex-initial flex items-center justify-center gap-2 rounded-full h-9 px-6 relative outline-none cursor-pointer text-sm font-medium transition-colors duration-300",
-            currentTab === "members" ? "text-gray-900 dark:text-gray-100 font-semibold" : "text-muted-foreground hover:text-foreground"
+            uiState.currentTab === "members" ? "text-gray-900 dark:text-gray-100 font-semibold" : "text-muted-foreground hover:text-foreground"
           )}
         >
-          {currentTab === "members" && (
-            <motion.div
+          {uiState.currentTab === "members" && (
+            <m.div
               layoutId="active-org-tab-pill"
               className="absolute inset-0 bg-white dark:bg-zinc-800 shadow-sm border border-zinc-200/10 dark:border-zinc-700/30 rounded-full -z-10"
               transition={{ type: "spring", stiffness: 380, damping: 30 }}
@@ -386,11 +456,11 @@ export default function OrganisationClientView({
           )}
           <Users className="size-4 shrink-0" />
           <span>Mitarbeiter</span>
-        </motion.button>
+        </m.button>
       </div>
 
       {/* Tab: Übersicht */}
-      {currentTab === "overview" && (
+      {uiState.currentTab === "overview" && (
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
           <StatCard
             title="Aktive Mitarbeiter"
@@ -420,21 +490,21 @@ export default function OrganisationClientView({
       )}
 
       {/* Tab: Mitarbeiter */}
-      {currentTab === "members" && (
+      {uiState.currentTab === "members" && (
         <div className="flex flex-col gap-8">
           {/* Header Controls & Filter */}
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center justify-between">
             <div className="flex flex-1 items-center gap-4 max-w-md">
               <SearchInput
                 placeholder="Mitarbeiter suchen..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
+                value={uiState.searchQuery}
+                onChange={(e) => dispatch({ type: 'SET_SEARCH_QUERY', payload: e.target.value })}
                 className="w-full"
               />
             </div>
 
             <div className="flex items-center gap-3">
-              <Select value={roleFilter} onValueChange={setRoleFilter}>
+              <Select value={uiState.roleFilter} onValueChange={(val) => dispatch({ type: 'SET_ROLE_FILTER', payload: val })}>
                 <SelectTrigger className="w-[160px] rounded-xl">
                   <SelectValue placeholder="Rolle filtern" />
                 </SelectTrigger>
@@ -446,7 +516,7 @@ export default function OrganisationClientView({
                 </SelectContent>
               </Select>
 
-              <Select value={statusFilter} onValueChange={setStatusFilter}>
+              <Select value={uiState.statusFilter} onValueChange={(val) => dispatch({ type: 'SET_STATUS_FILTER', payload: val })}>
                 <SelectTrigger className="w-[160px] rounded-xl">
                   <SelectValue placeholder="Status filtern" />
                 </SelectTrigger>
@@ -625,7 +695,7 @@ export default function OrganisationClientView({
                           </TableRow>
                         ) : (
                           invitations.map((invite) => {
-                            const isExpired = new Date(invite.expires_at) < new Date();
+                            const isExpired = expiredInvitationIds.has(invite.id);
                             return (
                               <TableRow key={invite.id} className="hover:bg-zinc-50/30 dark:hover:bg-zinc-900/30">
                                 <TableCell className="py-4 pl-6 font-medium text-sm flex items-center gap-3">
@@ -699,8 +769,8 @@ export default function OrganisationClientView({
                           id="email-input"
                           type="email"
                           placeholder="z.B. mitarbeiter@firma.de"
-                          value={inviteEmail}
-                          onChange={(e) => setInviteEmail(e.target.value)}
+                          value={uiState.inviteEmail}
+                          onChange={(e) => dispatch({ type: 'SET_INVITE_EMAIL', payload: e.target.value })}
                           className="rounded-xl border-zinc-200/80 dark:border-zinc-800/80 h-10"
                           required
                           disabled={isInviting}
@@ -712,8 +782,8 @@ export default function OrganisationClientView({
                           Rolle
                         </label>
                         <Select
-                          value={inviteRole}
-                          onValueChange={(val: any) => setInviteRole(val)}
+                          value={uiState.inviteRole}
+                          onValueChange={(val: any) => dispatch({ type: 'SET_INVITE_ROLE', payload: val })}
                           disabled={isInviting}
                         >
                           <SelectTrigger id="role-select" className="rounded-xl h-10">
@@ -726,11 +796,11 @@ export default function OrganisationClientView({
                         </Select>
                       </div>
 
-                      <Button
-                        type="submit"
-                        className="w-full mt-2 h-10 rounded-xl bg-primary hover:bg-primary/95 text-white flex items-center justify-center gap-2 font-medium"
-                        disabled={isInviting || !inviteEmail}
-                      >
+                       <Button
+                         type="submit"
+                         className="w-full mt-2 h-10 rounded-xl bg-primary hover:bg-primary/95 text-white flex items-center justify-center gap-2 font-medium"
+                         disabled={isInviting || !uiState.inviteEmail}
+                       >
                         {isInviting ? (
                           <>
                             <Clock className="size-4 animate-spin" />
@@ -753,30 +823,30 @@ export default function OrganisationClientView({
       )}
 
       {/* Confirmation Dialogs */}
-      <AlertDialog open={pendingConfirm !== null} onOpenChange={(open) => !open && setPendingConfirm(null)}>
+      <AlertDialog open={uiState.pendingConfirm !== null} onOpenChange={(open) => !open && dispatch({ type: 'SET_PENDING_CONFIRM', payload: null })}>
         <AlertDialogContent className="rounded-[2rem] max-w-md border border-zinc-200/50 dark:border-zinc-800/50">
           <AlertDialogHeader className="flex flex-col gap-3">
             <div className="mx-auto bg-amber-500/10 text-amber-500 p-4 rounded-full w-fit">
               <AlertTriangle className="size-8" />
             </div>
             <AlertDialogTitle className="text-xl font-bold text-center">
-              {pendingConfirm?.type === 'revoke' && "Einladung widerrufen"}
-              {pendingConfirm?.type === 'role' && "Rolle ändern"}
-              {pendingConfirm?.type === 'status' && "Status ändern"}
-              {pendingConfirm?.type === 'delete' && "Mitglied entfernen"}
+              {uiState.pendingConfirm?.type === 'revoke' && "Einladung widerrufen"}
+              {uiState.pendingConfirm?.type === 'role' && "Rolle ändern"}
+              {uiState.pendingConfirm?.type === 'status' && "Status ändern"}
+              {uiState.pendingConfirm?.type === 'delete' && "Mitglied entfernen"}
             </AlertDialogTitle>
             <AlertDialogDescription className="text-center text-sm text-muted-foreground leading-relaxed">
-              {pendingConfirm?.type === 'revoke' && (
-                <>Möchten Sie die Einladung für <strong className="text-foreground">{pendingConfirm.memberName}</strong> wirklich widerrufen? Die Person wird die Einladung nicht mehr annehmen können.</>
+              {uiState.pendingConfirm?.type === 'revoke' && (
+                <>Möchten Sie die Einladung für <strong className="text-foreground">{uiState.pendingConfirm.memberName}</strong> wirklich widerrufen? Die Person wird die Einladung nicht mehr annehmen können.</>
               )}
-              {pendingConfirm?.type === 'role' && (
-                <>Möchten Sie die Rolle von <strong className="text-foreground">{pendingConfirm.memberName}</strong> wirklich auf <strong className="text-foreground">{pendingConfirm.value === 'owner' ? 'Inhaber' : pendingConfirm.value === 'admin' ? 'Administrator' : 'Mitarbeiter'}</strong> ändern?</>
+              {uiState.pendingConfirm?.type === 'role' && (
+                <>Möchten Sie die Rolle von <strong className="text-foreground">{uiState.pendingConfirm.memberName}</strong> wirklich auf <strong className="text-foreground">{uiState.pendingConfirm.value === 'owner' ? 'Inhaber' : uiState.pendingConfirm.value === 'admin' ? 'Administrator' : 'Mitarbeiter'}</strong> ändern?</>
               )}
-              {pendingConfirm?.type === 'status' && (
-                <>Möchten Sie den Status von <strong className="text-foreground">{pendingConfirm.memberName}</strong> wirklich auf <strong className="text-foreground">{pendingConfirm.value === 'aktiv' ? 'Aktiv' : 'Deaktiviert'}</strong> ändern?</>
+              {uiState.pendingConfirm?.type === 'status' && (
+                <>Möchten Sie den Status von <strong className="text-foreground">{uiState.pendingConfirm.memberName}</strong> wirklich auf <strong className="text-foreground">{uiState.pendingConfirm.value === 'aktiv' ? 'Aktiv' : 'Deaktiviert'}</strong> ändern?</>
               )}
-              {pendingConfirm?.type === 'delete' && (
-                <>Möchten Sie <strong className="text-foreground">{pendingConfirm.memberName}</strong> wirklich aus der Organisation entfernen? Der Zugriff auf alle Daten dieser Organisation geht sofort verloren.</>
+              {uiState.pendingConfirm?.type === 'delete' && (
+                <>Möchten Sie <strong className="text-foreground">{uiState.pendingConfirm.memberName}</strong> wirklich aus der Organisation entfernen? Der Zugriff auf alle Daten dieser Organisation geht sofort verloren.</>
               )}
             </AlertDialogDescription>
           </AlertDialogHeader>
@@ -788,10 +858,10 @@ export default function OrganisationClientView({
               className="rounded-xl flex-1 bg-amber-500 hover:bg-amber-600 text-white font-medium"
               onClick={(e) => {
                 e.preventDefault();
-                if (pendingConfirm?.type === 'revoke') confirmRevoke();
-                if (pendingConfirm?.type === 'role') confirmRoleChange();
-                if (pendingConfirm?.type === 'status') confirmStatusChange();
-                if (pendingConfirm?.type === 'delete') confirmRemove();
+                if (uiState.pendingConfirm?.type === 'revoke') confirmRevoke();
+                if (uiState.pendingConfirm?.type === 'role') confirmRoleChange();
+                if (uiState.pendingConfirm?.type === 'status') confirmStatusChange();
+                if (uiState.pendingConfirm?.type === 'delete') confirmRemove();
               }}
               disabled={isPending}
             >
@@ -801,5 +871,6 @@ export default function OrganisationClientView({
         </AlertDialogContent>
       </AlertDialog>
     </div>
+    </LazyMotion>
   );
 }

--- a/app/(dashboard)/organisation/client-wrapper.tsx
+++ b/app/(dashboard)/organisation/client-wrapper.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useReducer, useTransition, useMemo, useCallback } from "react";
+import { useState, useReducer, useTransition, useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -16,21 +16,13 @@ import {
   Users,
   Shield,
   Mail,
-  UserMinus,
-  UserCheck,
-  UserX,
   X,
   PlusCircle,
   Network,
-  Calendar,
   Lock,
-  ArrowRight,
-  UserCog,
-  Pencil,
   Trash2,
   AlertTriangle,
-  Clock,
-  RotateCcw
+  Clock
 } from "lucide-react";
 import { SearchInput } from "@/components/ui/search-input";
 import {
@@ -146,8 +138,151 @@ function uiReducer(state: UiState, action: UiAction): UiState {
   }
 }
 
+// Extracted sub-components for maintainability
+function OrganisationTabToggle({
+  currentTab,
+  onTabChange
+}: {
+  currentTab: "overview" | "members";
+  onTabChange: (tab: "overview" | "members") => void;
+}) {
+  return (
+    <div className="flex items-center gap-1 bg-zinc-100/80 dark:bg-zinc-900/80 border border-zinc-200/30 dark:border-zinc-800/30 p-1 rounded-full relative w-full sm:w-fit max-w-[400px] select-none z-0">
+      <m.button
+        layout
+        type="button"
+        onClick={() => onTabChange("overview")}
+        className={cn(
+          "flex-1 sm:flex-initial flex items-center justify-center gap-2 rounded-full h-9 px-6 relative outline-none cursor-pointer text-sm font-medium transition-colors duration-300",
+          currentTab === "overview" ? "text-gray-900 dark:text-gray-100 font-semibold" : "text-muted-foreground hover:text-foreground"
+        )}
+      >
+        {currentTab === "overview" && (
+          <m.div
+            layoutId="active-org-tab-pill"
+            className="absolute inset-0 bg-white dark:bg-zinc-800 shadow-sm border border-zinc-200/10 dark:border-zinc-700/30 rounded-full -z-10"
+            transition={{ type: "spring", stiffness: 380, damping: 30 }}
+          />
+        )}
+        <Network className="size-4 shrink-0" />
+        <span>&Uuml;bersicht</span>
+      </m.button>
+
+      <m.button
+        layout
+        type="button"
+        onClick={() => onTabChange("members")}
+        className={cn(
+          "flex-1 sm:flex-initial flex items-center justify-center gap-2 rounded-full h-9 px-6 relative outline-none cursor-pointer text-sm font-medium transition-colors duration-300",
+          currentTab === "members" ? "text-gray-900 dark:text-gray-100 font-semibold" : "text-muted-foreground hover:text-foreground"
+        )}
+      >
+        {currentTab === "members" && (
+          <m.div
+            layoutId="active-org-tab-pill"
+            className="absolute inset-0 bg-white dark:bg-zinc-800 shadow-sm border border-zinc-200/10 dark:border-zinc-700/30 rounded-full -z-10"
+            transition={{ type: "spring", stiffness: 380, damping: 30 }}
+          />
+        )}
+        <Users className="size-4 shrink-0" />
+        <span>Mitarbeiter</span>
+      </m.button>
+    </div>
+  );
+}
+
+function OrganisationOverviewTab({ stats }: { stats: { active: number; admins: number; pendingInvites: number; ownerName: string } }) {
+  return (
+    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+      <StatCard
+        title="Aktive Mitarbeiter"
+        value={stats.active}
+        icon={<Users className="size-4 text-emerald-500" />}
+        description="Mitarbeiter mit aktivem Zugriff"
+      />
+      <StatCard
+        title="Administratoren / Inhaber"
+        value={stats.admins}
+        icon={<Shield className="size-4 text-purple-500" />}
+        description="Mitarbeiter mit Verwaltungsrechten"
+      />
+      <StatCard
+        title="Offene Einladungen"
+        value={stats.pendingInvites}
+        icon={<Mail className="size-4 text-amber-500" />}
+        description="Ausstehende Einladungen"
+      />
+      <StatCard
+        title="Organisationseigent&uuml;mer"
+        value={stats.ownerName.split('@')[0]}
+        icon={<Lock className="size-4 text-indigo-500" />}
+        description={stats.ownerName}
+      />
+    </div>
+  );
+}
+
+function OrganisationConfirmDialog({
+  pendingConfirm,
+  isPending,
+  onConfirm,
+  onClose
+}: {
+  pendingConfirm: UiState['pendingConfirm'];
+  isPending: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <AlertDialog open={pendingConfirm !== null} onOpenChange={(open) => !open && onClose()}>
+      <AlertDialogContent className="rounded-[2rem] max-w-md border border-zinc-200/50 dark:border-zinc-800/50">
+        <AlertDialogHeader className="flex flex-col gap-3">
+          <div className="mx-auto bg-amber-500/10 text-amber-500 p-4 rounded-full w-fit">
+            <AlertTriangle className="size-8" />
+          </div>
+          <AlertDialogTitle className="text-xl font-bold text-center">
+            {pendingConfirm?.type === 'revoke' && "Einladung widerrufen"}
+            {pendingConfirm?.type === 'role' && "Rolle &auml;ndern"}
+            {pendingConfirm?.type === 'status' && "Status &auml;ndern"}
+            {pendingConfirm?.type === 'delete' && "Mitglied entfernen"}
+          </AlertDialogTitle>
+          <AlertDialogDescription className="text-center text-sm text-muted-foreground leading-relaxed">
+            {pendingConfirm?.type === 'revoke' && (
+              <>M&ouml;chten Sie die Einladung f&uuml;r <strong className="text-foreground">{pendingConfirm.memberName}</strong> wirklich widerrufen? Die Person wird die Einladung nicht mehr annehmen k&ouml;nnen.</>
+            )}
+            {pendingConfirm?.type === 'role' && (
+              <>M&ouml;chten Sie die Rolle von <strong className="text-foreground">{pendingConfirm.memberName}</strong> wirklich auf <strong className="text-foreground">{pendingConfirm.value === 'owner' ? 'Inhaber' : pendingConfirm.value === 'admin' ? 'Administrator' : 'Mitarbeiter'}</strong> &auml;ndern?</>
+            )}
+            {pendingConfirm?.type === 'status' && (
+              <>M&ouml;chten Sie den Status von <strong className="text-foreground">{pendingConfirm.memberName}</strong> wirklich auf <strong className="text-foreground">{pendingConfirm.value === 'aktiv' ? 'Aktiv' : 'Deaktiviert'}</strong> &auml;ndern?</>
+            )}
+            {pendingConfirm?.type === 'delete' && (
+              <>M&ouml;chten Sie <strong className="text-foreground">{pendingConfirm.memberName}</strong> wirklich aus der Organisation entfernen? Der Zugriff auf alle Daten dieser Organisation geht sofort verloren.</>
+            )}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="flex flex-col-reverse sm:flex-row gap-2 mt-4">
+          <AlertDialogCancel className="rounded-xl flex-1 border border-zinc-200 dark:border-zinc-800" disabled={isPending}>
+            Abbrechen
+          </AlertDialogCancel>
+          <AlertDialogAction
+            className="rounded-xl flex-1 bg-amber-500 hover:bg-amber-600 text-white font-medium"
+            onClick={(e) => {
+              e.preventDefault();
+              onConfirm();
+            }}
+            disabled={isPending}
+          >
+            {isPending ? "Bitte warten..." : "Best&auml;tigen"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+// End of extracted sub-components
+
 export default function OrganisationClientView({
-  org,
   initialMembers,
   initialInvitations,
   currentUser,
@@ -157,9 +292,7 @@ export default function OrganisationClientView({
   const [uiState, dispatch] = useReducer(uiReducer, initialUiState);
   const [members, setMembers] = useState<Member[]>(initialMembers);
   const [invitations, setInvitations] = useState<Invitation[]>(initialInvitations);
-  const [expiredInvitationIds, setExpiredInvitationIds] = useState<Set<string>>(new Set());
-
-  useEffect(() => {
+  const expiredInvitationIds = useMemo(() => {
     const now = new Date();
     const expired = new Set<string>();
     invitations.forEach(invite => {
@@ -167,7 +300,7 @@ export default function OrganisationClientView({
         expired.add(invite.id);
       }
     });
-    setExpiredInvitationIds(expired);
+    return expired;
   }, [invitations]);
 
   const [isInviting, startInviteTransition] = useTransition();
@@ -282,7 +415,7 @@ export default function OrganisationClientView({
           } geändert.`,
           variant: "success"
         });
-        setMembers(prev => prev.map(m => m.mitglied_id === memberId ? { ...m, rolle: newRole as any } : m));
+        setMembers(prev => prev.map(m => m.mitglied_id === memberId ? { ...m, rolle: newRole as Member['rolle'] } : m));
       } else {
         toast({
           title: "Fehler beim Ändern der Rolle",
@@ -321,7 +454,7 @@ export default function OrganisationClientView({
           } geändert.`,
           variant: "success"
         });
-        setMembers(prev => prev.map(m => m.mitglied_id === memberId ? { ...m, status: newStatus as any } : m));
+        setMembers(prev => prev.map(m => m.mitglied_id === memberId ? { ...m, status: newStatus as Member['status'] } : m));
       } else {
         toast({
           title: "Fehler beim Ändern des Status",
@@ -416,78 +549,12 @@ export default function OrganisationClientView({
         </div>
       )}
 
-      {/* 2-way sliding toggle */}
-      <div className="flex items-center gap-1 bg-zinc-100/80 dark:bg-zinc-900/80 border border-zinc-200/30 dark:border-zinc-800/30 p-1 rounded-full relative w-full sm:w-fit max-w-[400px] select-none z-0">
-        <m.button
-          layout
-          type="button"
-          onClick={() => dispatch({ type: 'SET_TAB', payload: "overview" })}
-          className={cn(
-            "flex-1 sm:flex-initial flex items-center justify-center gap-2 rounded-full h-9 px-6 relative outline-none cursor-pointer text-sm font-medium transition-colors duration-300",
-            uiState.currentTab === "overview" ? "text-gray-900 dark:text-gray-100 font-semibold" : "text-muted-foreground hover:text-foreground"
-          )}
-        >
-          {uiState.currentTab === "overview" && (
-            <m.div
-              layoutId="active-org-tab-pill"
-              className="absolute inset-0 bg-white dark:bg-zinc-800 shadow-sm border border-zinc-200/10 dark:border-zinc-700/30 rounded-full -z-10"
-              transition={{ type: "spring", stiffness: 380, damping: 30 }}
-            />
-          )}
-          <Network className="size-4 shrink-0" />
-          <span>Übersicht</span>
-        </m.button>
+      <OrganisationTabToggle
+        currentTab={uiState.currentTab}
+        onTabChange={(tab) => dispatch({ type: 'SET_TAB', payload: tab })}
+      />
 
-        <m.button
-          layout
-          type="button"
-          onClick={() => dispatch({ type: 'SET_TAB', payload: "members" })}
-          className={cn(
-            "flex-1 sm:flex-initial flex items-center justify-center gap-2 rounded-full h-9 px-6 relative outline-none cursor-pointer text-sm font-medium transition-colors duration-300",
-            uiState.currentTab === "members" ? "text-gray-900 dark:text-gray-100 font-semibold" : "text-muted-foreground hover:text-foreground"
-          )}
-        >
-          {uiState.currentTab === "members" && (
-            <m.div
-              layoutId="active-org-tab-pill"
-              className="absolute inset-0 bg-white dark:bg-zinc-800 shadow-sm border border-zinc-200/10 dark:border-zinc-700/30 rounded-full -z-10"
-              transition={{ type: "spring", stiffness: 380, damping: 30 }}
-            />
-          )}
-          <Users className="size-4 shrink-0" />
-          <span>Mitarbeiter</span>
-        </m.button>
-      </div>
-
-      {/* Tab: Übersicht */}
-      {uiState.currentTab === "overview" && (
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-          <StatCard
-            title="Aktive Mitarbeiter"
-            value={stats.active}
-            icon={<Users className="size-4 text-emerald-500" />}
-            description="Mitarbeiter mit aktivem Zugriff"
-          />
-          <StatCard
-            title="Administratoren / Inhaber"
-            value={stats.admins}
-            icon={<Shield className="size-4 text-purple-500" />}
-            description="Mitarbeiter mit Verwaltungsrechten"
-          />
-          <StatCard
-            title="Offene Einladungen"
-            value={stats.pendingInvites}
-            icon={<Mail className="size-4 text-amber-500" />}
-            description="Ausstehende Einladungen"
-          />
-          <StatCard
-            title="Organisationseigentümer"
-            value={stats.ownerName.split('@')[0]}
-            icon={<Lock className="size-4 text-indigo-500" />}
-            description={stats.ownerName}
-          />
-        </div>
-      )}
+      {uiState.currentTab === "overview" && <OrganisationOverviewTab stats={stats} />}
 
       {/* Tab: Mitarbeiter */}
       {uiState.currentTab === "members" && (
@@ -783,7 +850,7 @@ export default function OrganisationClientView({
                         </label>
                         <Select
                           value={uiState.inviteRole}
-                          onValueChange={(val: any) => dispatch({ type: 'SET_INVITE_ROLE', payload: val })}
+                          onValueChange={(val: "admin" | "mitarbeiter") => dispatch({ type: 'SET_INVITE_ROLE', payload: val })}
                           disabled={isInviting}
                         >
                           <SelectTrigger id="role-select" className="rounded-xl h-10">
@@ -796,8 +863,8 @@ export default function OrganisationClientView({
                         </Select>
                       </div>
 
-                       <Button
-                         type="submit"
+                      <Button
+                        type="submit"
                          className="w-full mt-2 h-10 rounded-xl bg-primary hover:bg-primary/95 text-white flex items-center justify-center gap-2 font-medium"
                          disabled={isInviting || !uiState.inviteEmail}
                        >
@@ -822,54 +889,17 @@ export default function OrganisationClientView({
         </div>
       )}
 
-      {/* Confirmation Dialogs */}
-      <AlertDialog open={uiState.pendingConfirm !== null} onOpenChange={(open) => !open && dispatch({ type: 'SET_PENDING_CONFIRM', payload: null })}>
-        <AlertDialogContent className="rounded-[2rem] max-w-md border border-zinc-200/50 dark:border-zinc-800/50">
-          <AlertDialogHeader className="flex flex-col gap-3">
-            <div className="mx-auto bg-amber-500/10 text-amber-500 p-4 rounded-full w-fit">
-              <AlertTriangle className="size-8" />
-            </div>
-            <AlertDialogTitle className="text-xl font-bold text-center">
-              {uiState.pendingConfirm?.type === 'revoke' && "Einladung widerrufen"}
-              {uiState.pendingConfirm?.type === 'role' && "Rolle ändern"}
-              {uiState.pendingConfirm?.type === 'status' && "Status ändern"}
-              {uiState.pendingConfirm?.type === 'delete' && "Mitglied entfernen"}
-            </AlertDialogTitle>
-            <AlertDialogDescription className="text-center text-sm text-muted-foreground leading-relaxed">
-              {uiState.pendingConfirm?.type === 'revoke' && (
-                <>Möchten Sie die Einladung für <strong className="text-foreground">{uiState.pendingConfirm.memberName}</strong> wirklich widerrufen? Die Person wird die Einladung nicht mehr annehmen können.</>
-              )}
-              {uiState.pendingConfirm?.type === 'role' && (
-                <>Möchten Sie die Rolle von <strong className="text-foreground">{uiState.pendingConfirm.memberName}</strong> wirklich auf <strong className="text-foreground">{uiState.pendingConfirm.value === 'owner' ? 'Inhaber' : uiState.pendingConfirm.value === 'admin' ? 'Administrator' : 'Mitarbeiter'}</strong> ändern?</>
-              )}
-              {uiState.pendingConfirm?.type === 'status' && (
-                <>Möchten Sie den Status von <strong className="text-foreground">{uiState.pendingConfirm.memberName}</strong> wirklich auf <strong className="text-foreground">{uiState.pendingConfirm.value === 'aktiv' ? 'Aktiv' : 'Deaktiviert'}</strong> ändern?</>
-              )}
-              {uiState.pendingConfirm?.type === 'delete' && (
-                <>Möchten Sie <strong className="text-foreground">{uiState.pendingConfirm.memberName}</strong> wirklich aus der Organisation entfernen? Der Zugriff auf alle Daten dieser Organisation geht sofort verloren.</>
-              )}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter className="flex flex-col-reverse sm:flex-row gap-2 mt-4">
-            <AlertDialogCancel className="rounded-xl flex-1 border border-zinc-200 dark:border-zinc-800" disabled={isPending}>
-              Abbrechen
-            </AlertDialogCancel>
-            <AlertDialogAction
-              className="rounded-xl flex-1 bg-amber-500 hover:bg-amber-600 text-white font-medium"
-              onClick={(e) => {
-                e.preventDefault();
-                if (uiState.pendingConfirm?.type === 'revoke') confirmRevoke();
-                if (uiState.pendingConfirm?.type === 'role') confirmRoleChange();
-                if (uiState.pendingConfirm?.type === 'status') confirmStatusChange();
-                if (uiState.pendingConfirm?.type === 'delete') confirmRemove();
-              }}
-              disabled={isPending}
-            >
-              {isPending ? "Bitte warten..." : "Bestätigen"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <OrganisationConfirmDialog
+        pendingConfirm={uiState.pendingConfirm}
+        isPending={isPending}
+        onConfirm={() => {
+          if (uiState.pendingConfirm?.type === 'revoke') confirmRevoke();
+          if (uiState.pendingConfirm?.type === 'role') confirmRoleChange();
+          if (uiState.pendingConfirm?.type === 'status') confirmStatusChange();
+          if (uiState.pendingConfirm?.type === 'delete') confirmRemove();
+        }}
+        onClose={() => dispatch({ type: 'SET_PENDING_CONFIRM', payload: null })}
+      />
     </div>
     </LazyMotion>
   );

--- a/app/(dashboard)/organisation/client-wrapper.tsx
+++ b/app/(dashboard)/organisation/client-wrapper.tsx
@@ -280,6 +280,364 @@ function OrganisationConfirmDialog({
     </AlertDialog>
   );
 }
+function OrganisationMembersTable({
+  filteredMembers,
+  hasVerwaltenPermission,
+  isPending,
+  currentUserId,
+  onRoleChange,
+  onStatusChange,
+  onRemove
+}: {
+  filteredMembers: Member[];
+  hasVerwaltenPermission: boolean;
+  isPending: boolean;
+  currentUserId?: string;
+  onRoleChange: (memberId: string, name: string, newRole: string) => void;
+  onStatusChange: (memberId: string, name: string, newStatus: string) => void;
+  onRemove: (memberId: string, name: string) => void;
+}) {
+  return (
+    <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs overflow-hidden">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-xl">Aktive &amp; Deaktivierte Mitglieder</CardTitle>
+        <CardDescription>Mitglieder, die Zugriff auf diese Organisation haben.</CardDescription>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="overflow-x-auto">
+          <Table>
+            <TableHeader className="bg-zinc-50/50 dark:bg-zinc-900/50">
+              <TableRow>
+                <TableHead className="py-3 pl-6">Mitglied</TableHead>
+                <TableHead className="py-3">Rolle</TableHead>
+                <TableHead className="py-3">Status</TableHead>
+                <TableHead className="py-3">Hinzugef&uuml;gt am</TableHead>
+                {hasVerwaltenPermission && <TableHead className="py-3 pr-6 text-right">Aktionen</TableHead>}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredMembers.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={hasVerwaltenPermission ? 5 : 4} className="py-8 text-center text-muted-foreground">
+                    Keine Mitglieder gefunden.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                filteredMembers.map((member) => {
+                  const fullName = member.first_name || member.last_name
+                    ? `${member.first_name || ""} ${member.last_name || ""}`.trim()
+                    : "";
+                  const initials = member.first_name || member.last_name
+                    ? ((member.first_name?.charAt(0) ?? "") + (member.last_name?.charAt(0) ?? "")).toUpperCase()
+                    : member.email.charAt(0).toUpperCase();
+                  const isCurrentUser = member.user_id === currentUserId;
+                  const isOwnerRow = member.rolle === 'owner';
+
+                  return (
+                    <TableRow key={member.mitglied_id} className="hover:bg-zinc-50/30 dark:hover:bg-zinc-900/30">
+                      <TableCell className="py-4 pl-6 flex items-center gap-3">
+                        <Avatar className="h-9 w-9 border border-zinc-200/20">
+                          <AvatarFallback className="bg-primary/5 text-primary text-xs font-bold">{initials}</AvatarFallback>
+                        </Avatar>
+                        <div className="flex flex-col">
+                          <span className="font-semibold text-sm">
+                            {fullName || member.email.split('@')[0]}
+                            {isCurrentUser && <span className="text-[10px] ml-2 text-zinc-400 font-normal border border-zinc-200 dark:border-zinc-800 px-1.5 py-0.5 rounded-full">Du</span>}
+                          </span>
+                          <span className="text-xs text-muted-foreground">{member.email}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell className="py-4">
+                        {hasVerwaltenPermission && !isOwnerRow && !isCurrentUser ? (
+                          <Select defaultValue={member.rolle} onValueChange={(val) => onRoleChange(member.mitglied_id, fullName || member.email, val)} disabled={isPending}>
+                            <SelectTrigger className="w-[130px] h-8 rounded-lg text-xs"><SelectValue /></SelectTrigger>
+                            <SelectContent className="rounded-lg">
+                              <SelectItem value="admin">Admin</SelectItem>
+                              <SelectItem value="mitarbeiter">Mitarbeiter</SelectItem>
+                            </SelectContent>
+                          </Select>
+                        ) : (
+                          <Badge variant="outline" className={cn("capitalize rounded-full font-medium text-[11px]", isOwnerRow ? "bg-indigo-50/80 text-indigo-700 dark:bg-indigo-950/30 dark:text-indigo-400 border-indigo-200/50" : member.rolle === 'admin' ? "bg-purple-50/80 text-purple-700 dark:bg-purple-950/30 dark:text-purple-400 border-purple-200/50" : "bg-zinc-50/80 text-zinc-700 dark:bg-zinc-950/30 dark:text-zinc-400 border-zinc-200/50")}>
+                            {isOwnerRow ? "Inhaber" : member.rolle === 'admin' ? "Admin" : "Mitarbeiter"}
+                          </Badge>
+                        )}
+                      </TableCell>
+                      <TableCell className="py-4">
+                        {hasVerwaltenPermission && !isOwnerRow && !isCurrentUser ? (
+                          <Select defaultValue={member.status} onValueChange={(val) => onStatusChange(member.mitglied_id, fullName || member.email, val)} disabled={isPending}>
+                            <SelectTrigger className="w-[120px] h-8 rounded-lg text-xs"><SelectValue /></SelectTrigger>
+                            <SelectContent className="rounded-lg">
+                              <SelectItem value="aktiv">Aktiv</SelectItem>
+                              <SelectItem value="deaktiviert">Deaktiviert</SelectItem>
+                            </SelectContent>
+                          </Select>
+                        ) : (
+                          <Badge variant="outline" className={cn("rounded-full font-medium text-[11px]", member.status === 'aktiv' ? "bg-emerald-50/80 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400 border-emerald-200/50" : "bg-rose-50/80 text-rose-700 dark:bg-rose-950/30 dark:text-rose-400 border-rose-200/50")}>
+                            {member.status === 'aktiv' ? "Aktiv" : "Deaktiviert"}
+                          </Badge>
+                        )}
+                      </TableCell>
+                      <TableCell className="py-4 text-xs text-muted-foreground" suppressHydrationWarning>
+                        {new Date(member.erstellt_am).toLocaleDateString("de-DE")}
+                      </TableCell>
+                      {hasVerwaltenPermission && (
+                        <TableCell className="py-4 pr-6 text-right">
+                          {!isOwnerRow && !isCurrentUser ? (
+                            <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-red-500 rounded-lg" onClick={() => onRemove(member.mitglied_id, fullName || member.email)} disabled={isPending} title="Mitglied entfernen">
+                              <Trash2 className="size-4" />
+                            </Button>
+                          ) : null}
+                        </TableCell>
+                      )}
+                    </TableRow>
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function OrganisationInvitationsTable({
+  invitations,
+  expiredInvitationIds,
+  hasVerwaltenPermission,
+  isPending,
+  onRevoke
+}: {
+  invitations: Invitation[];
+  expiredInvitationIds: Set<string>;
+  hasVerwaltenPermission: boolean;
+  isPending: boolean;
+  onRevoke: (id: string, email: string) => void;
+}) {
+  return (
+    <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs overflow-hidden">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-xl">Ausstehende Einladungen</CardTitle>
+        <CardDescription>Eingeladene Personen, die ihre Einladung noch nicht angenommen haben.</CardDescription>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="overflow-x-auto">
+          <Table>
+            <TableHeader className="bg-zinc-50/50 dark:bg-zinc-900/50">
+              <TableRow>
+                <TableHead className="py-3 pl-6">E-Mail-Adresse</TableHead>
+                <TableHead className="py-3">Eingeladen als</TableHead>
+                <TableHead className="py-3">Eingeladen am</TableHead>
+                <TableHead className="py-3">Ablaufdatum</TableHead>
+                {hasVerwaltenPermission && <TableHead className="py-3 pr-6 text-right">Aktionen</TableHead>}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {invitations.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={hasVerwaltenPermission ? 5 : 4} className="py-8 text-center text-muted-foreground">
+                    Keine ausstehenden Einladungen vorhanden.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                invitations.map((invite) => {
+                  const isExpired = expiredInvitationIds.has(invite.id);
+                  return (
+                    <TableRow key={invite.id} className="hover:bg-zinc-50/30 dark:hover:bg-zinc-900/30">
+                      <TableCell className="py-4 pl-6 font-medium text-sm flex items-center gap-3">
+                        <Avatar className="h-9 w-9 border border-zinc-200/20">
+                          <AvatarFallback className="bg-zinc-100 text-zinc-500 text-xs font-bold"><Mail className="size-4" /></AvatarFallback>
+                        </Avatar>
+                        <div className="flex flex-col">
+                          <span className="font-semibold text-sm">{invite.email}</span>
+                          {isExpired && <span className="text-[10px] text-rose-500 font-medium">Abgelaufen</span>}
+                        </div>
+                      </TableCell>
+                      <TableCell className="py-4">
+                        <Badge variant="outline" className={cn("capitalize rounded-full font-medium text-[11px]", invite.rolle === 'admin' ? "bg-purple-50 text-purple-700 dark:bg-purple-950/30 dark:text-purple-400 border-purple-200/50" : "bg-zinc-50 text-zinc-700 dark:bg-zinc-950/30 dark:text-zinc-400 border-zinc-200/50")}>
+                          {invite.rolle === 'admin' ? "Admin" : "Mitarbeiter"}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="py-4 text-xs text-muted-foreground" suppressHydrationWarning>{new Date(invite.erstellt_am).toLocaleDateString("de-DE")}</TableCell>
+                      <TableCell className="py-4 text-xs text-muted-foreground" suppressHydrationWarning>{new Date(invite.expires_at).toLocaleDateString("de-DE")}</TableCell>
+                      {hasVerwaltenPermission && (
+                        <TableCell className="py-4 pr-6 text-right">
+                          <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-red-500 rounded-lg" onClick={() => onRevoke(invite.id, invite.email)} disabled={isPending} title="Einladung widerrufen">
+                            <X className="size-4" />
+                          </Button>
+                        </TableCell>
+                      )}
+                    </TableRow>
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function OrganisationInvitePanel({
+  inviteEmail,
+  inviteRole,
+  isInviting,
+  onInviteEmailChange,
+  onInviteRoleChange,
+  onInvite
+}: {
+  inviteEmail: string;
+  inviteRole: "admin" | "mitarbeiter";
+  isInviting: boolean;
+  onInviteEmailChange: (val: string) => void;
+  onInviteRoleChange: (val: "admin" | "mitarbeiter") => void;
+  onInvite: (e: React.FormEvent) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-6">
+      <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs">
+        <CardHeader>
+          <CardTitle className="text-xl">Mitarbeiter einladen</CardTitle>
+          <CardDescription>Senden Sie eine Einladung per E-Mail, um neue Teammitglieder hinzuzuf&uuml;gen.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={onInvite} className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <label className="text-xs font-semibold uppercase text-muted-foreground" htmlFor="email-input">E-Mail-Adresse</label>
+              <Input id="email-input" type="email" placeholder="z.B. mitarbeiter@firma.de" value={inviteEmail} onChange={(e) => onInviteEmailChange(e.target.value)} className="rounded-xl border-zinc-200/80 dark:border-zinc-800/80 h-10" required disabled={isInviting} />
+            </div>
+            <div className="flex flex-col gap-2">
+              <label className="text-xs font-semibold uppercase text-muted-foreground" htmlFor="role-select">Rolle</label>
+              <Select value={inviteRole} onValueChange={(val) => onInviteRoleChange(val as "admin" | "mitarbeiter")} disabled={isInviting}>
+                <SelectTrigger id="role-select" className="rounded-xl h-10"><SelectValue /></SelectTrigger>
+                <SelectContent className="rounded-xl">
+                  <SelectItem value="mitarbeiter">Mitarbeiter</SelectItem>
+                  <SelectItem value="admin">Administrator</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <Button type="submit" className="w-full mt-2 h-10 rounded-xl bg-primary hover:bg-primary/95 text-white flex items-center justify-center gap-2 font-medium" disabled={isInviting || !inviteEmail}>
+              {isInviting ? (
+                <><Clock className="size-4 animate-spin" /><span>Wird eingeladen...</span></>
+              ) : (
+                <><PlusCircle className="size-4" /><span>Einladen</span></>
+              )}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function OrganisationMembersTab({
+  searchQuery,
+  roleFilter,
+  statusFilter,
+  inviteEmail,
+  inviteRole,
+  filteredMembers,
+  invitations,
+  expiredInvitationIds,
+  hasVerwaltenPermission,
+  isPending,
+  isInviting,
+  currentUserId,
+  onSearchChange,
+  onRoleFilterChange,
+  onStatusFilterChange,
+  onInviteEmailChange,
+  onInviteRoleChange,
+  onInvite,
+  onRevoke,
+  onRoleChange,
+  onStatusChange,
+  onRemove
+}: {
+  searchQuery: string;
+  roleFilter: string;
+  statusFilter: string;
+  inviteEmail: string;
+  inviteRole: "admin" | "mitarbeiter";
+  filteredMembers: Member[];
+  invitations: Invitation[];
+  expiredInvitationIds: Set<string>;
+  hasVerwaltenPermission: boolean;
+  isPending: boolean;
+  isInviting: boolean;
+  currentUserId?: string;
+  onSearchChange: (val: string) => void;
+  onRoleFilterChange: (val: string) => void;
+  onStatusFilterChange: (val: string) => void;
+  onInviteEmailChange: (val: string) => void;
+  onInviteRoleChange: (val: "admin" | "mitarbeiter") => void;
+  onInvite: (e: React.FormEvent) => void;
+  onRevoke: (id: string, email: string) => void;
+  onRoleChange: (memberId: string, name: string, newRole: string) => void;
+  onStatusChange: (memberId: string, name: string, newStatus: string) => void;
+  onRemove: (memberId: string, name: string) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center justify-between">
+        <div className="flex flex-1 items-center gap-4 max-w-md">
+          <SearchInput placeholder="Mitarbeiter suchen..." value={searchQuery} onChange={(e) => onSearchChange(e.target.value)} className="w-full" />
+        </div>
+        <div className="flex items-center gap-3">
+          <Select value={roleFilter} onValueChange={(val) => onRoleFilterChange(val)}>
+            <SelectTrigger className="w-[160px] rounded-xl"><SelectValue placeholder="Rolle filtern" /></SelectTrigger>
+            <SelectContent className="rounded-xl">
+              <SelectItem value="all">Alle Rollen</SelectItem>
+              <SelectItem value="owner">Inhaber</SelectItem>
+              <SelectItem value="admin">Administrator</SelectItem>
+              <SelectItem value="mitarbeiter">Mitarbeiter</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={statusFilter} onValueChange={(val) => onStatusFilterChange(val)}>
+            <SelectTrigger className="w-[160px] rounded-xl"><SelectValue placeholder="Status filtern" /></SelectTrigger>
+            <SelectContent className="rounded-xl">
+              <SelectItem value="all">Alle Status</SelectItem>
+              <SelectItem value="aktiv">Aktiv</SelectItem>
+              <SelectItem value="deaktiviert">Deaktiviert</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="grid gap-8 lg:grid-cols-3 items-start">
+        <div className="lg:col-span-2 flex flex-col gap-6">
+          <OrganisationMembersTable
+            filteredMembers={filteredMembers}
+            hasVerwaltenPermission={hasVerwaltenPermission}
+            isPending={isPending}
+            currentUserId={currentUserId}
+            onRoleChange={onRoleChange}
+            onStatusChange={onStatusChange}
+            onRemove={onRemove}
+          />
+          <OrganisationInvitationsTable
+            invitations={invitations}
+            expiredInvitationIds={expiredInvitationIds}
+            hasVerwaltenPermission={hasVerwaltenPermission}
+            isPending={isPending}
+            onRevoke={onRevoke}
+          />
+        </div>
+        {hasVerwaltenPermission && (
+          <OrganisationInvitePanel
+            inviteEmail={inviteEmail}
+            inviteRole={inviteRole}
+            isInviting={isInviting}
+            onInviteEmailChange={onInviteEmailChange}
+            onInviteRoleChange={onInviteRoleChange}
+            onInvite={onInvite}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
 // End of extracted sub-components
 
 export default function OrganisationClientView({
@@ -556,337 +914,31 @@ export default function OrganisationClientView({
 
       {uiState.currentTab === "overview" && <OrganisationOverviewTab stats={stats} />}
 
-      {/* Tab: Mitarbeiter */}
       {uiState.currentTab === "members" && (
-        <div className="flex flex-col gap-8">
-          {/* Header Controls & Filter */}
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center justify-between">
-            <div className="flex flex-1 items-center gap-4 max-w-md">
-              <SearchInput
-                placeholder="Mitarbeiter suchen..."
-                value={uiState.searchQuery}
-                onChange={(e) => dispatch({ type: 'SET_SEARCH_QUERY', payload: e.target.value })}
-                className="w-full"
-              />
-            </div>
-
-            <div className="flex items-center gap-3">
-              <Select value={uiState.roleFilter} onValueChange={(val) => dispatch({ type: 'SET_ROLE_FILTER', payload: val })}>
-                <SelectTrigger className="w-[160px] rounded-xl">
-                  <SelectValue placeholder="Rolle filtern" />
-                </SelectTrigger>
-                <SelectContent className="rounded-xl">
-                  <SelectItem value="all">Alle Rollen</SelectItem>
-                  <SelectItem value="owner">Inhaber</SelectItem>
-                  <SelectItem value="admin">Administrator</SelectItem>
-                  <SelectItem value="mitarbeiter">Mitarbeiter</SelectItem>
-                </SelectContent>
-              </Select>
-
-              <Select value={uiState.statusFilter} onValueChange={(val) => dispatch({ type: 'SET_STATUS_FILTER', payload: val })}>
-                <SelectTrigger className="w-[160px] rounded-xl">
-                  <SelectValue placeholder="Status filtern" />
-                </SelectTrigger>
-                <SelectContent className="rounded-xl">
-                  <SelectItem value="all">Alle Status</SelectItem>
-                  <SelectItem value="aktiv">Aktiv</SelectItem>
-                  <SelectItem value="deaktiviert">Deaktiviert</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-
-          <div className="grid gap-8 lg:grid-cols-3 items-start">
-            {/* Table of Members */}
-            <div className="lg:col-span-2 flex flex-col gap-6">
-              <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs overflow-hidden">
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-xl">Aktive & Deaktivierte Mitglieder</CardTitle>
-                  <CardDescription>
-                    Mitglieder, die Zugriff auf diese Organisation haben.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="p-0">
-                  <div className="overflow-x-auto">
-                    <Table>
-                      <TableHeader className="bg-zinc-50/50 dark:bg-zinc-900/50">
-                        <TableRow>
-                          <TableHead className="py-3 pl-6">Mitglied</TableHead>
-                          <TableHead className="py-3">Rolle</TableHead>
-                          <TableHead className="py-3">Status</TableHead>
-                          <TableHead className="py-3">Hinzugefügt am</TableHead>
-                          {hasVerwaltenPermission && <TableHead className="py-3 pr-6 text-right">Aktionen</TableHead>}
-                        </TableRow>
-                      </TableHeader>
-                      <TableBody>
-                        {filteredMembers.length === 0 ? (
-                          <TableRow>
-                            <TableCell colSpan={hasVerwaltenPermission ? 5 : 4} className="py-8 text-center text-muted-foreground">
-                              Keine Mitglieder gefunden.
-                            </TableCell>
-                          </TableRow>
-                        ) : (
-                          filteredMembers.map((member) => {
-                            const fullName = member.first_name || member.last_name
-                              ? `${member.first_name || ""} ${member.last_name || ""}`.trim()
-                              : "";
-                            const initials = member.first_name || member.last_name
-                              ? ((member.first_name?.charAt(0) ?? "") + (member.last_name?.charAt(0) ?? "")).toUpperCase()
-                              : member.email.charAt(0).toUpperCase();
-
-                            const isCurrentUser = member.user_id === currentUser?.id;
-                            const isOwnerRow = member.rolle === 'owner';
-
-                            return (
-                              <TableRow key={member.mitglied_id} className="hover:bg-zinc-50/30 dark:hover:bg-zinc-900/30">
-                                <TableCell className="py-4 pl-6 flex items-center gap-3">
-                                  <Avatar className="h-9 w-9 border border-zinc-200/20">
-                                    <AvatarFallback className="bg-primary/5 text-primary text-xs font-bold">
-                                      {initials}
-                                    </AvatarFallback>
-                                  </Avatar>
-                                  <div className="flex flex-col">
-                                    <span className="font-semibold text-sm">
-                                      {fullName || member.email.split('@')[0]}
-                                      {isCurrentUser && <span className="text-[10px] ml-2 text-zinc-400 font-normal border border-zinc-200 dark:border-zinc-800 px-1.5 py-0.5 rounded-full">Du</span>}
-                                    </span>
-                                    <span className="text-xs text-muted-foreground">{member.email}</span>
-                                  </div>
-                                </TableCell>
-                                <TableCell className="py-4">
-                                  {hasVerwaltenPermission && !isOwnerRow && !isCurrentUser ? (
-                                    <Select
-                                      defaultValue={member.rolle}
-                                      onValueChange={(val) => handleRoleChange(member.mitglied_id, fullName || member.email, val)}
-                                      disabled={isPending}
-                                    >
-                                      <SelectTrigger className="w-[130px] h-8 rounded-lg text-xs">
-                                        <SelectValue />
-                                      </SelectTrigger>
-                                      <SelectContent className="rounded-lg">
-                                        <SelectItem value="admin">Admin</SelectItem>
-                                        <SelectItem value="mitarbeiter">Mitarbeiter</SelectItem>
-                                      </SelectContent>
-                                    </Select>
-                                  ) : (
-                                    <Badge variant="outline" className={cn(
-                                      "capitalize rounded-full font-medium text-[11px]",
-                                      isOwnerRow ? "bg-indigo-50/80 text-indigo-700 dark:bg-indigo-950/30 dark:text-indigo-400 border-indigo-200/50" :
-                                      member.rolle === 'admin' ? "bg-purple-50/80 text-purple-700 dark:bg-purple-950/30 dark:text-purple-400 border-purple-200/50" :
-                                      "bg-zinc-50/80 text-zinc-700 dark:bg-zinc-950/30 dark:text-zinc-400 border-zinc-200/50"
-                                    )}>
-                                      {isOwnerRow ? "Inhaber" : member.rolle === 'admin' ? "Admin" : "Mitarbeiter"}
-                                    </Badge>
-                                  )}
-                                </TableCell>
-                                <TableCell className="py-4">
-                                  {hasVerwaltenPermission && !isOwnerRow && !isCurrentUser ? (
-                                    <Select
-                                      defaultValue={member.status}
-                                      onValueChange={(val) => handleStatusChange(member.mitglied_id, fullName || member.email, val)}
-                                      disabled={isPending}
-                                    >
-                                      <SelectTrigger className="w-[120px] h-8 rounded-lg text-xs">
-                                        <SelectValue />
-                                      </SelectTrigger>
-                                      <SelectContent className="rounded-lg">
-                                        <SelectItem value="aktiv">Aktiv</SelectItem>
-                                        <SelectItem value="deaktiviert">Deaktiviert</SelectItem>
-                                      </SelectContent>
-                                    </Select>
-                                  ) : (
-                                    <Badge variant="outline" className={cn(
-                                      "rounded-full font-medium text-[11px]",
-                                      member.status === 'aktiv' ? "bg-emerald-50/80 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400 border-emerald-200/50" :
-                                      "bg-rose-50/80 text-rose-700 dark:bg-rose-950/30 dark:text-rose-400 border-rose-200/50"
-                                    )}>
-                                      {member.status === 'aktiv' ? "Aktiv" : "Deaktiviert"}
-                                    </Badge>
-                                  )}
-                                </TableCell>
-                                <TableCell className="py-4 text-xs text-muted-foreground" suppressHydrationWarning>
-                                  {new Date(member.erstellt_am).toLocaleDateString("de-DE")}
-                                </TableCell>
-                                {hasVerwaltenPermission && (
-                                  <TableCell className="py-4 pr-6 text-right">
-                                    {!isOwnerRow && !isCurrentUser ? (
-                                      <Button
-                                        variant="ghost"
-                                        size="icon"
-                                        className="h-8 w-8 text-muted-foreground hover:text-red-500 rounded-lg"
-                                        onClick={() => handleRemove(member.mitglied_id, fullName || member.email)}
-                                        disabled={isPending}
-                                        title="Mitglied entfernen"
-                                      >
-                                        <Trash2 className="size-4" />
-                                      </Button>
-                                    ) : null}
-                                  </TableCell>
-                                )}
-                              </TableRow>
-                            );
-                          })
-                        )}
-                      </TableBody>
-                    </Table>
-                  </div>
-                </CardContent>
-              </Card>
-
-              {/* Open Invitations Table */}
-              <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs overflow-hidden">
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-xl">Ausstehende Einladungen</CardTitle>
-                  <CardDescription>
-                    Eingeladene Personen, die ihre Einladung noch nicht angenommen haben.
-                  </CardDescription>
-                </CardHeader>
-                <CardContent className="p-0">
-                  <div className="overflow-x-auto">
-                    <Table>
-                      <TableHeader className="bg-zinc-50/50 dark:bg-zinc-900/50">
-                        <TableRow>
-                          <TableHead className="py-3 pl-6">E-Mail-Adresse</TableHead>
-                          <TableHead className="py-3">Eingeladen als</TableHead>
-                          <TableHead className="py-3">Eingeladen am</TableHead>
-                          <TableHead className="py-3">Ablaufdatum</TableHead>
-                          {hasVerwaltenPermission && <TableHead className="py-3 pr-6 text-right">Aktionen</TableHead>}
-                        </TableRow>
-                      </TableHeader>
-                      <TableBody>
-                        {invitations.length === 0 ? (
-                          <TableRow>
-                            <TableCell colSpan={hasVerwaltenPermission ? 5 : 4} className="py-8 text-center text-muted-foreground">
-                              Keine ausstehenden Einladungen vorhanden.
-                            </TableCell>
-                          </TableRow>
-                        ) : (
-                          invitations.map((invite) => {
-                            const isExpired = expiredInvitationIds.has(invite.id);
-                            return (
-                              <TableRow key={invite.id} className="hover:bg-zinc-50/30 dark:hover:bg-zinc-900/30">
-                                <TableCell className="py-4 pl-6 font-medium text-sm flex items-center gap-3">
-                                  <Avatar className="h-9 w-9 border border-zinc-200/20">
-                                    <AvatarFallback className="bg-zinc-100 text-zinc-500 text-xs font-bold">
-                                      <Mail className="size-4" />
-                                    </AvatarFallback>
-                                  </Avatar>
-                                  <div className="flex flex-col">
-                                    <span className="font-semibold text-sm">{invite.email}</span>
-                                    {isExpired && <span className="text-[10px] text-rose-500 font-medium">Abgelaufen</span>}
-                                  </div>
-                                </TableCell>
-                                <TableCell className="py-4">
-                                  <Badge variant="outline" className={cn(
-                                    "capitalize rounded-full font-medium text-[11px]",
-                                    invite.rolle === 'admin' ? "bg-purple-50 text-purple-700 dark:bg-purple-950/30 dark:text-purple-400 border-purple-200/50" :
-                                    "bg-zinc-50 text-zinc-700 dark:bg-zinc-950/30 dark:text-zinc-400 border-zinc-200/50"
-                                  )}>
-                                    {invite.rolle === 'admin' ? "Admin" : "Mitarbeiter"}
-                                  </Badge>
-                                </TableCell>
-                                <TableCell className="py-4 text-xs text-muted-foreground" suppressHydrationWarning>
-                                  {new Date(invite.erstellt_am).toLocaleDateString("de-DE")}
-                                </TableCell>
-                                <TableCell className="py-4 text-xs text-muted-foreground" suppressHydrationWarning>
-                                  {new Date(invite.expires_at).toLocaleDateString("de-DE")}
-                                </TableCell>
-                                {hasVerwaltenPermission && (
-                                  <TableCell className="py-4 pr-6 text-right">
-                                    <Button
-                                      variant="ghost"
-                                      size="icon"
-                                      className="h-8 w-8 text-muted-foreground hover:text-red-500 rounded-lg"
-                                      onClick={() => handleRevoke(invite.id, invite.email)}
-                                      disabled={isPending}
-                                      title="Einladung widerrufen"
-                                    >
-                                      <X className="size-4" />
-                                    </Button>
-                                  </TableCell>
-                                )}
-                              </TableRow>
-                            );
-                          })
-                        )}
-                      </TableBody>
-                    </Table>
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
-
-            {/* Invite Form Side Section */}
-            {hasVerwaltenPermission && (
-              <div className="flex flex-col gap-6">
-                <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs">
-                  <CardHeader>
-                    <CardTitle className="text-xl">Mitarbeiter einladen</CardTitle>
-                    <CardDescription>
-                      Senden Sie eine Einladung per E-Mail, um neue Teammitglieder hinzuzufügen.
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <form onSubmit={handleInvite} className="flex flex-col gap-4">
-                      <div className="flex flex-col gap-2">
-                        <label className="text-xs font-semibold uppercase text-muted-foreground" htmlFor="email-input">
-                          E-Mail-Adresse
-                        </label>
-                        <Input
-                          id="email-input"
-                          type="email"
-                          placeholder="z.B. mitarbeiter@firma.de"
-                          value={uiState.inviteEmail}
-                          onChange={(e) => dispatch({ type: 'SET_INVITE_EMAIL', payload: e.target.value })}
-                          className="rounded-xl border-zinc-200/80 dark:border-zinc-800/80 h-10"
-                          required
-                          disabled={isInviting}
-                        />
-                      </div>
-
-                      <div className="flex flex-col gap-2">
-                        <label className="text-xs font-semibold uppercase text-muted-foreground" htmlFor="role-select">
-                          Rolle
-                        </label>
-                        <Select
-                          value={uiState.inviteRole}
-                          onValueChange={(val: "admin" | "mitarbeiter") => dispatch({ type: 'SET_INVITE_ROLE', payload: val })}
-                          disabled={isInviting}
-                        >
-                          <SelectTrigger id="role-select" className="rounded-xl h-10">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent className="rounded-xl">
-                            <SelectItem value="mitarbeiter">Mitarbeiter</SelectItem>
-                            <SelectItem value="admin">Administrator</SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </div>
-
-                      <Button
-                        type="submit"
-                         className="w-full mt-2 h-10 rounded-xl bg-primary hover:bg-primary/95 text-white flex items-center justify-center gap-2 font-medium"
-                         disabled={isInviting || !uiState.inviteEmail}
-                       >
-                        {isInviting ? (
-                          <>
-                            <Clock className="size-4 animate-spin" />
-                            <span>Wird eingeladen...</span>
-                          </>
-                        ) : (
-                          <>
-                            <PlusCircle className="size-4" />
-                            <span>Einladen</span>
-                          </>
-                        )}
-                      </Button>
-                    </form>
-                  </CardContent>
-                </Card>
-              </div>
-            )}
-          </div>
-        </div>
+        <OrganisationMembersTab
+          searchQuery={uiState.searchQuery}
+          roleFilter={uiState.roleFilter}
+          statusFilter={uiState.statusFilter}
+          inviteEmail={uiState.inviteEmail}
+          inviteRole={uiState.inviteRole}
+          filteredMembers={filteredMembers}
+          invitations={invitations}
+          expiredInvitationIds={expiredInvitationIds}
+          hasVerwaltenPermission={hasVerwaltenPermission}
+          isPending={isPending}
+          isInviting={isInviting}
+          currentUserId={currentUser?.id}
+          onSearchChange={(val) => dispatch({ type: 'SET_SEARCH_QUERY', payload: val })}
+          onRoleFilterChange={(val) => dispatch({ type: 'SET_ROLE_FILTER', payload: val })}
+          onStatusFilterChange={(val) => dispatch({ type: 'SET_STATUS_FILTER', payload: val })}
+          onInviteEmailChange={(val) => dispatch({ type: 'SET_INVITE_EMAIL', payload: val })}
+          onInviteRoleChange={(val) => dispatch({ type: 'SET_INVITE_ROLE', payload: val })}
+          onInvite={handleInvite}
+          onRevoke={handleRevoke}
+          onRoleChange={handleRoleChange}
+          onStatusChange={handleStatusChange}
+          onRemove={handleRemove}
+        />
       )}
 
       <OrganisationConfirmDialog

--- a/app/(dashboard)/organisation/client-wrapper.tsx
+++ b/app/(dashboard)/organisation/client-wrapper.tsx
@@ -1,0 +1,805 @@
+"use client";
+
+import { useState, useTransition, useMemo, useCallback } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { AlertDialog, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogAction, AlertDialogCancel } from "@/components/ui/alert-dialog";
+import { StatCard } from "@/components/common/stat-card";
+import { toast } from "@/hooks/use-toast";
+import { motion } from "framer-motion";
+import { cn } from "@/lib/utils";
+import {
+  Users,
+  Shield,
+  Mail,
+  UserMinus,
+  UserCheck,
+  UserX,
+  X,
+  PlusCircle,
+  Network,
+  Calendar,
+  Lock,
+  ArrowRight,
+  UserCog,
+  Pencil,
+  Trash2,
+  AlertTriangle,
+  Clock,
+  RotateCcw
+} from "lucide-react";
+import { SearchInput } from "@/components/ui/search-input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  createEinladungAction,
+  revokeEinladungAction,
+  setMitgliedRolleAction,
+  setMitgliedStatusAction,
+  removeMitgliedAction
+} from "@/app/organisation-actions";
+
+interface Member {
+  mitglied_id: string;
+  user_id: string;
+  email: string;
+  first_name: string | null;
+  last_name: string | null;
+  rolle: 'owner' | 'admin' | 'mitarbeiter';
+  status: 'eingeladen' | 'aktiv' | 'deaktiviert';
+  erstellt_am: string;
+}
+
+interface Invitation {
+  id: string;
+  organisation_id: string;
+  token: string;
+  email: string;
+  expires_at: string;
+  status: 'offen' | 'angenommen' | 'widerrufen' | 'abgelaufen';
+  rolle: 'admin' | 'mitarbeiter';
+  erstellt_am: string;
+}
+
+interface OrganisationClientViewProps {
+  org: {
+    id: string;
+    owner_id: string;
+    ist_versteckt: boolean;
+    einstellungen: any;
+  };
+  initialMembers: Member[];
+  initialInvitations: Invitation[];
+  currentUser: any;
+  canManage?: boolean;
+  rpcError?: string | null;
+}
+
+export default function OrganisationClientView({
+  org,
+  initialMembers,
+  initialInvitations,
+  currentUser,
+  canManage = true,
+  rpcError = null
+}: OrganisationClientViewProps) {
+  const [currentTab, setCurrentTab] = useState<"overview" | "members">("overview");
+  const [members, setMembers] = useState<Member[]>(initialMembers);
+  const [invitations, setInvitations] = useState<Invitation[]>(initialInvitations);
+
+  // Search & Filter
+  const [searchQuery, setSearchQuery] = useState("");
+  const [roleFilter, setRoleFilter] = useState<string>("all");
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+
+  // Invite Form
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<"admin" | "mitarbeiter">("mitarbeiter");
+  const [isInviting, startInviteTransition] = useTransition();
+
+  // Pending action states
+  const [isPending, startActionTransition] = useTransition();
+  const [pendingConfirm, setPendingConfirm] = useState<{
+    type: 'role' | 'status' | 'delete' | 'revoke';
+    memberId?: string;
+    invitationId?: string;
+    value?: string;
+    memberName?: string;
+  } | null>(null);
+
+  const isUserOwner = useMemo(() => {
+    return members.some(m => m.user_id === currentUser?.id && m.rolle === 'owner');
+  }, [members, currentUser]);
+
+  const hasVerwaltenPermission = canManage || isUserOwner;
+
+  // Invite action
+  const handleInvite = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!inviteEmail) return;
+
+    // Client-side email validation
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(inviteEmail)) {
+      toast({
+        title: "Ungültige E-Mail-Adresse",
+        description: "Bitte geben Sie eine gültige E-Mail-Adresse ein.",
+        variant: "destructive"
+      });
+      return;
+    }
+
+    startInviteTransition(async () => {
+      const res = await createEinladungAction(inviteEmail, inviteRole);
+      if (res.success) {
+        toast({
+          title: "Einladung gesendet",
+          description: `Die Einladung für ${inviteEmail} wurde erfolgreich erstellt.`,
+          variant: "success"
+        });
+        setInviteEmail("");
+        // Optimistically add invitation or reload list
+        // Since Next.js action does revalidatePath, reloading the router or updating state:
+        if (res.data) {
+          setInvitations(prev => [res.data, ...prev]);
+        }
+      } else {
+        toast({
+          title: "Einladung fehlgeschlagen",
+          description: res.error?.message || "Ein Fehler ist aufgetreten.",
+          variant: "destructive"
+        });
+      }
+    });
+  };
+
+  // Revoke action
+  const handleRevoke = (id: string, email: string) => {
+    setPendingConfirm({
+      type: 'revoke',
+      invitationId: id,
+      memberName: email
+    });
+  };
+
+  const confirmRevoke = () => {
+    if (!pendingConfirm?.invitationId) return;
+    const { invitationId } = pendingConfirm;
+
+    startActionTransition(async () => {
+      const res = await revokeEinladungAction(invitationId);
+      if (res.success) {
+        toast({
+          title: "Einladung widerrufen",
+          description: "Die Einladung wurde erfolgreich widerrufen.",
+          variant: "success"
+        });
+        setInvitations(prev => prev.filter(i => i.id !== invitationId));
+      } else {
+        toast({
+          title: "Fehler",
+          description: res.error?.message || "Die Einladung konnte nicht widerrufen werden.",
+          variant: "destructive"
+        });
+      }
+      setPendingConfirm(null);
+    });
+  };
+
+  // Role change action
+  const handleRoleChange = (memberId: string, name: string, newRole: string) => {
+    setPendingConfirm({
+      type: 'role',
+      memberId,
+      value: newRole,
+      memberName: name
+    });
+  };
+
+  const confirmRoleChange = () => {
+    if (!pendingConfirm?.memberId || !pendingConfirm?.value) return;
+    const { memberId, value: newRole } = pendingConfirm;
+
+    startActionTransition(async () => {
+      const res = await setMitgliedRolleAction(memberId, newRole);
+      if (res.success) {
+        toast({
+          title: "Rolle aktualisiert",
+          description: `Die Rolle von ${pendingConfirm.memberName} wurde auf ${
+            newRole === 'owner' ? 'Inhaber' : newRole === 'admin' ? 'Administrator' : 'Mitarbeiter'
+          } geändert.`,
+          variant: "success"
+        });
+        setMembers(prev => prev.map(m => m.mitglied_id === memberId ? { ...m, rolle: newRole as any } : m));
+      } else {
+        toast({
+          title: "Fehler beim Ändern der Rolle",
+          description: res.error?.message || "Die Rolle konnte nicht geändert werden.",
+          variant: "destructive"
+        });
+      }
+      setPendingConfirm(null);
+    });
+  };
+
+  // Status change action
+  const handleStatusChange = (memberId: string, name: string, newStatus: string) => {
+    setPendingConfirm({
+      type: 'status',
+      memberId,
+      value: newStatus,
+      memberName: name
+    });
+  };
+
+  const confirmStatusChange = () => {
+    if (!pendingConfirm?.memberId || !pendingConfirm?.value) return;
+    const { memberId, value: newStatus } = pendingConfirm;
+
+    startActionTransition(async () => {
+      const res = await setMitgliedStatusAction(memberId, newStatus);
+      if (res.success) {
+        toast({
+          title: "Status aktualisiert",
+          description: `Der Status von ${pendingConfirm.memberName} wurde auf ${
+            newStatus === 'aktiv' ? 'Aktiv' : 'Deaktiviert'
+          } geändert.`,
+          variant: "success"
+        });
+        setMembers(prev => prev.map(m => m.mitglied_id === memberId ? { ...m, status: newStatus as any } : m));
+      } else {
+        toast({
+          title: "Fehler beim Ändern des Status",
+          description: res.error?.message || "Der Status konnte nicht geändert werden.",
+          variant: "destructive"
+        });
+      }
+      setPendingConfirm(null);
+    });
+  };
+
+  // Delete/Remove action
+  const handleRemove = (memberId: string, name: string) => {
+    setPendingConfirm({
+      type: 'delete',
+      memberId,
+      memberName: name
+    });
+  };
+
+  const confirmRemove = () => {
+    if (!pendingConfirm?.memberId) return;
+    const { memberId } = pendingConfirm;
+
+    startActionTransition(async () => {
+      const res = await removeMitgliedAction(memberId);
+      if (res.success) {
+        toast({
+          title: "Mitarbeiter entfernt",
+          description: `${pendingConfirm.memberName} wurde aus der Organisation entfernt.`,
+          variant: "success"
+        });
+        setMembers(prev => prev.filter(m => m.mitglied_id !== memberId));
+      } else {
+        toast({
+          title: "Fehler beim Entfernen",
+          description: res.error?.message || "Der Mitarbeiter konnte nicht entfernt werden.",
+          variant: "destructive"
+        });
+      }
+      setPendingConfirm(null);
+    });
+  };
+
+  // Compute stats for overview tab
+  const stats = useMemo(() => {
+    const active = members.filter(m => m.status === 'aktiv').length;
+    const admins = members.filter(m => m.rolle === 'admin' || m.rolle === 'owner').length;
+    const pendingInvites = invitations.filter(i => i.status === 'offen').length;
+    const ownerName = members.find(m => m.rolle === 'owner')?.email || "Unbekannt";
+
+    return { active, admins, pendingInvites, ownerName };
+  }, [members, invitations]);
+
+  // Filtered members list
+  const filteredMembers = useMemo(() => {
+    return members.filter(m => {
+      const name = `${m.first_name || ""} ${m.last_name || ""}`.toLowerCase();
+      const email = m.email.toLowerCase();
+      const query = searchQuery.toLowerCase();
+
+      const matchesSearch = name.includes(query) || email.includes(query);
+      const matchesRole = roleFilter === "all" || m.rolle === roleFilter;
+      const matchesStatus = statusFilter === "all" || m.status === statusFilter;
+
+      return matchesSearch && matchesRole && matchesStatus;
+    });
+  }, [members, searchQuery, roleFilter, statusFilter]);
+
+  return (
+    <div className="flex flex-col gap-6 sm:gap-8 p-4 sm:p-8">
+      {/* Page Header */}
+      <div className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold tracking-tight">Organisation</h1>
+        <p className="text-muted-foreground">
+          Verwalten Sie Ihre Organisation, Rollen und Berechtigungen der Mitarbeiter.
+        </p>
+      </div>
+
+      {/* Inline RPC error banner */}
+      {rpcError && (
+        <div role="alert" className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 dark:border-amber-800/40 dark:bg-amber-900/20 px-4 py-3 text-sm text-amber-800 dark:text-amber-300">
+          <AlertTriangle className="size-4 mt-0.5 shrink-0" />
+          <div>
+            <p className="font-medium">Mitgliederdaten konnten nicht geladen werden</p>
+            <p className="text-xs mt-0.5 opacity-75">{rpcError}</p>
+          </div>
+        </div>
+      )}
+
+      {/* 2-way sliding toggle */}
+      <div className="flex items-center gap-1 bg-zinc-100/80 dark:bg-zinc-900/80 border border-zinc-200/30 dark:border-zinc-800/30 p-1 rounded-full relative w-full sm:w-fit max-w-[400px] select-none z-0">
+        <motion.button
+          layout
+          type="button"
+          onClick={() => setCurrentTab("overview")}
+          className={cn(
+            "flex-1 sm:flex-initial flex items-center justify-center gap-2 rounded-full h-9 px-6 relative outline-none cursor-pointer text-sm font-medium transition-colors duration-300",
+            currentTab === "overview" ? "text-gray-900 dark:text-gray-100 font-semibold" : "text-muted-foreground hover:text-foreground"
+          )}
+        >
+          {currentTab === "overview" && (
+            <motion.div
+              layoutId="active-org-tab-pill"
+              className="absolute inset-0 bg-white dark:bg-zinc-800 shadow-sm border border-zinc-200/10 dark:border-zinc-700/30 rounded-full -z-10"
+              transition={{ type: "spring", stiffness: 380, damping: 30 }}
+            />
+          )}
+          <Network className="size-4 shrink-0" />
+          <span>Übersicht</span>
+        </motion.button>
+
+        <motion.button
+          layout
+          type="button"
+          onClick={() => setCurrentTab("members")}
+          className={cn(
+            "flex-1 sm:flex-initial flex items-center justify-center gap-2 rounded-full h-9 px-6 relative outline-none cursor-pointer text-sm font-medium transition-colors duration-300",
+            currentTab === "members" ? "text-gray-900 dark:text-gray-100 font-semibold" : "text-muted-foreground hover:text-foreground"
+          )}
+        >
+          {currentTab === "members" && (
+            <motion.div
+              layoutId="active-org-tab-pill"
+              className="absolute inset-0 bg-white dark:bg-zinc-800 shadow-sm border border-zinc-200/10 dark:border-zinc-700/30 rounded-full -z-10"
+              transition={{ type: "spring", stiffness: 380, damping: 30 }}
+            />
+          )}
+          <Users className="size-4 shrink-0" />
+          <span>Mitarbeiter</span>
+        </motion.button>
+      </div>
+
+      {/* Tab: Übersicht */}
+      {currentTab === "overview" && (
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+          <StatCard
+            title="Aktive Mitarbeiter"
+            value={stats.active}
+            icon={<Users className="size-4 text-emerald-500" />}
+            description="Mitarbeiter mit aktivem Zugriff"
+          />
+          <StatCard
+            title="Administratoren / Inhaber"
+            value={stats.admins}
+            icon={<Shield className="size-4 text-purple-500" />}
+            description="Mitarbeiter mit Verwaltungsrechten"
+          />
+          <StatCard
+            title="Offene Einladungen"
+            value={stats.pendingInvites}
+            icon={<Mail className="size-4 text-amber-500" />}
+            description="Ausstehende Einladungen"
+          />
+          <StatCard
+            title="Organisationseigentümer"
+            value={stats.ownerName.split('@')[0]}
+            icon={<Lock className="size-4 text-indigo-500" />}
+            description={stats.ownerName}
+          />
+        </div>
+      )}
+
+      {/* Tab: Mitarbeiter */}
+      {currentTab === "members" && (
+        <div className="flex flex-col gap-8">
+          {/* Header Controls & Filter */}
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center justify-between">
+            <div className="flex flex-1 items-center gap-4 max-w-md">
+              <SearchInput
+                placeholder="Mitarbeiter suchen..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full"
+              />
+            </div>
+
+            <div className="flex items-center gap-3">
+              <Select value={roleFilter} onValueChange={setRoleFilter}>
+                <SelectTrigger className="w-[160px] rounded-xl">
+                  <SelectValue placeholder="Rolle filtern" />
+                </SelectTrigger>
+                <SelectContent className="rounded-xl">
+                  <SelectItem value="all">Alle Rollen</SelectItem>
+                  <SelectItem value="owner">Inhaber</SelectItem>
+                  <SelectItem value="admin">Administrator</SelectItem>
+                  <SelectItem value="mitarbeiter">Mitarbeiter</SelectItem>
+                </SelectContent>
+              </Select>
+
+              <Select value={statusFilter} onValueChange={setStatusFilter}>
+                <SelectTrigger className="w-[160px] rounded-xl">
+                  <SelectValue placeholder="Status filtern" />
+                </SelectTrigger>
+                <SelectContent className="rounded-xl">
+                  <SelectItem value="all">Alle Status</SelectItem>
+                  <SelectItem value="aktiv">Aktiv</SelectItem>
+                  <SelectItem value="deaktiviert">Deaktiviert</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="grid gap-8 lg:grid-cols-3 items-start">
+            {/* Table of Members */}
+            <div className="lg:col-span-2 flex flex-col gap-6">
+              <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs overflow-hidden">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-xl">Aktive & Deaktivierte Mitglieder</CardTitle>
+                  <CardDescription>
+                    Mitglieder, die Zugriff auf diese Organisation haben.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="p-0">
+                  <div className="overflow-x-auto">
+                    <Table>
+                      <TableHeader className="bg-zinc-50/50 dark:bg-zinc-900/50">
+                        <TableRow>
+                          <TableHead className="py-3 pl-6">Mitglied</TableHead>
+                          <TableHead className="py-3">Rolle</TableHead>
+                          <TableHead className="py-3">Status</TableHead>
+                          <TableHead className="py-3">Hinzugefügt am</TableHead>
+                          {hasVerwaltenPermission && <TableHead className="py-3 pr-6 text-right">Aktionen</TableHead>}
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {filteredMembers.length === 0 ? (
+                          <TableRow>
+                            <TableCell colSpan={hasVerwaltenPermission ? 5 : 4} className="py-8 text-center text-muted-foreground">
+                              Keine Mitglieder gefunden.
+                            </TableCell>
+                          </TableRow>
+                        ) : (
+                          filteredMembers.map((member) => {
+                            const fullName = member.first_name || member.last_name
+                              ? `${member.first_name || ""} ${member.last_name || ""}`.trim()
+                              : "";
+                            const initials = member.first_name || member.last_name
+                              ? ((member.first_name?.charAt(0) ?? "") + (member.last_name?.charAt(0) ?? "")).toUpperCase()
+                              : member.email.charAt(0).toUpperCase();
+
+                            const isCurrentUser = member.user_id === currentUser?.id;
+                            const isOwnerRow = member.rolle === 'owner';
+
+                            return (
+                              <TableRow key={member.mitglied_id} className="hover:bg-zinc-50/30 dark:hover:bg-zinc-900/30">
+                                <TableCell className="py-4 pl-6 flex items-center gap-3">
+                                  <Avatar className="h-9 w-9 border border-zinc-200/20">
+                                    <AvatarFallback className="bg-primary/5 text-primary text-xs font-bold">
+                                      {initials}
+                                    </AvatarFallback>
+                                  </Avatar>
+                                  <div className="flex flex-col">
+                                    <span className="font-semibold text-sm">
+                                      {fullName || member.email.split('@')[0]}
+                                      {isCurrentUser && <span className="text-[10px] ml-2 text-zinc-400 font-normal border border-zinc-200 dark:border-zinc-800 px-1.5 py-0.5 rounded-full">Du</span>}
+                                    </span>
+                                    <span className="text-xs text-muted-foreground">{member.email}</span>
+                                  </div>
+                                </TableCell>
+                                <TableCell className="py-4">
+                                  {hasVerwaltenPermission && !isOwnerRow && !isCurrentUser ? (
+                                    <Select
+                                      defaultValue={member.rolle}
+                                      onValueChange={(val) => handleRoleChange(member.mitglied_id, fullName || member.email, val)}
+                                      disabled={isPending}
+                                    >
+                                      <SelectTrigger className="w-[130px] h-8 rounded-lg text-xs">
+                                        <SelectValue />
+                                      </SelectTrigger>
+                                      <SelectContent className="rounded-lg">
+                                        <SelectItem value="admin">Admin</SelectItem>
+                                        <SelectItem value="mitarbeiter">Mitarbeiter</SelectItem>
+                                      </SelectContent>
+                                    </Select>
+                                  ) : (
+                                    <Badge variant="outline" className={cn(
+                                      "capitalize rounded-full font-medium text-[11px]",
+                                      isOwnerRow ? "bg-indigo-50/80 text-indigo-700 dark:bg-indigo-950/30 dark:text-indigo-400 border-indigo-200/50" :
+                                      member.rolle === 'admin' ? "bg-purple-50/80 text-purple-700 dark:bg-purple-950/30 dark:text-purple-400 border-purple-200/50" :
+                                      "bg-zinc-50/80 text-zinc-700 dark:bg-zinc-950/30 dark:text-zinc-400 border-zinc-200/50"
+                                    )}>
+                                      {isOwnerRow ? "Inhaber" : member.rolle === 'admin' ? "Admin" : "Mitarbeiter"}
+                                    </Badge>
+                                  )}
+                                </TableCell>
+                                <TableCell className="py-4">
+                                  {hasVerwaltenPermission && !isOwnerRow && !isCurrentUser ? (
+                                    <Select
+                                      defaultValue={member.status}
+                                      onValueChange={(val) => handleStatusChange(member.mitglied_id, fullName || member.email, val)}
+                                      disabled={isPending}
+                                    >
+                                      <SelectTrigger className="w-[120px] h-8 rounded-lg text-xs">
+                                        <SelectValue />
+                                      </SelectTrigger>
+                                      <SelectContent className="rounded-lg">
+                                        <SelectItem value="aktiv">Aktiv</SelectItem>
+                                        <SelectItem value="deaktiviert">Deaktiviert</SelectItem>
+                                      </SelectContent>
+                                    </Select>
+                                  ) : (
+                                    <Badge variant="outline" className={cn(
+                                      "rounded-full font-medium text-[11px]",
+                                      member.status === 'aktiv' ? "bg-emerald-50/80 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-400 border-emerald-200/50" :
+                                      "bg-rose-50/80 text-rose-700 dark:bg-rose-950/30 dark:text-rose-400 border-rose-200/50"
+                                    )}>
+                                      {member.status === 'aktiv' ? "Aktiv" : "Deaktiviert"}
+                                    </Badge>
+                                  )}
+                                </TableCell>
+                                <TableCell className="py-4 text-xs text-muted-foreground">
+                                  {new Date(member.erstellt_am).toLocaleDateString("de-DE")}
+                                </TableCell>
+                                {hasVerwaltenPermission && (
+                                  <TableCell className="py-4 pr-6 text-right">
+                                    {!isOwnerRow && !isCurrentUser ? (
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8 text-muted-foreground hover:text-red-500 rounded-lg"
+                                        onClick={() => handleRemove(member.mitglied_id, fullName || member.email)}
+                                        disabled={isPending}
+                                        title="Mitglied entfernen"
+                                      >
+                                        <Trash2 className="size-4" />
+                                      </Button>
+                                    ) : null}
+                                  </TableCell>
+                                )}
+                              </TableRow>
+                            );
+                          })
+                        )}
+                      </TableBody>
+                    </Table>
+                  </div>
+                </CardContent>
+              </Card>
+
+              {/* Open Invitations Table */}
+              <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs overflow-hidden">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-xl">Ausstehende Einladungen</CardTitle>
+                  <CardDescription>
+                    Eingeladene Personen, die ihre Einladung noch nicht angenommen haben.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="p-0">
+                  <div className="overflow-x-auto">
+                    <Table>
+                      <TableHeader className="bg-zinc-50/50 dark:bg-zinc-900/50">
+                        <TableRow>
+                          <TableHead className="py-3 pl-6">E-Mail-Adresse</TableHead>
+                          <TableHead className="py-3">Eingeladen als</TableHead>
+                          <TableHead className="py-3">Eingeladen am</TableHead>
+                          <TableHead className="py-3">Ablaufdatum</TableHead>
+                          {hasVerwaltenPermission && <TableHead className="py-3 pr-6 text-right">Aktionen</TableHead>}
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {invitations.length === 0 ? (
+                          <TableRow>
+                            <TableCell colSpan={hasVerwaltenPermission ? 5 : 4} className="py-8 text-center text-muted-foreground">
+                              Keine ausstehenden Einladungen vorhanden.
+                            </TableCell>
+                          </TableRow>
+                        ) : (
+                          invitations.map((invite) => {
+                            const isExpired = new Date(invite.expires_at) < new Date();
+                            return (
+                              <TableRow key={invite.id} className="hover:bg-zinc-50/30 dark:hover:bg-zinc-900/30">
+                                <TableCell className="py-4 pl-6 font-medium text-sm flex items-center gap-3">
+                                  <Avatar className="h-9 w-9 border border-zinc-200/20">
+                                    <AvatarFallback className="bg-zinc-100 text-zinc-500 text-xs font-bold">
+                                      <Mail className="size-4" />
+                                    </AvatarFallback>
+                                  </Avatar>
+                                  <div className="flex flex-col">
+                                    <span className="font-semibold text-sm">{invite.email}</span>
+                                    {isExpired && <span className="text-[10px] text-rose-500 font-medium">Abgelaufen</span>}
+                                  </div>
+                                </TableCell>
+                                <TableCell className="py-4">
+                                  <Badge variant="outline" className={cn(
+                                    "capitalize rounded-full font-medium text-[11px]",
+                                    invite.rolle === 'admin' ? "bg-purple-50 text-purple-700 dark:bg-purple-950/30 dark:text-purple-400 border-purple-200/50" :
+                                    "bg-zinc-50 text-zinc-700 dark:bg-zinc-950/30 dark:text-zinc-400 border-zinc-200/50"
+                                  )}>
+                                    {invite.rolle === 'admin' ? "Admin" : "Mitarbeiter"}
+                                  </Badge>
+                                </TableCell>
+                                <TableCell className="py-4 text-xs text-muted-foreground">
+                                  {new Date(invite.erstellt_am).toLocaleDateString("de-DE")}
+                                </TableCell>
+                                <TableCell className="py-4 text-xs text-muted-foreground">
+                                  {new Date(invite.expires_at).toLocaleDateString("de-DE")}
+                                </TableCell>
+                                {hasVerwaltenPermission && (
+                                  <TableCell className="py-4 pr-6 text-right">
+                                    <Button
+                                      variant="ghost"
+                                      size="icon"
+                                      className="h-8 w-8 text-muted-foreground hover:text-red-500 rounded-lg"
+                                      onClick={() => handleRevoke(invite.id, invite.email)}
+                                      disabled={isPending}
+                                      title="Einladung widerrufen"
+                                    >
+                                      <X className="size-4" />
+                                    </Button>
+                                  </TableCell>
+                                )}
+                              </TableRow>
+                            );
+                          })
+                        )}
+                      </TableBody>
+                    </Table>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* Invite Form Side Section */}
+            {hasVerwaltenPermission && (
+              <div className="flex flex-col gap-6">
+                <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs">
+                  <CardHeader>
+                    <CardTitle className="text-xl">Mitarbeiter einladen</CardTitle>
+                    <CardDescription>
+                      Senden Sie eine Einladung per E-Mail, um neue Teammitglieder hinzuzufügen.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <form onSubmit={handleInvite} className="flex flex-col gap-4">
+                      <div className="flex flex-col gap-2">
+                        <label className="text-xs font-semibold uppercase text-muted-foreground" htmlFor="email-input">
+                          E-Mail-Adresse
+                        </label>
+                        <Input
+                          id="email-input"
+                          type="email"
+                          placeholder="z.B. mitarbeiter@firma.de"
+                          value={inviteEmail}
+                          onChange={(e) => setInviteEmail(e.target.value)}
+                          className="rounded-xl border-zinc-200/80 dark:border-zinc-800/80 h-10"
+                          required
+                          disabled={isInviting}
+                        />
+                      </div>
+
+                      <div className="flex flex-col gap-2">
+                        <label className="text-xs font-semibold uppercase text-muted-foreground" htmlFor="role-select">
+                          Rolle
+                        </label>
+                        <Select
+                          value={inviteRole}
+                          onValueChange={(val: any) => setInviteRole(val)}
+                          disabled={isInviting}
+                        >
+                          <SelectTrigger id="role-select" className="rounded-xl h-10">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent className="rounded-xl">
+                            <SelectItem value="mitarbeiter">Mitarbeiter</SelectItem>
+                            <SelectItem value="admin">Administrator</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+
+                      <Button
+                        type="submit"
+                        className="w-full mt-2 h-10 rounded-xl bg-primary hover:bg-primary/95 text-white flex items-center justify-center gap-2 font-medium"
+                        disabled={isInviting || !inviteEmail}
+                      >
+                        {isInviting ? (
+                          <>
+                            <Clock className="size-4 animate-spin" />
+                            <span>Wird eingeladen...</span>
+                          </>
+                        ) : (
+                          <>
+                            <PlusCircle className="size-4" />
+                            <span>Einladen</span>
+                          </>
+                        )}
+                      </Button>
+                    </form>
+                  </CardContent>
+                </Card>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Confirmation Dialogs */}
+      <AlertDialog open={pendingConfirm !== null} onOpenChange={(open) => !open && setPendingConfirm(null)}>
+        <AlertDialogContent className="rounded-[2rem] max-w-md border border-zinc-200/50 dark:border-zinc-800/50">
+          <AlertDialogHeader className="flex flex-col gap-3">
+            <div className="mx-auto bg-amber-500/10 text-amber-500 p-4 rounded-full w-fit">
+              <AlertTriangle className="size-8" />
+            </div>
+            <AlertDialogTitle className="text-xl font-bold text-center">
+              {pendingConfirm?.type === 'revoke' && "Einladung widerrufen"}
+              {pendingConfirm?.type === 'role' && "Rolle ändern"}
+              {pendingConfirm?.type === 'status' && "Status ändern"}
+              {pendingConfirm?.type === 'delete' && "Mitglied entfernen"}
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-center text-sm text-muted-foreground leading-relaxed">
+              {pendingConfirm?.type === 'revoke' && (
+                <>Möchten Sie die Einladung für <strong className="text-foreground">{pendingConfirm.memberName}</strong> wirklich widerrufen? Die Person wird die Einladung nicht mehr annehmen können.</>
+              )}
+              {pendingConfirm?.type === 'role' && (
+                <>Möchten Sie die Rolle von <strong className="text-foreground">{pendingConfirm.memberName}</strong> wirklich auf <strong className="text-foreground">{pendingConfirm.value === 'owner' ? 'Inhaber' : pendingConfirm.value === 'admin' ? 'Administrator' : 'Mitarbeiter'}</strong> ändern?</>
+              )}
+              {pendingConfirm?.type === 'status' && (
+                <>Möchten Sie den Status von <strong className="text-foreground">{pendingConfirm.memberName}</strong> wirklich auf <strong className="text-foreground">{pendingConfirm.value === 'aktiv' ? 'Aktiv' : 'Deaktiviert'}</strong> ändern?</>
+              )}
+              {pendingConfirm?.type === 'delete' && (
+                <>Möchten Sie <strong className="text-foreground">{pendingConfirm.memberName}</strong> wirklich aus der Organisation entfernen? Der Zugriff auf alle Daten dieser Organisation geht sofort verloren.</>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex flex-col-reverse sm:flex-row gap-2 mt-4">
+            <AlertDialogCancel className="rounded-xl flex-1 border border-zinc-200 dark:border-zinc-800" disabled={isPending}>
+              Abbrechen
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="rounded-xl flex-1 bg-amber-500 hover:bg-amber-600 text-white font-medium"
+              onClick={(e) => {
+                e.preventDefault();
+                if (pendingConfirm?.type === 'revoke') confirmRevoke();
+                if (pendingConfirm?.type === 'role') confirmRoleChange();
+                if (pendingConfirm?.type === 'status') confirmStatusChange();
+                if (pendingConfirm?.type === 'delete') confirmRemove();
+              }}
+              disabled={isPending}
+            >
+              {isPending ? "Bitte warten..." : "Bestätigen"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/app/(dashboard)/organisation/client-wrapper.tsx
+++ b/app/(dashboard)/organisation/client-wrapper.tsx
@@ -89,7 +89,7 @@ export default function OrganisationClientView({
   initialMembers,
   initialInvitations,
   currentUser,
-  canManage = true,
+  canManage = false,
   rpcError = null
 }: OrganisationClientViewProps) {
   const [currentTab, setCurrentTab] = useState<"overview" | "members">("overview");
@@ -567,7 +567,7 @@ export default function OrganisationClientView({
                                     </Badge>
                                   )}
                                 </TableCell>
-                                <TableCell className="py-4 text-xs text-muted-foreground">
+                                <TableCell className="py-4 text-xs text-muted-foreground" suppressHydrationWarning>
                                   {new Date(member.erstellt_am).toLocaleDateString("de-DE")}
                                 </TableCell>
                                 {hasVerwaltenPermission && (
@@ -648,10 +648,10 @@ export default function OrganisationClientView({
                                     {invite.rolle === 'admin' ? "Admin" : "Mitarbeiter"}
                                   </Badge>
                                 </TableCell>
-                                <TableCell className="py-4 text-xs text-muted-foreground">
+                                <TableCell className="py-4 text-xs text-muted-foreground" suppressHydrationWarning>
                                   {new Date(invite.erstellt_am).toLocaleDateString("de-DE")}
                                 </TableCell>
-                                <TableCell className="py-4 text-xs text-muted-foreground">
+                                <TableCell className="py-4 text-xs text-muted-foreground" suppressHydrationWarning>
                                   {new Date(invite.expires_at).toLocaleDateString("de-DE")}
                                 </TableCell>
                                 {hasVerwaltenPermission && (

--- a/app/(dashboard)/organisation/page.tsx
+++ b/app/(dashboard)/organisation/page.tsx
@@ -8,14 +8,14 @@ import OrganisationClientView from "./client-wrapper";
 import { safeRpcCall } from "@/lib/error-handling";
 
 export default async function OrganisationPage() {
-  // Enforce permission and authenticate in parallel
-  const [, { supabase, user }] = await Promise.all([
-    requirePermission('organisation', 'ansehen'),
-    requireAuthenticatedUser()
-  ]);
+  // Get authenticated user first
+  const { supabase, user } = await requireAuthenticatedUser();
 
-  // Get active organization using safeRpcCall
-  const orgIdResult = await safeRpcCall<string>(supabase, 'current_organisation_id', undefined, { userId: user.id });
+  // Enforce permission and get active organization in parallel
+  const [_, orgIdResult] = await Promise.all([
+    requirePermission('organisation', 'ansehen'),
+    safeRpcCall<string>(supabase, 'current_organisation_id', undefined, { userId: user.id })
+  ]);
   const orgId = orgIdResult.data;
   if (!orgIdResult.success || !orgId) {
     console.error("No organisation context found:", orgIdResult.message);

--- a/app/(dashboard)/organisation/page.tsx
+++ b/app/(dashboard)/organisation/page.tsx
@@ -5,6 +5,7 @@ import { requireAuthenticatedUser } from "@/lib/server/route-access";
 import { requirePermission, hasPermission } from "@/lib/permissions";
 import { redirect } from "next/navigation";
 import OrganisationClientView from "./client-wrapper";
+import { safeRpcCall } from "@/lib/error-handling";
 
 export default async function OrganisationPage() {
   // Enforce permission for viewing organisation page
@@ -12,10 +13,11 @@ export default async function OrganisationPage() {
 
   const { supabase, user } = await requireAuthenticatedUser();
 
-  // Get active organization
-  const { data: orgId, error: orgIdError } = await supabase.rpc('current_organisation_id');
-  if (orgIdError || !orgId) {
-    console.error("No organisation context found:", orgIdError);
+  // Get active organization using safeRpcCall
+  const orgIdResult = await safeRpcCall<string>(supabase, 'current_organisation_id', undefined, { userId: user.id });
+  const orgId = orgIdResult.data;
+  if (!orgIdResult.success || !orgId) {
+    console.error("No organisation context found:", orgIdResult.message);
     redirect("/unauthorized");
   }
 
@@ -33,7 +35,7 @@ export default async function OrganisationPage() {
 
   // Fetch members and open invitations in parallel
   const [membersResult, invitationsResult, canManage] = await Promise.all([
-    supabase.rpc('get_organisation_mitglieder'),
+    safeRpcCall<any[]>(supabase, 'get_organisation_mitglieder', undefined, { userId: user.id }),
     supabase
       .from('Organisation_Einladungen')
       .select('*')
@@ -43,13 +45,8 @@ export default async function OrganisationPage() {
     hasPermission('organisation', 'verwalten')
   ]);
 
-  if (membersResult.error) {
-    console.error("Error loading members details:", {
-      message: membersResult.error.message,
-      code: membersResult.error.code,
-      details: membersResult.error.details,
-      hint: membersResult.error.hint
-    });
+  if (!membersResult.success) {
+    console.error("Error loading members details:", membersResult.message);
   }
 
   const members = membersResult.data ?? [];
@@ -62,7 +59,7 @@ export default async function OrganisationPage() {
       initialInvitations={invitations}
       currentUser={user}
       canManage={canManage}
-      rpcError={membersResult.error ? membersResult.error.message : null}
+      rpcError={!membersResult.success ? (membersResult.message ?? 'Fehler beim Laden der Mitglieder') : null}
     />
   );
 }

--- a/app/(dashboard)/organisation/page.tsx
+++ b/app/(dashboard)/organisation/page.tsx
@@ -8,10 +8,11 @@ import OrganisationClientView from "./client-wrapper";
 import { safeRpcCall } from "@/lib/error-handling";
 
 export default async function OrganisationPage() {
-  // Enforce permission for viewing organisation page
-  await requirePermission('organisation', 'ansehen');
-
-  const { supabase, user } = await requireAuthenticatedUser();
+  // Enforce permission and authenticate in parallel
+  const [, { supabase, user }] = await Promise.all([
+    requirePermission('organisation', 'ansehen'),
+    requireAuthenticatedUser()
+  ]);
 
   // Get active organization using safeRpcCall
   const orgIdResult = await safeRpcCall<string>(supabase, 'current_organisation_id', undefined, { userId: user.id });

--- a/app/(dashboard)/organisation/page.tsx
+++ b/app/(dashboard)/organisation/page.tsx
@@ -49,6 +49,10 @@ export default async function OrganisationPage() {
     console.error("Error loading members details:", membersResult.message);
   }
 
+  if (invitationsResult.error) {
+    console.error("Error loading invitations:", invitationsResult.error.message);
+  }
+
   const members = membersResult.data ?? [];
   const invitations = invitationsResult.data ?? [];
 

--- a/app/(dashboard)/organisation/page.tsx
+++ b/app/(dashboard)/organisation/page.tsx
@@ -1,0 +1,68 @@
+export const dynamic = 'force-dynamic';
+export const runtime = 'edge';
+
+import { requireAuthenticatedUser } from "@/lib/server/route-access";
+import { requirePermission, hasPermission } from "@/lib/permissions";
+import { redirect } from "next/navigation";
+import OrganisationClientView from "./client-wrapper";
+
+export default async function OrganisationPage() {
+  // Enforce permission for viewing organisation page
+  await requirePermission('organisation', 'ansehen');
+
+  const { supabase, user } = await requireAuthenticatedUser();
+
+  // Get active organization
+  const { data: orgId, error: orgIdError } = await supabase.rpc('current_organisation_id');
+  if (orgIdError || !orgId) {
+    console.error("No organisation context found:", orgIdError);
+    redirect("/unauthorized");
+  }
+
+  // Fetch organisation details (to check ist_versteckt)
+  const { data: org, error: orgError } = await supabase
+    .from('Organisation')
+    .select('id, owner_id, ist_versteckt, einstellungen')
+    .eq('id', orgId)
+    .single();
+
+  if (orgError || !org || org.ist_versteckt) {
+    console.error("Organisation is hidden or does not exist:", orgError);
+    redirect("/unauthorized");
+  }
+
+  // Fetch members and open invitations in parallel
+  const [membersResult, invitationsResult, canManage] = await Promise.all([
+    supabase.rpc('get_organisation_mitglieder'),
+    supabase
+      .from('Organisation_Einladungen')
+      .select('*')
+      .eq('organisation_id', orgId)
+      .eq('status', 'offen')
+      .order('erstellt_am', { ascending: false }),
+    hasPermission('organisation', 'verwalten')
+  ]);
+
+  if (membersResult.error) {
+    console.error("Error loading members details:", {
+      message: membersResult.error.message,
+      code: membersResult.error.code,
+      details: membersResult.error.details,
+      hint: membersResult.error.hint
+    });
+  }
+
+  const members = membersResult.data ?? [];
+  const invitations = invitationsResult.data ?? [];
+
+  return (
+    <OrganisationClientView
+      org={org}
+      initialMembers={members}
+      initialInvitations={invitations}
+      currentUser={user}
+      canManage={canManage}
+      rpcError={membersResult.error ? membersResult.error.message : null}
+    />
+  );
+}

--- a/app/organisation-actions.ts
+++ b/app/organisation-actions.ts
@@ -27,6 +27,14 @@ export const createEinladungAction = withLogging(
       return { success: false, error: { message: "Keine Berechtigung zum Verwalten der Organisation." } };
     }
 
+    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      return { success: false, error: { message: "Ungültige E-Mail-Adresse." } };
+    }
+
+    if (rolle !== 'admin' && rolle !== 'mitarbeiter') {
+      return { success: false, error: { message: "Ungültige Rolle." } };
+    }
+
     const { data, error } = await supabase.rpc('create_einladung', {
       p_email: email,
       p_rolle: rolle,
@@ -96,6 +104,10 @@ export const setMitgliedRolleAction = withLogging(
       return { success: false, error: { message: "Keine Berechtigung zum Verwalten der Organisation." } };
     }
 
+    if (rolle !== 'admin' && rolle !== 'mitarbeiter') {
+      return { success: false, error: { message: "Ungültige Rolle." } };
+    }
+
     const { error } = await supabase.rpc('set_mitglied_rolle', {
       p_mitglied_id: mitgliedId,
       p_rolle: rolle
@@ -129,6 +141,10 @@ export const setMitgliedStatusAction = withLogging(
 
     if (!(await hasPermission('organisation', 'verwalten'))) {
       return { success: false, error: { message: "Keine Berechtigung zum Verwalten der Organisation." } };
+    }
+
+    if (status !== 'aktiv' && status !== 'deaktiviert') {
+      return { success: false, error: { message: "Ungültige Statusänderung." } };
     }
 
     const { error } = await supabase.rpc('set_mitglied_status', {

--- a/app/organisation-actions.ts
+++ b/app/organisation-actions.ts
@@ -1,0 +1,163 @@
+"use server";
+
+import { createClient } from "@/utils/supabase/server";
+import { ensureAuth } from "@/lib/auth-utils";
+import { revalidatePath } from "next/cache";
+import { hasPermission } from "@/lib/permissions";
+
+/**
+ * Invites a new member to the current organization.
+ */
+export async function createEinladungAction(
+  email: string,
+  rolle: string
+): Promise<{ success: boolean; data?: any; error?: { message: string } }> {
+  let user, supabase;
+  try {
+    ({ user, supabase } = await ensureAuth());
+  } catch (authError: unknown) {
+    const errorMessage = authError instanceof Error ? authError.message : "Nicht authentifiziert";
+    return { success: false, error: { message: errorMessage } };
+  }
+
+  if (!(await hasPermission('organisation', 'verwalten'))) {
+    return { success: false, error: { message: "Keine Berechtigung zum Verwalten der Organisation." } };
+  }
+
+  const { data, error } = await supabase.rpc('create_einladung', {
+    p_email: email,
+    p_rolle: rolle,
+    p_policy_ids: null
+  });
+
+  if (error) {
+    return { success: false, error: { message: error.message } };
+  }
+
+  revalidatePath('/organisation');
+  return { success: true, data };
+}
+
+/**
+ * Revokes an open invitation.
+ */
+export async function revokeEinladungAction(
+  einladungId: string
+): Promise<{ success: boolean; error?: { message: string } }> {
+  let user, supabase;
+  try {
+    ({ user, supabase } = await ensureAuth());
+  } catch (authError: unknown) {
+    const errorMessage = authError instanceof Error ? authError.message : "Nicht authentifiziert";
+    return { success: false, error: { message: errorMessage } };
+  }
+
+  if (!(await hasPermission('organisation', 'verwalten'))) {
+    return { success: false, error: { message: "Keine Berechtigung zum Verwalten der Organisation." } };
+  }
+
+  const { error } = await supabase.rpc('revoke_einladung', {
+    p_einladung_id: einladungId
+  });
+
+  if (error) {
+    return { success: false, error: { message: error.message } };
+  }
+
+  revalidatePath('/organisation');
+  return { success: true };
+}
+
+/**
+ * Changes a member's role.
+ */
+export async function setMitgliedRolleAction(
+  mitgliedId: string,
+  rolle: string
+): Promise<{ success: boolean; error?: { message: string } }> {
+  let user, supabase;
+  try {
+    ({ user, supabase } = await ensureAuth());
+  } catch (authError: unknown) {
+    const errorMessage = authError instanceof Error ? authError.message : "Nicht authentifiziert";
+    return { success: false, error: { message: errorMessage } };
+  }
+
+  if (!(await hasPermission('organisation', 'verwalten'))) {
+    return { success: false, error: { message: "Keine Berechtigung zum Verwalten der Organisation." } };
+  }
+
+  const { error } = await supabase.rpc('set_mitglied_rolle', {
+    p_mitglied_id: mitgliedId,
+    p_rolle: rolle
+  });
+
+  if (error) {
+    return { success: false, error: { message: error.message } };
+  }
+
+  revalidatePath('/organisation');
+  return { success: true };
+}
+
+/**
+ * Updates a member's status (aktiv, deaktiviert, etc.).
+ */
+export async function setMitgliedStatusAction(
+  mitgliedId: string,
+  status: string
+): Promise<{ success: boolean; error?: { message: string } }> {
+  let user, supabase;
+  try {
+    ({ user, supabase } = await ensureAuth());
+  } catch (authError: unknown) {
+    const errorMessage = authError instanceof Error ? authError.message : "Nicht authentifiziert";
+    return { success: false, error: { message: errorMessage } };
+  }
+
+  if (!(await hasPermission('organisation', 'verwalten'))) {
+    return { success: false, error: { message: "Keine Berechtigung zum Verwalten der Organisation." } };
+  }
+
+  const { error } = await supabase.rpc('set_mitglied_status', {
+    p_mitglied_id: mitgliedId,
+    p_status: status
+  });
+
+  if (error) {
+    return { success: false, error: { message: error.message } };
+  }
+
+  revalidatePath('/organisation');
+  return { success: true };
+}
+
+/**
+ * Removes a member from the organization.
+ */
+export async function removeMitgliedAction(
+  mitgliedId: string
+): Promise<{ success: boolean; error?: { message: string } }> {
+  let user, supabase;
+  try {
+    ({ user, supabase } = await ensureAuth());
+  } catch (authError: unknown) {
+    const errorMessage = authError instanceof Error ? authError.message : "Nicht authentifiziert";
+    return { success: false, error: { message: errorMessage } };
+  }
+
+  if (!(await hasPermission('organisation', 'verwalten'))) {
+    return { success: false, error: { message: "Keine Berechtigung zum Verwalten der Organisation." } };
+  }
+
+  const { error } = await supabase.rpc('remove_mitglied', {
+    p_mitglied_id: mitgliedId
+  });
+
+  if (error) {
+    return { success: false, error: { message: error.message } };
+  }
+
+  revalidatePath('/organisation');
+  return { success: true };
+}

--- a/app/organisation-actions.ts
+++ b/app/organisation-actions.ts
@@ -4,160 +4,176 @@ import { createClient } from "@/utils/supabase/server";
 import { ensureAuth } from "@/lib/auth-utils";
 import { revalidatePath } from "next/cache";
 import { hasPermission } from "@/lib/permissions";
+import { withLogging } from "@/lib/logging-middleware";
 
 /**
  * Invites a new member to the current organization.
  */
-export async function createEinladungAction(
-  email: string,
-  rolle: string
-): Promise<{ success: boolean; data?: any; error?: { message: string } }> {
-  let user, supabase;
-  try {
-    ({ user, supabase } = await ensureAuth());
-  } catch (authError: unknown) {
-    const errorMessage = authError instanceof Error ? authError.message : "Nicht authentifiziert";
-    return { success: false, error: { message: errorMessage } };
+export const createEinladungAction = withLogging(
+  'createEinladung',
+  async (
+    email: string,
+    rolle: string
+  ): Promise<{ success: boolean; data?: any; error?: { message: string } }> => {
+    let user, supabase;
+    try {
+      ({ user, supabase } = await ensureAuth());
+    } catch (authError: unknown) {
+      const errorMessage = authError instanceof Error ? authError.message : "Nicht authentifiziert";
+      return { success: false, error: { message: errorMessage } };
+    }
+
+    if (!(await hasPermission('organisation', 'verwalten'))) {
+      return { success: false, error: { message: "Keine Berechtigung zum Verwalten der Organisation." } };
+    }
+
+    const { data, error } = await supabase.rpc('create_einladung', {
+      p_email: email,
+      p_rolle: rolle,
+      p_policy_ids: null
+    });
+
+    if (error) {
+      return { success: false, error: { message: error.message } };
+    }
+
+    revalidatePath('/organisation');
+    return { success: true, data };
   }
-
-  if (!(await hasPermission('organisation', 'verwalten'))) {
-    return { success: false, error: { message: "Keine Berechtigung zum Verwalten der Organisation." } };
-  }
-
-  const { data, error } = await supabase.rpc('create_einladung', {
-    p_email: email,
-    p_rolle: rolle,
-    p_policy_ids: null
-  });
-
-  if (error) {
-    return { success: false, error: { message: error.message } };
-  }
-
-  revalidatePath('/organisation');
-  return { success: true, data };
-}
+);
 
 /**
  * Revokes an open invitation.
  */
-export async function revokeEinladungAction(
-  einladungId: string
-): Promise<{ success: boolean; error?: { message: string } }> {
-  let user, supabase;
-  try {
-    ({ user, supabase } = await ensureAuth());
-  } catch (authError: unknown) {
-    const errorMessage = authError instanceof Error ? authError.message : "Nicht authentifiziert";
-    return { success: false, error: { message: errorMessage } };
+export const revokeEinladungAction = withLogging(
+  'revokeEinladung',
+  async (
+    einladungId: string
+  ): Promise<{ success: boolean; error?: { message: string } }> => {
+    let user, supabase;
+    try {
+      ({ user, supabase } = await ensureAuth());
+    } catch (authError: unknown) {
+      const errorMessage = authError instanceof Error ? authError.message : "Nicht authentifiziert";
+      return { success: false, error: { message: errorMessage } };
+    }
+
+    if (!(await hasPermission('organisation', 'verwalten'))) {
+      return { success: false, error: { message: "Keine Berechtigung zum Verwalten der Organisation." } };
+    }
+
+    const { error } = await supabase.rpc('revoke_einladung', {
+      p_einladung_id: einladungId
+    });
+
+    if (error) {
+      return { success: false, error: { message: error.message } };
+    }
+
+    revalidatePath('/organisation');
+    return { success: true };
   }
-
-  if (!(await hasPermission('organisation', 'verwalten'))) {
-    return { success: false, error: { message: "Keine Berechtigung zum Verwalten der Organisation." } };
-  }
-
-  const { error } = await supabase.rpc('revoke_einladung', {
-    p_einladung_id: einladungId
-  });
-
-  if (error) {
-    return { success: false, error: { message: error.message } };
-  }
-
-  revalidatePath('/organisation');
-  return { success: true };
-}
+);
 
 /**
  * Changes a member's role.
  */
-export async function setMitgliedRolleAction(
-  mitgliedId: string,
-  rolle: string
-): Promise<{ success: boolean; error?: { message: string } }> {
-  let user, supabase;
-  try {
-    ({ user, supabase } = await ensureAuth());
-  } catch (authError: unknown) {
-    const errorMessage = authError instanceof Error ? authError.message : "Nicht authentifiziert";
-    return { success: false, error: { message: errorMessage } };
+export const setMitgliedRolleAction = withLogging(
+  'setMitgliedRolle',
+  async (
+    mitgliedId: string,
+    rolle: string
+  ): Promise<{ success: boolean; error?: { message: string } }> => {
+    let user, supabase;
+    try {
+      ({ user, supabase } = await ensureAuth());
+    } catch (authError: unknown) {
+      const errorMessage = authError instanceof Error ? authError.message : "Nicht authentifiziert";
+      return { success: false, error: { message: errorMessage } };
+    }
+
+    if (!(await hasPermission('organisation', 'verwalten'))) {
+      return { success: false, error: { message: "Keine Berechtigung zum Verwalten der Organisation." } };
+    }
+
+    const { error } = await supabase.rpc('set_mitglied_rolle', {
+      p_mitglied_id: mitgliedId,
+      p_rolle: rolle
+    });
+
+    if (error) {
+      return { success: false, error: { message: error.message } };
+    }
+
+    revalidatePath('/organisation');
+    return { success: true };
   }
-
-  if (!(await hasPermission('organisation', 'verwalten'))) {
-    return { success: false, error: { message: "Keine Berechtigung zum Verwalten der Organisation." } };
-  }
-
-  const { error } = await supabase.rpc('set_mitglied_rolle', {
-    p_mitglied_id: mitgliedId,
-    p_rolle: rolle
-  });
-
-  if (error) {
-    return { success: false, error: { message: error.message } };
-  }
-
-  revalidatePath('/organisation');
-  return { success: true };
-}
+);
 
 /**
  * Updates a member's status (aktiv, deaktiviert, etc.).
  */
-export async function setMitgliedStatusAction(
-  mitgliedId: string,
-  status: string
-): Promise<{ success: boolean; error?: { message: string } }> {
-  let user, supabase;
-  try {
-    ({ user, supabase } = await ensureAuth());
-  } catch (authError: unknown) {
-    const errorMessage = authError instanceof Error ? authError.message : "Nicht authentifiziert";
-    return { success: false, error: { message: errorMessage } };
+export const setMitgliedStatusAction = withLogging(
+  'setMitgliedStatus',
+  async (
+    mitgliedId: string,
+    status: string
+  ): Promise<{ success: boolean; error?: { message: string } }> => {
+    let user, supabase;
+    try {
+      ({ user, supabase } = await ensureAuth());
+    } catch (authError: unknown) {
+      const errorMessage = authError instanceof Error ? authError.message : "Nicht authentifiziert";
+      return { success: false, error: { message: errorMessage } };
+    }
+
+    if (!(await hasPermission('organisation', 'verwalten'))) {
+      return { success: false, error: { message: "Keine Berechtigung zum Verwalten der Organisation." } };
+    }
+
+    const { error } = await supabase.rpc('set_mitglied_status', {
+      p_mitglied_id: mitgliedId,
+      p_status: status
+    });
+
+    if (error) {
+      return { success: false, error: { message: error.message } };
+    }
+
+    revalidatePath('/organisation');
+    return { success: true };
   }
-
-  if (!(await hasPermission('organisation', 'verwalten'))) {
-    return { success: false, error: { message: "Keine Berechtigung zum Verwalten der Organisation." } };
-  }
-
-  const { error } = await supabase.rpc('set_mitglied_status', {
-    p_mitglied_id: mitgliedId,
-    p_status: status
-  });
-
-  if (error) {
-    return { success: false, error: { message: error.message } };
-  }
-
-  revalidatePath('/organisation');
-  return { success: true };
-}
+);
 
 /**
  * Removes a member from the organization.
  */
-export async function removeMitgliedAction(
-  mitgliedId: string
-): Promise<{ success: boolean; error?: { message: string } }> {
-  let user, supabase;
-  try {
-    ({ user, supabase } = await ensureAuth());
-  } catch (authError: unknown) {
-    const errorMessage = authError instanceof Error ? authError.message : "Nicht authentifiziert";
-    return { success: false, error: { message: errorMessage } };
+export const removeMitgliedAction = withLogging(
+  'removeMitglied',
+  async (
+    mitgliedId: string
+  ): Promise<{ success: boolean; error?: { message: string } }> => {
+    let user, supabase;
+    try {
+      ({ user, supabase } = await ensureAuth());
+    } catch (authError: unknown) {
+      const errorMessage = authError instanceof Error ? authError.message : "Nicht authentifiziert";
+      return { success: false, error: { message: errorMessage } };
+    }
+
+    if (!(await hasPermission('organisation', 'verwalten'))) {
+      return { success: false, error: { message: "Keine Berechtigung zum Verwalten der Organisation." } };
+    }
+
+    const { error } = await supabase.rpc('remove_mitglied', {
+      p_mitglied_id: mitgliedId
+    });
+
+    if (error) {
+      return { success: false, error: { message: error.message } };
+    }
+
+    revalidatePath('/organisation');
+    return { success: true };
   }
-
-  if (!(await hasPermission('organisation', 'verwalten'))) {
-    return { success: false, error: { message: "Keine Berechtigung zum Verwalten der Organisation." } };
-  }
-
-  const { error } = await supabase.rpc('remove_mitglied', {
-    p_mitglied_id: mitgliedId
-  });
-
-  if (error) {
-    return { success: false, error: { message: error.message } };
-  }
-
-  revalidatePath('/organisation');
-  return { success: true };
-}
+);

--- a/components/common/mobile-bottom-navigation.tsx
+++ b/components/common/mobile-bottom-navigation.tsx
@@ -18,6 +18,7 @@ import {
   Globe
 } from 'lucide-react'
 import { useSidebarActiveState } from '@/hooks/use-active-state-manager'
+import { SidebarUserData } from '@/lib/server/user-data'
 import { useCommandMenu } from '@/hooks/use-command-menu'
 import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { cn } from '@/lib/utils'
@@ -58,9 +59,10 @@ interface DropdownItem {
 
 interface MobileBottomNavigationProps {
   className?: string
+  sidebarData?: SidebarUserData
 }
 
-export default function MobileBottomNavigation({ className }: MobileBottomNavigationProps) {
+export default function MobileBottomNavigation({ className, sidebarData }: MobileBottomNavigationProps) {
   const { isRouteActive } = useSidebarActiveState()
   const { setOpen: setCommandMenuOpen } = useCommandMenu()
   const documentsEnabled = useFeatureFlagEnabled('documents_tab_access')
@@ -341,6 +343,13 @@ export default function MobileBottomNavigation({ className }: MobileBottomNaviga
       title: 'Betriebskosten',
       href: '/betriebskosten',
       icon: FileSpreadsheet
+    },
+    {
+      id: 'organisation',
+      title: 'Organisationen',
+      href: '/organisation',
+      icon: Building2,
+      hidden: !sidebarData?.hasOrganisationPermission || sidebarData?.isOrganisationHidden
     },
     {
       id: 'tasks',

--- a/components/common/mobile-bottom-navigation.tsx
+++ b/components/common/mobile-bottom-navigation.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect, useReducer, useRef, useCallback } from 'react'
+import React, { useEffect, useReducer, useRef, useCallback } from 'react'
 import Link from 'next/link'
 import {
   BarChart3,
@@ -86,8 +86,6 @@ type NavAction =
   | { type: 'SET_NAVIGATING'; payload: boolean }
   | { type: 'SET_TOUCH_START_TIME'; payload: number }
   | { type: 'SET_TOUCH_START_POSITION'; payload: { x: number; y: number } }
-  | { type: 'CLOSE_DROPDOWN_AND_ANNOUNCE'; payload: string }
-  | { type: 'OPEN_DROPDOWN_AND_FOCUS'; payload: string }
   | { type: 'TOGGLE_DROPDOWN' }
 
 const initialNavState: NavUiState = {
@@ -125,12 +123,8 @@ function navReducer(state: NavUiState, action: NavAction): NavUiState {
       return { ...state, touchStartTime: action.payload }
     case 'SET_TOUCH_START_POSITION':
       return { ...state, touchStartPosition: action.payload }
-    case 'CLOSE_DROPDOWN_AND_ANNOUNCE':
-      return { ...state, isDropdownOpen: false, focusedItemIndex: -1, announcement: action.payload }
-    case 'OPEN_DROPDOWN_AND_FOCUS':
-      return { ...state, isDropdownOpen: true, focusedItemIndex: -1, announcement: action.payload }
     case 'TOGGLE_DROPDOWN':
-      return { ...state, isDropdownOpen: !state.isDropdownOpen, focusedItemIndex: state.isDropdownOpen ? -1 : -1 }
+      return { ...state, isDropdownOpen: !state.isDropdownOpen, focusedItemIndex: !state.isDropdownOpen ? -1 : state.focusedItemIndex }
     default:
       return state
   }
@@ -217,12 +211,12 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
     dispatch({ type: 'SET_TOUCH_START_POSITION', payload: {
       x: event.touches[0].clientX,
       y: event.touches[0].clientY
-    }}
+    }})
   }, [])
 
   const handleTouchEnd = useCallback((itemId: string, event: React.TouchEvent) => {
     const touchEndTime = Date.now()
-    const touchDuration = touchEndTime - touchStartTime
+    const touchDuration = touchEndTime - navState.touchStartTime
 
     // Only trigger if it's a quick tap (not a long press or drag)
     if (touchDuration < 500) {
@@ -242,7 +236,7 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
         if ('vibrate' in navigator && typeof navigator.vibrate === 'function') {
           try {
             navigator.vibrate(10)
-          } catch (error) {
+          } catch {
             // Silently fail if vibration is not supported
           }
         }
@@ -253,7 +247,7 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
     if (touchDuration < 500 && 'vibrate' in navigator && typeof navigator.vibrate === 'function') {
       try {
         navigator.vibrate(10)
-      } catch (error) {
+      } catch {
         // Silently fail if vibration is not supported
       }
     }

--- a/components/common/mobile-bottom-navigation.tsx
+++ b/components/common/mobile-bottom-navigation.tsx
@@ -130,6 +130,351 @@ function navReducer(state: NavUiState, action: NavAction): NavUiState {
   }
 }
 
+// Extracted sub-components
+function PrimaryNavBar({
+  items,
+  moreButtonRef,
+  isMoreActive,
+  isDropdownOpen,
+  isNavigating,
+  touchedItem,
+  isRouteActive,
+  onNavigationSelect,
+  onMoreClick,
+  onTouchStart,
+  onTouchEnd,
+  onTouchCancel,
+  className
+}: {
+  items: NavigationItem[];
+  moreButtonRef: React.RefObject<HTMLButtonElement | null>;
+  isMoreActive: boolean;
+  isDropdownOpen: boolean;
+  isNavigating: boolean;
+  touchedItem: string | null;
+  isRouteActive: (route: string) => boolean;
+  onNavigationSelect: (itemTitle: string, callback?: () => void) => void;
+  onMoreClick: () => void;
+  onTouchStart: (itemId: string, event: React.TouchEvent) => void;
+  onTouchEnd: (itemId: string, event: React.TouchEvent) => void;
+  onTouchCancel: () => void;
+  className?: string;
+}) {
+  return (
+    <nav
+      className={cn(
+        "fixed bottom-0 left-0 right-0 z-50",
+        "bg-background/95 backdrop-blur-xs border-t border-border/50",
+        "shadow-lg shadow-black/5",
+        "mobile-nav-responsive",
+        "hydration-safe-mobile",
+        "prevent-layout-shift",
+        "mobile-nav-container",
+        className
+      )}
+      role="navigation"
+      aria-label="Main mobile navigation"
+      style={{
+        display: 'block',
+        paddingTop: '0.5rem',
+        paddingBottom: 'max(0.5rem, env(safe-area-inset-bottom))'
+      }}
+    >
+      <div className="flex items-center justify-around px-1 h-16">
+        {items.map((item) => {
+          const IconComponent = item.icon;
+          let isActive = false;
+          if (item.href) {
+            isActive = isRouteActive(item.href);
+          } else if (item.id === 'more') {
+            isActive = isMoreActive;
+          }
+
+          if (item.id === 'more') {
+            return (
+              <button
+                key={item.id}
+                ref={moreButtonRef}
+                onClick={onMoreClick}
+                onTouchStart={(e) => onTouchStart(item.id, e)}
+                onTouchEnd={(e) => onTouchEnd(item.id, e)}
+                onTouchCancel={onTouchCancel}
+                disabled={isNavigating}
+                className={cn(
+                  "flex flex-col items-center justify-center",
+                  "min-h-[44px] min-w-[44px] px-3 py-2 mobile-nav-item touch-feedback",
+                  "transition-all duration-200 ease-out",
+                  "rounded-lg relative",
+                  "focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:ring-offset-2 focus:ring-offset-background",
+                  "active:scale-95",
+                  touchedItem === item.id && "scale-95 bg-accent/20",
+                  isActive
+                    ? "bg-primary/10 text-primary shadow-xs"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent/10",
+                  isDropdownOpen && "bg-primary/15 text-primary",
+                  isNavigating && "opacity-70 pointer-events-none"
+                )}
+                aria-label={`${item.title} menu${isActive ? ' (current section)' : ''}`}
+                aria-current={isActive ? "page" : undefined}
+                aria-expanded={isDropdownOpen}
+                aria-haspopup="menu"
+                aria-controls={isDropdownOpen ? "more-dropdown-menu" : undefined}
+                aria-describedby="more-button-description"
+              >
+                <IconComponent
+                  className={cn("w-5 h-5 mb-1 transition-all duration-300 ease-out", isActive && "", isDropdownOpen && "rotate-180 ")}
+                  aria-hidden="true"
+                />
+                <span className={cn("text-xs transition-all duration-300 ease-out", isActive ? "font-semibold tracking-wide" : "font-medium", isDropdownOpen && "font-semibold tracking-wide")}>
+                  {item.title}
+                </span>
+              </button>
+            );
+          }
+
+          if (item.href) {
+            return (
+              <Link
+                key={item.id}
+                href={item.href}
+                onClick={(e) => {
+                  if (isNavigating) { e.preventDefault(); return; }
+                  onNavigationSelect(item.title);
+                }}
+                onTouchStart={(e) => onTouchStart(item.id, e)}
+                onTouchEnd={(e) => onTouchEnd(item.id, e)}
+                onTouchCancel={onTouchCancel}
+                className={cn(
+                  "flex flex-col items-center justify-center",
+                  "min-h-[44px] min-w-[44px] px-3 py-2 mobile-nav-item touch-feedback",
+                  "transition-all duration-200 ease-out",
+                  "rounded-lg relative",
+                  "focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:ring-offset-2 focus:ring-offset-background",
+                  "active:scale-95",
+                  touchedItem === item.id && "scale-95 bg-accent/20",
+                  isActive
+                    ? "bg-primary/10 text-primary shadow-xs"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent/10 ",
+                  isNavigating && "opacity-70 pointer-events-none"
+                )}
+                aria-label={`Navigate to ${item.title}${isActive ? ' (current page)' : ''}`}
+                aria-current={isActive ? "page" : undefined}
+              >
+                <IconComponent className={cn("w-5 h-5 mb-1 transition-all duration-300 ease-out", isActive && "")} aria-hidden="true" />
+                <span className={cn("text-xs transition-all duration-300 ease-out", isActive ? "font-semibold tracking-wide" : "font-medium")}>
+                  {item.title}
+                </span>
+              </Link>
+            );
+          } else {
+            return (
+              <button
+                key={item.id}
+                onClick={() => { onNavigationSelect(item.title, () => { item.onClick?.(); }); }}
+                onTouchStart={(e) => onTouchStart(item.id, e)}
+                onTouchEnd={(e) => onTouchEnd(item.id, e)}
+                onTouchCancel={onTouchCancel}
+                disabled={isNavigating}
+                className={cn(
+                  "flex flex-col items-center justify-center",
+                  "min-h-[44px] min-w-[44px] px-3 py-2 mobile-nav-item touch-feedback",
+                  "transition-all duration-200 ease-out",
+                  "rounded-lg relative",
+                  "focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:ring-offset-2 focus:ring-offset-background",
+                  "active:scale-95",
+                  touchedItem === item.id && "scale-95 bg-accent/20",
+                  isActive
+                    ? "bg-primary/10 text-primary shadow-xs"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent/10 ",
+                  isNavigating && "opacity-70 pointer-events-none"
+                )}
+                aria-label={`${item.title}${item.id === 'search' ? ' - Open search' : ''}${isActive ? ' (current page)' : ''}`}
+                aria-current={isActive ? "page" : undefined}
+              >
+                <IconComponent className={cn("w-5 h-5 mb-1 transition-all duration-300 ease-out", isActive && "")} aria-hidden="true" />
+                <span className={cn("text-xs transition-all duration-300 ease-out", isActive ? "font-semibold tracking-wide" : "font-medium")}>
+                  {item.title}
+                </span>
+              </button>
+            );
+          }
+        })}
+      </div>
+    </nav>
+  );
+}
+
+function MoreDropdownMenu({
+  isOpen,
+  dropdownRef,
+  items,
+  focusedItemIndex,
+  touchedItem,
+  onItemRef,
+  isRouteActive,
+  onNavigationSelect,
+  onTouchStart,
+  onTouchEnd,
+  onTouchCancel,
+  onFocusItem,
+  onCloseDropdown
+}: {
+  isOpen: boolean;
+  dropdownRef: React.RefObject<HTMLDivElement | null>;
+  items: DropdownItem[];
+  focusedItemIndex: number;
+  touchedItem: string | null;
+  onItemRef: (index: number, el: HTMLAnchorElement | HTMLButtonElement | null) => void;
+  isRouteActive: (route: string) => boolean;
+  onNavigationSelect: (itemTitle: string, callback?: () => void) => void;
+  onTouchStart: (itemId: string, event: React.TouchEvent) => void;
+  onTouchEnd: (itemId: string, event: React.TouchEvent) => void;
+  onTouchCancel: () => void;
+  onFocusItem: (index: number) => void;
+  onCloseDropdown: () => void;
+}) {
+  if (!isOpen) return null;
+
+  const visibleItems = items.filter(item => !item.hidden);
+
+  return (
+    <div
+      id="more-dropdown-menu"
+      ref={dropdownRef}
+      className={cn(
+        "fixed bottom-16 left-0 right-0 z-40",
+        "bg-background/98 backdrop-blur-md border border-border/40 rounded-t-xl shadow-xl shadow-black/15",
+        "mx-3 mb-2 mobile-dropdown",
+        "animate-in slide-in-from-bottom-4 fade-in-0 duration-300 ease-out",
+        "overflow-hidden"
+      )}
+      role="menu"
+      aria-label="More navigation options"
+      aria-orientation="vertical"
+      aria-activedescendant={
+        focusedItemIndex >= 0
+          ? `dropdown-item-${visibleItems[focusedItemIndex]?.id}`
+          : undefined
+      }
+    >
+      <div className="py-2">
+        {visibleItems.map((item, index) => {
+          const IconComponent = item.icon;
+          const isActive = item.href ? isRouteActive(item.href) : false;
+          const isFocused = index === focusedItemIndex;
+
+          if (item.onClick) {
+            return (
+              <div key={item.id}>
+                <button
+                  id={`dropdown-item-${item.id}`}
+                  ref={(el) => onItemRef(index, el as any)}
+                  onClick={() => {
+                    onNavigationSelect(item.title, () => {
+                      item.onClick?.();
+                    });
+                  }}
+                  onMouseEnter={() => onFocusItem(index)}
+                  onFocus={() => onFocusItem(index)}
+                  onTouchStart={(e) => onTouchStart(`dropdown-${item.id}`, e)}
+                  onTouchEnd={(e) => onTouchEnd(`dropdown-${item.id}`, e)}
+                  onTouchCancel={onTouchCancel}
+                  className={cn(
+                    "flex items-center px-4 py-3 mx-2 rounded-lg",
+                    "min-h-[44px] mobile-dropdown-item touch-feedback",
+                    "transition-all duration-200 ease-out",
+                    "focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:ring-offset-2 focus:ring-offset-background",
+                    "active:scale-95",
+                    touchedItem === `dropdown-${item.id}` && "scale-95 bg-accent/20",
+                    "text-foreground hover:bg-accent/10",
+                    isFocused && "bg-accent/5"
+                  )}
+                  role="menuitem"
+                  tabIndex={0}
+                  aria-label={`Open ${item.title}`}
+                >
+                  <IconComponent
+                    className={cn(
+                      "w-5 h-5 mr-3 transition-all duration-300 ease-out",
+                      isFocused && "text-foreground"
+                    )}
+                    aria-hidden="true"
+                  />
+                  <span className={cn(
+                    "text-sm transition-all duration-300 ease-out",
+                    "font-medium",
+                    isFocused && "font-medium"
+                  )}>
+                    {item.title}
+                  </span>
+                </button>
+                {item.id === 'profile' && (
+                  <div className="mx-4 my-3 border-t border-border/30" />
+                )}
+              </div>
+            );
+          }
+
+          return (
+            <div key={item.id}>
+              <Link
+                id={`dropdown-item-${item.id}`}
+                ref={(el) => onItemRef(index, el)}
+                href={item.href!}
+                onClick={() => {
+                  onNavigationSelect(item.title, () => {
+                    onCloseDropdown();
+                  });
+                }}
+                onMouseEnter={() => onFocusItem(index)}
+                onFocus={() => onFocusItem(index)}
+                onTouchStart={(e) => onTouchStart(`dropdown-${item.id}`, e)}
+                onTouchEnd={(e) => onTouchEnd(`dropdown-${item.id}`, e)}
+                onTouchCancel={onTouchCancel}
+                className={cn(
+                  "flex items-center px-4 py-3 mx-2 rounded-lg",
+                  "min-h-[44px] mobile-dropdown-item touch-feedback",
+                  "transition-all duration-200 ease-out",
+                  "focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:ring-offset-2 focus:ring-offset-background",
+                  "active:scale-95",
+                  touchedItem === `dropdown-${item.id}` && "scale-95 bg-accent/20",
+                  isActive
+                    ? "bg-primary/10 text-primary shadow-xs"
+                    : "text-foreground hover:bg-accent/10",
+                  isFocused && !isActive && "bg-accent/5"
+                )}
+                role="menuitem"
+                tabIndex={0}
+                aria-current={isActive ? "page" : undefined}
+                aria-label={`Navigate to ${item.title}${isActive ? ' (current page)' : ''}`}
+              >
+                <IconComponent
+                  className={cn(
+                    "w-5 h-5 mr-3 transition-all duration-300 ease-out",
+                    isActive && "text-primary",
+                    isFocused && !isActive && "text-foreground"
+                  )}
+                  aria-hidden="true"
+                />
+                <span className={cn(
+                  "text-sm transition-all duration-300 ease-out",
+                  isActive ? "font-semibold text-primary" : "font-medium",
+                  isFocused && !isActive && "font-medium"
+                )}>
+                  {item.title}
+                </span>
+              </Link>
+              {item.id === 'documents' && (
+                <div className="mx-4 my-3 border-t border-border/30" />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export default function MobileBottomNavigation({ className, sidebarData }: MobileBottomNavigationProps) {
   const { isRouteActive } = useSidebarActiveState()
   const { setOpen: setCommandMenuOpen } = useCommandMenu()
@@ -602,162 +947,21 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
 
   return (
     <>
-      {/* Dropdown Menu - positioned above navigation bar */}
-      {navState.isDropdownOpen && (
-        <div
-          id="more-dropdown-menu"
-          ref={dropdownRef}
-          className={cn(
-            "fixed bottom-16 left-0 right-0 z-40",
-            "bg-background/98 backdrop-blur-md border border-border/40 rounded-t-xl shadow-xl shadow-black/15",
-            "mx-3 mb-2 mobile-dropdown",
-            "animate-in slide-in-from-bottom-4 fade-in-0 duration-300 ease-out",
-            // Ensure proper background and prevent overlap
-            "overflow-hidden"
-          )}
-          role="menu"
-          aria-label="More navigation options"
-          aria-orientation="vertical"
-          aria-activedescendant={
-            navState.focusedItemIndex >= 0
-              ? `dropdown-item-${visibleDropdownItems[navState.focusedItemIndex]?.id}`
-              : undefined
-          }
-        >
-          <div className="py-2">
-            {visibleDropdownItems.map((item, index) => {
-              const IconComponent = item.icon
-              const isActive = item.href ? isRouteActive(item.href) : false
-              const isFocused = index === navState.focusedItemIndex
-
-              // Handle button items (like profile)
-              if (item.onClick) {
-                return (
-                  <div key={item.id}>
-                    <button
-                      id={`dropdown-item-${item.id}`}
-                      ref={(el) => {
-                        dropdownItemRefs.current[index] = el as any
-                      }}
-                      onClick={() => {
-                        handleNavigationSelect(item.title, () => {
-                          item.onClick?.()
-                        })
-                      }}
-                      onMouseEnter={() => dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: index })}
-                      onFocus={() => dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: index })}
-                      onTouchStart={(e) => handleTouchStart(`dropdown-${item.id}`, e)}
-                      onTouchEnd={(e) => handleTouchEnd(`dropdown-${item.id}`, e)}
-                      onTouchCancel={handleTouchCancel}
-                      className={cn(
-                        "flex items-center px-4 py-3 mx-2 rounded-lg",
-                        "min-h-[44px] mobile-dropdown-item touch-feedback",
-                        "transition-all duration-200 ease-out",
-                        "focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:ring-offset-2 focus:ring-offset-background",
-                        "active:scale-95",
-                        // Enhanced touch feedback
-                        navState.touchedItem === `dropdown-${item.id}` && "scale-95 bg-accent/20",
-                        // Button styling - exactly identical to link items (no active state since buttons don't have href)
-                        "text-foreground hover:bg-accent/10",
-                        // Focus state styling - exactly identical to link items
-                        isFocused && "bg-accent/5"
-                      )}
-                      role="menuitem"
-                      tabIndex={0}
-                      aria-label={`Open ${item.title}`}
-                    >
-                      <IconComponent
-                        className={cn(
-                          "w-5 h-5 mr-3 transition-all duration-300 ease-out",
-                          // Icon styling exactly identical to link items (no active state for buttons)
-                          isFocused && "text-foreground"
-                        )}
-                        aria-hidden="true"
-                      />
-                      <span className={cn(
-                        "text-sm transition-all duration-300 ease-out",
-                        // Text styling exactly identical to link items (no active state for buttons)
-                        "font-medium",
-                        isFocused && "font-medium"
-                      )}>
-                        {item.title}
-                      </span>
-                    </button>
-                    {/* Add separator after profile */}
-                    {item.id === 'profile' && (
-                      <div className="mx-4 my-3 border-t border-border/30" />
-                    )}
-                  </div>
-                )
-              }
-
-              // Handle link items
-              return (
-                <div key={item.id}>
-                  <Link
-                    id={`dropdown-item-${item.id}`}
-                    ref={(el) => {
-                      dropdownItemRefs.current[index] = el
-                    }}
-                    href={item.href!}
-                      onClick={() => {
-                        handleNavigationSelect(item.title, () => {
-                          dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
-                        })
-                      }}
-                      onMouseEnter={() => dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: index })}
-                      onFocus={() => dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: index })}
-                      onTouchStart={(e) => handleTouchStart(`dropdown-${item.id}`, e)}
-                      onTouchEnd={(e) => handleTouchEnd(`dropdown-${item.id}`, e)}
-                      onTouchCancel={handleTouchCancel}
-                      className={cn(
-                        "flex items-center px-4 py-3 mx-2 rounded-lg",
-                        "min-h-[44px] mobile-dropdown-item touch-feedback",
-                        "transition-all duration-200 ease-out",
-                        "focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:ring-offset-2 focus:ring-offset-background",
-                        "active:scale-95",
-                        // Enhanced touch feedback
-                        navState.touchedItem === `dropdown-${item.id}` && "scale-95 bg-accent/20",
-                      // Active state styling - mobile optimized without scaling
-                      isActive
-                        ? "bg-primary/10 text-primary shadow-xs"
-                        : "text-foreground hover:bg-accent/10",
-                      // Focus state styling - mobile optimized without scaling
-                      isFocused && !isActive && "bg-accent/5"
-                    )}
-                    role="menuitem"
-                    tabIndex={0}
-                    aria-current={isActive ? "page" : undefined}
-                    aria-label={`Navigate to ${item.title}${isActive ? ' (current page)' : ''}`}
-                  >
-                    <IconComponent
-                      className={cn(
-                        "w-5 h-5 mr-3 transition-all duration-300 ease-out",
-                        isActive && "text-primary",
-                        isFocused && !isActive && "text-foreground"
-                      )}
-                      aria-hidden="true"
-                    />
-                    <span className={cn(
-                      "text-sm transition-all duration-300 ease-out",
-                      isActive ? "font-semibold text-primary" : "font-medium",
-                      isFocused && !isActive && "font-medium"
-                    )}>
-                      {item.title}
-                    </span>
-                  </Link>
-                  {/* Add separator before logout */}
-                  {item.id === 'documents' && (
-                    <div className="mx-4 my-3 border-t border-border/30" />
-                  )}
-                </div>
-              )
-            })}
-
-
-          </div>
-        </div>
-      )}
+      <MoreDropdownMenu
+        isOpen={navState.isDropdownOpen}
+        dropdownRef={dropdownRef}
+        items={dropdownItems}
+        focusedItemIndex={navState.focusedItemIndex}
+        touchedItem={navState.touchedItem}
+        onItemRef={(index, el) => { dropdownItemRefs.current[index] = el as HTMLAnchorElement | null; }}
+        isRouteActive={isRouteActive}
+        onNavigationSelect={handleNavigationSelect}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+        onTouchCancel={handleTouchCancel}
+        onFocusItem={(index) => dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: index })}
+        onCloseDropdown={() => dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })}
+      />
 
       {/* Screen reader announcements */}
       <div
@@ -774,201 +978,21 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
         Opens additional navigation options. Use arrow keys to navigate when open.
       </div>
 
-      <nav
-        className={cn(
-          "fixed bottom-0 left-0 right-0 z-50",
-          "bg-background/95 backdrop-blur-xs border-t border-border/50",
-          "shadow-lg shadow-black/5",
-          // Enhanced CSS-only responsive fallbacks
-          "mobile-nav-responsive",
-          "hydration-safe-mobile",
-          // Prevent layout shift during hydration
-          "prevent-layout-shift",
-          // Mobile navigation container optimizations
-          "mobile-nav-container",
-          className
-        )}
-        role="navigation"
-        aria-label="Main mobile navigation"
-        // Enhanced CSS-only fallback for responsive behavior
-        style={{
-          // Ensure proper responsive behavior even without JS
-          display: 'block',
-          // Safe area support with balanced padding
-          paddingTop: '0.5rem',
-          paddingBottom: 'max(0.5rem, env(safe-area-inset-bottom))'
-        }}
-      >
-        {/* Main navigation items */}
-        <div className="flex items-center justify-around px-1 h-16">
-          {primaryNavItems.map((item) => {
-            const IconComponent = item.icon
-
-            // Determine if this item is active
-            let isActive = false
-            if (item.href) {
-              isActive = isRouteActive(item.href)
-            } else if (item.id === 'more') {
-              // Special case: "More" button is active if any dropdown route is active
-              isActive = isMoreActive
-            }
-
-            // Handle "More" button separately due to ref requirement
-            if (item.id === 'more') {
-              return (
-                <button
-                  key={item.id}
-                  ref={moreButtonRef}
-                  onClick={item.onClick}
-                  onTouchStart={(e) => handleTouchStart(item.id, e)}
-                  onTouchEnd={(e) => handleTouchEnd(item.id, e)}
-                  onTouchCancel={handleTouchCancel}
-                  disabled={navState.isNavigating}
-                  className={cn(
-                    "flex flex-col items-center justify-center",
-                    "min-h-[44px] min-w-[44px] px-3 py-2 mobile-nav-item touch-feedback",
-                    "transition-all duration-200 ease-out",
-                    "rounded-lg relative",
-                    "focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:ring-offset-2 focus:ring-offset-background",
-                    "active:scale-95",
-                    // Enhanced touch feedback
-                    navState.touchedItem === item.id && "scale-95 bg-accent/20",
-                    // Active state styling - mobile optimized without scaling
-                    isActive
-                      ? "bg-primary/10 text-primary shadow-xs"
-                      : "text-muted-foreground hover:text-foreground hover:bg-accent/10",
-                    // Special styling when dropdown is open
-                    navState.isDropdownOpen && "bg-primary/15 text-primary",
-                    // Disabled state for navigation debouncing
-                    navState.isNavigating && "opacity-70 pointer-events-none"
-                  )}
-                  aria-label={`${item.title} menu${isActive ? ' (current section)' : ''}`}
-                  aria-current={isActive ? "page" : undefined}
-                  aria-expanded={navState.isDropdownOpen}
-                  aria-haspopup="menu"
-                  aria-controls={navState.isDropdownOpen ? "more-dropdown-menu" : undefined}
-                  aria-describedby="more-button-description"
-                >
-                  <IconComponent
-                    className={cn(
-                      "w-5 h-5 mb-1 transition-all duration-300 ease-out",
-                      isActive && "",
-                      navState.isDropdownOpen && "rotate-180 "
-                    )}
-                    aria-hidden="true"
-                  />
-                  <span className={cn(
-                    "text-xs transition-all duration-300 ease-out",
-                    isActive ? "font-semibold tracking-wide" : "font-medium",
-                    navState.isDropdownOpen && "font-semibold tracking-wide"
-                  )}>
-                    {item.title}
-                  </span>
-                </button>
-              )
-            }
-
-            // If item has href, render as Link, otherwise as button
-            if (item.href) {
-              return (
-                <Link
-                  key={item.id}
-                  href={item.href}
-                  onClick={(e) => {
-                    if (navState.isNavigating) {
-                      e.preventDefault()
-                      return
-                    }
-                    handleNavigationSelect(item.title)
-                  }}
-                  onTouchStart={(e) => handleTouchStart(item.id, e)}
-                  onTouchEnd={(e) => handleTouchEnd(item.id, e)}
-                  onTouchCancel={handleTouchCancel}
-                  className={cn(
-                    "flex flex-col items-center justify-center",
-                    "min-h-[44px] min-w-[44px] px-3 py-2 mobile-nav-item touch-feedback",
-                    "transition-all duration-200 ease-out",
-                    "rounded-lg relative",
-                    "focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:ring-offset-2 focus:ring-offset-background",
-                    "active:scale-95",
-                    // Enhanced touch feedback
-                    navState.touchedItem === item.id && "scale-95 bg-accent/20",
-                    // Active state styling matching desktop navigation
-                    isActive
-                      ? "bg-primary/10 text-primary shadow-xs"
-                      : "text-muted-foreground hover:text-foreground hover:bg-accent/10 ",
-                    // Disabled state for navigation debouncing
-                    navState.isNavigating && "opacity-70 pointer-events-none"
-                  )}
-                  aria-label={`Navigate to ${item.title}${isActive ? ' (current page)' : ''}`}
-                  aria-current={isActive ? "page" : undefined}
-                >
-                  <IconComponent
-                    className={cn(
-                      "w-5 h-5 mb-1 transition-all duration-300 ease-out",
-                      isActive && ""
-                    )}
-                    aria-hidden="true"
-                  />
-                  <span className={cn(
-                    "text-xs transition-all duration-300 ease-out",
-                    isActive ? "font-semibold tracking-wide" : "font-medium"
-                  )}>
-                    {item.title}
-                  </span>
-                </Link>
-              )
-            } else {
-              return (
-                <button
-                  key={item.id}
-                  onClick={() => {
-                    handleNavigationSelect(item.title, () => {
-                      item.onClick?.()
-                    })
-                  }}
-                  onTouchStart={(e) => handleTouchStart(item.id, e)}
-                  onTouchEnd={(e) => handleTouchEnd(item.id, e)}
-                  onTouchCancel={handleTouchCancel}
-                  disabled={navState.isNavigating}
-                  className={cn(
-                    "flex flex-col items-center justify-center",
-                    "min-h-[44px] min-w-[44px] px-3 py-2 mobile-nav-item touch-feedback",
-                    "transition-all duration-200 ease-out",
-                    "rounded-lg relative",
-                    "focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:ring-offset-2 focus:ring-offset-background",
-                    "active:scale-95",
-                    // Enhanced touch feedback
-                    navState.touchedItem === item.id && "scale-95 bg-accent/20",
-                    // Active state styling matching desktop navigation
-                    isActive
-                      ? "bg-primary/10 text-primary shadow-xs"
-                      : "text-muted-foreground hover:text-foreground hover:bg-accent/10 ",
-                    // Disabled state for navigation debouncing
-                    navState.isNavigating && "opacity-70 pointer-events-none"
-                  )}
-                  aria-label={`${item.title}${item.id === 'search' ? ' - Open search' : ''}${isActive ? ' (current page)' : ''}`}
-                  aria-current={isActive ? "page" : undefined}
-                >
-                  <IconComponent
-                    className={cn(
-                      "w-5 h-5 mb-1 transition-all duration-300 ease-out",
-                      isActive && ""
-                    )}
-                    aria-hidden="true"
-                  />
-                  <span className={cn(
-                    "text-xs transition-all duration-300 ease-out",
-                    isActive ? "font-semibold tracking-wide" : "font-medium"
-                  )}>
-                    {item.title}
-                  </span>
-                </button>
-              )
-            }
-          })}
-        </div>
-      </nav>
+      <PrimaryNavBar
+        items={primaryNavItems}
+        moreButtonRef={moreButtonRef}
+        isMoreActive={isMoreActive}
+        isDropdownOpen={navState.isDropdownOpen}
+        isNavigating={navState.isNavigating}
+        touchedItem={navState.touchedItem}
+        isRouteActive={isRouteActive}
+        onNavigationSelect={handleNavigationSelect}
+        onMoreClick={() => dispatch({ type: 'TOGGLE_DROPDOWN' })}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+        onTouchCancel={handleTouchCancel}
+        className={className}
+      />
       {/* Settings Modal */}
       <SettingsModal open={navState.isSettingsModalOpen} onOpenChange={(open) => dispatch({ type: 'SET_SETTINGS_MODAL_OPEN', payload: open })} />
     </>

--- a/components/common/mobile-bottom-navigation.tsx
+++ b/components/common/mobile-bottom-navigation.tsx
@@ -130,14 +130,335 @@ function navReducer(state: NavUiState, action: NavAction): NavUiState {
   }
 }
 
+function useMobileNavigation(sidebarData: SidebarUserData | undefined, isRouteActive: (route: string) => boolean) {
+  const { setOpen: setCommandMenuOpen } = useCommandMenu()
+  const documentsEnabled = useFeatureFlagEnabled('documents_tab_access')
+
+  const [navState, dispatch] = useReducer(navReducer, initialNavState)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const moreButtonRef = useRef<HTMLButtonElement>(null)
+  const dropdownItemRefs = useRef<(HTMLAnchorElement | null)[]>([])
+  const navigationTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined)
+
+  // Hydration safety and responsive behavior
+  useEffect(() => {
+    dispatch({ type: 'SET_MOUNTED', payload: true })
+
+    const checkScreenSize = () => {
+      const newIsMobile = window.innerWidth < 768
+      dispatch({ type: 'SET_MOBILE', payload: newIsMobile })
+      return newIsMobile
+    }
+
+    checkScreenSize()
+
+    let resizeTimeout: ReturnType<typeof setTimeout>
+    const handleResize = () => {
+      clearTimeout(resizeTimeout)
+      resizeTimeout = setTimeout(() => {
+        const newIsMobile = checkScreenSize()
+
+        if (!newIsMobile && navState.isDropdownOpen) {
+          dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
+          dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'Navigation switched to desktop mode.' })
+        }
+
+        if (newIsMobile !== navState.isMobile) {
+          dispatch({ type: 'SET_ANNOUNCEMENT', payload:
+            newIsMobile
+              ? 'Switched to mobile navigation.'
+              : 'Switched to desktop navigation.'
+          })
+        }
+      }, 150)
+    }
+
+    window.addEventListener('resize', handleResize, { passive: true })
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+      clearTimeout(resizeTimeout)
+    }
+  }, [navState.isDropdownOpen, navState.isMobile])
+
+  // Debounced navigation handler
+  const debouncedNavigate = useDebouncedCallback((callback: () => void) => {
+    if (navState.isNavigating) return
+
+    dispatch({ type: 'SET_NAVIGATING', payload: true })
+    callback()
+
+    if (navigationTimeoutRef.current) {
+      clearTimeout(navigationTimeoutRef.current)
+    }
+    navigationTimeoutRef.current = setTimeout(() => {
+      dispatch({ type: 'SET_NAVIGATING', payload: false })
+    }, 300)
+  }, 150)
+
+  // Touch feedback handlers
+  const handleTouchStart = useCallback((itemId: string, event: React.TouchEvent) => {
+    dispatch({ type: 'SET_TOUCHED_ITEM', payload: itemId })
+    dispatch({ type: 'SET_TOUCH_START_TIME', payload: Date.now() })
+    dispatch({ type: 'SET_TOUCH_START_POSITION', payload: {
+      x: event.touches[0].clientX,
+      y: event.touches[0].clientY
+    }})
+  }, [])
+
+  const handleTouchEnd = useCallback((itemId: string, event: React.TouchEvent) => {
+    const touchEndTime = Date.now()
+    const touchDuration = touchEndTime - navState.touchStartTime
+
+    if (touchDuration < 500) {
+      const touchEndPosition = {
+        x: event.changedTouches[0].clientX,
+        y: event.changedTouches[0].clientY
+      }
+      const touchDistance = Math.sqrt(
+        Math.pow(touchEndPosition.x - navState.touchStartPosition.x, 2) +
+        Math.pow(touchEndPosition.y - navState.touchStartPosition.y, 2)
+      )
+      if (touchDistance < 10) {
+        if ('vibrate' in navigator && typeof navigator.vibrate === 'function') {
+          try { navigator.vibrate(10) } catch { }
+        }
+      }
+    }
+
+    if (touchDuration < 500 && 'vibrate' in navigator && typeof navigator.vibrate === 'function') {
+      try { navigator.vibrate(10) } catch { }
+    }
+
+    setTimeout(() => {
+      dispatch({ type: 'SET_TOUCHED_ITEM', payload: null })
+    }, 150)
+  }, [navState.touchStartTime, navState.touchStartPosition])
+
+  const handleTouchCancel = useCallback(() => {
+    dispatch({ type: 'SET_TOUCHED_ITEM', payload: null })
+  }, [])
+
+  // Dropdown toggle
+  const handleMoreClick = () => {
+    debouncedNavigate(() => {
+      const newState = !navState.isDropdownOpen
+      dispatch({ type: 'SET_DROPDOWN_OPEN', payload: newState })
+      dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: -1 })
+
+      if (newState) {
+        dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'More menu opened. Use arrow keys to navigate.' })
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            if (dropdownItemRefs.current[0]) {
+              dropdownItemRefs.current[0]?.focus()
+              dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: 0 })
+            }
+          })
+        })
+      } else {
+        dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'More menu closed.' })
+        requestAnimationFrame(() => {
+          moreButtonRef.current?.focus()
+        })
+      }
+    })
+  }
+
+  // Search click
+  const handleSearchClick = () => {
+    debouncedNavigate(() => {
+      setCommandMenuOpen(true)
+      dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'Search opened.' })
+    })
+  }
+
+  // Primary navigation items
+  const primaryNavItems: NavigationItem[] = [
+    { id: 'home', title: 'Home', href: ROUTES.HOME, icon: BarChart3 },
+    { id: 'tenants', title: 'Mieter', href: '/mieter', icon: Users },
+    { id: 'search', title: 'Suchen', icon: SearchIcon, onClick: handleSearchClick },
+    { id: 'finance', title: 'Finanzen', href: '/finanzen', icon: Wallet },
+    { id: 'more', title: 'Mehr', icon: Menu, onClick: handleMoreClick }
+  ]
+
+  // Profile click
+  const handleProfileClick = () => {
+    dispatch({ type: 'SET_SETTINGS_MODAL_OPEN', payload: true })
+    dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
+    dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'Settings opened.' })
+  }
+
+  // Logout
+  const handleLogout = async () => {
+    dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
+    dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'Logging out...' })
+
+    try {
+      const supabase = createClient()
+      const { error } = await supabase.auth.signOut()
+      if (error) throw error
+    } catch (error) {
+      console.error('Error signing out:', error)
+      dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'Logout failed.' })
+    }
+  }
+
+  // Dropdown items
+  const dropdownItems: DropdownItem[] = [
+    { id: 'profile', title: 'Profil', icon: User, onClick: handleProfileClick },
+    { id: 'homepage', title: 'Homepage', href: '/', icon: Globe },
+    { id: 'houses', title: 'Häuser', href: '/haeuser', icon: Building2 },
+    { id: 'apartments', title: 'Wohnungen', href: '/wohnungen', icon: Home },
+    { id: 'operating-costs', title: 'Betriebskosten', href: '/betriebskosten', icon: FileSpreadsheet },
+    { id: 'organisation', title: 'Organisationen', href: '/organisation', icon: Building2, hidden: !sidebarData?.hasOrganisationPermission || sidebarData?.isOrganisationHidden },
+    { id: 'tasks', title: 'Aufgaben', href: '/todos', icon: CheckSquare },
+    { id: 'documents', title: 'Dokumente', href: '/dateien', icon: Folder, hidden: !documentsEnabled },
+    { id: 'logout', title: 'Abmelden', icon: LogOut, onClick: handleLogout }
+  ]
+
+  // More button active state
+  const dropdownRoutes = dropdownItems
+    .filter(item => item.href && !item.onClick)
+    .map(item => item.href!)
+
+  const isMoreActive = dropdownRoutes.some(route => isRouteActive(route))
+
+  // Visible dropdown items
+  const visibleDropdownItems = dropdownItems.filter(item => !item.hidden)
+
+  // Keyboard navigation
+  const handleDropdownKeyDown = useCallback((event: KeyboardEvent) => {
+    if (!navState.isDropdownOpen) return
+
+    switch (event.key) {
+      case 'Escape':
+        event.preventDefault()
+        dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
+        dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'More menu closed.' })
+        moreButtonRef.current?.focus()
+        break
+      case 'ArrowDown':
+        event.preventDefault()
+        const nextIndex = navState.focusedItemIndex < visibleDropdownItems.length - 1
+          ? navState.focusedItemIndex + 1
+          : 0
+        dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: nextIndex })
+        dropdownItemRefs.current[nextIndex]?.focus()
+        break
+      case 'ArrowUp':
+        event.preventDefault()
+        const prevIndex = navState.focusedItemIndex > 0
+          ? navState.focusedItemIndex - 1
+          : visibleDropdownItems.length - 1
+        dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: prevIndex })
+        dropdownItemRefs.current[prevIndex]?.focus()
+        break
+      case 'Home':
+        event.preventDefault()
+        dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: 0 })
+        dropdownItemRefs.current[0]?.focus()
+        break
+      case 'End':
+        event.preventDefault()
+        const lastIndex = visibleDropdownItems.length - 1
+        dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: lastIndex })
+        dropdownItemRefs.current[lastIndex]?.focus()
+        break
+      case 'Tab':
+        dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
+        dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'More menu closed.' })
+        break
+    }
+  }, [navState.isDropdownOpen, navState.focusedItemIndex, visibleDropdownItems.length])
+
+  // Navigation selection
+  const handleNavigationSelect = useCallback((itemTitle: string, callback?: () => void) => {
+    if (navState.isNavigating) return
+
+    dispatch({ type: 'SET_NAVIGATING', payload: true })
+    dispatch({ type: 'SET_ANNOUNCEMENT', payload: `Navigating to ${itemTitle}.` })
+
+    callback?.()
+
+    setTimeout(() => {
+      dispatch({ type: 'SET_NAVIGATING', payload: false })
+    }, 300)
+  }, [navState.isNavigating])
+
+  // Click outside handler
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent | TouchEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node) &&
+        moreButtonRef.current &&
+        !moreButtonRef.current.contains(event.target as Node)
+      ) {
+        dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
+        dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'More menu closed.' })
+      }
+    }
+
+    if (navState.isDropdownOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+      document.addEventListener('touchstart', handleClickOutside, { passive: true })
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside)
+        document.removeEventListener('touchstart', handleClickOutside)
+      }
+    }
+  }, [navState.isDropdownOpen])
+
+  // Keyboard event listener
+  useEffect(() => {
+    if (navState.isDropdownOpen) {
+      document.addEventListener('keydown', handleDropdownKeyDown)
+      return () => {
+        document.removeEventListener('keydown', handleDropdownKeyDown)
+      }
+    }
+  }, [navState.isDropdownOpen, handleDropdownKeyDown])
+
+  // Announcement auto-clear
+  useEffect(() => {
+    if (navState.announcement) {
+      const timer = setTimeout(() => dispatch({ type: 'SET_ANNOUNCEMENT', payload: '' }), 1000)
+      return () => clearTimeout(timer)
+    }
+  }, [navState.announcement])
+
+  // Cleanup navigation timeout
+  useEffect(() => {
+    return () => {
+      if (navigationTimeoutRef.current) {
+        clearTimeout(navigationTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  return {
+    navState,
+    dispatch,
+    dropdownRef,
+    moreButtonRef,
+    dropdownItemRefs,
+    primaryNavItems,
+    dropdownItems,
+    isMoreActive,
+    visibleDropdownItems,
+    handleNavigationSelect,
+    handleTouchStart,
+    handleTouchEnd,
+    handleTouchCancel
+  }
+}
+
 // Extracted sub-components
 function PrimaryNavBar({
   items,
   moreButtonRef,
-  isMoreActive,
-  isDropdownOpen,
-  isNavigating,
-  touchedItem,
+  navState: { isMoreActive, isDropdownOpen, isNavigating, touchedItem },
   isRouteActive,
   onNavigationSelect,
   onMoreClick,
@@ -148,10 +469,7 @@ function PrimaryNavBar({
 }: {
   items: NavigationItem[];
   moreButtonRef: React.RefObject<HTMLButtonElement | null>;
-  isMoreActive: boolean;
-  isDropdownOpen: boolean;
-  isNavigating: boolean;
-  touchedItem: string | null;
+  navState: { isMoreActive: boolean; isDropdownOpen: boolean; isNavigating: boolean; touchedItem: string | null };
   isRouteActive: (route: string) => boolean;
   onNavigationSelect: (itemTitle: string, callback?: () => void) => void;
   onMoreClick: () => void;
@@ -477,427 +795,14 @@ function MoreDropdownMenu({
 
 export default function MobileBottomNavigation({ className, sidebarData }: MobileBottomNavigationProps) {
   const { isRouteActive } = useSidebarActiveState()
-  const { setOpen: setCommandMenuOpen } = useCommandMenu()
-  const documentsEnabled = useFeatureFlagEnabled('documents_tab_access')
 
-  const [navState, dispatch] = useReducer(navReducer, initialNavState)
-  const dropdownRef = useRef<HTMLDivElement>(null)
-  const moreButtonRef = useRef<HTMLButtonElement>(null)
-  const dropdownItemRefs = useRef<(HTMLAnchorElement | null)[]>([])
-  const navigationTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined)
+  const {
+    navState, dispatch,
+    dropdownRef, moreButtonRef, dropdownItemRefs,
+    primaryNavItems, dropdownItems, isMoreActive,
+    handleNavigationSelect, handleTouchStart, handleTouchEnd, handleTouchCancel
+  } = useMobileNavigation(sidebarData, isRouteActive)
 
-  // Hydration safety and responsive behavior
-  useEffect(() => {
-    // Set mounted to true to prevent hydration mismatches
-    dispatch({ type: 'SET_MOUNTED', payload: true })
-
-    // Check initial screen size
-    const checkScreenSize = () => {
-      const newIsMobile = window.innerWidth < 768
-      dispatch({ type: 'SET_MOBILE', payload: newIsMobile })
-      return newIsMobile
-    }
-
-    // Set initial state
-    checkScreenSize()
-
-    // Add resize listener for responsive behavior with debouncing
-    let resizeTimeout: ReturnType<typeof setTimeout>
-    const handleResize = () => {
-      clearTimeout(resizeTimeout)
-      resizeTimeout = setTimeout(() => {
-        const newIsMobile = checkScreenSize()
-
-        // Close dropdown when switching from mobile to desktop
-        if (!newIsMobile && navState.isDropdownOpen) {
-          dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
-          dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'Navigation switched to desktop mode.' })
-        }
-
-        // Announce responsive behavior changes
-        if (newIsMobile !== navState.isMobile) {
-          dispatch({ type: 'SET_ANNOUNCEMENT', payload:
-            newIsMobile
-              ? 'Switched to mobile navigation.'
-              : 'Switched to desktop navigation.'
-          })
-        }
-      }, 150) // Debounce resize events
-    }
-
-    window.addEventListener('resize', handleResize, { passive: true })
-
-    return () => {
-      window.removeEventListener('resize', handleResize)
-      clearTimeout(resizeTimeout)
-    }
-  }, [navState.isDropdownOpen, navState.isMobile])
-
-  // Debounced navigation handler to prevent rapid navigation attempts
-  const debouncedNavigate = useDebouncedCallback((callback: () => void) => {
-    if (navState.isNavigating) return
-
-    dispatch({ type: 'SET_NAVIGATING', payload: true })
-    callback()
-
-    // Reset navigation state after a short delay
-    if (navigationTimeoutRef.current) {
-      clearTimeout(navigationTimeoutRef.current)
-    }
-    navigationTimeoutRef.current = setTimeout(() => {
-      dispatch({ type: 'SET_NAVIGATING', payload: false })
-    }, 300)
-  }, 150)
-
-  // Enhanced touch feedback handlers
-  const handleTouchStart = useCallback((itemId: string, event: React.TouchEvent) => {
-    dispatch({ type: 'SET_TOUCHED_ITEM', payload: itemId })
-    dispatch({ type: 'SET_TOUCH_START_TIME', payload: Date.now() })
-    dispatch({ type: 'SET_TOUCH_START_POSITION', payload: {
-      x: event.touches[0].clientX,
-      y: event.touches[0].clientY
-    }})
-  }, [])
-
-  const handleTouchEnd = useCallback((itemId: string, event: React.TouchEvent) => {
-    const touchEndTime = Date.now()
-    const touchDuration = touchEndTime - navState.touchStartTime
-
-    // Only trigger if it's a quick tap (not a long press or drag)
-    if (touchDuration < 500) {
-      const touchEndPosition = {
-        x: event.changedTouches[0].clientX,
-        y: event.changedTouches[0].clientY
-      }
-
-      // Check if touch didn't move too much (not a swipe)
-      const touchDistance = Math.sqrt(
-        Math.pow(touchEndPosition.x - navState.touchStartPosition.x, 2) +
-        Math.pow(touchEndPosition.y - navState.touchStartPosition.y, 2)
-      )
-
-      if (touchDistance < 10) {
-        // Valid tap - provide haptic feedback if available
-        if ('vibrate' in navigator && typeof navigator.vibrate === 'function') {
-          try {
-            navigator.vibrate(10)
-          } catch {
-            // Silently fail if vibration is not supported
-          }
-        }
-      }
-    }
-
-    // Always provide haptic feedback for valid touch end events
-    if (touchDuration < 500 && 'vibrate' in navigator && typeof navigator.vibrate === 'function') {
-      try {
-        navigator.vibrate(10)
-      } catch {
-        // Silently fail if vibration is not supported
-      }
-    }
-
-    // Clear touched state after a short delay for visual feedback
-    setTimeout(() => {
-      dispatch({ type: 'SET_TOUCHED_ITEM', payload: null })
-    }, 150)
-  }, [navState.touchStartTime, navState.touchStartPosition])
-
-  const handleTouchCancel = useCallback(() => {
-    dispatch({ type: 'SET_TOUCHED_ITEM', payload: null })
-  }, [])
-
-  // Handle dropdown toggle with debouncing
-  const handleMoreClick = () => {
-    debouncedNavigate(() => {
-      const newState = !navState.isDropdownOpen
-      dispatch({ type: 'SET_DROPDOWN_OPEN', payload: newState })
-      dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: -1 })
-
-      // Announce state change to screen readers
-      if (newState) {
-        dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'More menu opened. Use arrow keys to navigate.' })
-        // Focus first item when opening - use multiple animation frames for better timing
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            if (dropdownItemRefs.current[0]) {
-              dropdownItemRefs.current[0]?.focus()
-              dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: 0 })
-            }
-          })
-        })
-      } else {
-        dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'More menu closed.' })
-        // Return focus to More button when closing
-        requestAnimationFrame(() => {
-          moreButtonRef.current?.focus()
-        })
-      }
-    })
-  }
-
-  // Handle search button click with debouncing
-  const handleSearchClick = () => {
-    debouncedNavigate(() => {
-      setCommandMenuOpen(true)
-      dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'Search opened.' })
-    })
-  }
-
-
-
-  // Define primary navigation items
-  const primaryNavItems: NavigationItem[] = [
-    {
-      id: 'home',
-      title: 'Home',
-      href: ROUTES.HOME,
-      icon: BarChart3
-    },
-    {
-      id: 'tenants',
-      title: 'Mieter',
-      href: '/mieter',
-      icon: Users
-    },
-    {
-      id: 'search',
-      title: 'Suchen',
-      icon: SearchIcon,
-      onClick: handleSearchClick
-    },
-    {
-      id: 'finance',
-      title: 'Finanzen',
-      href: '/finanzen',
-      icon: Wallet
-    },
-    {
-      id: 'more',
-      title: 'Mehr',
-      icon: Menu,
-      onClick: handleMoreClick
-    }
-  ]
-
-  // Handle profile button click
-  const handleProfileClick = () => {
-    dispatch({ type: 'SET_SETTINGS_MODAL_OPEN', payload: true })
-    dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
-    dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'Settings opened.' })
-  }
-
-  // Handle logout
-  const handleLogout = async () => {
-    dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
-    dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'Logging out...' })
-
-    try {
-      const supabase = createClient()
-      const { error } = await supabase.auth.signOut()
-      if (error) {
-        throw error
-      }
-      // Redirect will be handled by middleware
-    } catch (error) {
-      console.error('Error signing out:', error)
-      dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'Logout failed.' })
-    }
-  }
-
-
-
-  // Define dropdown items for "More" menu
-  const dropdownItems: DropdownItem[] = [
-    {
-      id: 'profile',
-      title: 'Profil',
-      icon: User,
-      onClick: handleProfileClick
-    },
-    {
-      id: 'homepage',
-      title: 'Homepage',
-      href: '/',
-      icon: Globe
-    },
-    {
-      id: 'houses',
-      title: 'Häuser',
-      href: '/haeuser',
-      icon: Building2
-    },
-    {
-      id: 'apartments',
-      title: 'Wohnungen',
-      href: '/wohnungen',
-      icon: Home
-    },
-    {
-      id: 'operating-costs',
-      title: 'Betriebskosten',
-      href: '/betriebskosten',
-      icon: FileSpreadsheet
-    },
-    {
-      id: 'organisation',
-      title: 'Organisationen',
-      href: '/organisation',
-      icon: Building2,
-      hidden: !sidebarData?.hasOrganisationPermission || sidebarData?.isOrganisationHidden
-    },
-    {
-      id: 'tasks',
-      title: 'Aufgaben',
-      href: '/todos',
-      icon: CheckSquare
-    },
-    {
-      id: 'documents',
-      title: 'Dokumente',
-      href: '/dateien',
-      icon: Folder,
-      hidden: !documentsEnabled
-    },
-    {
-      id: 'logout',
-      title: 'Abmelden',
-      icon: LogOut,
-      onClick: handleLogout
-    }
-  ]
-
-  // Define dropdown routes to check for "More" button active state (only include items with href)
-  const dropdownRoutes = dropdownItems
-    .filter(item => item.href && !item.onClick) // Only include link items, not button items
-    .map(item => item.href!)
-
-  // Check if any dropdown route is active to highlight "More" button
-  const isMoreActive = dropdownRoutes.some(route => isRouteActive(route))
-
-  // Get visible dropdown items for keyboard navigation
-  const visibleDropdownItems = dropdownItems.filter(item => !item.hidden)
-
-  // Keyboard navigation handler for dropdown
-  const handleDropdownKeyDown = useCallback((event: KeyboardEvent) => {
-    if (!navState.isDropdownOpen) return
-
-    switch (event.key) {
-      case 'Escape':
-        event.preventDefault()
-        dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
-        dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'More menu closed.' })
-        moreButtonRef.current?.focus()
-        break
-
-      case 'ArrowDown':
-        event.preventDefault()
-        const nextIndex = navState.focusedItemIndex < visibleDropdownItems.length - 1
-          ? navState.focusedItemIndex + 1
-          : 0
-        dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: nextIndex })
-        dropdownItemRefs.current[nextIndex]?.focus()
-        break
-
-      case 'ArrowUp':
-        event.preventDefault()
-        const prevIndex = navState.focusedItemIndex > 0
-          ? navState.focusedItemIndex - 1
-          : visibleDropdownItems.length - 1
-        dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: prevIndex })
-        dropdownItemRefs.current[prevIndex]?.focus()
-        break
-
-      case 'Home':
-        event.preventDefault()
-        dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: 0 })
-        dropdownItemRefs.current[0]?.focus()
-        break
-
-      case 'End':
-        event.preventDefault()
-        const lastIndex = visibleDropdownItems.length - 1
-        dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: lastIndex })
-        dropdownItemRefs.current[lastIndex]?.focus()
-        break
-
-      case 'Tab':
-        // Allow normal tab behavior but close dropdown
-        dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
-        dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'More menu closed.' })
-        break
-    }
-  }, [navState.isDropdownOpen, navState.focusedItemIndex, visibleDropdownItems.length])
-
-  // Handle navigation item selection with debouncing
-  const handleNavigationSelect = useCallback((itemTitle: string, callback?: () => void) => {
-    if (navState.isNavigating) return
-
-    dispatch({ type: 'SET_NAVIGATING', payload: true })
-    dispatch({ type: 'SET_ANNOUNCEMENT', payload: `Navigating to ${itemTitle}.` })
-
-    // Execute callback immediately for better UX
-    callback?.()
-
-    // Reset navigation state after delay
-    setTimeout(() => {
-      dispatch({ type: 'SET_NAVIGATING', payload: false })
-    }, 300)
-  }, [navState.isNavigating])
-
-  // Enhanced click/touch outside handler to close dropdown
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent | TouchEvent) {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node) &&
-        moreButtonRef.current &&
-        !moreButtonRef.current.contains(event.target as Node)
-      ) {
-        dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
-        dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'More menu closed.' })
-      }
-    }
-
-    if (navState.isDropdownOpen) {
-      // Listen for both mouse and touch events for better mobile support
-      document.addEventListener('mousedown', handleClickOutside)
-      document.addEventListener('touchstart', handleClickOutside, { passive: true })
-      return () => {
-        document.removeEventListener('mousedown', handleClickOutside)
-        document.removeEventListener('touchstart', handleClickOutside)
-      }
-    }
-  }, [navState.isDropdownOpen])
-
-  // Keyboard navigation event listener
-  useEffect(() => {
-    if (navState.isDropdownOpen) {
-      document.addEventListener('keydown', handleDropdownKeyDown)
-      return () => {
-        document.removeEventListener('keydown', handleDropdownKeyDown)
-      }
-    }
-  }, [navState.isDropdownOpen, handleDropdownKeyDown])
-
-  // Clear announcement after it's been read
-  useEffect(() => {
-    if (navState.announcement) {
-      const timer = setTimeout(() => dispatch({ type: 'SET_ANNOUNCEMENT', payload: '' }), 1000)
-      return () => clearTimeout(timer)
-    }
-  }, [navState.announcement])
-
-  // Cleanup navigation timeout on unmount
-  useEffect(() => {
-    return () => {
-      if (navigationTimeoutRef.current) {
-        clearTimeout(navigationTimeoutRef.current)
-      }
-    }
-  }, [])
-
-  // Prevent hydration mismatches by rendering a CSS-only fallback until mounted
   if (!navState.mounted) {
     return (
       <nav
@@ -905,16 +810,12 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
         role="navigation"
         aria-label="Main mobile navigation"
         style={{
-          // CSS-only fallback - ensure proper responsive behavior
           display: 'block',
-          // Safe area support with balanced padding
           paddingTop: '0.5rem',
           paddingBottom: 'max(0.5rem, env(safe-area-inset-bottom))'
         }}
       >
-        {/* Main navigation items fallback */}
         <div className="flex items-center justify-around px-1 h-16">
-          {/* Render static navigation items as fallback with enhanced styling */}
           <div className="flex flex-col items-center justify-center min-h-[44px] min-w-[44px] px-3 py-2 text-muted-foreground rounded-lg mobile-nav-item">
             <BarChart3 className="w-5 h-5 mb-1 transition-all duration-300" aria-hidden="true" />
             <span className="text-xs font-medium transition-all duration-300">Home</span>
@@ -940,7 +841,6 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
     )
   }
 
-  // Don't render on desktop screens (additional safety check)
   if (!navState.isMobile && navState.mounted) {
     return null
   }
@@ -963,17 +863,10 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
         onCloseDropdown={() => dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })}
       />
 
-      {/* Screen reader announcements */}
-      <div
-        className="sr-only"
-        aria-live="polite"
-        aria-atomic="true"
-        role="status"
-      >
+      <output className="sr-only" aria-live="polite" aria-atomic="true">
         {navState.announcement}
-      </div>
+      </output>
 
-      {/* Hidden description for More button */}
       <div id="more-button-description" className="sr-only">
         Opens additional navigation options. Use arrow keys to navigate when open.
       </div>
@@ -981,10 +874,12 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
       <PrimaryNavBar
         items={primaryNavItems}
         moreButtonRef={moreButtonRef}
-        isMoreActive={isMoreActive}
-        isDropdownOpen={navState.isDropdownOpen}
-        isNavigating={navState.isNavigating}
-        touchedItem={navState.touchedItem}
+        navState={{
+          isMoreActive,
+          isDropdownOpen: navState.isDropdownOpen,
+          isNavigating: navState.isNavigating,
+          touchedItem: navState.touchedItem
+        }}
         isRouteActive={isRouteActive}
         onNavigationSelect={handleNavigationSelect}
         onMoreClick={() => dispatch({ type: 'TOGGLE_DROPDOWN' })}
@@ -993,7 +888,6 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
         onTouchCancel={handleTouchCancel}
         className={className}
       />
-      {/* Settings Modal */}
       <SettingsModal open={navState.isSettingsModalOpen} onOpenChange={(open) => dispatch({ type: 'SET_SETTINGS_MODAL_OPEN', payload: open })} />
     </>
   )

--- a/components/common/mobile-bottom-navigation.tsx
+++ b/components/common/mobile-bottom-navigation.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect, useRef, useCallback } from 'react'
+import React, { useState, useEffect, useReducer, useRef, useCallback } from 'react'
 import Link from 'next/link'
 import {
   BarChart3,
@@ -62,44 +62,100 @@ interface MobileBottomNavigationProps {
   sidebarData?: SidebarUserData
 }
 
+type NavUiState = {
+  mounted: boolean
+  isMobile: boolean
+  isDropdownOpen: boolean
+  focusedItemIndex: number
+  isSettingsModalOpen: boolean
+  announcement: string
+  touchedItem: string | null
+  isNavigating: boolean
+  touchStartTime: number
+  touchStartPosition: { x: number; y: number }
+}
+
+type NavAction =
+  | { type: 'SET_MOUNTED'; payload: boolean }
+  | { type: 'SET_MOBILE'; payload: boolean }
+  | { type: 'SET_DROPDOWN_OPEN'; payload: boolean }
+  | { type: 'SET_FOCUSED_ITEM_INDEX'; payload: number }
+  | { type: 'SET_SETTINGS_MODAL_OPEN'; payload: boolean }
+  | { type: 'SET_ANNOUNCEMENT'; payload: string }
+  | { type: 'SET_TOUCHED_ITEM'; payload: string | null }
+  | { type: 'SET_NAVIGATING'; payload: boolean }
+  | { type: 'SET_TOUCH_START_TIME'; payload: number }
+  | { type: 'SET_TOUCH_START_POSITION'; payload: { x: number; y: number } }
+  | { type: 'CLOSE_DROPDOWN_AND_ANNOUNCE'; payload: string }
+  | { type: 'OPEN_DROPDOWN_AND_FOCUS'; payload: string }
+  | { type: 'TOGGLE_DROPDOWN' }
+
+const initialNavState: NavUiState = {
+  mounted: false,
+  isMobile: false,
+  isDropdownOpen: false,
+  focusedItemIndex: -1,
+  isSettingsModalOpen: false,
+  announcement: '',
+  touchedItem: null,
+  isNavigating: false,
+  touchStartTime: 0,
+  touchStartPosition: { x: 0, y: 0 },
+}
+
+function navReducer(state: NavUiState, action: NavAction): NavUiState {
+  switch (action.type) {
+    case 'SET_MOUNTED':
+      return { ...state, mounted: action.payload }
+    case 'SET_MOBILE':
+      return { ...state, isMobile: action.payload }
+    case 'SET_DROPDOWN_OPEN':
+      return { ...state, isDropdownOpen: action.payload, focusedItemIndex: action.payload ? -1 : state.focusedItemIndex }
+    case 'SET_FOCUSED_ITEM_INDEX':
+      return { ...state, focusedItemIndex: action.payload }
+    case 'SET_SETTINGS_MODAL_OPEN':
+      return { ...state, isSettingsModalOpen: action.payload }
+    case 'SET_ANNOUNCEMENT':
+      return { ...state, announcement: action.payload }
+    case 'SET_TOUCHED_ITEM':
+      return { ...state, touchedItem: action.payload }
+    case 'SET_NAVIGATING':
+      return { ...state, isNavigating: action.payload }
+    case 'SET_TOUCH_START_TIME':
+      return { ...state, touchStartTime: action.payload }
+    case 'SET_TOUCH_START_POSITION':
+      return { ...state, touchStartPosition: action.payload }
+    case 'CLOSE_DROPDOWN_AND_ANNOUNCE':
+      return { ...state, isDropdownOpen: false, focusedItemIndex: -1, announcement: action.payload }
+    case 'OPEN_DROPDOWN_AND_FOCUS':
+      return { ...state, isDropdownOpen: true, focusedItemIndex: -1, announcement: action.payload }
+    case 'TOGGLE_DROPDOWN':
+      return { ...state, isDropdownOpen: !state.isDropdownOpen, focusedItemIndex: state.isDropdownOpen ? -1 : -1 }
+    default:
+      return state
+  }
+}
+
 export default function MobileBottomNavigation({ className, sidebarData }: MobileBottomNavigationProps) {
   const { isRouteActive } = useSidebarActiveState()
   const { setOpen: setCommandMenuOpen } = useCommandMenu()
   const documentsEnabled = useFeatureFlagEnabled('documents_tab_access')
 
-  // Hydration safety - prevent SSR/client mismatch
-  const [mounted, setMounted] = useState(false)
-  const [isMobile, setIsMobile] = useState(false)
-
-  // Local state for dropdown management
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
-  const [focusedItemIndex, setFocusedItemIndex] = useState(-1)
-  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false)
+  const [navState, dispatch] = useReducer(navReducer, initialNavState)
   const dropdownRef = useRef<HTMLDivElement>(null)
   const moreButtonRef = useRef<HTMLButtonElement>(null)
   const dropdownItemRefs = useRef<(HTMLAnchorElement | null)[]>([])
-
-  // Screen reader announcement state
-  const [announcement, setAnnouncement] = useState('')
-
-  // Touch interaction states for enhanced feedback
-  const [touchedItem, setTouchedItem] = useState<string | null>(null)
-  const [isNavigating, setIsNavigating] = useState(false)
   const navigationTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined)
-
-  // Touch event tracking for better mobile interactions
-  const [touchStartTime, setTouchStartTime] = useState(0)
-  const [touchStartPosition, setTouchStartPosition] = useState({ x: 0, y: 0 })
 
   // Hydration safety and responsive behavior
   useEffect(() => {
     // Set mounted to true to prevent hydration mismatches
-    setMounted(true)
+    dispatch({ type: 'SET_MOUNTED', payload: true })
 
     // Check initial screen size
     const checkScreenSize = () => {
       const newIsMobile = window.innerWidth < 768
-      setIsMobile(newIsMobile)
+      dispatch({ type: 'SET_MOBILE', payload: newIsMobile })
       return newIsMobile
     }
 
@@ -107,25 +163,25 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
     checkScreenSize()
 
     // Add resize listener for responsive behavior with debouncing
-    let resizeTimeout: NodeJS.Timeout
+    let resizeTimeout: ReturnType<typeof setTimeout>
     const handleResize = () => {
       clearTimeout(resizeTimeout)
       resizeTimeout = setTimeout(() => {
         const newIsMobile = checkScreenSize()
 
         // Close dropdown when switching from mobile to desktop
-        if (!newIsMobile && isDropdownOpen) {
-          setIsDropdownOpen(false)
-          setAnnouncement('Navigation switched to desktop mode.')
+        if (!newIsMobile && navState.isDropdownOpen) {
+          dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
+          dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'Navigation switched to desktop mode.' })
         }
 
         // Announce responsive behavior changes
-        if (newIsMobile !== isMobile) {
-          setAnnouncement(
+        if (newIsMobile !== navState.isMobile) {
+          dispatch({ type: 'SET_ANNOUNCEMENT', payload:
             newIsMobile
               ? 'Switched to mobile navigation.'
               : 'Switched to desktop navigation.'
-          )
+          })
         }
       }, 150) // Debounce resize events
     }
@@ -136,13 +192,13 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
       window.removeEventListener('resize', handleResize)
       clearTimeout(resizeTimeout)
     }
-  }, [isDropdownOpen, isMobile])
+  }, [navState.isDropdownOpen, navState.isMobile])
 
   // Debounced navigation handler to prevent rapid navigation attempts
   const debouncedNavigate = useDebouncedCallback((callback: () => void) => {
-    if (isNavigating) return
+    if (navState.isNavigating) return
 
-    setIsNavigating(true)
+    dispatch({ type: 'SET_NAVIGATING', payload: true })
     callback()
 
     // Reset navigation state after a short delay
@@ -150,18 +206,18 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
       clearTimeout(navigationTimeoutRef.current)
     }
     navigationTimeoutRef.current = setTimeout(() => {
-      setIsNavigating(false)
+      dispatch({ type: 'SET_NAVIGATING', payload: false })
     }, 300)
   }, 150)
 
   // Enhanced touch feedback handlers
   const handleTouchStart = useCallback((itemId: string, event: React.TouchEvent) => {
-    setTouchedItem(itemId)
-    setTouchStartTime(Date.now())
-    setTouchStartPosition({
+    dispatch({ type: 'SET_TOUCHED_ITEM', payload: itemId })
+    dispatch({ type: 'SET_TOUCH_START_TIME', payload: Date.now() })
+    dispatch({ type: 'SET_TOUCH_START_POSITION', payload: {
       x: event.touches[0].clientX,
       y: event.touches[0].clientY
-    })
+    }}
   }, [])
 
   const handleTouchEnd = useCallback((itemId: string, event: React.TouchEvent) => {
@@ -177,8 +233,8 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
 
       // Check if touch didn't move too much (not a swipe)
       const touchDistance = Math.sqrt(
-        Math.pow(touchEndPosition.x - touchStartPosition.x, 2) +
-        Math.pow(touchEndPosition.y - touchStartPosition.y, 2)
+        Math.pow(touchEndPosition.x - navState.touchStartPosition.x, 2) +
+        Math.pow(touchEndPosition.y - navState.touchStartPosition.y, 2)
       )
 
       if (touchDistance < 10) {
@@ -204,35 +260,35 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
 
     // Clear touched state after a short delay for visual feedback
     setTimeout(() => {
-      setTouchedItem(null)
+      dispatch({ type: 'SET_TOUCHED_ITEM', payload: null })
     }, 150)
-  }, [touchStartTime, touchStartPosition])
+  }, [navState.touchStartTime, navState.touchStartPosition])
 
   const handleTouchCancel = useCallback(() => {
-    setTouchedItem(null)
+    dispatch({ type: 'SET_TOUCHED_ITEM', payload: null })
   }, [])
 
   // Handle dropdown toggle with debouncing
   const handleMoreClick = () => {
     debouncedNavigate(() => {
-      const newState = !isDropdownOpen
-      setIsDropdownOpen(newState)
-      setFocusedItemIndex(-1)
+      const newState = !navState.isDropdownOpen
+      dispatch({ type: 'SET_DROPDOWN_OPEN', payload: newState })
+      dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: -1 })
 
       // Announce state change to screen readers
       if (newState) {
-        setAnnouncement('More menu opened. Use arrow keys to navigate.')
+        dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'More menu opened. Use arrow keys to navigate.' })
         // Focus first item when opening - use multiple animation frames for better timing
         requestAnimationFrame(() => {
           requestAnimationFrame(() => {
             if (dropdownItemRefs.current[0]) {
               dropdownItemRefs.current[0]?.focus()
-              setFocusedItemIndex(0)
+              dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: 0 })
             }
           })
         })
       } else {
-        setAnnouncement('More menu closed.')
+        dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'More menu closed.' })
         // Return focus to More button when closing
         requestAnimationFrame(() => {
           moreButtonRef.current?.focus()
@@ -245,7 +301,7 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
   const handleSearchClick = () => {
     debouncedNavigate(() => {
       setCommandMenuOpen(true)
-      setAnnouncement('Search opened.')
+      dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'Search opened.' })
     })
   }
 
@@ -287,15 +343,15 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
 
   // Handle profile button click
   const handleProfileClick = () => {
-    setIsSettingsModalOpen(true)
-    setIsDropdownOpen(false)
-    setAnnouncement('Settings opened.')
+    dispatch({ type: 'SET_SETTINGS_MODAL_OPEN', payload: true })
+    dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
+    dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'Settings opened.' })
   }
 
   // Handle logout
   const handleLogout = async () => {
-    setIsDropdownOpen(false)
-    setAnnouncement('Logging out...')
+    dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
+    dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'Logging out...' })
 
     try {
       const supabase = createClient()
@@ -306,7 +362,7 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
       // Redirect will be handled by middleware
     } catch (error) {
       console.error('Error signing out:', error)
-      setAnnouncement('Logout failed.')
+      dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'Logout failed.' })
     }
   }
 
@@ -385,70 +441,70 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
 
   // Keyboard navigation handler for dropdown
   const handleDropdownKeyDown = useCallback((event: KeyboardEvent) => {
-    if (!isDropdownOpen) return
+    if (!navState.isDropdownOpen) return
 
     switch (event.key) {
       case 'Escape':
         event.preventDefault()
-        setIsDropdownOpen(false)
-        setAnnouncement('More menu closed.')
+        dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
+        dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'More menu closed.' })
         moreButtonRef.current?.focus()
         break
 
       case 'ArrowDown':
         event.preventDefault()
-        const nextIndex = focusedItemIndex < visibleDropdownItems.length - 1
-          ? focusedItemIndex + 1
+        const nextIndex = navState.focusedItemIndex < visibleDropdownItems.length - 1
+          ? navState.focusedItemIndex + 1
           : 0
-        setFocusedItemIndex(nextIndex)
+        dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: nextIndex })
         dropdownItemRefs.current[nextIndex]?.focus()
         break
 
       case 'ArrowUp':
         event.preventDefault()
-        const prevIndex = focusedItemIndex > 0
-          ? focusedItemIndex - 1
+        const prevIndex = navState.focusedItemIndex > 0
+          ? navState.focusedItemIndex - 1
           : visibleDropdownItems.length - 1
-        setFocusedItemIndex(prevIndex)
+        dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: prevIndex })
         dropdownItemRefs.current[prevIndex]?.focus()
         break
 
       case 'Home':
         event.preventDefault()
-        setFocusedItemIndex(0)
+        dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: 0 })
         dropdownItemRefs.current[0]?.focus()
         break
 
       case 'End':
         event.preventDefault()
         const lastIndex = visibleDropdownItems.length - 1
-        setFocusedItemIndex(lastIndex)
+        dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: lastIndex })
         dropdownItemRefs.current[lastIndex]?.focus()
         break
 
       case 'Tab':
         // Allow normal tab behavior but close dropdown
-        setIsDropdownOpen(false)
-        setAnnouncement('More menu closed.')
+        dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
+        dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'More menu closed.' })
         break
     }
-  }, [isDropdownOpen, focusedItemIndex, visibleDropdownItems.length])
+  }, [navState.isDropdownOpen, navState.focusedItemIndex, visibleDropdownItems.length])
 
   // Handle navigation item selection with debouncing
   const handleNavigationSelect = useCallback((itemTitle: string, callback?: () => void) => {
-    if (isNavigating) return
+    if (navState.isNavigating) return
 
-    setIsNavigating(true)
-    setAnnouncement(`Navigating to ${itemTitle}.`)
+    dispatch({ type: 'SET_NAVIGATING', payload: true })
+    dispatch({ type: 'SET_ANNOUNCEMENT', payload: `Navigating to ${itemTitle}.` })
 
     // Execute callback immediately for better UX
     callback?.()
 
     // Reset navigation state after delay
     setTimeout(() => {
-      setIsNavigating(false)
+      dispatch({ type: 'SET_NAVIGATING', payload: false })
     }, 300)
-  }, [isNavigating])
+  }, [navState.isNavigating])
 
   // Enhanced click/touch outside handler to close dropdown
   useEffect(() => {
@@ -459,12 +515,12 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
         moreButtonRef.current &&
         !moreButtonRef.current.contains(event.target as Node)
       ) {
-        setIsDropdownOpen(false)
-        setAnnouncement('More menu closed.')
+        dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
+        dispatch({ type: 'SET_ANNOUNCEMENT', payload: 'More menu closed.' })
       }
     }
 
-    if (isDropdownOpen) {
+    if (navState.isDropdownOpen) {
       // Listen for both mouse and touch events for better mobile support
       document.addEventListener('mousedown', handleClickOutside)
       document.addEventListener('touchstart', handleClickOutside, { passive: true })
@@ -473,25 +529,25 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
         document.removeEventListener('touchstart', handleClickOutside)
       }
     }
-  }, [isDropdownOpen])
+  }, [navState.isDropdownOpen])
 
   // Keyboard navigation event listener
   useEffect(() => {
-    if (isDropdownOpen) {
+    if (navState.isDropdownOpen) {
       document.addEventListener('keydown', handleDropdownKeyDown)
       return () => {
         document.removeEventListener('keydown', handleDropdownKeyDown)
       }
     }
-  }, [isDropdownOpen, handleDropdownKeyDown])
+  }, [navState.isDropdownOpen, handleDropdownKeyDown])
 
   // Clear announcement after it's been read
   useEffect(() => {
-    if (announcement) {
-      const timer = setTimeout(() => setAnnouncement(''), 1000)
+    if (navState.announcement) {
+      const timer = setTimeout(() => dispatch({ type: 'SET_ANNOUNCEMENT', payload: '' }), 1000)
       return () => clearTimeout(timer)
     }
-  }, [announcement])
+  }, [navState.announcement])
 
   // Cleanup navigation timeout on unmount
   useEffect(() => {
@@ -503,7 +559,7 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
   }, [])
 
   // Prevent hydration mismatches by rendering a CSS-only fallback until mounted
-  if (!mounted) {
+  if (!navState.mounted) {
     return (
       <nav
         className="fixed bottom-0 left-0 right-0 z-50 bg-background/95 backdrop-blur-xs border-t border-border/50 shadow-lg shadow-black/5 mobile-nav-responsive hydration-safe-mobile prevent-layout-shift"
@@ -546,14 +602,14 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
   }
 
   // Don't render on desktop screens (additional safety check)
-  if (!isMobile && mounted) {
+  if (!navState.isMobile && navState.mounted) {
     return null
   }
 
   return (
     <>
       {/* Dropdown Menu - positioned above navigation bar */}
-      {isDropdownOpen && (
+      {navState.isDropdownOpen && (
         <div
           id="more-dropdown-menu"
           ref={dropdownRef}
@@ -569,8 +625,8 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
           aria-label="More navigation options"
           aria-orientation="vertical"
           aria-activedescendant={
-            focusedItemIndex >= 0
-              ? `dropdown-item-${visibleDropdownItems[focusedItemIndex]?.id}`
+            navState.focusedItemIndex >= 0
+              ? `dropdown-item-${visibleDropdownItems[navState.focusedItemIndex]?.id}`
               : undefined
           }
         >
@@ -578,7 +634,7 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
             {visibleDropdownItems.map((item, index) => {
               const IconComponent = item.icon
               const isActive = item.href ? isRouteActive(item.href) : false
-              const isFocused = index === focusedItemIndex
+              const isFocused = index === navState.focusedItemIndex
 
               // Handle button items (like profile)
               if (item.onClick) {
@@ -594,8 +650,8 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
                           item.onClick?.()
                         })
                       }}
-                      onMouseEnter={() => setFocusedItemIndex(index)}
-                      onFocus={() => setFocusedItemIndex(index)}
+                      onMouseEnter={() => dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: index })}
+                      onFocus={() => dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: index })}
                       onTouchStart={(e) => handleTouchStart(`dropdown-${item.id}`, e)}
                       onTouchEnd={(e) => handleTouchEnd(`dropdown-${item.id}`, e)}
                       onTouchCancel={handleTouchCancel}
@@ -606,7 +662,7 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
                         "focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:ring-offset-2 focus:ring-offset-background",
                         "active:scale-95",
                         // Enhanced touch feedback
-                        touchedItem === `dropdown-${item.id}` && "scale-95 bg-accent/20",
+                        navState.touchedItem === `dropdown-${item.id}` && "scale-95 bg-accent/20",
                         // Button styling - exactly identical to link items (no active state since buttons don't have href)
                         "text-foreground hover:bg-accent/10",
                         // Focus state styling - exactly identical to link items
@@ -650,24 +706,24 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
                       dropdownItemRefs.current[index] = el
                     }}
                     href={item.href!}
-                    onClick={() => {
-                      handleNavigationSelect(item.title, () => {
-                        setIsDropdownOpen(false)
-                      })
-                    }}
-                    onMouseEnter={() => setFocusedItemIndex(index)}
-                    onFocus={() => setFocusedItemIndex(index)}
-                    onTouchStart={(e) => handleTouchStart(`dropdown-${item.id}`, e)}
-                    onTouchEnd={(e) => handleTouchEnd(`dropdown-${item.id}`, e)}
-                    onTouchCancel={handleTouchCancel}
-                    className={cn(
-                      "flex items-center px-4 py-3 mx-2 rounded-lg",
-                      "min-h-[44px] mobile-dropdown-item touch-feedback",
-                      "transition-all duration-200 ease-out",
-                      "focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:ring-offset-2 focus:ring-offset-background",
-                      "active:scale-95",
-                      // Enhanced touch feedback
-                      touchedItem === `dropdown-${item.id}` && "scale-95 bg-accent/20",
+                      onClick={() => {
+                        handleNavigationSelect(item.title, () => {
+                          dispatch({ type: 'SET_DROPDOWN_OPEN', payload: false })
+                        })
+                      }}
+                      onMouseEnter={() => dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: index })}
+                      onFocus={() => dispatch({ type: 'SET_FOCUSED_ITEM_INDEX', payload: index })}
+                      onTouchStart={(e) => handleTouchStart(`dropdown-${item.id}`, e)}
+                      onTouchEnd={(e) => handleTouchEnd(`dropdown-${item.id}`, e)}
+                      onTouchCancel={handleTouchCancel}
+                      className={cn(
+                        "flex items-center px-4 py-3 mx-2 rounded-lg",
+                        "min-h-[44px] mobile-dropdown-item touch-feedback",
+                        "transition-all duration-200 ease-out",
+                        "focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:ring-offset-2 focus:ring-offset-background",
+                        "active:scale-95",
+                        // Enhanced touch feedback
+                        navState.touchedItem === `dropdown-${item.id}` && "scale-95 bg-accent/20",
                       // Active state styling - mobile optimized without scaling
                       isActive
                         ? "bg-primary/10 text-primary shadow-xs"
@@ -716,7 +772,7 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
         aria-atomic="true"
         role="status"
       >
-        {announcement}
+        {navState.announcement}
       </div>
 
       {/* Hidden description for More button */}
@@ -773,7 +829,7 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
                   onTouchStart={(e) => handleTouchStart(item.id, e)}
                   onTouchEnd={(e) => handleTouchEnd(item.id, e)}
                   onTouchCancel={handleTouchCancel}
-                  disabled={isNavigating}
+                  disabled={navState.isNavigating}
                   className={cn(
                     "flex flex-col items-center justify-center",
                     "min-h-[44px] min-w-[44px] px-3 py-2 mobile-nav-item touch-feedback",
@@ -782,35 +838,35 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
                     "focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:ring-offset-2 focus:ring-offset-background",
                     "active:scale-95",
                     // Enhanced touch feedback
-                    touchedItem === item.id && "scale-95 bg-accent/20",
+                    navState.touchedItem === item.id && "scale-95 bg-accent/20",
                     // Active state styling - mobile optimized without scaling
                     isActive
                       ? "bg-primary/10 text-primary shadow-xs"
                       : "text-muted-foreground hover:text-foreground hover:bg-accent/10",
                     // Special styling when dropdown is open
-                    isDropdownOpen && "bg-primary/15 text-primary",
+                    navState.isDropdownOpen && "bg-primary/15 text-primary",
                     // Disabled state for navigation debouncing
-                    isNavigating && "opacity-70 pointer-events-none"
+                    navState.isNavigating && "opacity-70 pointer-events-none"
                   )}
                   aria-label={`${item.title} menu${isActive ? ' (current section)' : ''}`}
                   aria-current={isActive ? "page" : undefined}
-                  aria-expanded={isDropdownOpen}
+                  aria-expanded={navState.isDropdownOpen}
                   aria-haspopup="menu"
-                  aria-controls={isDropdownOpen ? "more-dropdown-menu" : undefined}
+                  aria-controls={navState.isDropdownOpen ? "more-dropdown-menu" : undefined}
                   aria-describedby="more-button-description"
                 >
                   <IconComponent
                     className={cn(
                       "w-5 h-5 mb-1 transition-all duration-300 ease-out",
                       isActive && "",
-                      isDropdownOpen && "rotate-180 "
+                      navState.isDropdownOpen && "rotate-180 "
                     )}
                     aria-hidden="true"
                   />
                   <span className={cn(
                     "text-xs transition-all duration-300 ease-out",
                     isActive ? "font-semibold tracking-wide" : "font-medium",
-                    isDropdownOpen && "font-semibold tracking-wide"
+                    navState.isDropdownOpen && "font-semibold tracking-wide"
                   )}>
                     {item.title}
                   </span>
@@ -825,7 +881,7 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
                   key={item.id}
                   href={item.href}
                   onClick={(e) => {
-                    if (isNavigating) {
+                    if (navState.isNavigating) {
                       e.preventDefault()
                       return
                     }
@@ -842,13 +898,13 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
                     "focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:ring-offset-2 focus:ring-offset-background",
                     "active:scale-95",
                     // Enhanced touch feedback
-                    touchedItem === item.id && "scale-95 bg-accent/20",
+                    navState.touchedItem === item.id && "scale-95 bg-accent/20",
                     // Active state styling matching desktop navigation
                     isActive
                       ? "bg-primary/10 text-primary shadow-xs"
                       : "text-muted-foreground hover:text-foreground hover:bg-accent/10 ",
                     // Disabled state for navigation debouncing
-                    isNavigating && "opacity-70 pointer-events-none"
+                    navState.isNavigating && "opacity-70 pointer-events-none"
                   )}
                   aria-label={`Navigate to ${item.title}${isActive ? ' (current page)' : ''}`}
                   aria-current={isActive ? "page" : undefined}
@@ -880,7 +936,7 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
                   onTouchStart={(e) => handleTouchStart(item.id, e)}
                   onTouchEnd={(e) => handleTouchEnd(item.id, e)}
                   onTouchCancel={handleTouchCancel}
-                  disabled={isNavigating}
+                  disabled={navState.isNavigating}
                   className={cn(
                     "flex flex-col items-center justify-center",
                     "min-h-[44px] min-w-[44px] px-3 py-2 mobile-nav-item touch-feedback",
@@ -889,13 +945,13 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
                     "focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:ring-offset-2 focus:ring-offset-background",
                     "active:scale-95",
                     // Enhanced touch feedback
-                    touchedItem === item.id && "scale-95 bg-accent/20",
+                    navState.touchedItem === item.id && "scale-95 bg-accent/20",
                     // Active state styling matching desktop navigation
                     isActive
                       ? "bg-primary/10 text-primary shadow-xs"
                       : "text-muted-foreground hover:text-foreground hover:bg-accent/10 ",
                     // Disabled state for navigation debouncing
-                    isNavigating && "opacity-70 pointer-events-none"
+                    navState.isNavigating && "opacity-70 pointer-events-none"
                   )}
                   aria-label={`${item.title}${item.id === 'search' ? ' - Open search' : ''}${isActive ? ' (current page)' : ''}`}
                   aria-current={isActive ? "page" : undefined}
@@ -920,7 +976,7 @@ export default function MobileBottomNavigation({ className, sidebarData }: Mobil
         </div>
       </nav>
       {/* Settings Modal */}
-      <SettingsModal open={isSettingsModalOpen} onOpenChange={setIsSettingsModalOpen} />
+      <SettingsModal open={navState.isSettingsModalOpen} onOpenChange={(open) => dispatch({ type: 'SET_SETTINGS_MODAL_OPEN', payload: open })} />
     </>
   )
 }

--- a/components/dashboard/dashboard-layout.tsx
+++ b/components/dashboard/dashboard-layout.tsx
@@ -138,7 +138,7 @@ export function DashboardLayout({
           </main>
         </div>
 
-        {mounted && isMobile && <MobileBottomNavigation />}
+        {mounted && isMobile && <MobileBottomNavigation sidebarData={sidebarData} />}
       </div>
     </TaskDndProvider>
   )

--- a/components/dashboard/dashboard-sidebar-navigation.test.tsx
+++ b/components/dashboard/dashboard-sidebar-navigation.test.tsx
@@ -36,6 +36,8 @@ const mockSidebarData: SidebarUserData = {
   userInitials: 'TU',
   apartmentCount: 5,
   apartmentLimit: 10,
+  hasOrganisationPermission: true,
+  isOrganisationHidden: false,
 }
 
 describe('DashboardSidebar Navigation', () => {

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom"
 import Link from "next/link"
 import Image from "next/image"
 import { usePathname } from "next/navigation"
-import { BarChart3, Building2, Home, Users, Wallet, FileSpreadsheet, CheckSquare, Menu, X, Folder, FolderOpen, Mail, Search, ChevronLeft, ChevronRight, Inbox, MessageCircle, PanelLeft, ChevronDown, User, Truck, Package, MapPin, ShoppingCart, Lock, Settings, PlusCircle, Activity, Bell, Loader2, Droplet, Flame, Gauge, Zap, Fuel, Thermometer, Clock, CalendarOff, CheckCircle2, Circle, GripVertical, FileText, HardDrive, File, Archive } from "lucide-react"
+import { BarChart3, Building2, Home, Users, Wallet, FileSpreadsheet, CheckSquare, Menu, X, Folder, FolderOpen, Mail, Search, ChevronLeft, ChevronRight, Inbox, MessageCircle, PanelLeft, ChevronDown, User, Truck, Package, MapPin, ShoppingCart, Lock, Settings, PlusCircle, Activity, Bell, Loader2, Droplet, Flame, Gauge, Zap, Fuel, Thermometer, Clock, CalendarOff, CheckCircle2, Circle, GripVertical, FileText, HardDrive, File, Archive, Network } from "lucide-react"
 import { motion, Variants, AnimatePresence } from "framer-motion"
 import { LOGO_URL, ROUTES } from "@/lib/constants"
 import { createClient as createBrowserClient } from "@/utils/supabase/client"
@@ -75,6 +75,11 @@ const sidebarNavGroups: SidebarNavGroupType[] = [
         title: "Suche",
         href: ROUTES.SEARCH,
         icon: Search,
+      },
+      {
+        title: "Organisationen",
+        href: "/organisation",
+        icon: Network,
       },
     ]
   },
@@ -500,7 +505,15 @@ function SidebarContent({
         <nav className="grid gap-1 px-3">
           <TooltipProvider delayDuration={100} skipDelayDuration={300}>
             {sidebarNavGroups.flatMap((group) => group.items).filter(
-              item => !featureFlags.has(item.href) || featureFlags.get(item.href)
+              item => {
+                if (featureFlags.has(item.href) && !featureFlags.get(item.href)) {
+                  return false;
+                }
+                if (item.href === "/organisation") {
+                  return sidebarData.hasOrganisationPermission && !sidebarData.isOrganisationHidden;
+                }
+                return true;
+              }
             ).map((item) => {
               const isActive = isRouteActive(item.href);
 

--- a/components/settings/user-settings-progress.test.tsx
+++ b/components/settings/user-settings-progress.test.tsx
@@ -60,6 +60,8 @@ describe('UserSettings with Progress Bar', () => {
     userInitials: 'TU',
     apartmentCount: 0,
     apartmentLimit: null,
+    hasOrganisationPermission: true,
+    isOrganisationHidden: false,
   }
 
   const setupMocks = (apartmentCount: number, apartmentLimit: number | null) => {

--- a/lib/error-handling.ts
+++ b/lib/error-handling.ts
@@ -12,6 +12,7 @@
 
 import { logger } from '@/utils/logger';
 import { SupabaseClient } from '@supabase/supabase-js';
+import { posthogLogger } from '@/lib/posthog-logger';
 
 /**
  * Performance metrics for database function calls
@@ -232,6 +233,19 @@ export async function safeRpcCall<T>(
         retryable: structuredError.retryable
       });
 
+      try {
+        posthogLogger.error(`RPC call failed: ${functionName}`, {
+          'rpc.function': functionName,
+          'rpc.user_id': userId,
+          'rpc.error_message': error.message || 'Unknown database error',
+          'rpc.error_code': error.code || 'unknown',
+          'rpc.duration_ms': executionTime,
+          'rpc.error_category': structuredError.category
+        });
+      } catch (phError) {
+        console.error('Failed to log RPC failure to PostHog:', phError);
+      }
+
       return {
         success: false,
         message: structuredError.userMessage,
@@ -271,6 +285,18 @@ export async function safeRpcCall<T>(
         errorCategory: ErrorCategory.TIMEOUT
       });
 
+      try {
+        posthogLogger.error(`RPC call timeout: ${functionName}`, {
+          'rpc.function': functionName,
+          'rpc.user_id': userId,
+          'rpc.duration_ms': executionTime,
+          'rpc.timeout_ms': timeoutMs,
+          'rpc.error_category': ErrorCategory.TIMEOUT
+        });
+      } catch (phError) {
+        console.error('Failed to log RPC timeout to PostHog:', phError);
+      }
+
       return {
         success: false,
         message: 'Die Anfrage dauerte zu lange. Bitte versuchen Sie es erneut.',
@@ -287,6 +313,17 @@ export async function safeRpcCall<T>(
         errorCategory: ErrorCategory.NETWORK
       });
 
+      try {
+        posthogLogger.error(`RPC call network error: ${functionName}`, {
+          'rpc.function': functionName,
+          'rpc.user_id': userId,
+          'rpc.duration_ms': executionTime,
+          'rpc.error_category': ErrorCategory.NETWORK
+        });
+      } catch (phError) {
+        console.error('Failed to log RPC network error to PostHog:', phError);
+      }
+
       return {
         success: false,
         message: 'Netzwerkfehler. Bitte überprüfen Sie Ihre Internetverbindung.',
@@ -301,6 +338,18 @@ export async function safeRpcCall<T>(
       executionTime,
       errorCategory: ErrorCategory.UNKNOWN
     });
+
+    try {
+      posthogLogger.error(`Unexpected error in RPC call: ${functionName}`, {
+        'rpc.function': functionName,
+        'rpc.user_id': userId,
+        'rpc.duration_ms': executionTime,
+        'rpc.error_message': error.message || 'Unknown error',
+        'rpc.error_category': ErrorCategory.UNKNOWN
+      });
+    } catch (phError) {
+      console.error('Failed to log unexpected RPC error to PostHog:', phError);
+    }
 
     return {
       success: false,

--- a/lib/server/user-data.ts
+++ b/lib/server/user-data.ts
@@ -10,6 +10,8 @@ export interface SidebarUserData {
   userInitials: string;
   apartmentCount: number;
   apartmentLimit: number | typeof Infinity | null;
+  hasOrganisationPermission: boolean;
+  isOrganisationHidden: boolean;
 }
 
 /**
@@ -28,14 +30,16 @@ export async function getSidebarUserData(
       ...guestData,
       apartmentCount: 0,
       apartmentLimit: Infinity, // Guest users = unlimited (consistent with normalizeApartmentLimit)
+      hasOrganisationPermission: false,
+      isOrganisationHidden: false,
     }
   }
 
   // Use shared utility for display name and initials
   const displayData = getUserDisplayData(user);
 
-  // Parallel fetch for apartment count and profile if not provided
-  const [countResult, secondaryProfileResult] = await Promise.all([
+  // Parallel fetch for apartment count, profile, organisation info if not provided
+  const [countResult, secondaryProfileResult, hasOrgPermResult, orgIdResult] = await Promise.all([
     supabase
       .from('Wohnungen')
       .select('id', { count: 'exact', head: true })
@@ -45,8 +49,26 @@ export async function getSidebarUserData(
       .from('profiles')
       .select('stripe_subscription_status, stripe_price_id')
       .eq('id', user.id)
-      .single() : Promise.resolve({ data: profile })
+      .single() : Promise.resolve({ data: profile }),
+    supabase.rpc('check_permission', {
+      p_modul: 'organisation',
+      p_aktion: 'ansehen',
+    }),
+    supabase.rpc('current_organisation_id')
   ]);
+
+  const hasOrganisationPermission = hasOrgPermResult.data === true;
+  const orgId = orgIdResult.data;
+  let isOrganisationHidden = false;
+
+  if (orgId) {
+    const { data: orgData } = await supabase
+      .from('Organisation')
+      .select('ist_versteckt')
+      .eq('id', orgId)
+      .maybeSingle();
+    isOrganisationHidden = orgData?.ist_versteckt ?? false;
+  }
 
   let apartmentLimit: number | typeof Infinity | null = null;
   const activeProfile = profile || secondaryProfileResult.data;
@@ -77,5 +99,7 @@ export async function getSidebarUserData(
     ...displayData,
     apartmentCount: countResult.count || 0,
     apartmentLimit,
+    hasOrganisationPermission,
+    isOrganisationHidden,
   }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -18,6 +18,7 @@ const MANAGED_ROUTE_PREFIXES = [
   "/dateien",
   "/oauth",
   "/checkout/success",
+  "/organisation",
 ]
 
 const ROUTE_PERMISSIONS: Record<string, string> = {
@@ -242,5 +243,7 @@ export const config = {
     "/dateien/:path*",
     "/checkout/success",
     "/oauth/:path*",
+    "/organisation",
+    "/organisation/:path*",
   ],
 }


### PR DESCRIPTION
## Description

Introduces the organisation management feature: a dedicated /organisation page to manage members, roles, statuses and invitations.

## Summary of Changes

- New `organisation/client-wrapper.tsx` (~960 lines): overview stats (active members, admins, pending invites, owner), members table with role/status selects and remove action, invitations table with revoke, invite panel, confirmation dialogs, pill tab navigation
- `organisation/page.tsx`: server-side permission + membership checks with redirects
- Sidebar: new "Organisationen" nav item, shown only with organisation permission and when the org is not hidden
- `lib/server/user-data.ts`: exposes `hasOrganisationPermission` and `isOrganisationHidden`
- Middleware: `/organisation` routes registered
- `lib/error-handling.ts`: RPC failures/timeouts/network errors now also logged to PostHog with function name, duration and category
- Tests updated for the new sidebar fields