### PR TITLE
fix(ci): use PR head sha for posthog visual review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,5 +91,5 @@ jobs:
           --type playwright
           --token ${{ secrets.POSTHOG_VR_TOKEN }}
           --branch ${{ github.head_ref }}
-          --commit ${{ github.sha }}
+          --commit ${{ github.event.pull_request.head.sha || github.sha }}
           --pr ${{ github.event.pull_request.number }}

--- a/playwright/snapshots.yml
+++ b/playwright/snapshots.yml
@@ -1,6 +1,254 @@
 version: 1
 config:
-  api: https://eu.posthog.com
-  team: '76914'
-  repo: 'f63cdd2e-ce5d-40ed-9d64-f49fafb448bc'
-snapshots: {}
+    api: https://eu.posthog.com
+    team: '76914'
+    repo: f63cdd2e-ce5d-40ed-9d64-f49fafb448bc
+snapshots:
+    agb-dark-chromium-linux:
+        hash: v1.k04ffa068.628535fc9ddc86a61449463c8db820d787e9a28aa94ea4ba413ec18b09a7236b.uX5Ed98S7wWptmqy-0ta9tIH7-ryulrqVB51MDrc2NY
+    agb-dark-firefox-linux:
+        hash: v1.k04ffa068.95c0e100d9633b7f63dab975bb003f79420d872367e3283d251a7334161af8e7.8qG86wIzC5EhO7uO8BNER4eXbQqel4u9BdJlk7tAOjs
+    agb-dark-webkit-linux:
+        hash: v1.k04ffa068.f9212211b7806b0083e9b57ada8661d8375c4c1faa1dabf7398ff5e52dc5af0f.hnUcyKAedYzaYHUorDqybyuueuJjClYjhjIrtCzUfdQ
+    agb-light-chromium-linux:
+        hash: v1.k04ffa068.2bbe298f6ffc32167d1e44315cffe92dfb49ffa7dcb1e42591a86a9bf3900f77.cZAnlSeGSWwuRSTqOHWHdudHfY42UvG7AT-y51ZM0iQ
+    agb-light-firefox-linux:
+        hash: v1.k04ffa068.fdd134933aad0ad67cf48116b83fd2c81efa4a048ed55aa6c260e891953e1918.gEZW-v9Bjpk4eODo5zANdT-9XUtk33uZiQ3zrKfC3Uw
+    agb-light-webkit-linux:
+        hash: v1.k04ffa068.3fa82aa71ba36a8313a6698862c81c1c6c87b2deef5f774d828449adc5580498.rXPg-g1aOEZABhK4VQMZ7RvoqQ2nY8pfAVm_Thd0qM4
+    dashboard-betriebskosten-dark-chromium-linux:
+        hash: v1.k04ffa068.8d9da50c7e18c343dffecbd2256e1302d5588b9af54d04c1a7063a01260cf32c.NfXwowGkrQ9G1RqITZLSM6FGa4R0fOh7qYiDZjG5UKg
+    dashboard-betriebskosten-dark-firefox-linux:
+        hash: v1.k04ffa068.f3af1a0cbd6eeed8e7291ba87ca3ec1fe09d8b62521ca4173a69257baba9b65e.KjgTDxiziqAX1Ran_Iq1Ht4bheEU6psgcVdPkjuQyxY
+    dashboard-betriebskosten-dark-webkit-linux:
+        hash: v1.k04ffa068.2d698f3959109db5c1d77f64073e6a553a4eca31af1e8d1a42018e37ceb87def.UwC1f59St8kXaO0q0vDTZzbMq-0Wpc0gEhoffzlorWw
+    dashboard-betriebskosten-light-chromium-linux:
+        hash: v1.k04ffa068.15f62356d47e05eb7be9996fbfdd9ef2f7eee3fb0e01a855d9db352a06aec491.a7wSzJphJ7QfTR15Hd3TpgNrSRIlSvE-YndZdQg3Qv4
+    dashboard-betriebskosten-light-firefox-linux:
+        hash: v1.k04ffa068.44914ff63dc83b83b939f542b3b55900ff8b871fec4ad2426a3ff13df752f58b.kEzLueb9vecx9VZPmJAwZ-EMox9Qeve9V6LgjtY3IXI
+    dashboard-betriebskosten-light-webkit-linux:
+        hash: v1.k04ffa068.d7b0c56e86cd218e4c2588ec9599eebf9a497138745981b24af5412d1eb0aef9.ix-gBlXDX-B9q8ZbIAra4CZmYFlvuT5qEvvaWGveT9M
+    dashboard-dashboard-dark-firefox-linux:
+        hash: v1.k04ffa068.f23a9370211e1e20fbddbb909ac1fe559f615f9e33e79136fd9b2866b5e04ca7.6PzTHekU6nLhRUyE5IsadFWDaehkeeVVlgtuZJ3d3Vg
+    dashboard-dashboard-dark-webkit-linux:
+        hash: v1.k04ffa068.20b1902c509f5ba5d115cf5b50b31046be4bbcc50e49c72e36e02c1506ec7d45.YAaWxAvWZkkWC9D23Yps85--3TwmJjuK4pMrBOQpdis
+    dashboard-dashboard-light-firefox-linux:
+        hash: v1.k04ffa068.c3f06063eed642d1a1e06e5303679796cc31a4a42ccec4730d7d281fee494083.Exm_A5Nqlwmda7Cm9-POAeXFVuXYDTZbOFWEBUxnc1Q
+    dashboard-dashboard-light-webkit-linux:
+        hash: v1.k04ffa068.27b3b880656e6b179d725903b9cefb6b08f337abcef076ab1fe2e30a3d1b8f03.vPXP4EYc9aKSrPeh1uC3Ea8O9qCeBIGVkD4-pGTcuE0
+    dashboard-dateien-dark-chromium-linux:
+        hash: v1.k04ffa068.dc1894e101b594da6e78d95951fdb40f64244703f8cb5f384e6e5eef34d9dec5.NYy18L23DaKF7IeG3sDnU8befFzF2hCXRUbNwPWGS5w
+    dashboard-dateien-dark-firefox-linux:
+        hash: v1.k04ffa068.8ea7ebcc517bf59875da02a05748e4add917ca74e43107333eaf9267d9492017.LpuLb6Nl9JpM81jG3JFrlT9l0E0cmRkd-6_YuuZVehM
+    dashboard-dateien-dark-webkit-linux:
+        hash: v1.k04ffa068.7d649e43cc567daa3ef8ede3db230af7184b838e838398d4dd0ad2f88fed8eb1.rEduPFPL6EqplxmSKQtEh7hbIYUQuCz4_i_4nb5zEtM
+    dashboard-dateien-light-chromium-linux:
+        hash: v1.k04ffa068.9684d8143e27b88d1f7c1470c37bae22f537b6bdf10f4ceba71952f5fe9bea27.i7Lr1OkrwMf5iurxTAyNAjxiUNc7ACmpKpGYm4m_uHc
+    dashboard-dateien-light-firefox-linux:
+        hash: v1.k04ffa068.8393f554a71a1f4fe16afc44d21433c678b9a5e472fc7773f8a5e6e8a28febce.wrXOEdXQW2L5If8v8M1a7vWvGn_xtJum7a2RcBWOL2U
+    dashboard-dateien-light-webkit-linux:
+        hash: v1.k04ffa068.1bab8f8df3a8d84066609cd3408192ded356ee000d92c9fdc44081728950770f.7Y3eQDbRtQgGBPuTztumskyV0nf4gz7Vl8E8bu7Tomk
+    dashboard-finanzen-dark-chromium-linux:
+        hash: v1.k04ffa068.97553103716a86200a552061639366ea69dc0252ff66cd14045912d90973acbf.4tJVXjyG41T_J8oTMZ0nSiQHfYFEgURaAPX9KH6EOok
+    dashboard-finanzen-dark-firefox-linux:
+        hash: v1.k04ffa068.1d1db05d90abc7e7fc1a8d36587ba096fa9c955f11edf05aeecd39d1f8801912._RqEZj21-5x2Zb6hPSG4qLR7IOw_6og0wZS2o60YEfk
+    dashboard-finanzen-dark-webkit-linux:
+        hash: v1.k04ffa068.5be87c6c847799f297e8619421201a5d193c827cad5ea8887ee1b9ebdcbcb618.AyR-_gzITPRmfGd2bAHGhDplrA3XRHBCe-6Lj0ZeXuQ
+    dashboard-finanzen-light-chromium-linux:
+        hash: v1.k04ffa068.3c8389f288081ca2c6a26c61b3ed5fa954913db001d18d6f4a9a672523704191.auqrN6J_T5Jrcc_v-lJJDyuVUzAyFFXm1SNU257Sx1M
+    dashboard-finanzen-light-firefox-linux:
+        hash: v1.k04ffa068.0690b26580e213a1de5c3744770e3db418d9240c798116af438d1a2065a160bc._K6nNG8e5i_MofAEuaeOocaxx0Zw_9ZKAJIWo011O6w
+    dashboard-finanzen-light-webkit-linux:
+        hash: v1.k04ffa068.784fdc825c1102a39eda318bdab168bdcab8225394f683e95b0fe0bc0527e373.XfIFUdZ1fGkTOlxS8IAHamzu5MbNWtCOWLNGqw2Eezc
+    dashboard-haeuser-dark-chromium-linux:
+        hash: v1.k04ffa068.06f86f8b1c51c6e52dff6bbbafbebf6101a412d7810dd6d11faf1c157a471d5e.XBE8MCdp0JliRLZO-iD6_Zq5F4YvRQ-syyOXyHI-ENA
+    dashboard-haeuser-dark-firefox-linux:
+        hash: v1.k04ffa068.edab9c34e5443c8250278bf333953b4036c730f38e41614a8a2439e847521e3a.mWFRbHW9abhVIcf0rzGSGoAIMBpCrT4P1TnqY7CG_-E
+    dashboard-haeuser-dark-webkit-linux:
+        hash: v1.k04ffa068.74214abf5de69e8a809e0b9a1bcb77c497709f0fe155b6aba5c379c78d360a87.5EwrtKLTGfxOlKJxlNQ4MPsDEl0QNGMPaZABuR--nEY
+    dashboard-haeuser-light-chromium-linux:
+        hash: v1.k04ffa068.1bd692baefa77a6791102d79d87ff09faabb0b397572b64cf3ae988f4f6afedb.gVMYVyjAsEYQ_eM11UJ3CZfN_l_sJIm-hLfKIlGHqvA
+    dashboard-haeuser-light-firefox-linux:
+        hash: v1.k04ffa068.cfbacd53997fe570252db8f3aa4c45d5ad4eaee5bc84c41579ecac7c7e69d9dc.YlGp_BTJ8NYKABMkUqScicNhXjL6ouQ0DeY61ONBnEI
+    dashboard-haeuser-light-webkit-linux:
+        hash: v1.k04ffa068.23bd133df0765c01f1b69eba7a3002f1caa0c2ac2bfb1d9a585e404b8a1a437a.jq1Xnb10-Qg494fwpAML11KG3uYQ13jli2DUM9DMQuI
+    dashboard-mails-dark-chromium-linux:
+        hash: v1.k04ffa068.dbc9b7028182142483f04a91f67e28d2509eebeec3d16c80ebfa13632984f22e.u008yzfbRE9xXg6YhZ4droRJaRNCu5HpDlSfnlHwf4o
+    dashboard-mails-dark-firefox-linux:
+        hash: v1.k04ffa068.20874aa685d82f88274ab9205e0c0e3341cc4eea6ab630e40771a6d608c1bb82.uwoz8wjnBCbcsTg_vOVNZpqIThNSoe90DdYIsH1tZe8
+    dashboard-mails-dark-webkit-linux:
+        hash: v1.k04ffa068.ebc69f1a2e69690424fc925b265aa390641da385babb2267ba03b85ac00313d1.Ox8iyrtoZUgUdehTCUvHkF7sPcN2JdpZ-WXDTd6_TQc
+    dashboard-mails-light-chromium-linux:
+        hash: v1.k04ffa068.4af1cb4f2b2cd9ffc7e03e570cf8f28fd6faff52b7f68e9a11f0d3b48d3e6226.CaX-8eCFJ4bUjYBcwdW71QwcxBdQxOMhGfB__QhLFx4
+    dashboard-mails-light-firefox-linux:
+        hash: v1.k04ffa068.046d2822e0efee76db5810426dd83b0c191dc3241cc725e6b3d50cde89cf2fa0.JYBOGdwjMZVvD2v2Iy6-UdC5sA_5SqvHenzj3u4UPfM
+    dashboard-mails-light-webkit-linux:
+        hash: v1.k04ffa068.d013eeb472e8c89cbd26bb1399f81d7b853bae951a9941a5e8bb07b5d5d91af6.LgO_XDoR_CH6ENaCwpq2hgznVYLUloahf70RnyX60Y0
+    dashboard-mieter-dark-chromium-linux:
+        hash: v1.k04ffa068.559f0acc02642c776f75c98cfa2b862330ab77d654206adf9b9db1fe5a0029db.Nv4sEJKEcvoOdJ-5oJBzbVlxA5u-Z5sh2w-h904tc1I
+    dashboard-mieter-dark-firefox-linux:
+        hash: v1.k04ffa068.c8ea6aea87565f950f33c7f4000f700eca46e3ebb0769cdbdb1ef77ba32eca4c.5lxwF1fUkFuYUnQf6lCrfcAeHMm6sJCbrxhkjnakEEA
+    dashboard-mieter-dark-webkit-linux:
+        hash: v1.k04ffa068.378088c42995193dcc5c2faead951af3db768d3fc41d05fca92d2310401eb59c.reB6cUvV6afOprlwK4V0oS6J9vkJK6EJRuiZkl3eWiw
+    dashboard-mieter-light-chromium-linux:
+        hash: v1.k04ffa068.e7c79e18825eb600642e45c73f97ac8f1238b758e01c912848ee91b1e6a531e1.zi_ahYQcAO6CWwIV_1p8bHghZSVZqg09C5aM9z6GE2E
+    dashboard-mieter-light-firefox-linux:
+        hash: v1.k04ffa068.5201031595e5567549a2e3535dadafebf903a7dec156c9ef14edcc975ec6d663.4By3KdgyhiPmr7aCp19HeMR_ngl-7O61CeNznL-CsHk
+    dashboard-mieter-light-webkit-linux:
+        hash: v1.k04ffa068.8243d02371c78c104753bc94a696cc3fb792cfcdf8c4623424f40e8fa1210002.iVd_3b0FQivcmiWQn1nGyz0OExYYBWdxfsyH1LWEKZ0
+    dashboard-todos-dark-chromium-linux:
+        hash: v1.k04ffa068.b5efc77f3b5501412b536d8a7d5f96bbc3447babbe57210e6e9f6996245b7e92.js07uAgjgAYmFAe2NyHxzdgttB8zeOM74WQu8a2eEv8
+    dashboard-todos-dark-firefox-linux:
+        hash: v1.k04ffa068.6c9c5c12285ef0a46118c89fbd318b44172ac8d6169389d08ebc9f367780b3b5.kQSd6J3vTQUCk03TU26kGD5ggwEAARMLPr61bHHHH3U
+    dashboard-todos-dark-webkit-linux:
+        hash: v1.k04ffa068.f44b62fe558ee6f172579ee82c570a1e3a8d2b82ac823c751d7549c36f920366.5jnYYLcgn77wsW4_GL18cyOzn9hS67AvV4EpIcKa4YQ
+    dashboard-todos-light-chromium-linux:
+        hash: v1.k04ffa068.fb54a11d6b76ee2d3c1b3b248d3360dab8672e146cb30b96c0fa1f03e6f68a95.Vkv-X9XA077GCQZ6BW_pywpEulG86HBLjU9OEQAo09I
+    dashboard-todos-light-firefox-linux:
+        hash: v1.k04ffa068.1ff5cc6a188beb2c31d60ff1fcbaeeb8a5213817f5ae47ced5c2ea2f5ce585c3.BN_Ay8rC6ViE0dzUh93gA2LSKkHWABRBgFc6NqLwfYE
+    dashboard-todos-light-webkit-linux:
+        hash: v1.k04ffa068.970e39df469b4b03850da82dcc529759441ff25b350d210acce81661590f589e.zEQ2KgbWRWPvSkgvjZlIUoOEY_QpkMWDaaNTKP2hER4
+    dashboard-wohnungen-dark-chromium-linux:
+        hash: v1.k04ffa068.3174af0f3ef422d75483f3435e8d675dfbb32a78a965892dd49ea47c5677ddf0.bry9ms2zHbMiASC69or8QUEvWlySSnALFW30YbFSoWk
+    dashboard-wohnungen-dark-firefox-linux:
+        hash: v1.k04ffa068.5ced62e1e3635e32359ad585ce0ce20c4b7de0e3b3b590f62bfa5bea1a9aa89a.71bXoP9m_RL_nBWri-kMqphX6C7AA1VuWoudrxsdsKI
+    dashboard-wohnungen-dark-webkit-linux:
+        hash: v1.k04ffa068.c91bf7f8460742f62d5e44a50397e33ea9ad4e1e1bb9549d50b9e8d969e88f74.g9Pvkn02PhG2mwIFbr7NisdhGs3uXBhKXhemsO8xXnU
+    dashboard-wohnungen-light-chromium-linux:
+        hash: v1.k04ffa068.14058f76db5180e1e0fe5ea8ea3d0b7bf5ff3ba9f126eaf8b3b942084be25808.RZW5c1_yWvG03S_TB0bJiJW2q_589Sm6TtvmYmwVNzM
+    dashboard-wohnungen-light-firefox-linux:
+        hash: v1.k04ffa068.4b366e0143c34c48a0d676246aad39329783abd1775ecf377a12d09ac674e553.l4TDOmh79rpoXhPJ15afugTie24KDjbteDNYpiQQRcs
+    dashboard-wohnungen-light-webkit-linux:
+        hash: v1.k04ffa068.cbe4c2f93e80ead4f1a906b7fb1a369c6aae56c2e0fa4e619dbe068a988442e8.WSGquS_ywm8vdgLLdHbeinyXVfZqp1k8pjBV2pibg4w
+    datenschutz-dark-chromium-linux:
+        hash: v1.k04ffa068.62ec6fe25f9869e43c8aafd20e3af7b92305da5ab33b11407849586c46e205c2.4q1klq-Eac6JxD4HhkdJ3fHa-r1neLM-jRqOxggOpjc
+    datenschutz-dark-firefox-linux:
+        hash: v1.k04ffa068.e6d3bb2b6b0dc82a19a75a83f4dcab7e0defb2d5fa2e96f1acc5d0a3e65ccb5d.S6yVTVwu23dSsTzYmh3ZcB5UOxtin2-paeswELpRtPo
+    datenschutz-dark-webkit-linux:
+        hash: v1.k04ffa068.8d76176f02d06e877d742ee50a39a054976c5f0c31c31c2a59c883b0b39fbbab.dsMXe887PPDAAmsj5r71YMflCPyFRnB65CH1lH7wby0
+    datenschutz-light-chromium-linux:
+        hash: v1.k04ffa068.5aba1e5c9208cb70c9b25227c126e85ee7214cb0cf61f13443d40c2099791a7c.GweYgLZ2d-U-h6CQJM4aySesK_s8YjfDRnRMSFbHM7s
+    datenschutz-light-firefox-linux:
+        hash: v1.k04ffa068.b90e7ebeaa2fb5120bbc07e2bc6c677226472a18ed6c37bee0ebbb7b72b83d45.wzbQImPmakWdsQXY3A7K0mt6mGwcffNV45cViSfL9ts
+    datenschutz-light-webkit-linux:
+        hash: v1.k04ffa068.1912208b493b0c8439afb9219bf29304bc5ea01611e4a89c65e73d6777ffb44c.JK6VqI_10LTplLnH2tYo6woVWQfLWqKA4lDEIpcLmZg
+    funktionen-betriebskosten-dark-chromium-linux:
+        hash: v1.k04ffa068.7c6439f819f4e47e7a5c9ec85c235a944148121ec08f81b8d851a1867e5605b3.dUnIS5Vd-ckf8Kg1MFLma7T4xgg2Ui1_BbpJeQbq0nw
+    funktionen-betriebskosten-dark-firefox-linux:
+        hash: v1.k04ffa068.0b794ca124ecf5d1fa974f431246be919480704d2510e031287114e7bd397915.bNQFcVFGT8qvhIti0IkxrXQsVZJIueXHuEkyvDN1LUI
+    funktionen-betriebskosten-dark-webkit-linux:
+        hash: v1.k04ffa068.4a82de95370b0fb597dbac677457328de401981f5bfbff15f6a406af2ffef0ea.JuyVOcsbEJR8DKOHyzf2hOXL3iegcKt0Xh4NGNZNh_A
+    funktionen-betriebskosten-light-chromium-linux:
+        hash: v1.k04ffa068.d4461c9719dff8cb919a130d355762a9feb6cb29aab594421474d979ed7d5896.byALBh6guXucx1gt4OKdCH3G1uqxuaqx9mWD7XKzgFk
+    funktionen-betriebskosten-light-firefox-linux:
+        hash: v1.k04ffa068.b1b34da64c74fdb2b9449628d9eb2f53966a69f02d921949e42ec172e839b429.0lOFhNBTFUWrcQ8Q-CAHG6efazX_-wYuUsT79u-nkaM
+    funktionen-betriebskosten-light-webkit-linux:
+        hash: v1.k04ffa068.62e441216dcc8949f669258721300d2947f3fff95df84006e725d8626e93ffd1.Lxco8K6l3pagODsKDIBzgw25cLzin4ec4sS1o_vXJ0w
+    funktionen-finanzverwaltung-dark-chromium-linux:
+        hash: v1.k04ffa068.e23da65bb6a90ca82a99ad694635f73b8cb167b1633b07f12ce61deb8c9dc2cf.NNl0eJeHAENAzs_iyirELotfs_59F11-nBvqOwORtmM
+    funktionen-finanzverwaltung-dark-firefox-linux:
+        hash: v1.k04ffa068.21de06db3e5e653710e11445e87c09cebce84a2386ef05d36f0b53f6e74b0307.us5gmjwfepwOMYiXMCZ1UVQ-IhWIhpKgQTgRYIh-2sQ
+    funktionen-finanzverwaltung-dark-webkit-linux:
+        hash: v1.k04ffa068.c298dd0de407e99f64d00176e994ab7208b9311c268a80626e11e20f290d6a11.ZuFnzL-ew4fbwesskFQg67hecoSQVCiDYVRGU2Hpc4U
+    funktionen-finanzverwaltung-light-chromium-linux:
+        hash: v1.k04ffa068.4c8eacdcc5a740a806e3f02ef4b6a008ac037edba0dd884a44a5cf2609933641.xrRUpli3dkzgjNYUAkradqaENry4Lj-kmblBwlYmhnM
+    funktionen-finanzverwaltung-light-firefox-linux:
+        hash: v1.k04ffa068.a21131c4554024498cf8c18571633b217021540af75f3cc5bc59ecb85c960606.QP5FXidbzdD0LJNKAKDXXAsCqp3Zj90YpxNfM2tdzc8
+    funktionen-finanzverwaltung-light-webkit-linux:
+        hash: v1.k04ffa068.a42d33af60d64f62ee2894b475c3f07455bfec14fecb2acd05cf68053c7d9b99.221652Xmo-RGy425Qy_5_drGwkhP8pfEJJ-WrgK5lAk
+    funktionen-wohnungsverwaltung-dark-chromium-linux:
+        hash: v1.k04ffa068.975480aaf4a7db59d06a57e201f26599201aa6e19ae799293015dac9bac3715b.pu00rQ0mmycb1wYfpPipV34WAcH8oJMbMGy8b_nVs54
+    funktionen-wohnungsverwaltung-dark-firefox-linux:
+        hash: v1.k04ffa068.4fc7560f7f55bf9b76a90ae18b427ad149e28f05d2047385d1c1fa53d2b3201b.6-xVp-aJQrnkLogqHHkehzIoy3F4WE8yU2Yo_gMymuo
+    funktionen-wohnungsverwaltung-dark-webkit-linux:
+        hash: v1.k04ffa068.4682ef602185444a49b560c0297813a29d64f050874c43b15002fef719efe5c2.nNKQsWXbKJG5xdA4oc24RfTVWQFR6uU95QIWVdS5exs
+    funktionen-wohnungsverwaltung-light-chromium-linux:
+        hash: v1.k04ffa068.6a372e94923f5069821543b91ce80198f0f91d2e71a69477ccc245588ce90d98.W2d8LbkpXnH9XkVpJPPYGyR31ulZtxlwVUO7HhLap1I
+    funktionen-wohnungsverwaltung-light-firefox-linux:
+        hash: v1.k04ffa068.a091f3e163bfaf71e59b6fe7f822968a54a496706ecaa3c30f4000cb3fad2354.VS10opRc_c6MbsF9Cm-_XhYEATGpgwkNBILCMStB73o
+    funktionen-wohnungsverwaltung-light-webkit-linux:
+        hash: v1.k04ffa068.80d1ec35ddae6ac57d348b4a96685f984cd68e1e95cb0bdfd43d2d4048474f26.P0RYY_AFvxV0jY09mSuP5AYmpK_Dgo2F5WKEepI6blw
+    impressum-dark-chromium-linux:
+        hash: v1.k04ffa068.dff4de2a5645649787ef632e991a60644473bc4b841a6a04ade5cefddb69ad34.8wVzWJ0jp0lKN7WT6XVwYUydCPHihIzObAgP8L_8p44
+    impressum-dark-firefox-linux:
+        hash: v1.k04ffa068.3e9dba84f154014fd471fd2cd97293b8e4e5f962f8b79e05a3adf1ca83c8ad51.smVuywVsQqKWsmDPDCRqoSiU5WrlIU5LediPGcphBko
+    impressum-dark-webkit-linux:
+        hash: v1.k04ffa068.9bd7b092be61630c6af6d719601c0286f2db08a5e646b0d7f663129275f907e8.5Th0jlFLmJ3Gm5IW5UGVbsMldTBVJUbO0ulhuR5B5Aw
+    impressum-light-chromium-linux:
+        hash: v1.k04ffa068.635a38e33b8c2810aacfa63452e21b410ff1c94dbc819dc4fcebf10bb7dae373.QN0cm_d-M3WnSw3nNqtL3cSZDFxDKKycKCZ4IBbG1mc
+    impressum-light-firefox-linux:
+        hash: v1.k04ffa068.60f8ac5dbe9d0575c35f9c879a2947534b22bf2faa6e2102c5ed648feb4578af.Y0wuPojjhwy6lsvJQxGGKwv5-SjGxExAgVSDnDHZtj4
+    impressum-light-webkit-linux:
+        hash: v1.k04ffa068.21962b775f957841f9c7bac2d55650511845a16fcf42e6d4171e74effc268d61.OKw_YjOgk_Y_3hWLZMXUkznSXItNAZxaomI4wjUnJhI
+    loesungen-grosse-hausverwaltungen-dark-chromium-linux:
+        hash: v1.k04ffa068.f734ad26f4ac9991e4601d4691d1fe68cb1730ac8b03310aa452817d34fe5dd3.fTDote7HMVM5ub00YdbT53aJghTPrT73rXlm6gLJqeo
+    loesungen-grosse-hausverwaltungen-dark-firefox-linux:
+        hash: v1.k04ffa068.17c42b3ba1d98a4e6fe855ff163e4e5e8dc67cd0825a4b33652b2648fd661c05.kopquPWDbY8hxEVEl_ckkWs-ETS-IicEF0oU-2z7d9o
+    loesungen-grosse-hausverwaltungen-dark-webkit-linux:
+        hash: v1.k04ffa068.a731389a8d2c23fc21c12a61ee9912c5fd4f7de903203425eb3661946d8a99b5.7XhPzxZkkfvn29zsDoOWw2Y5c9_tFJ1X1U_GVrrWKgk
+    loesungen-grosse-hausverwaltungen-light-chromium-linux:
+        hash: v1.k04ffa068.1c51054f6b0226df063ec4f88bd548520d1e13b30e398a01a9eeeeb0142490f8.2zn71Sqtlx-lNpcouJOesgfGsiBRY8zQOfFt5IUhASM
+    loesungen-grosse-hausverwaltungen-light-firefox-linux:
+        hash: v1.k04ffa068.af025c925305251a054efb0d81f92b70b69061737d289c5a895a4680a0ccbd2b.q9VXCV8hiD8fn0jGGiH2AQHtIKQTz0W9UuEG90PSZGo
+    loesungen-grosse-hausverwaltungen-light-webkit-linux:
+        hash: v1.k04ffa068.476bc295c38f1f079a98ea26c50d618dbab3b2d6223053f010b00ac499bd9ada.C3EPVYptuAv3POtd-mlSP7QOkeViSUxuAx8t1C949Tc
+    loesungen-kleine-mittlere-hausverwaltungen-dark-chromium-linux:
+        hash: v1.k04ffa068.f734ad26f4ac9991e4601d4691d1fe68cb1730ac8b03310aa452817d34fe5dd3.KGcLotILlaDQrLXcj-dJX9kuJ_v68il0XdjsXUEA3XE
+    loesungen-kleine-mittlere-hausverwaltungen-dark-firefox-linux:
+        hash: v1.k04ffa068.17c42b3ba1d98a4e6fe855ff163e4e5e8dc67cd0825a4b33652b2648fd661c05.lnOq9GcGT8RmboXE-qSzh4WEIU8D4xT2whT-h9EYP7k
+    loesungen-kleine-mittlere-hausverwaltungen-dark-webkit-linux:
+        hash: v1.k04ffa068.a731389a8d2c23fc21c12a61ee9912c5fd4f7de903203425eb3661946d8a99b5.Ea2fLIu8b9QYQxyUww11vkIa-RHkr5C1EPMMt3ZkJ2U
+    loesungen-kleine-mittlere-hausverwaltungen-light-chromium-linux:
+        hash: v1.k04ffa068.1c51054f6b0226df063ec4f88bd548520d1e13b30e398a01a9eeeeb0142490f8.v3shj-v_Q_jQYMbDuF2wBCkvQiIGmv_D-EJswaTjW74
+    loesungen-kleine-mittlere-hausverwaltungen-light-firefox-linux:
+        hash: v1.k04ffa068.af025c925305251a054efb0d81f92b70b69061737d289c5a895a4680a0ccbd2b.a932t0SL_uV5pKTlYtQH9D4MHdLWFNOwwBJnsXiqnas
+    loesungen-kleine-mittlere-hausverwaltungen-light-webkit-linux:
+        hash: v1.k04ffa068.476bc295c38f1f079a98ea26c50d618dbab3b2d6223053f010b00ac499bd9ada.nxaaZQ8wHBRMIfrmePO6RzzSsWfkfRpK1LYXvN5VK1Y
+    loesungen-privatvermieter-dark-chromium-linux:
+        hash: v1.k04ffa068.f734ad26f4ac9991e4601d4691d1fe68cb1730ac8b03310aa452817d34fe5dd3.3ehAQ-kMejo7m4fnofnxqcCs0kTglPipbi2fjchnjsA
+    loesungen-privatvermieter-dark-firefox-linux:
+        hash: v1.k04ffa068.17c42b3ba1d98a4e6fe855ff163e4e5e8dc67cd0825a4b33652b2648fd661c05.QakvF_BMDd6c6dfMv41o6HNuR7IX6gzwZutAhtGqvbg
+    loesungen-privatvermieter-dark-webkit-linux:
+        hash: v1.k04ffa068.a731389a8d2c23fc21c12a61ee9912c5fd4f7de903203425eb3661946d8a99b5.UBMFSacDxOTri7D-142aSF2w15fh4Yso4sOe3b8pG_w
+    loesungen-privatvermieter-light-chromium-linux:
+        hash: v1.k04ffa068.1c51054f6b0226df063ec4f88bd548520d1e13b30e398a01a9eeeeb0142490f8.Ci0Um6wbma55BQpBeObKSd7q_Begje8-Noorx5Ufupg
+    loesungen-privatvermieter-light-firefox-linux:
+        hash: v1.k04ffa068.af025c925305251a054efb0d81f92b70b69061737d289c5a895a4680a0ccbd2b.n98tQdo8e3qn2N6Ue1wYyvILL-shEi83YfZxiBAgiwQ
+    loesungen-privatvermieter-light-webkit-linux:
+        hash: v1.k04ffa068.476bc295c38f1f079a98ea26c50d618dbab3b2d6223053f010b00ac499bd9ada.8KGW6prbEnoC6pT5h777NxbWGzKkrElu-XZx5idyV00
+    preise-dark-chromium-linux:
+        hash: v1.k04ffa068.244adeb32ce5cb2e9f6e9f21d5ce8853942a66a5a7f3f076f839c8f3e3a7460a.9SXtrN9lOeAhA8gdhTPYAAcZ-5xFu2T4FQsEXHeBLKE
+    preise-dark-firefox-linux:
+        hash: v1.k04ffa068.76c0c9d4a83026b32b5c723661df8af8ccd04a5cc9e19a2b66746a519c0124c8.h6p9HFQnxop3DNxY5VAfDZYsYlqM3QRkaDUZvFwgZZU
+    preise-dark-webkit-linux:
+        hash: v1.k04ffa068.1c34e0a151662adb6a1ffa673e048609ce7db06368c75123d9eda098b4524581.VmLBTl_wzUL9vE4WncL9247aj5jHFWbs4s2qNv8WYPo
+    preise-light-chromium-linux:
+        hash: v1.k04ffa068.f448356d8db1253f13b93b808e0ce186772886103292728e82975712e19c000e.rzFFWZIiqCZK5v7GaCq8exIOvUPa2ljJjMauZcAP0sA
+    preise-light-firefox-linux:
+        hash: v1.k04ffa068.facdea13d813909d2d4e8997b4c0db18a63f51262634db816cd797e80539c46c.EzZluHXbpbcSsYT01plUBYtJlR3cNjkd1Ayy5qyTnxo
+    preise-light-webkit-linux:
+        hash: v1.k04ffa068.184194587a6bfc2fe7197150509cf935fe29f78ffd5911005558e360b3b7e50c.mn5P45u-P2X1cghpzIH4jCzmuRJ9_DuS-VFmrsQz7OM
+    warteliste-browser-erweiterung-dark-chromium-linux:
+        hash: v1.k04ffa068.f734ad26f4ac9991e4601d4691d1fe68cb1730ac8b03310aa452817d34fe5dd3.46GfqfQZjslMPjiB6EjqjhKwed_XbRl1-LA4k1-16_U
+    warteliste-browser-erweiterung-dark-firefox-linux:
+        hash: v1.k04ffa068.17c42b3ba1d98a4e6fe855ff163e4e5e8dc67cd0825a4b33652b2648fd661c05.mwH5uOBXInS6Mht0HLJfLY_-t4w7_iyg0WgXfFr0Zes
+    warteliste-browser-erweiterung-dark-webkit-linux:
+        hash: v1.k04ffa068.a731389a8d2c23fc21c12a61ee9912c5fd4f7de903203425eb3661946d8a99b5.vAbJzlp0E7W43a3zCimpovwJ_0ztY1sTZJhMjdnq4a8
+    warteliste-browser-erweiterung-light-chromium-linux:
+        hash: v1.k04ffa068.1c51054f6b0226df063ec4f88bd548520d1e13b30e398a01a9eeeeb0142490f8.285AbMoiw5VDBI1mCx213aq1NrdoKBoOwoOxyNucMtk
+    warteliste-browser-erweiterung-light-firefox-linux:
+        hash: v1.k04ffa068.af025c925305251a054efb0d81f92b70b69061737d289c5a895a4680a0ccbd2b.HZFGLd3HmwNcHUD3AYJRgLIQFRLWz4rux59wFPI9prk
+    warteliste-browser-erweiterung-light-webkit-linux:
+        hash: v1.k04ffa068.476bc295c38f1f079a98ea26c50d618dbab3b2d6223053f010b00ac499bd9ada.95f4R37KZPlVXGk-lY0FyHdhIbh08il5W_3jb_spw6c
+    warteliste-mobile-app-dark-chromium-linux:
+        hash: v1.k04ffa068.f734ad26f4ac9991e4601d4691d1fe68cb1730ac8b03310aa452817d34fe5dd3.RFGz8c6eEsPReBHCixXDT70M4mCX7FfSxOxkFSrN1io
+    warteliste-mobile-app-dark-firefox-linux:
+        hash: v1.k04ffa068.17c42b3ba1d98a4e6fe855ff163e4e5e8dc67cd0825a4b33652b2648fd661c05.pKLagi0J39uUQyRox2-WAH_EIRfX5UAlI52zApo6qR4
+    warteliste-mobile-app-dark-webkit-linux:
+        hash: v1.k04ffa068.a731389a8d2c23fc21c12a61ee9912c5fd4f7de903203425eb3661946d8a99b5.Ed82JHSKyWph4jC_ya3KLarWmcAL_gmMzZZusWg_agA
+    warteliste-mobile-app-light-chromium-linux:
+        hash: v1.k04ffa068.1c51054f6b0226df063ec4f88bd548520d1e13b30e398a01a9eeeeb0142490f8.NZ-NS5wVyC4lm55TFRiPBz4GjpSv9S3H1dDaOW3ozjQ
+    warteliste-mobile-app-light-firefox-linux:
+        hash: v1.k04ffa068.af025c925305251a054efb0d81f92b70b69061737d289c5a895a4680a0ccbd2b.92lqPL_v1ZkQynH-yaHQXLz2mMV4ZZuXuY46xOd--W0
+    warteliste-mobile-app-light-webkit-linux:
+        hash: v1.k04ffa068.476bc295c38f1f079a98ea26c50d618dbab3b2d6223053f010b00ac499bd9ada.aDUMzwaIYHEv9E0wx68aOOPBcREm4VHDWD-99rf_U18


### PR DESCRIPTION
This PR fixes the CI error where PostHog Visual Review expects the branch head SHA but receives a newer commit SHA (the pull request merge commit).

The `commit` argument passed to the PostHog Visual Review CLI has been updated to use `${{ github.event.pull_request.head.sha || github.sha }}` instead of just `${{ github.sha }}`. This ensures that the correct commit SHA is used during pull request builds, while maintaining functionality for branch builds where `pull_request` context is missing.

---
*PR created automatically by Jules for task [12963855525008837626](https://jules.google.com/task/12963855525008837626) started by @NtFelix*