### PR TITLE
Integrate native PostHog support flow

### DIFF
--- a/app/api/support/identity/route.ts
+++ b/app/api/support/identity/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server'
+import { requireAuthenticatedUserForApi } from '@/lib/server/route-access'
+import { NO_CACHE_HEADERS } from '@/lib/constants/http'
+
+export const runtime = 'edge'
+
+function bufferToHex(buffer: ArrayBuffer) {
+  return Array.from(new Uint8Array(buffer))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+export async function GET() {
+  const authResult = await requireAuthenticatedUserForApi()
+
+  if (authResult instanceof NextResponse) {
+    return authResult
+  }
+
+  const { user } = authResult
+  const supportSecret = process.env.POSTHOG_SUPPORT_SECRET
+
+  if (!supportSecret) {
+    return NextResponse.json(
+      { error: 'Support identity is not configured' },
+      { status: 503, headers: NO_CACHE_HEADERS },
+    )
+  }
+
+  const encoder = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(supportSecret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(user.id))
+
+  return NextResponse.json(
+    {
+      distinctId: user.id,
+      hash: bufferToHex(signature),
+    },
+    { headers: NO_CACHE_HEADERS },
+  )
+}
+

--- a/app/auth/register/content.tsx
+++ b/app/auth/register/content.tsx
@@ -21,6 +21,7 @@ import { handleGoogleSignIn, handleMicrosoftSignIn } from "@/lib/auth-helpers"
 import { GoogleIcon } from "@/components/icons/google-icon"
 import { MicrosoftIcon } from "@/components/icons/microsoft-icon"
 import { authState } from "@/lib/auth-state"
+import { syncSupportIdentity } from "@/lib/posthog-support"
 
 const benefits = [
   "14 Tage kostenlos testen",
@@ -112,6 +113,7 @@ export default function RegisterPage() {
           is_anonymous: false,
         })
       }
+      await syncSupportIdentity(posthog, data.user.id)
       // Track registration success (GDPR-compliant - checks consent internally)
       trackRegisterSuccess('email')
     }

--- a/components/auth/login-content.tsx
+++ b/components/auth/login-content.tsx
@@ -21,6 +21,7 @@ import { handleGoogleSignIn, handleMicrosoftSignIn } from "@/lib/auth-helpers"
 import { GoogleIcon } from "@/components/icons/google-icon"
 import { MicrosoftIcon } from "@/components/icons/microsoft-icon"
 import { getSafeAuthRedirect } from "@/lib/auth-redirects"
+import { syncSupportIdentity } from "@/lib/posthog-support"
 
 export default function LoginContent() {
   const searchParams = useSearchParams()
@@ -112,6 +113,7 @@ export default function LoginContent() {
           is_anonymous: false,
         })
       }
+      await syncSupportIdentity(posthog, data.user.id)
       // Track login success (GDPR-compliant - checks consent internally)
       trackLoginSuccess('email')
     }

--- a/components/dashboard/dashboard-layout.tsx
+++ b/components/dashboard/dashboard-layout.tsx
@@ -9,6 +9,12 @@ import { cn } from "@/lib/utils"
 import { SidebarUserData } from "@/lib/server/user-data"
 import { useSidebarStore } from "@/hooks/use-sidebar-store"
 import { TaskDndProvider } from "@/components/tasks/task-dnd-provider"
+import dynamic from "next/dynamic"
+
+const SupportLauncher = dynamic(
+  () => import("@/components/support/support-launcher").then((mod) => mod.SupportLauncher),
+  { ssr: false },
+)
 
 export function DashboardLayout({ 
   children,
@@ -138,7 +144,8 @@ export function DashboardLayout({
           </main>
         </div>
 
-        {mounted && isMobile && <MobileBottomNavigation sidebarData={sidebarData} />}
+        {mounted && isMobile && <MobileBottomNavigation />}
+        <SupportLauncher />
       </div>
     </TaskDndProvider>
   )

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type React from "react"
 import { useState, useEffect, useMemo, useCallback } from "react"
 import { createPortal } from "react-dom"
 import Link from "next/link"
@@ -34,6 +35,7 @@ import { useOnboardingStore } from "@/hooks/use-onboarding-store"
 import { SidebarUserData } from "@/lib/server/user-data"
 import { useSidebarStore } from "@/hooks/use-sidebar-store"
 import { useModalStore } from "@/hooks/use-modal-store"
+import { useSupportStore } from "@/hooks/use-support-store"
 import { usePropertyHierarchy } from "@/hooks/use-property-hierarchy"
 import { useFolderNavigation } from "@/components/common/navigation-interceptor"
 import { buildUserPath, buildHousePath, buildApartmentPath, buildTenantPath } from "@/lib/path-utils"
@@ -403,10 +405,11 @@ function SidebarContent({
   // Feature flags for sidebar bottom actions
   const supportButtonEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.SUPPORT_BUTTON)
   const notificationCenterFeatureEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.NOTIFICATION_CENTER)
+  const { openSupport, unreadCount: supportUnreadCount } = useSupportStore()
 
   // Unread badge indicators for sidebar bottom actions
   // TODO: Implement later logic to check for unread messages / support requests in the inbox
-  const hasUnreadMessages = false
+  const hasUnreadMessages = supportUnreadCount > 0
   // TODO: Implement later logic to check for unread notifications in the notification center
   const hasUnreadNotifications = false
 
@@ -605,7 +608,7 @@ function SidebarContent({
               <div className="flex flex-col gap-4">
                 <div className="flex items-center justify-between border-b border-zinc-100 dark:border-zinc-800/60 pb-3">
                   <h3 className="font-bold text-sm text-zinc-900 dark:text-zinc-50">Support</h3>
-                  <span className="text-[10px] font-semibold bg-accent/10 text-accent px-2 py-0.5 rounded-full">0 Offen</span>
+                  <span className="text-[10px] font-semibold bg-accent/10 text-accent px-2 py-0.5 rounded-full">{supportUnreadCount} Offen</span>
                 </div>
                 <div className="flex flex-col items-center justify-center py-6 text-center">
                   <div className="size-12 rounded-full bg-zinc-50 dark:bg-zinc-900/50 flex items-center justify-center border border-zinc-100 dark:border-zinc-800/50 mb-3 shadow-inner">
@@ -617,12 +620,13 @@ function SidebarContent({
                   </p>
                 </div>
                 <div className="border-t border-zinc-100 dark:border-zinc-800/60 pt-3">
-                  <Link 
-                    href="/support" 
+                  <button
+                    type="button"
+                    onClick={() => openSupport()}
                     className="flex items-center justify-center w-full py-2 rounded-xl bg-zinc-50 hover:bg-zinc-100 dark:bg-zinc-900/40 dark:hover:bg-zinc-900/80 border border-zinc-200/30 dark:border-zinc-800/30 text-xs font-medium text-zinc-700 dark:text-zinc-300 hover:text-zinc-900 dark:hover:text-zinc-100 transition-all duration-200"
                   >
-                    Support kontaktieren
-                  </Link>
+                    Support öffnen
+                  </button>
                 </div>
               </div>
             </PopoverContent>
@@ -685,4 +689,3 @@ function SidebarContent({
     </div>
   )
 }
-

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -608,7 +608,7 @@ function SidebarContent({
               <div className="flex flex-col gap-4">
                 <div className="flex items-center justify-between border-b border-zinc-100 dark:border-zinc-800/60 pb-3">
                   <h3 className="font-bold text-sm text-zinc-900 dark:text-zinc-50">Support</h3>
-                  <span className="text-[10px] font-semibold bg-accent/10 text-accent px-2 py-0.5 rounded-full">{supportUnreadCount} Offen</span>
+                  <span className="text-[10px] font-semibold bg-accent/10 text-accent px-2 py-0.5 rounded-full">{supportUnreadCount} Ungelesen</span>
                 </div>
                 <div className="flex flex-col items-center justify-center py-6 text-center">
                   <div className="size-12 rounded-full bg-zinc-50 dark:bg-zinc-900/50 flex items-center justify-center border border-zinc-100 dark:border-zinc-800/50 mb-3 shadow-inner">

--- a/components/providers/posthog-provider.tsx
+++ b/components/providers/posthog-provider.tsx
@@ -5,6 +5,7 @@ import { PostHogProvider as PHProvider } from 'posthog-js/react'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { useEffect, Suspense, useState, useReducer } from 'react'
 import posthogProxyConfig from '@/lib/posthog-proxy'
+import { syncSupportIdentity } from '@/lib/posthog-support'
 
 const { POSTHOG_PROXY_PATH, POSTHOG_UI_HOST } = posthogProxyConfig
 
@@ -153,6 +154,9 @@ function PostHogTracking({ children }: { children: React.ReactNode }) {
               is_anonymous: false,
             });
           }
+
+          // Sync the PostHog Support identity so tickets follow the user across browsers/devices.
+          await syncSupportIdentity(posthog, user.id)
         }
         // Note: Anonymous tracking for documentation pages removed for GDPR compliance
         // Users must accept cookies before any tracking occurs
@@ -232,6 +236,8 @@ function PostHogTracking({ children }: { children: React.ReactNode }) {
               user_type: 'authenticated',
               is_anonymous: false,
             })
+
+            void syncSupportIdentity(posthog, user.id)
 
             posthog.capture('user_logged_in', {
               provider: provider || 'email',

--- a/components/support/support-button.tsx
+++ b/components/support/support-button.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { MessageCircle } from "lucide-react"
+import { useSupportStore } from "@/hooks/use-support-store"
+import { cn } from "@/lib/utils"
+
+interface SupportButtonProps {
+  className?: string
+}
+
+export function SupportButton({ className }: SupportButtonProps) {
+  const { openSupport, unreadCount, isAvailable } = useSupportStore()
+
+  return (
+    <button
+      type="button"
+      onClick={openSupport}
+      className={cn(
+        "relative inline-flex size-11 items-center justify-center rounded-2xl border border-zinc-200/80 bg-white text-zinc-600 shadow-lg shadow-zinc-950/5 transition-all duration-200 hover:scale-105 hover:text-zinc-950 dark:border-zinc-800/80 dark:bg-[#181818] dark:text-zinc-300 dark:hover:text-zinc-50",
+        className,
+      )}
+      aria-label="Support öffnen"
+      title="Support öffnen"
+    >
+      <MessageCircle className="size-5" />
+      {unreadCount > 0 && (
+        <span className="absolute -right-1 -top-1 flex min-h-5 min-w-5 items-center justify-center rounded-full bg-rose-500 px-1 text-[10px] font-semibold leading-none text-white shadow-md">
+          {unreadCount > 99 ? '99+' : unreadCount}
+        </span>
+      )}
+      {!isAvailable && (
+        <span className="absolute bottom-0 right-0 size-2 rounded-full bg-amber-400 shadow-[0_0_0_2px_white] dark:shadow-[0_0_0_2px_#181818]" />
+      )}
+    </button>
+  )
+}
+

--- a/components/support/support-launcher.tsx
+++ b/components/support/support-launcher.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import dynamic from "next/dynamic"
+import { useFeatureFlagEnabled } from "posthog-js/react"
+import { POSTHOG_FEATURE_FLAGS } from "@/lib/constants"
+import { SupportButton } from "@/components/support/support-button"
+
+const SupportPanel = dynamic(
+  () => import("@/components/support/support-panel").then((mod) => mod.SupportPanel),
+  { ssr: false },
+)
+
+export function SupportLauncher() {
+  const supportEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.SUPPORT_BUTTON)
+
+  if (!supportEnabled) {
+    return null
+  }
+
+  return (
+    <>
+      <div className="fixed bottom-24 right-4 z-40 md:bottom-6 md:right-6">
+        <SupportButton />
+      </div>
+      <SupportPanel />
+    </>
+  )
+}
+

--- a/components/support/support-panel.tsx
+++ b/components/support/support-panel.tsx
@@ -1,0 +1,634 @@
+"use client"
+
+import type React from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { usePostHog } from "posthog-js/react"
+import { useAuth } from "@/components/auth/auth-provider"
+import { useSupportStore } from "@/hooks/use-support-store"
+import { syncSupportIdentity, buildSupportTraits, SUPPORT_POLL_INTERVAL_MS, type SupportMessage, type SupportTicket } from "@/lib/posthog-support"
+import { getUserDisplayData } from "@/lib/utils/user"
+import { formatRelativeTime } from "@/lib/format-relative-time"
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { cn } from "@/lib/utils"
+import { Loader2, MessageCircle, Plus, RefreshCcw, RotateCcw, Send } from "lucide-react"
+
+const ticketStatusLabels: Record<string, string> = {
+  new: 'Neu',
+  open: 'Offen',
+  pending: 'Wartet',
+  on_hold: 'Pausiert',
+  resolved: 'Gelöst',
+}
+
+const ticketStatusClasses: Record<string, string> = {
+  new: 'bg-blue-500/10 text-blue-600 dark:text-blue-300',
+  open: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-300',
+  pending: 'bg-amber-500/10 text-amber-700 dark:text-amber-300',
+  on_hold: 'bg-zinc-500/10 text-zinc-600 dark:text-zinc-300',
+  resolved: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-300',
+}
+
+function normalizeMessages(messages: SupportMessage[]) {
+  return messages.filter((message) => !message.is_private)
+}
+
+function formatTicketTitle(ticket: SupportTicket) {
+  return ticket.last_message?.trim() || `Ticket ${ticket.id.slice(0, 8)}`
+}
+
+function getTicketPreview(ticket: SupportTicket) {
+  if (ticket.last_message?.trim()) {
+    return ticket.last_message.trim()
+  }
+
+  return `${ticket.message_count} Nachricht${ticket.message_count === 1 ? '' : 'en'}`
+}
+
+async function loadSupportTickets(posthog: ReturnType<typeof usePostHog>) {
+  if (!posthog?.conversations?.isAvailable?.() || typeof posthog.conversations.getTickets !== 'function') {
+    return null
+  }
+
+  return posthog.conversations.getTickets()
+}
+
+async function loadSupportMessages(
+  posthog: ReturnType<typeof usePostHog>,
+  ticketId?: string | null,
+) {
+  if (!ticketId || !posthog?.conversations?.isAvailable?.() || typeof posthog.conversations.getMessages !== 'function') {
+    return null
+  }
+
+  return posthog.conversations.getMessages(ticketId)
+}
+
+export function SupportPanel() {
+  const posthog = usePostHog()
+  const { user } = useAuth()
+  const { isOpen, closeSupport, unreadCount, setUnreadCount, isAvailable, setIsAvailable } = useSupportStore()
+  const [tickets, setTickets] = useState<SupportTicket[]>([])
+  const [ticketsLoading, setTicketsLoading] = useState(false)
+  const [ticketsError, setTicketsError] = useState<string | null>(null)
+  const [selectedTicketId, setSelectedTicketId] = useState<string | null>(null)
+  const [currentTicketId, setCurrentTicketId] = useState<string | null>(null)
+  const [messages, setMessages] = useState<SupportMessage[]>([])
+  const [messagesLoading, setMessagesLoading] = useState(false)
+  const [messageError, setMessageError] = useState<string | null>(null)
+  const [draft, setDraft] = useState('')
+  const [isSending, setIsSending] = useState(false)
+  const [identityReady, setIdentityReady] = useState(false)
+  const [isComposingNewTicket, setIsComposingNewTicket] = useState(false)
+  const [isMobile, setIsMobile] = useState(false)
+  const lastIdentityUserId = useRef<string | null>(null)
+  const visibleTicketId = isComposingNewTicket ? null : (selectedTicketId || currentTicketId)
+  const visibleTicket = tickets.find((ticket) => ticket.id === visibleTicketId) || null
+  const visibleMessages = useMemo(() => normalizeMessages(messages), [messages])
+  const canReplyToSelection = isComposingNewTicket || !selectedTicketId || selectedTicketId === currentTicketId
+  const userDisplay = getUserDisplayData(user)
+  const supportTraits = buildSupportTraits(user)
+
+  useEffect(() => {
+    let cancelled = false
+    let availabilityCheck: number | undefined
+
+    const updateAvailability = () => {
+      const available = Boolean(posthog?.conversations?.isAvailable?.())
+      setIsAvailable(available)
+
+      if (available) {
+        setTicketsError(null)
+        setIdentityReady(true)
+        return true
+      }
+
+      return false
+    }
+
+    if (updateAvailability()) {
+      return
+    }
+
+    availabilityCheck = window.setInterval(() => {
+      if (cancelled) {
+        return
+      }
+
+      if (updateAvailability() && availabilityCheck) {
+        window.clearInterval(availabilityCheck)
+      }
+    }, 500)
+
+    return () => {
+      cancelled = true
+      if (availabilityCheck) {
+        window.clearInterval(availabilityCheck)
+      }
+    }
+  }, [posthog, setIsAvailable])
+
+  useEffect(() => {
+    const updateViewport = () => {
+      setIsMobile(window.innerWidth < 640)
+    }
+
+    updateViewport()
+    window.addEventListener('resize', updateViewport, { passive: true })
+
+    return () => {
+      window.removeEventListener('resize', updateViewport)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!user?.id || !posthog || !isAvailable) {
+      return
+    }
+
+    if (lastIdentityUserId.current === user.id) {
+      return
+    }
+
+    lastIdentityUserId.current = user.id
+    void syncSupportIdentity(posthog, user.id).then((identity) => {
+      if (identity) {
+        setIdentityReady(true)
+      }
+    })
+  }, [isAvailable, posthog, user?.id])
+
+  const refreshTickets = useCallback(async () => {
+    if (!posthog || !isAvailable) {
+      return
+    }
+
+    setTicketsLoading(true)
+    try {
+      const response = await loadSupportTickets(posthog)
+
+      if (!response) {
+        return
+      }
+
+      const normalizedTickets = [...response.results].sort((a, b) => {
+        return new Date(b.last_message_at || b.created_at).getTime() - new Date(a.last_message_at || a.created_at).getTime()
+      })
+
+      setTickets(normalizedTickets)
+      setUnreadCount(normalizedTickets.reduce((total, ticket) => total + (ticket.unread_count || 0), 0))
+      const activeTicketId = isComposingNewTicket ? null : posthog.conversations?.getCurrentTicketId?.() || null
+      setCurrentTicketId(activeTicketId)
+
+      if (!selectedTicketId && !isComposingNewTicket) {
+        setSelectedTicketId(activeTicketId || normalizedTickets[0]?.id || null)
+      }
+    } catch (error) {
+      setTicketsError(error instanceof Error ? error.message : 'Tickets konnten nicht geladen werden.')
+    } finally {
+      setTicketsLoading(false)
+    }
+  }, [isAvailable, isComposingNewTicket, posthog, selectedTicketId, setUnreadCount])
+
+  const refreshMessages = useCallback(async (ticketId: string | null) => {
+    if (!posthog || !isAvailable || !ticketId) {
+      setMessages([])
+      return
+    }
+
+    setMessagesLoading(true)
+    setMessageError(null)
+
+    try {
+      const response = await loadSupportMessages(posthog, ticketId)
+
+      if (!response) {
+        setMessages([])
+        return
+      }
+
+      setMessages(response.messages)
+
+      if (response.unread_count > 0 && typeof posthog.conversations?.markAsRead === 'function') {
+        await posthog.conversations.markAsRead(ticketId)
+      }
+    } catch (error) {
+      setMessageError(error instanceof Error ? error.message : 'Nachrichten konnten nicht geladen werden.')
+    } finally {
+      setMessagesLoading(false)
+    }
+  }, [isAvailable, posthog])
+
+  useEffect(() => {
+    if (!isAvailable) {
+      return
+    }
+
+    void refreshTickets()
+  }, [isAvailable, refreshTickets])
+
+  useEffect(() => {
+    if (!selectedTicketId && currentTicketId) {
+      void refreshMessages(currentTicketId)
+      return
+    }
+
+    if (selectedTicketId) {
+      void refreshMessages(selectedTicketId)
+    }
+  }, [currentTicketId, isAvailable, refreshMessages, selectedTicketId])
+
+  useEffect(() => {
+    if (!isAvailable) {
+      return
+    }
+
+    const ticketsTimer = window.setInterval(() => {
+      void refreshTickets()
+    }, SUPPORT_POLL_INTERVAL_MS)
+
+    return () => window.clearInterval(ticketsTimer)
+  }, [isAvailable, refreshTickets])
+
+  useEffect(() => {
+    if (!isOpen || !isAvailable || !visibleTicketId) {
+      return
+    }
+
+    const messagesTimer = window.setInterval(() => {
+      void refreshMessages(visibleTicketId)
+    }, SUPPORT_POLL_INTERVAL_MS)
+
+    return () => window.clearInterval(messagesTimer)
+  }, [isAvailable, isOpen, refreshMessages, visibleTicketId])
+
+  const handleSelectTicket = (ticket: SupportTicket) => {
+    setIsComposingNewTicket(false)
+    setSelectedTicketId(ticket.id)
+    setDraft('')
+    void refreshMessages(ticket.id)
+  }
+
+  const handleStartNewTicket = () => {
+    setIsComposingNewTicket(true)
+    setSelectedTicketId(null)
+    setCurrentTicketId(null)
+    setMessages([])
+    setDraft('')
+    setMessageError(null)
+  }
+
+  const handleSendMessage = () => {
+    if (!posthog || !supportTraits || !draft.trim() || !isAvailable || !canReplyToSelection || typeof posthog.conversations?.sendMessage !== 'function') {
+      return
+    }
+
+    const message = draft.trim()
+    const shouldCreateNewTicket = isComposingNewTicket || !currentTicketId || selectedTicketId === null
+
+    setDraft('')
+    setMessageError(null)
+    setIsSending(true)
+
+    void posthog.conversations?.sendMessage?.(message, supportTraits, shouldCreateNewTicket)
+      .then((response) => {
+        if (!response) {
+          return
+        }
+
+        setCurrentTicketId(response.ticket_id)
+        setSelectedTicketId(response.ticket_id)
+        setIsComposingNewTicket(false)
+        void refreshTickets()
+        void refreshMessages(response.ticket_id)
+      })
+      .catch((error) => {
+        setDraft(message)
+        setMessageError(error instanceof Error ? error.message : 'Nachricht konnte nicht gesendet werden.')
+      })
+      .finally(() => {
+        setIsSending(false)
+      })
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+      event.preventDefault()
+      handleSendMessage()
+    }
+  }
+
+  return (
+    <Sheet open={isOpen} onOpenChange={(open) => (open ? undefined : closeSupport())}>
+      <SheetContent
+        side={isMobile ? "bottom" : "right"}
+        className={cn(
+          "flex h-[100dvh] w-full flex-col gap-0 border-zinc-200/70 bg-[#fcfcfd] p-0 dark:border-zinc-800/70 dark:bg-[#111111]",
+          isMobile ? "h-[88vh] max-h-[88vh] max-w-none rounded-t-[1.75rem]" : "sm:max-w-[46rem]",
+        )}
+      >
+        <div className="flex h-full flex-col overflow-hidden">
+          <SheetHeader className="border-b border-zinc-200/70 px-5 py-4 text-left dark:border-zinc-800/70">
+            <div className="flex items-start justify-between gap-4">
+              <div className="space-y-1">
+                <SheetTitle className="flex items-center gap-2 text-base font-semibold text-zinc-950 dark:text-zinc-50">
+                  <MessageCircle className="size-4" />
+                  Support
+                </SheetTitle>
+                <SheetDescription className="text-sm text-zinc-500 dark:text-zinc-400">
+                  {identityReady
+                    ? 'Tickets, Nachrichten und Antworten direkt in Mietevo.'
+                    : 'Lade Support-Verbindungen...'}
+                </SheetDescription>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void refreshTickets()}
+                  className="gap-2"
+                >
+                  <RefreshCcw className="size-3.5" />
+                  Aktualisieren
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={handleStartNewTicket}
+                  className="gap-2"
+                >
+                  <Plus className="size-3.5" />
+                  Neues Ticket
+                </Button>
+              </div>
+            </div>
+          </SheetHeader>
+
+          {!isAvailable && (
+            <div className="px-5 py-4">
+              <Alert>
+                <Loader2 className="size-4 animate-spin" />
+                <AlertTitle>Support wird geladen</AlertTitle>
+                <AlertDescription>
+                  Wir verbinden Mietevo mit PostHog Conversations. Wenn der Dienst aktiviert ist, erscheinen hier automatisch Ihre Tickets.
+                </AlertDescription>
+              </Alert>
+            </div>
+          )}
+
+          {ticketsError && (
+            <div className="px-5 pt-4">
+              <Alert variant="destructive">
+                <AlertTitle>Tickets konnten nicht geladen werden</AlertTitle>
+                <AlertDescription>{ticketsError}</AlertDescription>
+              </Alert>
+            </div>
+          )}
+
+          <div className="grid flex-1 min-h-0 gap-0 lg:grid-cols-[18rem_minmax(0,1fr)]">
+            <aside className="border-b border-zinc-200/70 bg-white/80 dark:border-zinc-800/70 dark:bg-zinc-950/40 lg:border-b-0 lg:border-r">
+              <div className="flex items-center justify-between border-b border-zinc-200/70 px-4 py-3 dark:border-zinc-800/70">
+                <div>
+                  <p className="text-sm font-semibold text-zinc-950 dark:text-zinc-50">Tickets</p>
+                  <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                    {unreadCount > 0 ? `${unreadCount} unbeantwortete Nachricht${unreadCount === 1 ? '' : 'en'}` : 'Keine ungelesenen Antworten'}
+                  </p>
+                </div>
+                <Badge variant="outline" className="border-zinc-200 bg-zinc-50 text-[11px] font-medium text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300">
+                  {ticketsLoading ? 'Laden' : `${tickets.length}`}
+                </Badge>
+              </div>
+
+              <ScrollArea className="h-[26rem] lg:h-[calc(100dvh-12rem)]">
+                <div className="p-2">
+                  {tickets.length === 0 && !ticketsLoading ? (
+                    <div className="flex flex-col items-center justify-center gap-2 px-4 py-12 text-center">
+                      <div className="flex size-12 items-center justify-center rounded-2xl bg-zinc-100 text-zinc-500 dark:bg-zinc-900">
+                        <MessageCircle className="size-5" />
+                      </div>
+                      <p className="text-sm font-medium text-zinc-950 dark:text-zinc-50">Noch keine Tickets</p>
+                      <p className="text-xs leading-relaxed text-zinc-500 dark:text-zinc-400">
+                        Starten Sie eine neue Support-Anfrage, sobald Sie Hilfe benötigen.
+                      </p>
+                    </div>
+                  ) : (
+                    tickets.map((ticket) => {
+                      const active = ticket.id === selectedTicketId
+                      const unread = ticket.unread_count || 0
+
+                      return (
+                        <button
+                          key={ticket.id}
+                          type="button"
+                          onClick={() => handleSelectTicket(ticket)}
+                          className={cn(
+                            "mb-2 w-full rounded-2xl border p-3 text-left transition-all duration-200",
+                            active
+                              ? "border-primary/40 bg-primary/5 shadow-sm"
+                              : "border-zinc-200/70 bg-white hover:border-zinc-300 hover:bg-zinc-50 dark:border-zinc-800/70 dark:bg-zinc-950/40 dark:hover:bg-zinc-900/50",
+                          )}
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0 space-y-1">
+                              <p className="truncate text-sm font-semibold text-zinc-950 dark:text-zinc-50">
+                                {formatTicketTitle(ticket)}
+                              </p>
+                              <p className="line-clamp-2 text-xs leading-relaxed text-zinc-500 dark:text-zinc-400">
+                                {getTicketPreview(ticket)}
+                              </p>
+                            </div>
+                            <div className="flex flex-col items-end gap-1">
+                              <Badge
+                                variant="outline"
+                                className={cn(
+                                  "border-0 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+                                  ticketStatusClasses[ticket.status] || 'bg-zinc-500/10 text-zinc-600 dark:text-zinc-300',
+                                )}
+                              >
+                                {ticketStatusLabels[ticket.status] || ticket.status}
+                              </Badge>
+                              {unread > 0 && (
+                                <Badge variant="destructive" className="px-2 py-0.5 text-[10px] font-semibold">
+                                  {unread}
+                                </Badge>
+                              )}
+                            </div>
+                          </div>
+                          <div className="mt-2 flex items-center justify-between text-[11px] text-zinc-400 dark:text-zinc-500">
+                            <span>{formatRelativeTime(ticket.last_message_at || ticket.created_at)}</span>
+                            <span>{ticket.message_count} Nachricht{ticket.message_count === 1 ? '' : 'en'}</span>
+                          </div>
+                        </button>
+                      )
+                    })
+                  )}
+                </div>
+              </ScrollArea>
+            </aside>
+
+            <section className="flex min-h-0 flex-col bg-[#fcfcfd] dark:bg-[#111111]">
+              <div className="flex items-center justify-between border-b border-zinc-200/70 px-5 py-4 dark:border-zinc-800/70">
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-semibold text-zinc-950 dark:text-zinc-50">
+                    {visibleTicket ? formatTicketTitle(visibleTicket) : 'Neue Support-Anfrage'}
+                  </p>
+                  <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                    {visibleTicket
+                      ? `Status: ${ticketStatusLabels[visibleTicket.status] || visibleTicket.status}`
+                      : 'Schreiben Sie uns direkt aus Mietevo.'}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                    {selectedTicketId && selectedTicketId !== currentTicketId && !isComposingNewTicket && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={handleStartNewTicket}
+                      className="gap-2"
+                    >
+                      <RotateCcw className="size-3.5" />
+                      Neue Anfrage
+                    </Button>
+                  )}
+                  <Badge variant="outline" className="border-zinc-200 bg-white text-[11px] font-medium text-zinc-600 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-300">
+                    {canReplyToSelection ? 'Antwort möglich' : 'Nur Verlauf'}
+                  </Badge>
+                </div>
+              </div>
+
+              <div className="flex min-h-0 flex-1 flex-col">
+                <ScrollArea className="flex-1">
+                  <div className="space-y-4 px-5 py-4">
+                    {messagesLoading && (
+                      <div className="flex items-center gap-2 rounded-2xl border border-zinc-200/70 bg-white px-4 py-3 text-sm text-zinc-500 dark:border-zinc-800/70 dark:bg-zinc-950/40 dark:text-zinc-400">
+                        <Loader2 className="size-4 animate-spin" />
+                        Nachrichten werden geladen...
+                      </div>
+                    )}
+
+                    {messageError && (
+                      <Alert variant="destructive">
+                        <AlertTitle>Nachrichten konnten nicht geladen werden</AlertTitle>
+                        <AlertDescription>{messageError}</AlertDescription>
+                      </Alert>
+                    )}
+
+                    {!messagesLoading && visibleMessages.length === 0 && (
+                      <div className="flex min-h-[18rem] flex-col items-center justify-center gap-3 rounded-[1.75rem] border border-dashed border-zinc-200 bg-white/70 px-6 py-10 text-center dark:border-zinc-800 dark:bg-zinc-950/30">
+                        <div className="flex size-14 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                          <MessageCircle className="size-6" />
+                        </div>
+                        <div className="space-y-1">
+                          <p className="text-sm font-semibold text-zinc-950 dark:text-zinc-50">
+                            {selectedTicketId && !isComposingNewTicket ? 'Kein Verlauf verfügbar' : 'Starten Sie den Support-Chat'}
+                          </p>
+                          <p className="max-w-md text-sm leading-relaxed text-zinc-500 dark:text-zinc-400">
+                            {selectedTicketId && !isComposingNewTicket
+                              ? 'Dieses Ticket enthält aktuell keine sichtbaren Nachrichten.'
+                              : 'Beschreiben Sie Ihr Anliegen in ein bis zwei Sätzen. Wir erstellen automatisch ein Ticket und beantworten es direkt in Mietevo.'}
+                          </p>
+                        </div>
+                      </div>
+                    )}
+
+                    {visibleMessages.map((message) => {
+                      const isCustomer = message.author_type === 'customer'
+                      const isHuman = message.author_type === 'human'
+                      const isAssistant = message.author_type === 'AI'
+                      const alignRight = isCustomer
+
+                      return (
+                        <div
+                          key={message.id}
+                          className={cn(
+                            "flex",
+                            alignRight ? "justify-end" : "justify-start",
+                          )}
+                        >
+                          <div
+                            className={cn(
+                              "max-w-[85%] rounded-[1.5rem] border px-4 py-3 shadow-sm",
+                              alignRight
+                                ? "border-primary/20 bg-primary text-primary-foreground"
+                                : "border-zinc-200/70 bg-white dark:border-zinc-800/70 dark:bg-zinc-950/60",
+                            )}
+                          >
+                            <div className="mb-2 flex items-center justify-between gap-4">
+                              <div className="text-xs font-semibold uppercase tracking-wide opacity-80">
+                                {isCustomer ? 'Sie' : isHuman ? 'Support-Team' : isAssistant ? 'PostHog AI' : message.author_name || 'Nachricht'}
+                              </div>
+                              <div className={cn("text-[11px]", alignRight ? "text-primary-foreground/70" : "text-zinc-400 dark:text-zinc-500")}>
+                                {formatRelativeTime(message.created_at)}
+                              </div>
+                            </div>
+                            <p className={cn("whitespace-pre-wrap text-sm leading-relaxed", alignRight ? "text-primary-foreground" : "text-zinc-700 dark:text-zinc-200")}>
+                              {message.content}
+                            </p>
+                          </div>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </ScrollArea>
+
+                <div className="border-t border-zinc-200/70 bg-white/90 px-5 py-4 backdrop-blur-sm dark:border-zinc-800/70 dark:bg-[#111111]/90">
+                  {!canReplyToSelection && (
+                    <div className="mb-3 rounded-2xl border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-900 dark:text-amber-200">
+                      Sie sehen gerade den Verlauf eines älteren Tickets. Für eine neue Antwort starten Sie bitte ein neues Ticket.
+                    </div>
+                  )}
+
+                  <div className="space-y-3">
+                    <Textarea
+                      value={draft}
+                      onChange={(event) => setDraft(event.target.value)}
+                      onKeyDown={handleKeyDown}
+                      placeholder="Schreiben Sie Ihre Nachricht an den Support..."
+                      className="min-h-[7rem] resize-none rounded-[1.25rem] border-zinc-200/80 bg-white shadow-xs dark:border-zinc-800/80 dark:bg-zinc-950/70"
+                    />
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                      <p className="text-xs leading-relaxed text-zinc-500 dark:text-zinc-400">
+                        Drücken Sie <kbd className="rounded border border-zinc-200 bg-zinc-50 px-1.5 py-0.5 text-[10px] text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300">Cmd</kbd> + <kbd className="rounded border border-zinc-200 bg-zinc-50 px-1.5 py-0.5 text-[10px] text-zinc-600 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-300">Enter</kbd> zum Senden.
+                      </p>
+                      <Button
+                        type="button"
+                        onClick={handleSendMessage}
+                        disabled={!draft.trim() || isSending || !isAvailable || !supportTraits || !canReplyToSelection}
+                        className="gap-2 rounded-full px-5"
+                      >
+                        {isSending ? (
+                          <>
+                            <Loader2 className="size-4 animate-spin" />
+                            Wird gesendet
+                          </>
+                        ) : (
+                          <>
+                            <Send className="size-4" />
+                            Senden
+                          </>
+                        )}
+                      </Button>
+                    </div>
+                    {!supportTraits && (
+                      <p className="text-xs text-zinc-400 dark:text-zinc-500">
+                        {userDisplay.userEmail === 'Nicht angemeldet'
+                          ? 'Für Support-Nachrichten muss ein Nutzer angemeldet sein.'
+                          : 'Benutzerinformationen werden geladen...'}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/components/support/support-panel.tsx
+++ b/components/support/support-panel.tsx
@@ -162,12 +162,14 @@ export function SupportPanel() {
     })
   }, [isAvailable, posthog, user?.id])
 
-  const refreshTickets = useCallback(async () => {
+  const refreshTickets = useCallback(async (isBackground = false) => {
     if (!posthog || !isAvailable) {
       return
     }
 
-    setTicketsLoading(true)
+    if (!isBackground) {
+      setTicketsLoading(true)
+    }
     try {
       const response = await loadSupportTickets(posthog)
 
@@ -175,7 +177,7 @@ export function SupportPanel() {
         return
       }
 
-      const normalizedTickets = [...response.results].sort((a, b) => {
+      const normalizedTickets = response.results.toSorted((a, b) => {
         return new Date(b.last_message_at || b.created_at).getTime() - new Date(a.last_message_at || a.created_at).getTime()
       })
 
@@ -190,17 +192,21 @@ export function SupportPanel() {
     } catch (error) {
       setTicketsError(error instanceof Error ? error.message : 'Tickets konnten nicht geladen werden.')
     } finally {
-      setTicketsLoading(false)
+      if (!isBackground) {
+        setTicketsLoading(false)
+      }
     }
   }, [isAvailable, isComposingNewTicket, posthog, selectedTicketId, setUnreadCount])
 
-  const refreshMessages = useCallback(async (ticketId: string | null) => {
+  const refreshMessages = useCallback(async (ticketId: string | null, isBackground = false) => {
     if (!posthog || !isAvailable || !ticketId) {
       setMessages([])
       return
     }
 
-    setMessagesLoading(true)
+    if (!isBackground) {
+      setMessagesLoading(true)
+    }
     setMessageError(null)
 
     try {
@@ -219,7 +225,9 @@ export function SupportPanel() {
     } catch (error) {
       setMessageError(error instanceof Error ? error.message : 'Nachrichten konnten nicht geladen werden.')
     } finally {
-      setMessagesLoading(false)
+      if (!isBackground) {
+        setMessagesLoading(false)
+      }
     }
   }, [isAvailable, posthog])
 
@@ -248,7 +256,7 @@ export function SupportPanel() {
     }
 
     const ticketsTimer = window.setInterval(() => {
-      void refreshTickets()
+      void refreshTickets(true)
     }, SUPPORT_POLL_INTERVAL_MS)
 
     return () => window.clearInterval(ticketsTimer)
@@ -260,7 +268,7 @@ export function SupportPanel() {
     }
 
     const messagesTimer = window.setInterval(() => {
-      void refreshMessages(visibleTicketId)
+      void refreshMessages(visibleTicketId, true)
     }, SUPPORT_POLL_INTERVAL_MS)
 
     return () => window.clearInterval(messagesTimer)

--- a/hooks/use-support-store.ts
+++ b/hooks/use-support-store.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand'
+
+interface SupportState {
+  isOpen: boolean
+  unreadCount: number
+  isAvailable: boolean
+  setOpen: (isOpen: boolean) => void
+  openSupport: () => void
+  closeSupport: () => void
+  setUnreadCount: (count: number) => void
+  setIsAvailable: (isAvailable: boolean) => void
+}
+
+export const useSupportStore = create<SupportState>((set) => ({
+  isOpen: false,
+  unreadCount: 0,
+  isAvailable: false,
+  setOpen: (isOpen) => set({ isOpen }),
+  openSupport: () => set({ isOpen: true }),
+  closeSupport: () => set({ isOpen: false }),
+  setUnreadCount: (unreadCount) => set({ unreadCount }),
+  setIsAvailable: (isAvailable) => set({ isAvailable }),
+}))
+

--- a/lib/posthog-support.d.ts
+++ b/lib/posthog-support.d.ts
@@ -1,0 +1,16 @@
+import 'posthog-js'
+import type {
+  SupportConversationsClient,
+  SupportIdentityResponse,
+} from './posthog-support'
+
+declare module 'posthog-js' {
+  interface PostHog {
+    conversations?: SupportConversationsClient
+    setIdentity?: (distinctId: string, hash: string) => void
+    get_distinct_id?: () => string
+  }
+}
+
+export type PostHogSupportIdentity = SupportIdentityResponse
+

--- a/lib/posthog-support.ts
+++ b/lib/posthog-support.ts
@@ -69,7 +69,7 @@ export interface SupportConversationsClient {
   restoreFromUrlToken?: () => Promise<unknown>
 }
 
-const supportIdentityCache = new Map<string, SupportIdentityResponse>()
+const supportIdentityCache = new Map<string, Promise<SupportIdentityResponse | null>>()
 
 export function buildSupportTraits(user: User | null | undefined) {
   if (!user) {
@@ -100,35 +100,49 @@ export async function syncSupportIdentity(
     return null
   }
 
-  const cachedIdentity = supportIdentityCache.get(distinctId)
-  if (cachedIdentity) {
-    supportPosthog.setIdentity(cachedIdentity.distinctId, cachedIdentity.hash)
-    return cachedIdentity
+  const cachedPromise = supportIdentityCache.get(distinctId)
+  if (cachedPromise) {
+    const identity = await cachedPromise
+    if (identity) {
+      supportPosthog.setIdentity(identity.distinctId, identity.hash)
+    }
+    return identity
   }
 
-  try {
-    const response = await fetch('/api/support/identity', {
-      method: 'GET',
-      credentials: 'same-origin',
-      headers: {
-        accept: 'application/json',
-      },
-    })
+  const fetchPromise = (async () => {
+    try {
+      const response = await fetch('/api/support/identity', {
+        method: 'GET',
+        credentials: 'same-origin',
+        headers: {
+          accept: 'application/json',
+        },
+      })
 
-    if (!response.ok) {
+      if (!response.ok) {
+        return null
+      }
+
+      const payload = (await response.json()) as SupportIdentityResponse
+
+      if (!payload?.distinctId || !payload?.hash) {
+        return null
+      }
+
+      return payload
+    } catch {
       return null
     }
+  })()
 
-    const payload = (await response.json()) as SupportIdentityResponse
+  supportIdentityCache.set(distinctId, fetchPromise)
 
-    if (!payload?.distinctId || !payload?.hash) {
-      return null
-    }
-
-    supportIdentityCache.set(payload.distinctId, payload)
-    supportPosthog.setIdentity(payload.distinctId, payload.hash)
-    return payload
-  } catch {
-    return null
+  const identity = await fetchPromise
+  if (identity) {
+    supportPosthog.setIdentity(identity.distinctId, identity.hash)
+  } else {
+    supportIdentityCache.delete(distinctId)
   }
+
+  return identity
 }

--- a/lib/posthog-support.ts
+++ b/lib/posthog-support.ts
@@ -1,0 +1,134 @@
+import type { PostHog } from 'posthog-js'
+import type { User } from '@supabase/supabase-js'
+
+export const SUPPORT_POLL_INTERVAL_MS = 10_000
+
+export interface SupportIdentityResponse {
+  distinctId: string
+  hash: string
+}
+
+export interface SupportTicket {
+  id: string
+  status: 'new' | 'open' | 'pending' | 'on_hold' | 'resolved' | string
+  last_message?: string
+  last_message_at?: string
+  message_count: number
+  created_at: string
+  unread_count?: number
+}
+
+export interface SupportMessage {
+  id: string
+  content: string
+  author_type: 'customer' | 'AI' | 'human' | string
+  author_name?: string
+  created_at: string
+  is_private: boolean
+}
+
+export interface SupportMessagesResponse {
+  ticket_id: string
+  ticket_status: string
+  messages: SupportMessage[]
+  has_more: boolean
+  unread_count: number
+}
+
+export interface SupportTicketsResponse {
+  count: number
+  results: SupportTicket[]
+}
+
+export interface SupportConversationsClient {
+  isAvailable?: () => boolean
+  getTickets?: (options?: {
+    status?: string
+    limit?: number
+    offset?: number
+  }) => Promise<SupportTicketsResponse | null>
+  getMessages?: (ticketId?: string, after?: string) => Promise<SupportMessagesResponse | null>
+  markAsRead?: (ticketId?: string) => Promise<{ success: boolean; unread_count: number } | null>
+  sendMessage?: (
+    message: string,
+    userTraits?: {
+      name?: string
+      email?: string
+    },
+    newTicket?: boolean
+  ) => Promise<{
+    ticket_id: string
+    message_id: string
+    ticket_status: string
+    created_at: string
+    unread_count: number
+  } | null>
+  getCurrentTicketId?: () => string | null
+  getWidgetSessionId?: () => string | null
+  requestRestoreLink?: (email: string) => Promise<void>
+  restoreFromUrlToken?: () => Promise<unknown>
+}
+
+const supportIdentityCache = new Map<string, SupportIdentityResponse>()
+
+export function buildSupportTraits(user: User | null | undefined) {
+  if (!user) {
+    return undefined
+  }
+
+  return {
+    name:
+      [user.user_metadata?.first_name, user.user_metadata?.last_name]
+        .filter((part): part is string => typeof part === 'string' && part.trim().length > 0)
+        .join(' ')
+      || user.user_metadata?.name
+      || user.email
+      || undefined,
+    email: user.email || undefined,
+  }
+}
+
+export async function syncSupportIdentity(
+  posthog: PostHog | null | undefined,
+  distinctId: string | null | undefined,
+): Promise<SupportIdentityResponse | null> {
+  const supportPosthog = posthog as PostHog & {
+    setIdentity?: (distinctId: string, hash: string) => void
+  }
+
+  if (!supportPosthog || !distinctId || typeof supportPosthog.setIdentity !== 'function') {
+    return null
+  }
+
+  const cachedIdentity = supportIdentityCache.get(distinctId)
+  if (cachedIdentity) {
+    supportPosthog.setIdentity(cachedIdentity.distinctId, cachedIdentity.hash)
+    return cachedIdentity
+  }
+
+  try {
+    const response = await fetch('/api/support/identity', {
+      method: 'GET',
+      credentials: 'same-origin',
+      headers: {
+        accept: 'application/json',
+      },
+    })
+
+    if (!response.ok) {
+      return null
+    }
+
+    const payload = (await response.json()) as SupportIdentityResponse
+
+    if (!payload?.distinctId || !payload?.hash) {
+      return null
+    }
+
+    supportIdentityCache.set(payload.distinctId, payload)
+    supportPosthog.setIdentity(payload.distinctId, payload.hash)
+    return payload
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- Add support identity sync during login and registration so tickets stay tied to the same user across devices.
- Mount the native support launcher inside the dashboard shell and route the sidebar support entry to the in-app panel.
- Keep unread counts in sync through the shared support store.

## Testing
- `npm run build` completed successfully.
- `git diff --check` passed.