### PR TITLE
feat(house): redesign house edit modal as a premium sidebar

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -65,6 +65,7 @@
   --color-context-menu-checkbox: hsl(var(--primary) / 0.15);
   --color-context-menu-radio: hsl(var(--primary) / 0.15);
   --color-modal-close-hover: hsl(var(--primary) / 0.15);
+  --color-hover-bg: hsl(var(--hover-bg));
 
   --color-muted: hsl(var(--muted));
   --color-muted-foreground: hsl(var(--muted-foreground));
@@ -732,6 +733,7 @@
     --border: 180 6% 95%;
     --input: 214.3 31.8% 91.4%;
     --ring: 210 29% 24%;
+    --hover-bg: 220 13% 91%;
     --radius: 1rem;
 
     /* Chart Farben */
@@ -786,6 +788,7 @@
     /* #22252b - input-bg (original) */
     --ring: 220 39% 25%;
     /* #2D4A6B - darker blue ring */
+    --hover-bg: 220 11% 20%;
 
     /* Custom variables for specific use cases */
     --btn-bg: 215 25% 19%;

--- a/components/finance/sortable-cost-item.tsx
+++ b/components/finance/sortable-cost-item.tsx
@@ -99,7 +99,7 @@ export function SortableCostItem({
         <div className="flex items-center justify-center flex-none w-8 h-10">
           <button
             type="button"
-            className="cursor-grab active:cursor-grabbing p-2 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg transition-colors flex items-center justify-center w-8 h-8 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600"
+            className="cursor-grab active:cursor-grabbing p-2 hover:bg-hover-bg rounded-lg transition-colors flex items-center justify-center w-8 h-8 bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600"
             {...attributes}
             {...listeners}
             aria-label="Kostenposition verschieben"

--- a/components/houses/haus-overview-modal.tsx
+++ b/components/houses/haus-overview-modal.tsx
@@ -41,6 +41,11 @@ export function HausOverviewModal() {
   React.useEffect(() => {
     if (hausOverviewLoading) {
       setLoadingStartTime(Date.now())
+    }
+  }, [hausOverviewLoading])
+
+  React.useEffect(() => {
+    if (hausOverviewLoading) {
       setLoadingProgress(0)
       setIsSlowLoading(false)
 
@@ -63,16 +68,15 @@ export function HausOverviewModal() {
       }
     } else {
       // Complete progress when loading finishes
-      if (loadingStartTime) {
-        setLoadingProgress(100)
-        setTimeout(() => {
-          setLoadingProgress(0)
-          setIsSlowLoading(false)
-          setLoadingStartTime(null)
-        }, 300)
-      }
+      setLoadingProgress(100)
+      const cleanupTimeout = setTimeout(() => {
+        setLoadingProgress(0)
+        setIsSlowLoading(false)
+        setLoadingStartTime(null)
+      }, 300)
+      return () => clearTimeout(cleanupTimeout)
     }
-  }, [hausOverviewLoading, loadingStartTime])
+  }, [hausOverviewLoading])
 
   const handleRetry = async () => {
     if (hausOverviewData?.id) {

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -424,22 +424,25 @@ export function HouseEditModal(props: HouseEditModalProps) {
   const [isDeleting, setIsDeleting] = useState(false);
   const isPending = isSubmitting || isDeleting;
 
-  const [width, setWidth] = useState(() => {
-    if (typeof window !== "undefined") {
-      const savedWidth = localStorage.getItem("house-modal-width");
-      if (savedWidth) {
-        const parsed = parseInt(savedWidth, 10);
-        if (!isNaN(parsed)) return parsed;
-      }
-    }
-    return 600;
-  });
+  const [width, setWidth] = useState(600);
   const [isResizing, setIsResizing] = useState(false);
   const widthRef = useRef(width);
 
   useEffect(() => {
     widthRef.current = width;
   }, [width]);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const savedWidth = localStorage.getItem("house-modal-width");
+      if (savedWidth) {
+        const parsed = parseInt(savedWidth, 10);
+        if (!isNaN(parsed)) {
+          setWidth(parsed);
+        }
+      }
+    }
+  }, []);
 
   useEffect(() => {
     if (typeof window !== "undefined") {

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -302,10 +302,10 @@ export function HouseEditModal(props: HouseEditModalProps) {
 
         <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0">
           <ScrollArea className="flex-1">
-            <div className="max-w-[90%] mx-auto pt-14 sm:pt-20 pb-10 px-4 sm:px-8 space-y-6 sm:space-y-12">
+            <div className="max-w-[90%] mx-auto pt-10 sm:pt-14 pb-6 px-4 sm:px-8 space-y-4 sm:space-y-8">
               
               {/* Header Section */}
-              <div className="space-y-3 sm:space-y-4">
+              <div className="space-y-2 sm:space-y-3">
                 <div className="text-primary/80">
                   <Building2 className="h-8 w-8 sm:h-10 sm:w-10" />
                 </div>
@@ -331,15 +331,15 @@ export function HouseEditModal(props: HouseEditModalProps) {
               </div>
 
               {/* Properties Section */}
-              <div className="space-y-4 sm:space-y-8">
+              <div className="space-y-3 sm:space-y-6">
 
                 {/* Address Section */}
-                <div className="sm:space-y-6 sm:pt-4 sm:border-t sm:border-border/40">
+                <div className="sm:space-y-4 sm:pt-3 sm:border-t sm:border-border/40">
                   <div className="hidden sm:flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
                     Standort
                   </div>
                   
-                  <div className="sm:grid sm:gap-6 space-y-3 sm:space-y-0">
+                  <div className="sm:grid sm:gap-4 space-y-2 sm:space-y-0">
                     <div className="sm:grid sm:grid-cols-[140px_1fr] sm:items-center sm:gap-4 space-y-1 sm:space-y-0">
                       <PropertyHeader 
                         icon={MapPin}
@@ -379,12 +379,12 @@ export function HouseEditModal(props: HouseEditModalProps) {
                 </div>
 
                 {/* Calculation Section */}
-                <div className="sm:space-y-6 sm:pt-4 sm:border-t sm:border-border/40">
+                <div className="sm:space-y-4 sm:pt-3 sm:border-t sm:border-border/40">
                   <div className="hidden sm:flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
                     Kennzahlen
                   </div>
 
-                  <div className="sm:grid sm:gap-6 space-y-3 sm:space-y-0">
+                  <div className="sm:grid sm:gap-4 space-y-2 sm:space-y-0">
                     <div className="sm:grid sm:grid-cols-[140px_1fr] sm:items-center sm:gap-4 space-y-1 sm:space-y-0">
                       <PropertyHeader 
                         icon={Ruler}
@@ -433,7 +433,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
                 </div>
 
                 {/* Additional Info / Description Style */}
-                <div className="hidden sm:block space-y-4 pt-4 border-t border-border/40">
+                <div className="hidden sm:block space-y-3 pt-3 border-t border-border/40">
                   <div className="flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
                     Beschreibung
                   </div>

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -240,10 +240,6 @@ export function HouseEditModal(props: HouseEditModalProps) {
     }
   };
 
-  if (!isHouseModalOpen) {
-    return null;
-  }
-
   return (
     <Sheet open={isHouseModalOpen} onOpenChange={(open) => !open && attemptClose()}>
       <SheetContent
@@ -263,7 +259,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="rounded-lg opacity-50 hover:opacity-100 hover:bg-muted pointer-events-auto cursor-pointer"
+                  className="rounded-lg opacity-50 hover:opacity-100 hover:bg-gray-200 pointer-events-auto cursor-pointer h-8 w-8"
                 >
                   <MoreHorizontal className="h-5 w-5" />
                   <span className="sr-only">Aktionen</span>

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import {
   Sheet,
   SheetContent,
@@ -101,6 +101,77 @@ export function HouseEditModal(props: HouseEditModalProps) {
   const [isDeleting, setIsDeleting] = useState(false);
   const isPending = isSubmitting || isDeleting;
   const { openHausOverviewModal } = useModalStore();
+
+  // Resize State & Ref
+  const [width, setWidth] = useState(600); // default width in px
+  const [isResizing, setIsResizing] = useState(false);
+  const widthRef = useRef(width);
+
+  useEffect(() => {
+    widthRef.current = width;
+  }, [width]);
+
+  // Load saved width from localStorage on mount
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const savedWidth = localStorage.getItem("house-modal-width");
+      if (savedWidth) {
+        const parsed = parseInt(savedWidth, 10);
+        if (!isNaN(parsed)) {
+          setWidth(parsed);
+        }
+      }
+    }
+  }, []);
+
+  // Listen to reset event from settings
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const handleResetWidth = () => {
+        setWidth(600);
+      };
+      window.addEventListener("reset-house-modal-width", handleResetWidth);
+      return () => {
+        window.removeEventListener("reset-house-modal-width", handleResetWidth);
+      };
+    }
+  }, []);
+
+  const startResizing = (mouseDownEvent: React.MouseEvent) => {
+    mouseDownEvent.preventDefault();
+    setIsResizing(true);
+  };
+
+  useEffect(() => {
+    if (!isResizing) return;
+
+    document.body.style.cursor = "ew-resize";
+    document.body.style.userSelect = "none";
+
+    const handleMouseMove = (mouseMoveEvent: MouseEvent) => {
+      const newWidth = window.innerWidth - mouseMoveEvent.clientX;
+      const minWidth = 360;
+      const maxWidth = window.innerWidth * 0.9;
+      setWidth(Math.max(minWidth, Math.min(newWidth, maxWidth)));
+    };
+
+    const handleMouseUp = () => {
+      setIsResizing(false);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      localStorage.setItem("house-modal-width", String(widthRef.current));
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [isResizing]);
 
   const {
     isHouseModalOpen,
@@ -264,10 +335,28 @@ export function HouseEditModal(props: HouseEditModalProps) {
     <Sheet open={isHouseModalOpen} onOpenChange={(open) => !open && attemptClose()}>
       <SheetContent
         id="house-form-container"
-        className="sm:max-w-[50vw] flex flex-col h-full p-0 gap-0"
+        className="w-full sm:w-[var(--sheet-width)] sm:max-w-none flex flex-col h-full p-0 gap-0"
+        style={{
+          "--sheet-width": `${width}px`,
+          transition: isResizing ? "none" : undefined
+        } as React.CSSProperties}
         isDirty={isHouseModalDirty}
         onAttemptClose={attemptClose}
       >
+        {/* Resize Handle */}
+        <div
+          onMouseDown={startResizing}
+          className={cn(
+            "absolute -left-1 top-0 bottom-0 w-2 cursor-ew-resize z-50 select-none group/resize-handle hidden sm:block",
+            isResizing ? "cursor-ew-resize" : ""
+          )}
+        >
+          {/* Visual highlight line positioned exactly on the border (center of the handle) */}
+          <div className={cn(
+            "absolute inset-y-0 left-1/2 w-[2px] -translate-x-1/2 transition-all duration-150 ease-in-out",
+            isResizing ? "bg-primary" : "bg-transparent group-hover/resize-handle:bg-primary/40"
+          )} />
+        </div>
         {/* Top Navigation Bar */}
         <div className="absolute top-0 left-0 right-0 h-14 flex items-center justify-between px-4 z-10 pointer-events-none">
           <div className="pointer-events-auto">

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -399,18 +399,19 @@ export function HouseEditModal(props: HouseEditModalProps) {
                   <Building2 className="h-8 w-8 sm:h-10 sm:w-10" />
                 </div>
                 <div className="space-y-1">
-                  <SheetTitle asChild className="text-2xl sm:text-4xl font-bold tracking-tight">
-                    <input
-                      type="text"
-                      id="name"
-                      name="name"
-                      value={formData.name}
-                      onChange={handleInputChange}
-                      placeholder={houseInitialData ? "Unbenanntes Haus" : "Haus hinzufügen"}
-                      disabled={isSubmitting}
-                      className="text-2xl sm:text-4xl font-bold tracking-tight w-full bg-transparent border-none outline-none focus:outline-none focus:ring-0 p-0 text-foreground placeholder:opacity-30 placeholder:text-muted-foreground/50 cursor-text"
-                    />
+                  <SheetTitle className="sr-only">
+                    {houseInitialData ? "Haus bearbeiten" : "Haus hinzufügen"}
                   </SheetTitle>
+                  <input
+                    type="text"
+                    id="name"
+                    name="name"
+                    value={formData.name}
+                    onChange={handleInputChange}
+                    placeholder={houseInitialData ? "Unbenanntes Haus" : "Haus hinzufügen"}
+                    disabled={isSubmitting}
+                    className="text-2xl sm:text-4xl font-bold tracking-tight w-full bg-transparent border-none outline-none focus:outline-none focus:ring-0 p-0 text-foreground placeholder:opacity-30 placeholder:text-muted-foreground/50 cursor-text"
+                  />
                   <SheetDescription className="text-sm sm:text-base text-muted-foreground/80">
                     {houseInitialData 
                       ? "Bearbeiten Sie die Informationen für dieses Objekt." 

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -449,18 +449,24 @@ export function HouseEditModal(props: HouseEditModalProps) {
                 variant="ghost" 
                 onClick={handleCancelClick} 
                 disabled={isSubmitting}
-                className="flex-1 rounded-xl h-11 text-muted-foreground hover:text-foreground"
+                className="flex-1 rounded-xl h-11 text-muted-foreground hover:text-foreground hover:scale-[1.005] active:scale-[0.995] hover:shadow-none"
               >
                 Abbrechen
               </Button>
               <Button 
                 type="submit" 
                 disabled={isSubmitting}
-                className="flex-1 rounded-xl h-11 shadow-sm font-semibold"
+                className="flex-1 rounded-xl h-11 shadow-sm font-semibold hover:scale-[1.005] active:scale-[0.995] hover:shadow-sm"
               >
-                {isSubmitting 
-                  ? "Wird gespeichert..." 
-                  : (houseInitialData ? "Änderungen speichern" : "Haus anlegen")}
+                {isSubmitting ? (
+                  <span className="flex items-center gap-2">
+                    <svg className="animate-spin h-5 w-5" style={{ animationDuration: "1.25s" }} viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                    </svg>
+                    Wird gespeichert...
+                  </span>
+                ) : (houseInitialData ? "Änderungen speichern" : "Haus anlegen")}
               </Button>
             </div>
           </SheetFooter>

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -47,16 +47,15 @@ function PropertyHeader({ icon: Icon, label, infoText, htmlFor }: { icon: Lucide
       <div className="hidden sm:block">
         <HoverCard openDelay={200} closeDelay={100}>
           <HoverCardTrigger asChild>
-            <div
-              tabIndex={0}
-              role="button"
+            <button
+              type="button"
               className="flex items-center gap-3 text-muted-foreground/70 cursor-help transition-colors hover:text-foreground/90 w-fit group/header focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:rounded-[4px]"
             >
               <Icon className="h-4 w-4 group-hover/header:text-primary transition-colors" />
               <Label htmlFor={htmlFor} className="text-sm font-medium uppercase tracking-wider cursor-help group-hover/header:text-foreground transition-colors">
                 {label}
               </Label>
-            </div>
+            </button>
           </HoverCardTrigger>
           <HoverCardContent side="top" align="start" className="w-80 shadow-2xl border-border/40 bg-background/95 backdrop-blur-md rounded-[28px] p-5 overflow-hidden">
             <div className="flex gap-4 items-start">

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -2,60 +2,77 @@
 
 import { useEffect, useState } from "react";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-} from "@/components/ui/dialog";
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  SheetFooter,
+} from "@/components/ui/sheet";
 import { Input } from "@/components/ui/input";
 import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { LabelWithTooltip } from "@/components/ui/label-with-tooltip";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
 import { useRouter } from "next/navigation";
 import { toast } from "@/hooks/use-toast";
-import { useModalStore } from "@/hooks/use-modal-store"; // Import the modal store
+import { useModalStore } from "@/hooks/use-modal-store";
 import { useOnboardingStore } from "@/hooks/use-onboarding-store";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Building2, MapPin, Ruler, Info, Home, MoreHorizontal, Lightbulb } from "lucide-react";
+import { cn } from "@/lib/utils";
 
-// Basic House interface - replace with actual type if available elsewhere
+// Helper component for Property Header with Hover Info
+function PropertyHeader({ icon: Icon, label, infoText, htmlFor }: { icon: any, label: string, infoText: string, htmlFor: string }) {
+  return (
+    <HoverCard openDelay={200} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <div className="flex items-center gap-3 text-muted-foreground/70 cursor-help transition-colors hover:text-foreground/90 w-fit group/header">
+          <Icon className="h-4 w-4 group-hover/header:text-primary transition-colors" />
+          <Label htmlFor={htmlFor} className="text-sm font-medium uppercase tracking-wider cursor-help group-hover/header:text-foreground transition-colors">
+            {label}
+          </Label>
+        </div>
+      </HoverCardTrigger>
+      <HoverCardContent side="top" align="start" className="w-80 shadow-2xl border-border/40 bg-background/95 backdrop-blur-md rounded-[28px] p-5 overflow-hidden">
+        <div className="flex gap-4 items-start">
+          <div className="flex-none h-12 w-12 rounded-full bg-amber-500/10 dark:bg-amber-500/20 text-amber-600 dark:text-amber-400 flex items-center justify-center shadow-inner border border-amber-500/20">
+            <Lightbulb className="h-6 w-6" />
+          </div>
+          <div className="space-y-1.5 pt-1">
+            <h4 className="font-bold text-foreground text-sm uppercase tracking-tight">Tipp</h4>
+            <p className="text-sm leading-relaxed text-muted-foreground/90">{infoText}</p>
+          </div>
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+// Basic House interface
 interface House {
   id: string;
   name: string;
   strasse?: string;
   ort: string;
   groesse?: number | null;
-  // Add other fields as necessary
 }
 
 interface HouseEditModalProps {
-  // open: boolean; // Controlled by useModalStore.isHouseModalOpen
-  // onOpenChange: (open: boolean) => void; // Now useModalStore.closeHouseModal
-  // initialData?: House; // Now useModalStore.houseInitialData
   serverAction: (id: string | null, formData: FormData) => Promise<{
     success: boolean;
     error?: { message: string };
     data?: any;
   }>;
-  // onSuccess?: (data: any) => void; // Now useModalStore.houseModalOnSuccess
 }
 
-// Note: The props `open`, `onOpenChange`, `initialData`, `onSuccess` are now
-// managed via `useModalStore`. This component might be simplified if it directly
-// consumes from the store, or the parent component using this modal will pass these
-// props from the store. For this step, we'll assume the props are still passed
-// but we'll also use the store for dirty checking and close confirmation.
-
 export function HouseEditModal(props: HouseEditModalProps) {
-  const {
-    // open, // Now from store
-    // onOpenChange, // Now from store's closeHouseModal
-    // initialData, // Now from store
-    serverAction,
-    // onSuccess // Now from store
-  } = props;
+  const { serverAction } = props;
 
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -69,67 +86,56 @@ export function HouseEditModal(props: HouseEditModalProps) {
     houseModalOnSuccess,
     isHouseModalDirty,
     setHouseModalDirty,
-    openConfirmationModal,
-    confirmationModalConfig // Added to avoid direct call to CONFIRMATION_MODAL_DEFAULTS from component
   } = useModalStore();
 
   const [formData, setFormData] = useState({
-    name: houseInitialData?.name || "",
-    strasse: houseInitialData?.strasse || "",
-    ort: houseInitialData?.ort || "",
-    groesse: houseInitialData?.groesse ?? null,
+    name: "",
+    strasse: "",
+    ort: "",
+    groesse: null as number | null,
   });
 
   useEffect(() => {
-    if (houseInitialData) {
-      setFormData({
-        name: houseInitialData.name,
-        strasse: houseInitialData.strasse || "",
-        ort: houseInitialData.ort,
-        groesse: houseInitialData.groesse ?? null,
-      });
-      if (houseInitialData.groesse != null) {
-        setAutomaticSize(false);
-        setManualGroesse(String(houseInitialData.groesse));
+    if (isHouseModalOpen) {
+      if (houseInitialData) {
+        setFormData({
+          name: houseInitialData.name,
+          strasse: houseInitialData.strasse || "",
+          ort: houseInitialData.ort,
+          groesse: houseInitialData.groesse ?? null,
+        });
+        if (houseInitialData.groesse != null) {
+          setAutomaticSize(false);
+          setManualGroesse(String(houseInitialData.groesse));
+        } else {
+          setAutomaticSize(true);
+          setManualGroesse('');
+        }
       } else {
+        setFormData({ name: "", strasse: "", ort: "", groesse: null });
         setAutomaticSize(true);
         setManualGroesse('');
       }
-    } else {
-      setFormData({ name: "", strasse: "", ort: "", groesse: null });
-      setAutomaticSize(true);
-      setManualGroesse('');
     }
-    // When modal opens or initialData changes, reset dirty state
-    setHouseModalDirty(false);
-  }, [houseInitialData, isHouseModalOpen, setHouseModalDirty]); // Added isHouseModalOpen to reset on open
+  }, [houseInitialData, isHouseModalOpen]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setFormData(prev => ({ ...prev, [name]: value }));
-    setHouseModalDirty(true); // Set dirty on any input change
-  };
-
-  const handleCheckboxChange = (checked: boolean) => {
-    setAutomaticSize(checked);
-    setHouseModalDirty(true); // Set dirty on checkbox change
+    if (!isHouseModalDirty) setHouseModalDirty(true);
   };
 
   const handleManualGroesseChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setManualGroesse(e.target.value);
-    setHouseModalDirty(true); // Set dirty on manual size change
+    if (!isHouseModalDirty) setHouseModalDirty(true);
   };
 
   const attemptClose = () => {
-    // This function is called by DialogContent's onAttemptClose
-    // or by the cancel button if dirty.
-    // The store's closeHouseModal() already has the logic to check isHouseModalDirty
-    // and open confirmation if needed.
     closeHouseModal();
   };
 
   const handleCancelClick = () => {
-    closeHouseModal({ force: true }); // Force close for "Abbrechen" button
+    closeHouseModal({ force: true });
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -165,9 +171,9 @@ export function HouseEditModal(props: HouseEditModalProps) {
           houseModalOnSuccess(successData);
         }
 
-        setHouseModalDirty(false); // Reset dirty state on successful save
+        setHouseModalDirty(false);
         useOnboardingStore.getState().completeStep('create-house-form');
-        closeHouseModal(); // This will now close directly as dirty is false
+        closeHouseModal();
       } else {
         throw new Error(result.error?.message || "Ein unbekannter Fehler ist aufgetreten.");
       }
@@ -182,109 +188,219 @@ export function HouseEditModal(props: HouseEditModalProps) {
     }
   };
 
-  // If the modal is not open (controlled by store), don't render anything
   if (!isHouseModalOpen) {
     return null;
   }
 
   return (
-    <Dialog open={isHouseModalOpen} onOpenChange={(open) => !open && attemptClose()}>
-      <DialogContent
+    <Sheet open={isHouseModalOpen} onOpenChange={(open) => !open && attemptClose()}>
+      <SheetContent
         id="house-form-container"
-        className="sm:max-w-[425px]"
+        className="sm:max-w-[600px] flex flex-col h-full p-0 gap-0"
         isDirty={isHouseModalDirty}
-        onAttemptClose={attemptClose} // Use the new prop
+        onAttemptClose={attemptClose}
       >
-        <DialogHeader>
-          <DialogTitle>{houseInitialData ? "Haus bearbeiten" : "Haus hinzufügen"}</DialogTitle>
-          <DialogDescription>
-            {houseInitialData ? "Aktualisiere die Hausinformationen." : "Gib die Hausinformationen ein."}
-          </DialogDescription>
-        </DialogHeader>
-        <form onSubmit={handleSubmit} className="grid gap-3 sm:gap-4">
-          <div className="space-y-2">
-            <LabelWithTooltip
-              htmlFor="name"
-              infoText="Geben Sie einen eindeutigen Namen für das Haus ein. Dieser wird in der Übersicht und in Dropdown-Menüs angezeigt."
-            >
-              Name
-            </LabelWithTooltip>
-            <Input
-              id="name"
-              name="name"
-              value={formData.name}
-              onChange={handleInputChange}
-              placeholder="z.B. Hauptstraße"
-              disabled={isSubmitting}
-            />
+        {/* Top Navigation Bar */}
+        <div className="absolute top-0 left-0 right-0 h-14 flex items-center justify-between px-4 z-10 pointer-events-none">
+          <div className="pointer-events-auto">
+            {/* The actual SheetClose button is in components/ui/sheet.tsx at left-4 top-4 */}
           </div>
-          <div className="space-y-2">
-            <LabelWithTooltip
-              htmlFor="strasse"
-              infoText="Geben Sie die vollständige Adresse des Hauses ein. Dieses Feld wird für die Abrechnung und die generierte PDF benötigt. Wir empfehlen dringend, die Adresse anzugeben, da sie in den offiziellen Dokumenten erscheint."
-            >
-              Straße
-            </LabelWithTooltip>
-            <Input
-              id="strasse"
-              name="strasse"
-              value={formData.strasse}
-              onChange={handleInputChange}
-              placeholder="z.B. Hauptstraße 1"
-              disabled={isSubmitting}
-            />
-          </div>
-          <div className="space-y-2">
-            <LabelWithTooltip
-              htmlFor="ort"
-              infoText="Geben Sie den Ort des Hauses ein. Dieses Feld ist optional, wird aber für die Abrechnung und die generierte PDF benötigt. Die Ortsangabe erscheint in den offiziellen Dokumenten und wird für die korrekte Zuordnung verwendet."
-            >
-              Ort
-            </LabelWithTooltip>
-            <Input
-              id="ort"
-              name="ort"
-              value={formData.ort}
-              onChange={handleInputChange}
-              placeholder="z.B. Berlin"
-              disabled={isSubmitting}
-            />
-          </div>
-          <div className="flex items-center space-x-2">
-            <Checkbox
-              id="automaticSize"
-              checked={automaticSize}
-              onCheckedChange={(checked) => handleCheckboxChange(Boolean(checked))}
-              disabled={isSubmitting}
-            />
-            <LabelWithTooltip
-              htmlFor="automaticSize"
-              infoText="Wenn aktiviert, wird die Gesamtgröße des Hauses automatisch aus der Summe der Wohnungsflächen berechnet. Deaktivieren Sie diese Option, um die Größe manuell festzulegen."
-            >
-              Größe automatisch berechnen
-            </LabelWithTooltip>
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="manualGroesse">Größe in m²</Label>
-            <NumberInput
-              id="manualGroesse"
-              name="manualGroesse"
-              value={manualGroesse}
-              onChange={handleManualGroesseChange}
-              disabled={automaticSize || isSubmitting}
-              placeholder={automaticSize ? "Automatisch berechnet" : "Manuell eingeben"}
-            />
-          </div>
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={handleCancelClick} disabled={isSubmitting}>
-              Abbrechen
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? "Wird gespeichert..." : (houseInitialData ? "Aktualisieren" : "Speichern")}
-            </Button>
-          </DialogFooter>
+          <Button 
+            variant="ghost" 
+            size="icon" 
+            className="rounded-lg opacity-50 hover:opacity-100 hover:bg-muted pointer-events-auto"
+          >
+            <MoreHorizontal className="h-5 w-5" />
+            <span className="sr-only">Actions</span>
+          </Button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0">
+          <ScrollArea className="flex-1">
+            <div className="max-w-[520px] mx-auto pt-20 pb-10 px-8 space-y-12">
+              
+              {/* Header Section */}
+              <div className="space-y-4">
+                <div className="text-primary/80">
+                  <Building2 className="h-10 w-10" />
+                </div>
+                <div className="space-y-1">
+                  <SheetTitle className="text-4xl font-bold tracking-tight">
+                    {houseInitialData ? formData.name || "Unbenanntes Haus" : "Haus hinzufügen"}
+                  </SheetTitle>
+                  <SheetDescription className="text-base text-muted-foreground/80">
+                    {houseInitialData 
+                      ? "Bearbeiten Sie die Informationen für dieses Objekt." 
+                      : "Legen Sie ein neues Haus in Ihrer Verwaltung an."}
+                  </SheetDescription>
+                </div>
+              </div>
+
+              {/* Properties Section */}
+              <div className="space-y-8">
+                {/* Name Property */}
+                <div className="space-y-2">
+                  <PropertyHeader 
+                    icon={Home}
+                    label="Name"
+                    htmlFor="name"
+                    infoText="Geben Sie einen eindeutigen Namen für das Haus ein. Dieser wird in der Übersicht und in Dropdown-Menüs angezeigt."
+                  />
+                  <Input
+                    id="name"
+                    name="name"
+                    value={formData.name}
+                    onChange={handleInputChange}
+                    placeholder="Einen Namen geben..."
+                    disabled={isSubmitting}
+                    className="text-xl font-medium placeholder:opacity-30 h-auto py-2 rounded-xl border-primary/20 bg-primary/5 focus:bg-background transition-colors"
+                  />
+                </div>
+
+                {/* Address Section */}
+                <div className="space-y-6 pt-4 border-t border-border/40">
+                  <div className="flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
+                    Standort
+                  </div>
+                  
+                  <div className="grid gap-6">
+                    <div className="grid grid-cols-[140px_1fr] items-center gap-4">
+                      <PropertyHeader 
+                        icon={MapPin}
+                        label="Straße"
+                        htmlFor="strasse"
+                        infoText="Geben Sie die vollständige Adresse des Hauses ein. Dieses Feld wird für die Abrechnung und die generierte PDF benötigt."
+                      />
+                      <Input
+                        id="strasse"
+                        name="strasse"
+                        value={formData.strasse}
+                        onChange={handleInputChange}
+                        placeholder="Straße und Hausnummer"
+                        disabled={isSubmitting}
+                        className="rounded-xl h-10 text-sm border-primary/20 bg-primary/5 focus:bg-background transition-colors"
+                      />
+                    </div>
+
+                    <div className="grid grid-cols-[140px_1fr] items-center gap-4">
+                      <PropertyHeader 
+                        icon={MapPin}
+                        label="Ort"
+                        htmlFor="ort"
+                        infoText="Geben Sie den Ort des Hauses ein. Die Ortsangabe erscheint in den offiziellen Dokumenten."
+                      />
+                      <Input
+                        id="ort"
+                        name="ort"
+                        value={formData.ort}
+                        onChange={handleInputChange}
+                        placeholder="PLZ und Stadt"
+                        disabled={isSubmitting}
+                        className="rounded-xl h-10 text-sm border-primary/20 bg-primary/5 focus:bg-background transition-colors"
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                {/* Calculation Section */}
+                <div className="space-y-6 pt-4 border-t border-border/40">
+                  <div className="flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
+                    Kennzahlen
+                  </div>
+
+                  <div className="grid gap-6">
+                    <div className="grid grid-cols-[140px_1fr] items-center gap-4">
+                      <PropertyHeader 
+                        icon={Ruler}
+                        label="Berechnung"
+                        htmlFor="automaticSize"
+                        infoText="Wenn aktiviert, wird die Gesamtgröße des Hauses automatisch aus der Summe der Wohnungsflächen berechnet."
+                      />
+                      <Label 
+                        htmlFor="automaticSize"
+                        className={cn(
+                          "flex items-center justify-between h-10 px-3 rounded-xl cursor-pointer transition-colors border outline-hidden focus-within:ring-1 focus-within:ring-ring",
+                          automaticSize ? "bg-primary/5 text-primary border-primary/10" : "bg-muted/30 text-muted-foreground border-border/50"
+                        )}
+                      >
+                        <span className="text-sm font-medium cursor-pointer">Automatisch</span>
+                        <Checkbox
+                          id="automaticSize"
+                          checked={automaticSize}
+                          onCheckedChange={(checked) => {
+                            setAutomaticSize(!!checked);
+                            if (!isHouseModalDirty) setHouseModalDirty(true);
+                          }}
+                          disabled={isSubmitting}
+                          className="h-4 w-4"
+                        />
+                      </Label>
+                    </div>
+
+                    {!automaticSize && (
+                      <div className="grid grid-cols-[140px_1fr] items-center gap-4 animate-in fade-in slide-in-from-top-1">
+                        <div className="flex items-center gap-2 text-muted-foreground/70">
+                          <Ruler className="h-4 w-4 opacity-0" />
+                          <Label htmlFor="manualGroesse" className="text-sm">Fläche (m²)</Label>
+                        </div>
+                        <div className="relative">
+                          <NumberInput
+                            id="manualGroesse"
+                            name="manualGroesse"
+                            value={manualGroesse}
+                            onChange={handleManualGroesseChange}
+                            disabled={isSubmitting}
+                            placeholder="Manuelle Größe..."
+                            className="rounded-xl h-10 text-sm border-primary/20 bg-primary/5 focus:bg-background transition-colors"
+                          />
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* Additional Info / Description Style */}
+                <div className="space-y-4 pt-4 border-t border-border/40">
+                  <div className="flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
+                    Beschreibung
+                  </div>
+                  <div className="bg-muted/20 rounded-xl p-4 text-sm text-muted-foreground/80 leading-relaxed border border-border/50">
+                    <div className="flex gap-2 items-start">
+                      <Info className="h-4 w-4 mt-0.5 shrink-0 opacity-40" />
+                      <p>
+                        Diese Informationen werden für die automatische Erstellung von Nebenkostenabrechnungen und offiziellen Dokumenten verwendet. Bitte stellen Sie sicher, dass alle Standortdaten korrekt sind.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </ScrollArea>
+
+          <SheetFooter className="p-8 pt-4">
+            <div className="max-w-[520px] mx-auto w-full flex gap-3">
+              <Button 
+                type="button" 
+                variant="ghost" 
+                onClick={handleCancelClick} 
+                disabled={isSubmitting}
+                className="flex-1 rounded-xl h-11 text-muted-foreground hover:text-foreground"
+              >
+                Abbrechen
+              </Button>
+              <Button 
+                type="submit" 
+                disabled={isSubmitting}
+                className="flex-1 rounded-xl h-11 shadow-sm font-semibold"
+              >
+                {isSubmitting 
+                  ? "Wird gespeichert..." 
+                  : (houseInitialData ? "Änderungen speichern" : "Haus anlegen")}
+              </Button>
+            </div>
+          </SheetFooter>
         </form>
-      </DialogContent>
-    </Dialog>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -264,7 +264,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
     <Sheet open={isHouseModalOpen} onOpenChange={(open) => !open && attemptClose()}>
       <SheetContent
         id="house-form-container"
-        className="sm:max-w-[600px] flex flex-col h-full p-0 gap-0"
+        className="sm:max-w-[50vw] flex flex-col h-full p-0 gap-0"
         isDirty={isHouseModalDirty}
         onAttemptClose={attemptClose}
       >
@@ -302,7 +302,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
 
         <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0">
           <ScrollArea className="flex-1">
-            <div className="max-w-[520px] mx-auto pt-14 sm:pt-20 pb-10 px-4 sm:px-8 space-y-6 sm:space-y-12">
+            <div className="max-w-[90%] mx-auto pt-14 sm:pt-20 pb-10 px-4 sm:px-8 space-y-6 sm:space-y-12">
               
               {/* Header Section */}
               <div className="space-y-3 sm:space-y-4">
@@ -460,7 +460,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
           </ScrollArea>
 
           <SheetFooter className="px-4 pb-6 pt-2 sm:p-8 sm:pt-4">
-            <div className="max-w-[520px] mx-auto w-full flex gap-3">
+            <div className="max-w-[90%] mx-auto w-full flex gap-3">
               <Button 
                 type="button" 
                 variant="ghost" 

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -259,7 +259,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="rounded-lg opacity-50 hover:opacity-100 hover:bg-gray-200 pointer-events-auto cursor-pointer h-8 w-8"
+                  className="rounded-lg opacity-50 hover:opacity-100 hover:bg-hover-bg pointer-events-auto cursor-pointer h-8 w-8"
                 >
                   <MoreHorizontal className="h-5 w-5" />
                   <span className="sr-only">Aktionen</span>

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -310,8 +310,17 @@ export function HouseEditModal(props: HouseEditModalProps) {
                   <Building2 className="h-8 w-8 sm:h-10 sm:w-10" />
                 </div>
                 <div className="space-y-1">
-                  <SheetTitle className="text-2xl sm:text-4xl font-bold tracking-tight">
-                    {houseInitialData ? formData.name || "Unbenanntes Haus" : "Haus hinzufügen"}
+                  <SheetTitle asChild className="text-2xl sm:text-4xl font-bold tracking-tight">
+                    <input
+                      type="text"
+                      id="name"
+                      name="name"
+                      value={formData.name}
+                      onChange={handleInputChange}
+                      placeholder={houseInitialData ? "Unbenanntes Haus" : "Haus hinzufügen"}
+                      disabled={isSubmitting}
+                      className="text-2xl sm:text-4xl font-bold tracking-tight w-full bg-transparent border-none outline-none focus:outline-none focus:ring-0 p-0 text-foreground placeholder:opacity-30 placeholder:text-muted-foreground/50 cursor-text"
+                    />
                   </SheetTitle>
                   <SheetDescription className="text-sm sm:text-base text-muted-foreground/80">
                     {houseInitialData 
@@ -323,24 +332,6 @@ export function HouseEditModal(props: HouseEditModalProps) {
 
               {/* Properties Section */}
               <div className="space-y-4 sm:space-y-8">
-                {/* Name Property */}
-                <div className="space-y-1.5 sm:space-y-2">
-                  <PropertyHeader 
-                    icon={Home}
-                    label="Name"
-                    htmlFor="name"
-                    infoText="Geben Sie einen eindeutigen Namen für das Haus ein. Dieser wird in der Übersicht und in Dropdown-Menüs angezeigt."
-                  />
-                  <Input
-                    id="name"
-                    name="name"
-                    value={formData.name}
-                    onChange={handleInputChange}
-                    placeholder="Einen Namen geben..."
-                    disabled={isSubmitting}
-                    className="text-base sm:text-xl font-medium placeholder:opacity-30 h-auto py-2 rounded-xl border-primary/20 bg-primary/5 focus:bg-background transition-colors"
-                  />
-                </div>
 
                 {/* Address Section */}
                 <div className="sm:space-y-6 sm:pt-4 sm:border-t sm:border-border/40">
@@ -363,7 +354,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
                         onChange={handleInputChange}
                         placeholder="Straße und Hausnummer"
                         disabled={isSubmitting}
-                        className="rounded-xl h-10 text-sm border-primary/20 bg-primary/5 focus:bg-background transition-colors"
+                        className="bg-transparent border-none shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 hover:bg-muted/10 focus:bg-muted/20 px-2 py-1 -mx-2 rounded-lg transition-all h-auto text-sm focus-visible:scale-100 hover:border-transparent focus:border-transparent"
                       />
                     </div>
 
@@ -381,7 +372,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
                         onChange={handleInputChange}
                         placeholder="PLZ und Stadt"
                         disabled={isSubmitting}
-                        className="rounded-xl h-10 text-sm border-primary/20 bg-primary/5 focus:bg-background transition-colors"
+                        className="bg-transparent border-none shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 hover:bg-muted/10 focus:bg-muted/20 px-2 py-1 -mx-2 rounded-lg transition-all h-auto text-sm focus-visible:scale-100 hover:border-transparent focus:border-transparent"
                       />
                     </div>
                   </div>
@@ -433,7 +424,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
                             onChange={handleManualGroesseChange}
                             disabled={isSubmitting}
                             placeholder="Manuelle Größe..."
-                            className="rounded-xl h-10 text-sm border-primary/20 bg-primary/5 focus:bg-background transition-colors"
+                            className="bg-transparent border-none shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 hover:bg-muted/10 focus:bg-muted/20 px-2 py-1 -mx-2 rounded-lg transition-all h-auto text-sm focus-visible:scale-100 hover:border-transparent focus:border-transparent"
                           />
                         </div>
                       </div>

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -24,8 +24,20 @@ import { toast } from "@/hooks/use-toast";
 import { useModalStore } from "@/hooks/use-modal-store";
 import { useOnboardingStore } from "@/hooks/use-onboarding-store";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Building2, MapPin, Ruler, Info, Home, MoreHorizontal, Lightbulb } from "lucide-react";
+import { Building2, MapPin, Ruler, Info, Home, MoreHorizontal, Lightbulb, Eye, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { CustomDropdown, CustomDropdownItem, CustomDropdownSeparator } from "@/components/ui/custom-dropdown";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { deleteHouseAction } from "@/app/(dashboard)/haeuser/actions";
 
 // Helper component for Property Header with Hover Info
 function PropertyHeader({ icon: Icon, label, infoText, htmlFor }: { icon: any, label: string, infoText: string, htmlFor: string }) {
@@ -78,6 +90,9 @@ export function HouseEditModal(props: HouseEditModalProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [automaticSize, setAutomaticSize] = useState(true);
   const [manualGroesse, setManualGroesse] = useState<string>('');
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const { openHausOverviewModal } = useModalStore();
 
   const {
     isHouseModalOpen,
@@ -136,6 +151,43 @@ export function HouseEditModal(props: HouseEditModalProps) {
 
   const handleCancelClick = () => {
     closeHouseModal({ force: true });
+  };
+
+  const handleDelete = async () => {
+    if (!houseInitialData) return;
+    try {
+      setIsDeleting(true);
+      const result = await deleteHouseAction(houseInitialData.id);
+
+      if (result.success) {
+        toast({
+          title: "Erfolg",
+          description: `Das Haus "${formData.name}" wurde erfolgreich gelöscht.`,
+          variant: "success",
+        });
+        setHouseModalDirty(false);
+        closeHouseModal();
+        if (houseModalOnSuccess) {
+          houseModalOnSuccess({ deleted: true, id: houseInitialData.id });
+        }
+      } else {
+        toast({
+          title: "Fehler",
+          description: result.error?.message || "Das Haus konnte nicht gelöscht werden.",
+          variant: "destructive",
+        });
+      }
+    } catch (error) {
+      console.error("Unerwarteter Fehler beim Löschen des Hauses:", error);
+      toast({
+        title: "Systemfehler",
+        description: "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es später erneut.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsDeleting(false);
+      setDeleteDialogOpen(false);
+    }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -205,14 +257,31 @@ export function HouseEditModal(props: HouseEditModalProps) {
           <div className="pointer-events-auto">
             {/* The actual SheetClose button is in components/ui/sheet.tsx at left-4 top-4 */}
           </div>
-          <Button 
-            variant="ghost" 
-            size="icon" 
-            className="rounded-lg opacity-50 hover:opacity-100 hover:bg-muted pointer-events-auto"
-          >
-            <MoreHorizontal className="h-5 w-5" />
-            <span className="sr-only">Actions</span>
-          </Button>
+          {houseInitialData && (
+            <CustomDropdown
+              trigger={
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="rounded-lg opacity-50 hover:opacity-100 hover:bg-muted pointer-events-auto cursor-pointer"
+                >
+                  <MoreHorizontal className="h-5 w-5" />
+                  <span className="sr-only">Aktionen</span>
+                </Button>
+              }
+              align="end"
+            >
+              <CustomDropdownItem onClick={() => openHausOverviewModal(houseInitialData.id)}>
+                <Eye className="h-4 w-4 mr-2" />
+                <span>Übersicht</span>
+              </CustomDropdownItem>
+              <CustomDropdownSeparator />
+              <CustomDropdownItem onClick={() => setDeleteDialogOpen(true)} className="text-red-600 focus:text-red-600">
+                <Trash2 className="h-4 w-4 mr-2" />
+                <span>Löschen</span>
+              </CustomDropdownItem>
+            </CustomDropdown>
+          )}
         </div>
 
         <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0">
@@ -400,6 +469,23 @@ export function HouseEditModal(props: HouseEditModalProps) {
             </div>
           </SheetFooter>
         </form>
+
+        <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Haus löschen?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Möchten Sie das Haus "{formData.name}" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isDeleting}>Abbrechen</AlertDialogCancel>
+              <AlertDialogAction onClick={handleDelete} disabled={isDeleting} className="bg-red-600 hover:bg-red-700">
+                {isDeleting ? "Löschen..." : "Löschen"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </SheetContent>
     </Sheet>
   );

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -44,7 +44,11 @@ function PropertyHeader({ icon: Icon, label, infoText, htmlFor }: { icon: Lucide
   return (
     <HoverCard openDelay={200} closeDelay={100}>
       <HoverCardTrigger asChild>
-        <div className="flex items-center gap-3 text-muted-foreground/70 cursor-help transition-colors hover:text-foreground/90 w-fit group/header">
+        <div
+          tabIndex={0}
+          role="button"
+          className="flex items-center gap-3 text-muted-foreground/70 cursor-help transition-colors hover:text-foreground/90 w-fit group/header"
+        >
           <Icon className="h-4 w-4 group-hover/header:text-primary transition-colors" />
           <Label htmlFor={htmlFor} className="text-sm font-medium uppercase tracking-wider cursor-help group-hover/header:text-foreground transition-colors">
             {label}
@@ -92,6 +96,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
   const [manualGroesse, setManualGroesse] = useState<string>('');
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const isPending = isSubmitting || isDeleting;
   const { openHausOverviewModal } = useModalStore();
 
   const {
@@ -155,7 +160,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
   };
 
   const handleDelete = async () => {
-    if (!houseInitialData) return;
+    if (!houseInitialData || isPending) return;
     try {
       setIsDeleting(true);
       const result = await deleteHouseAction(houseInitialData.id);
@@ -193,6 +198,17 @@ export function HouseEditModal(props: HouseEditModalProps) {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (isPending) return;
+
+    if (!automaticSize && (manualGroesse === '' || isNaN(Number(manualGroesse)))) {
+      toast({
+        title: "Eingabefehler",
+        description: "Bitte geben Sie eine gültige Größe in m² ein.",
+        variant: "destructive",
+      });
+      return;
+    }
+
     setIsSubmitting(true);
 
     const form = new FormData();

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -37,7 +37,29 @@ import {
 } from "@/components/ui/alert-dialog";
 import { deleteHouseAction } from "@/app/(dashboard)/haeuser/actions";
 
-// Helper component for Property Header with Hover Info
+interface House {
+  id: string;
+  name: string;
+  strasse?: string;
+  ort: string;
+  groesse?: number | null;
+}
+
+interface HouseFormData {
+  name: string;
+  strasse: string;
+  ort: string;
+  groesse: number | null;
+}
+
+interface HouseEditModalProps {
+  serverAction: (id: string | null, formData: FormData) => Promise<{
+    success: boolean;
+    error?: { message: string };
+    data?: any;
+  }>;
+}
+
 function PropertyHeader({ icon: Icon, label, infoText, htmlFor }: { icon: LucideIcon, label: string, infoText: string, htmlFor: string }) {
   return (
     <>
@@ -74,21 +96,322 @@ function PropertyHeader({ icon: Icon, label, infoText, htmlFor }: { icon: Lucide
   );
 }
 
-// Basic House interface
-interface House {
-  id: string;
-  name: string;
-  strasse?: string;
-  ort: string;
-  groesse?: number | null;
+function ResizeHandle({
+  isResizing,
+  setWidth,
+  onMouseDown,
+}: {
+  isResizing: boolean;
+  setWidth: React.Dispatch<React.SetStateAction<number>>;
+  onMouseDown: (e: React.MouseEvent) => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label="Panelgröße anpassen"
+      onMouseDown={onMouseDown}
+      onKeyDown={(e) => {
+        if (e.key === 'ArrowLeft') {
+          e.preventDefault();
+          setWidth(prev => Math.max(360, prev - 20));
+        } else if (e.key === 'ArrowRight') {
+          e.preventDefault();
+          setWidth(prev => Math.min(window.innerWidth * 0.9, prev + 20));
+        }
+      }}
+      className={cn(
+        "absolute -left-1 top-0 bottom-0 w-2 cursor-ew-resize z-50 select-none group/resize-handle hidden sm:block appearance-none bg-transparent border-none p-0",
+        isResizing ? "cursor-ew-resize" : ""
+      )}
+    >
+      <div className={cn(
+        "absolute inset-y-0 left-1/2 w-[2px] -translate-x-1/2 transition-all duration-150 ease-in-out",
+        isResizing ? "bg-primary" : "bg-transparent group-hover/resize-handle:bg-primary/40"
+      )} />
+    </button>
+  );
 }
 
-interface HouseEditModalProps {
-  serverAction: (id: string | null, formData: FormData) => Promise<{
-    success: boolean;
-    error?: { message: string };
-    data?: any;
-  }>;
+function TopBar({
+  houseInitialData,
+  onOverviewClick,
+  onDeleteRequest,
+}: {
+  houseInitialData: House | null;
+  onOverviewClick: () => void;
+  onDeleteRequest: () => void;
+}) {
+  if (!houseInitialData) return null;
+
+  return (
+    <div className="absolute top-0 left-0 right-0 h-14 flex items-center justify-end px-4 z-10 pointer-events-none">
+      <CustomDropdown
+        trigger={
+          <Button
+            variant="ghost"
+            size="icon"
+            className="rounded-lg opacity-50 hover:opacity-100 hover:bg-hover-bg pointer-events-auto cursor-pointer h-8 w-8"
+          >
+            <MoreHorizontal className="h-5 w-5" />
+            <span className="sr-only">Aktionen</span>
+          </Button>
+        }
+        align="end"
+      >
+        <CustomDropdownItem onClick={onOverviewClick}>
+          <Eye className="h-4 w-4 mr-2" />
+          <span>Übersicht</span>
+        </CustomDropdownItem>
+        <CustomDropdownSeparator />
+        <CustomDropdownItem onClick={onDeleteRequest} className="text-red-600 focus:text-red-600">
+          <Trash2 className="h-4 w-4 mr-2" />
+          <span>Löschen</span>
+        </CustomDropdownItem>
+      </CustomDropdown>
+    </div>
+  );
+}
+
+function FormFields({
+  formData,
+  onFieldChange,
+  automaticSize,
+  onAutomaticSizeChange,
+  manualGroesse,
+  onManualGroesseChange,
+  isSubmitting,
+  houseInitialData,
+  isHouseModalDirty,
+  setHouseModalDirty,
+}: {
+  formData: HouseFormData;
+  onFieldChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  automaticSize: boolean;
+  onAutomaticSizeChange: (checked: boolean) => void;
+  manualGroesse: string;
+  onManualGroesseChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  isSubmitting: boolean;
+  houseInitialData: House | null;
+  isHouseModalDirty: boolean;
+  setHouseModalDirty: (dirty: boolean) => void;
+}) {
+  return (
+    <div className="max-w-[90%] mx-auto pt-10 sm:pt-14 pb-6 px-4 sm:px-8 space-y-4 sm:space-y-8">
+      <div className="space-y-2 sm:space-y-3">
+        <div className="text-primary/80">
+          <Building2 className="h-8 w-8 sm:h-10 sm:w-10" />
+        </div>
+        <div className="space-y-1">
+          <SheetTitle className="sr-only">
+            {houseInitialData ? "Haus bearbeiten" : "Haus hinzufügen"}
+          </SheetTitle>
+          <input
+            type="text"
+            id="name"
+            name="name"
+            value={formData.name}
+            onChange={onFieldChange}
+            placeholder={houseInitialData ? "Unbenanntes Haus" : "Haus hinzufügen"}
+            disabled={isSubmitting}
+            aria-label={houseInitialData ? "Name des Hauses" : "Name des neuen Hauses"}
+            className="text-2xl sm:text-4xl font-bold tracking-tight w-full bg-transparent border-none outline-none focus:outline-none focus:ring-0 p-0 text-foreground placeholder:opacity-30 placeholder:text-muted-foreground/50 cursor-text"
+          />
+          <SheetDescription className="text-sm sm:text-base text-muted-foreground/80">
+            {houseInitialData
+              ? "Bearbeiten Sie die Informationen für dieses Objekt."
+              : "Legen Sie ein neues Haus in Ihrer Verwaltung an."}
+          </SheetDescription>
+        </div>
+      </div>
+
+      <div className="space-y-3 sm:space-y-6">
+        <div className="sm:space-y-4 sm:pt-3 sm:border-t sm:border-border/40">
+          <div className="hidden sm:flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
+            Standort
+          </div>
+
+          <div className="sm:grid sm:gap-4 space-y-2 sm:space-y-0">
+            <div className="sm:grid sm:grid-cols-[140px_1fr] sm:items-center sm:gap-4 space-y-1 sm:space-y-0">
+              <PropertyHeader
+                icon={MapPin}
+                label="Straße"
+                htmlFor="strasse"
+                infoText="Geben Sie die vollständige Adresse des Hauses ein. Dieses Feld wird für die Abrechnung und die generierte PDF benötigt."
+              />
+              <Input
+                id="strasse"
+                name="strasse"
+                value={formData.strasse}
+                onChange={onFieldChange}
+                placeholder="Straße und Hausnummer"
+                disabled={isSubmitting}
+                className="bg-transparent border-none shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 hover:bg-muted/10 focus:bg-muted/20 px-2 py-1 -mx-2 rounded-lg transition-all h-auto text-sm focus-visible:scale-100 hover:border-transparent focus:border-transparent"
+              />
+            </div>
+
+            <div className="sm:grid sm:grid-cols-[140px_1fr] sm:items-center sm:gap-4 space-y-1 sm:space-y-0">
+              <PropertyHeader
+                icon={MapPin}
+                label="Ort"
+                htmlFor="ort"
+                infoText="Geben Sie den Ort des Hauses ein. Die Ortsangabe erscheint in den offiziellen Dokumenten."
+              />
+              <Input
+                id="ort"
+                name="ort"
+                value={formData.ort}
+                onChange={onFieldChange}
+                placeholder="PLZ und Stadt"
+                disabled={isSubmitting}
+                className="bg-transparent border-none shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 hover:bg-muted/10 focus:bg-muted/20 px-2 py-1 -mx-2 rounded-lg transition-all h-auto text-sm focus-visible:scale-100 hover:border-transparent focus:border-transparent"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="sm:space-y-4 sm:pt-3 sm:border-t sm:border-border/40">
+          <div className="hidden sm:flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
+            Kennzahlen
+          </div>
+
+          <div className="sm:grid sm:gap-4 space-y-2 sm:space-y-0">
+            <div className="sm:grid sm:grid-cols-[140px_1fr] sm:items-center sm:gap-4 space-y-1 sm:space-y-0">
+              <PropertyHeader
+                icon={Ruler}
+                label="Berechnung"
+                htmlFor="automaticSize"
+                infoText="Wenn aktiviert, wird die Gesamtgröße des Hauses automatisch aus der Summe der Wohnungsflächen berechnet."
+              />
+              <Label
+                htmlFor="automaticSize"
+                className={cn(
+                  "flex items-center justify-between h-10 px-3 rounded-xl cursor-pointer transition-colors border outline-hidden focus-within:ring-1 focus-within:ring-ring",
+                  automaticSize ? "bg-primary/5 text-primary border-primary/10" : "bg-muted/30 text-muted-foreground border-border/50"
+                )}
+              >
+                <span className="text-sm font-medium cursor-pointer">Automatisch</span>
+                <Checkbox
+                  id="automaticSize"
+                  checked={automaticSize}
+                  onCheckedChange={(checked) => {
+                    onAutomaticSizeChange(!!checked);
+                    if (!isHouseModalDirty) setHouseModalDirty(true);
+                  }}
+                  disabled={isSubmitting}
+                  className="h-4 w-4"
+                />
+              </Label>
+            </div>
+
+            {!automaticSize && (
+              <div className="sm:grid sm:grid-cols-[140px_1fr] sm:items-center sm:gap-4 space-y-1 sm:space-y-0 animate-in fade-in slide-in-from-top-1">
+                <Label htmlFor="manualGroesse" className="text-sm text-muted-foreground/70">Fläche (m²)</Label>
+                <div className="relative">
+                  <NumberInput
+                    id="manualGroesse"
+                    name="manualGroesse"
+                    value={manualGroesse}
+                    onChange={onManualGroesseChange}
+                    disabled={isSubmitting}
+                    placeholder="Manuelle Größe..."
+                    className="bg-transparent border-none shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 hover:bg-muted/10 focus:bg-muted/20 px-2 py-1 -mx-2 rounded-lg transition-all h-auto text-sm focus-visible:scale-100 hover:border-transparent focus:border-transparent"
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="hidden sm:block space-y-3 pt-3 border-t border-border/40">
+          <div className="flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
+            Beschreibung
+          </div>
+          <div className="bg-muted/20 rounded-xl p-4 text-sm text-muted-foreground/80 leading-relaxed border border-border/50">
+            <div className="flex gap-2 items-start">
+              <Info className="h-4 w-4 mt-0.5 shrink-0 opacity-40" />
+              <p>
+                Diese Informationen werden für die automatische Erstellung von Nebenkostenabrechnungen und offiziellen Dokumenten verwendet. Bitte stellen Sie sicher, dass alle Standortdaten korrekt sind.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FormActions({
+  isSubmitting,
+  onCancel,
+  houseInitialData,
+}: {
+  isSubmitting: boolean;
+  onCancel: () => void;
+  houseInitialData: House | null;
+}) {
+  return (
+    <SheetFooter className="px-4 pb-6 pt-2 sm:p-8 sm:pt-4">
+      <div className="max-w-[90%] mx-auto w-full flex gap-3">
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={onCancel}
+          disabled={isSubmitting}
+          className="flex-1 rounded-xl h-11 text-muted-foreground hover:text-foreground hover:scale-[1.005] active:scale-[0.995] hover:shadow-none"
+        >
+          Abbrechen
+        </Button>
+        <Button
+          type="submit"
+          disabled={isSubmitting}
+          className="flex-1 rounded-xl h-11 shadow-sm font-semibold hover:scale-[1.005] active:scale-[0.995] hover:shadow-sm"
+        >
+          {isSubmitting ? (
+            <span className="flex items-center gap-2">
+              <svg className="animate-spin h-5 w-5" style={{ animationDuration: "600ms" }} viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+              Wird gespeichert...
+            </span>
+          ) : (houseInitialData ? "Änderungen speichern" : "Haus anlegen")}
+        </Button>
+      </div>
+    </SheetFooter>
+  );
+}
+
+function DeleteHouseDialog({
+  open,
+  onOpenChange,
+  houseName,
+  isDeleting,
+  onDelete,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  houseName: string;
+  isDeleting: boolean;
+  onDelete: () => void;
+}) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Haus löschen?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Möchten Sie das Haus &ldquo;{houseName}&rdquo; wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Abbrechen</AlertDialogCancel>
+          <AlertDialogAction onClick={(e) => { e.preventDefault(); onDelete(); }} disabled={isDeleting} className="bg-red-600 hover:bg-red-700">
+            {isDeleting ? "Löschen..." : "Löschen"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
 }
 
 export function HouseEditModal(props: HouseEditModalProps) {
@@ -100,10 +423,17 @@ export function HouseEditModal(props: HouseEditModalProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const isPending = isSubmitting || isDeleting;
-  const { openHausOverviewModal } = useModalStore();
 
-  // Resize State & Ref
-  const [width, setWidth] = useState(600); // default width in px
+  const [width, setWidth] = useState(() => {
+    if (typeof window !== "undefined") {
+      const savedWidth = localStorage.getItem("house-modal-width");
+      if (savedWidth) {
+        const parsed = parseInt(savedWidth, 10);
+        if (!isNaN(parsed)) return parsed;
+      }
+    }
+    return 600;
+  });
   const [isResizing, setIsResizing] = useState(false);
   const widthRef = useRef(width);
 
@@ -111,20 +441,6 @@ export function HouseEditModal(props: HouseEditModalProps) {
     widthRef.current = width;
   }, [width]);
 
-  // Load saved width from localStorage on mount
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      const savedWidth = localStorage.getItem("house-modal-width");
-      if (savedWidth) {
-        const parsed = parseInt(savedWidth, 10);
-        if (!isNaN(parsed)) {
-          setWidth(parsed);
-        }
-      }
-    }
-  }, []);
-
-  // Listen to reset event from settings
   useEffect(() => {
     if (typeof window !== "undefined") {
       const handleResetWidth = () => {
@@ -180,13 +496,14 @@ export function HouseEditModal(props: HouseEditModalProps) {
     houseModalOnSuccess,
     isHouseModalDirty,
     setHouseModalDirty,
+    openHausOverviewModal,
   } = useModalStore();
 
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<HouseFormData>({
     name: "",
     strasse: "",
     ort: "",
-    groesse: null as number | null,
+    groesse: null,
   });
 
   useEffect(() => {
@@ -223,6 +540,10 @@ export function HouseEditModal(props: HouseEditModalProps) {
   const handleManualGroesseChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setManualGroesse(e.target.value);
     if (!isHouseModalDirty) setHouseModalDirty(true);
+  };
+
+  const handleAutomaticSizeChange = (checked: boolean) => {
+    setAutomaticSize(checked);
   };
 
   const attemptClose = () => {
@@ -343,249 +664,48 @@ export function HouseEditModal(props: HouseEditModalProps) {
         isDirty={isHouseModalDirty}
         onAttemptClose={attemptClose}
       >
-        {/* Resize Handle */}
-        <div
+        <ResizeHandle
+          isResizing={isResizing}
+          setWidth={setWidth}
           onMouseDown={startResizing}
-          className={cn(
-            "absolute -left-1 top-0 bottom-0 w-2 cursor-ew-resize z-50 select-none group/resize-handle hidden sm:block",
-            isResizing ? "cursor-ew-resize" : ""
-          )}
-        >
-          {/* Visual highlight line positioned exactly on the border (center of the handle) */}
-          <div className={cn(
-            "absolute inset-y-0 left-1/2 w-[2px] -translate-x-1/2 transition-all duration-150 ease-in-out",
-            isResizing ? "bg-primary" : "bg-transparent group-hover/resize-handle:bg-primary/40"
-          )} />
-        </div>
-        {/* Top Navigation Bar */}
-        <div className="absolute top-0 left-0 right-0 h-14 flex items-center justify-between px-4 z-10 pointer-events-none">
-          <div className="pointer-events-auto">
-            {/* The actual SheetClose button is in components/ui/sheet.tsx at left-4 top-4 */}
-          </div>
-          {houseInitialData && (
-            <CustomDropdown
-              trigger={
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="rounded-lg opacity-50 hover:opacity-100 hover:bg-hover-bg pointer-events-auto cursor-pointer h-8 w-8"
-                >
-                  <MoreHorizontal className="h-5 w-5" />
-                  <span className="sr-only">Aktionen</span>
-                </Button>
-              }
-              align="end"
-            >
-              <CustomDropdownItem onClick={() => openHausOverviewModal(houseInitialData.id)}>
-                <Eye className="h-4 w-4 mr-2" />
-                <span>Übersicht</span>
-              </CustomDropdownItem>
-              <CustomDropdownSeparator />
-              <CustomDropdownItem onClick={() => setDeleteDialogOpen(true)} className="text-red-600 focus:text-red-600">
-                <Trash2 className="h-4 w-4 mr-2" />
-                <span>Löschen</span>
-              </CustomDropdownItem>
-            </CustomDropdown>
-          )}
-        </div>
+        />
+
+        <TopBar
+          houseInitialData={houseInitialData}
+          onOverviewClick={() => houseInitialData && openHausOverviewModal(houseInitialData.id)}
+          onDeleteRequest={() => setDeleteDialogOpen(true)}
+        />
 
         <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0">
           <ScrollArea className="flex-1">
-            <div className="max-w-[90%] mx-auto pt-10 sm:pt-14 pb-6 px-4 sm:px-8 space-y-4 sm:space-y-8">
-              
-              {/* Header Section */}
-              <div className="space-y-2 sm:space-y-3">
-                <div className="text-primary/80">
-                  <Building2 className="h-8 w-8 sm:h-10 sm:w-10" />
-                </div>
-                <div className="space-y-1">
-                  <SheetTitle className="sr-only">
-                    {houseInitialData ? "Haus bearbeiten" : "Haus hinzufügen"}
-                  </SheetTitle>
-                  <input
-                    type="text"
-                    id="name"
-                    name="name"
-                    value={formData.name}
-                    onChange={handleInputChange}
-                    placeholder={houseInitialData ? "Unbenanntes Haus" : "Haus hinzufügen"}
-                    disabled={isSubmitting}
-                    className="text-2xl sm:text-4xl font-bold tracking-tight w-full bg-transparent border-none outline-none focus:outline-none focus:ring-0 p-0 text-foreground placeholder:opacity-30 placeholder:text-muted-foreground/50 cursor-text"
-                  />
-                  <SheetDescription className="text-sm sm:text-base text-muted-foreground/80">
-                    {houseInitialData 
-                      ? "Bearbeiten Sie die Informationen für dieses Objekt." 
-                      : "Legen Sie ein neues Haus in Ihrer Verwaltung an."}
-                  </SheetDescription>
-                </div>
-              </div>
-
-              {/* Properties Section */}
-              <div className="space-y-3 sm:space-y-6">
-
-                {/* Address Section */}
-                <div className="sm:space-y-4 sm:pt-3 sm:border-t sm:border-border/40">
-                  <div className="hidden sm:flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
-                    Standort
-                  </div>
-                  
-                  <div className="sm:grid sm:gap-4 space-y-2 sm:space-y-0">
-                    <div className="sm:grid sm:grid-cols-[140px_1fr] sm:items-center sm:gap-4 space-y-1 sm:space-y-0">
-                      <PropertyHeader 
-                        icon={MapPin}
-                        label="Straße"
-                        htmlFor="strasse"
-                        infoText="Geben Sie die vollständige Adresse des Hauses ein. Dieses Feld wird für die Abrechnung und die generierte PDF benötigt."
-                      />
-                      <Input
-                        id="strasse"
-                        name="strasse"
-                        value={formData.strasse}
-                        onChange={handleInputChange}
-                        placeholder="Straße und Hausnummer"
-                        disabled={isSubmitting}
-                        className="bg-transparent border-none shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 hover:bg-muted/10 focus:bg-muted/20 px-2 py-1 -mx-2 rounded-lg transition-all h-auto text-sm focus-visible:scale-100 hover:border-transparent focus:border-transparent"
-                      />
-                    </div>
-
-                    <div className="sm:grid sm:grid-cols-[140px_1fr] sm:items-center sm:gap-4 space-y-1 sm:space-y-0">
-                      <PropertyHeader 
-                        icon={MapPin}
-                        label="Ort"
-                        htmlFor="ort"
-                        infoText="Geben Sie den Ort des Hauses ein. Die Ortsangabe erscheint in den offiziellen Dokumenten."
-                      />
-                      <Input
-                        id="ort"
-                        name="ort"
-                        value={formData.ort}
-                        onChange={handleInputChange}
-                        placeholder="PLZ und Stadt"
-                        disabled={isSubmitting}
-                        className="bg-transparent border-none shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 hover:bg-muted/10 focus:bg-muted/20 px-2 py-1 -mx-2 rounded-lg transition-all h-auto text-sm focus-visible:scale-100 hover:border-transparent focus:border-transparent"
-                      />
-                    </div>
-                  </div>
-                </div>
-
-                {/* Calculation Section */}
-                <div className="sm:space-y-4 sm:pt-3 sm:border-t sm:border-border/40">
-                  <div className="hidden sm:flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
-                    Kennzahlen
-                  </div>
-
-                  <div className="sm:grid sm:gap-4 space-y-2 sm:space-y-0">
-                    <div className="sm:grid sm:grid-cols-[140px_1fr] sm:items-center sm:gap-4 space-y-1 sm:space-y-0">
-                      <PropertyHeader 
-                        icon={Ruler}
-                        label="Berechnung"
-                        htmlFor="automaticSize"
-                        infoText="Wenn aktiviert, wird die Gesamtgröße des Hauses automatisch aus der Summe der Wohnungsflächen berechnet."
-                      />
-                      <Label 
-                        htmlFor="automaticSize"
-                        className={cn(
-                          "flex items-center justify-between h-10 px-3 rounded-xl cursor-pointer transition-colors border outline-hidden focus-within:ring-1 focus-within:ring-ring",
-                          automaticSize ? "bg-primary/5 text-primary border-primary/10" : "bg-muted/30 text-muted-foreground border-border/50"
-                        )}
-                      >
-                        <span className="text-sm font-medium cursor-pointer">Automatisch</span>
-                        <Checkbox
-                          id="automaticSize"
-                          checked={automaticSize}
-                          onCheckedChange={(checked) => {
-                            setAutomaticSize(!!checked);
-                            if (!isHouseModalDirty) setHouseModalDirty(true);
-                          }}
-                          disabled={isSubmitting}
-                          className="h-4 w-4"
-                        />
-                      </Label>
-                    </div>
-
-                    {!automaticSize && (
-                      <div className="sm:grid sm:grid-cols-[140px_1fr] sm:items-center sm:gap-4 space-y-1 sm:space-y-0 animate-in fade-in slide-in-from-top-1">
-                        <Label htmlFor="manualGroesse" className="text-sm text-muted-foreground/70">Fläche (m²)</Label>
-                        <div className="relative">
-                          <NumberInput
-                            id="manualGroesse"
-                            name="manualGroesse"
-                            value={manualGroesse}
-                            onChange={handleManualGroesseChange}
-                            disabled={isSubmitting}
-                            placeholder="Manuelle Größe..."
-                            className="bg-transparent border-none shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 hover:bg-muted/10 focus:bg-muted/20 px-2 py-1 -mx-2 rounded-lg transition-all h-auto text-sm focus-visible:scale-100 hover:border-transparent focus:border-transparent"
-                          />
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                </div>
-
-                {/* Additional Info / Description Style */}
-                <div className="hidden sm:block space-y-3 pt-3 border-t border-border/40">
-                  <div className="flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
-                    Beschreibung
-                  </div>
-                  <div className="bg-muted/20 rounded-xl p-4 text-sm text-muted-foreground/80 leading-relaxed border border-border/50">
-                    <div className="flex gap-2 items-start">
-                      <Info className="h-4 w-4 mt-0.5 shrink-0 opacity-40" />
-                      <p>
-                        Diese Informationen werden für die automatische Erstellung von Nebenkostenabrechnungen und offiziellen Dokumenten verwendet. Bitte stellen Sie sicher, dass alle Standortdaten korrekt sind.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <FormFields
+              formData={formData}
+              onFieldChange={handleInputChange}
+              automaticSize={automaticSize}
+              onAutomaticSizeChange={handleAutomaticSizeChange}
+              manualGroesse={manualGroesse}
+              onManualGroesseChange={handleManualGroesseChange}
+              isSubmitting={isSubmitting}
+              houseInitialData={houseInitialData}
+              isHouseModalDirty={isHouseModalDirty}
+              setHouseModalDirty={setHouseModalDirty}
+            />
           </ScrollArea>
 
-          <SheetFooter className="px-4 pb-6 pt-2 sm:p-8 sm:pt-4">
-            <div className="max-w-[90%] mx-auto w-full flex gap-3">
-              <Button 
-                type="button" 
-                variant="ghost" 
-                onClick={handleCancelClick} 
-                disabled={isSubmitting}
-                className="flex-1 rounded-xl h-11 text-muted-foreground hover:text-foreground hover:scale-[1.005] active:scale-[0.995] hover:shadow-none"
-              >
-                Abbrechen
-              </Button>
-              <Button 
-                type="submit" 
-                disabled={isSubmitting}
-                className="flex-1 rounded-xl h-11 shadow-sm font-semibold hover:scale-[1.005] active:scale-[0.995] hover:shadow-sm"
-              >
-                {isSubmitting ? (
-                  <span className="flex items-center gap-2">
-                    <svg className="animate-spin h-5 w-5" style={{ animationDuration: "600ms" }} viewBox="0 0 24 24">
-                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
-                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-                    </svg>
-                    Wird gespeichert...
-                  </span>
-                ) : (houseInitialData ? "Änderungen speichern" : "Haus anlegen")}
-              </Button>
-            </div>
-          </SheetFooter>
+          <FormActions
+            isSubmitting={isSubmitting}
+            onCancel={handleCancelClick}
+            houseInitialData={houseInitialData}
+          />
         </form>
 
-        <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Haus löschen?</AlertDialogTitle>
-              <AlertDialogDescription>
-                Möchten Sie das Haus "{houseInitialData?.name || formData.name}" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel disabled={isDeleting}>Abbrechen</AlertDialogCancel>
-              <AlertDialogAction onClick={(e) => { e.preventDefault(); handleDelete(); }} disabled={isDeleting} className="bg-red-600 hover:bg-red-700">
-                {isDeleting ? "Löschen..." : "Löschen"}
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+        <DeleteHouseDialog
+          open={deleteDialogOpen}
+          onOpenChange={setDeleteDialogOpen}
+          houseName={houseInitialData?.name || formData.name}
+          isDeleting={isDeleting}
+          onDelete={handleDelete}
+        />
       </SheetContent>
     </Sheet>
   );

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -24,7 +24,7 @@ import { toast } from "@/hooks/use-toast";
 import { useModalStore } from "@/hooks/use-modal-store";
 import { useOnboardingStore } from "@/hooks/use-onboarding-store";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Building2, MapPin, Ruler, Info, Home, MoreHorizontal, Lightbulb, Eye, Trash2 } from "lucide-react";
+import { Building2, MapPin, Ruler, Info, Home, MoreHorizontal, Lightbulb, Eye, Trash2, type LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CustomDropdown, CustomDropdownItem, CustomDropdownSeparator } from "@/components/ui/custom-dropdown";
 import {
@@ -40,7 +40,7 @@ import {
 import { deleteHouseAction } from "@/app/(dashboard)/haeuser/actions";
 
 // Helper component for Property Header with Hover Info
-function PropertyHeader({ icon: Icon, label, infoText, htmlFor }: { icon: any, label: string, infoText: string, htmlFor: string }) {
+function PropertyHeader({ icon: Icon, label, infoText, htmlFor }: { icon: LucideIcon, label: string, infoText: string, htmlFor: string }) {
   return (
     <HoverCard openDelay={200} closeDelay={100}>
       <HoverCardTrigger asChild>
@@ -131,8 +131,9 @@ export function HouseEditModal(props: HouseEditModalProps) {
         setAutomaticSize(true);
         setManualGroesse('');
       }
+      setHouseModalDirty(false);
     }
-  }, [houseInitialData, isHouseModalOpen]);
+  }, [houseInitialData, isHouseModalOpen, setHouseModalDirty]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -460,7 +460,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
               >
                 {isSubmitting ? (
                   <span className="flex items-center gap-2">
-                    <svg className="animate-spin h-5 w-5" style={{ animationDuration: "1.25s" }} viewBox="0 0 24 24">
+                    <svg className="animate-spin h-5 w-5" style={{ animationDuration: "600ms" }} viewBox="0 0 24 24">
                       <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
                       <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                     </svg>

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -478,7 +478,10 @@ export function HouseEditModal(props: HouseEditModalProps) {
       setIsResizing(false);
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
-      localStorage.setItem("house-modal-width", String(widthRef.current));
+      const finalWidth = widthRef.current;
+      if (typeof finalWidth === "number" && !isNaN(finalWidth) && finalWidth >= 360) {
+        localStorage.setItem("house-modal-width", String(finalWidth));
+      }
     };
 
     document.addEventListener("mousemove", handleMouseMove);

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -24,8 +24,20 @@ import { toast } from "@/hooks/use-toast";
 import { useModalStore } from "@/hooks/use-modal-store";
 import { useOnboardingStore } from "@/hooks/use-onboarding-store";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Building2, MapPin, Ruler, Info, Home, MoreHorizontal, Lightbulb } from "lucide-react";
+import { Building2, MapPin, Ruler, Info, Home, MoreHorizontal, Lightbulb, Eye, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { CustomDropdown, CustomDropdownItem, CustomDropdownSeparator } from "@/components/ui/custom-dropdown";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { deleteHouseAction } from "@/app/(dashboard)/haeuser/actions";
 
 // Helper component for Property Header with Hover Info
 function PropertyHeader({ icon: Icon, label, infoText, htmlFor }: { icon: any, label: string, infoText: string, htmlFor: string }) {
@@ -78,6 +90,9 @@ export function HouseEditModal(props: HouseEditModalProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [automaticSize, setAutomaticSize] = useState(true);
   const [manualGroesse, setManualGroesse] = useState<string>('');
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const { openHausOverviewModal } = useModalStore();
 
   const {
     isHouseModalOpen,
@@ -136,6 +151,43 @@ export function HouseEditModal(props: HouseEditModalProps) {
 
   const handleCancelClick = () => {
     closeHouseModal({ force: true });
+  };
+
+  const handleDelete = async () => {
+    if (!houseInitialData) return;
+    try {
+      setIsDeleting(true);
+      const result = await deleteHouseAction(houseInitialData.id);
+
+      if (result.success) {
+        toast({
+          title: "Erfolg",
+          description: `Das Haus "${formData.name}" wurde erfolgreich gelöscht.`,
+          variant: "success",
+        });
+        setHouseModalDirty(false);
+        closeHouseModal();
+        if (houseModalOnSuccess) {
+          houseModalOnSuccess({ deleted: true, id: houseInitialData.id });
+        }
+      } else {
+        toast({
+          title: "Fehler",
+          description: result.error?.message || "Das Haus konnte nicht gelöscht werden.",
+          variant: "destructive",
+        });
+      }
+    } catch (error) {
+      console.error("Unerwarteter Fehler beim Löschen des Hauses:", error);
+      toast({
+        title: "Systemfehler",
+        description: "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es später erneut.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsDeleting(false);
+      setDeleteDialogOpen(false);
+    }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -205,14 +257,33 @@ export function HouseEditModal(props: HouseEditModalProps) {
           <div className="pointer-events-auto">
             {/* The actual SheetClose button is in components/ui/sheet.tsx at left-4 top-4 */}
           </div>
-          <Button 
-            variant="ghost" 
-            size="icon" 
-            className="rounded-lg opacity-50 hover:opacity-100 hover:bg-muted pointer-events-auto"
+          <CustomDropdown
+            trigger={
+              <Button
+                variant="ghost"
+                size="icon"
+                className="rounded-lg opacity-50 hover:opacity-100 hover:bg-gray-200 dark:hover:bg-gray-800 pointer-events-auto cursor-pointer h-8 w-8"
+              >
+                <MoreHorizontal className="h-5 w-5" />
+                <span className="sr-only">Aktionen</span>
+              </Button>
+            }
+            align="end"
           >
-            <MoreHorizontal className="h-5 w-5" />
-            <span className="sr-only">Actions</span>
-          </Button>
+            {houseInitialData && (
+              <>
+                <CustomDropdownItem onClick={() => openHausOverviewModal(houseInitialData.id)}>
+                  <Eye className="h-4 w-4 mr-2" />
+                  <span>Übersicht</span>
+                </CustomDropdownItem>
+                <CustomDropdownSeparator />
+                <CustomDropdownItem onClick={() => setDeleteDialogOpen(true)} className="text-red-600 focus:text-red-600">
+                  <Trash2 className="h-4 w-4 mr-2" />
+                  <span>Löschen</span>
+                </CustomDropdownItem>
+              </>
+            )}
+          </CustomDropdown>
         </div>
 
         <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0">
@@ -400,6 +471,23 @@ export function HouseEditModal(props: HouseEditModalProps) {
             </div>
           </SheetFooter>
         </form>
+
+        <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Haus löschen?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Möchten Sie das Haus "{formData.name}" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isDeleting}>Abbrechen</AlertDialogCancel>
+              <AlertDialogAction onClick={handleDelete} disabled={isDeleting} className="bg-red-600 hover:bg-red-700">
+                {isDeleting ? "Löschen..." : "Löschen"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </SheetContent>
     </Sheet>
   );

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import {
   Sheet,
   SheetContent,
-  SheetHeader,
   SheetTitle,
   SheetDescription,
   SheetFooter,
@@ -19,7 +18,6 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
-import { useRouter } from "next/navigation";
 import { toast } from "@/hooks/use-toast";
 import { useModalStore } from "@/hooks/use-modal-store";
 import { useOnboardingStore } from "@/hooks/use-onboarding-store";
@@ -42,31 +40,38 @@ import { deleteHouseAction } from "@/app/(dashboard)/haeuser/actions";
 // Helper component for Property Header with Hover Info
 function PropertyHeader({ icon: Icon, label, infoText, htmlFor }: { icon: LucideIcon, label: string, infoText: string, htmlFor: string }) {
   return (
-    <HoverCard openDelay={200} closeDelay={100}>
-      <HoverCardTrigger asChild>
-        <div
-          tabIndex={0}
-          role="button"
-          className="flex items-center gap-3 text-muted-foreground/70 cursor-help transition-colors hover:text-foreground/90 w-fit group/header"
-        >
-          <Icon className="h-4 w-4 group-hover/header:text-primary transition-colors" />
-          <Label htmlFor={htmlFor} className="text-sm font-medium uppercase tracking-wider cursor-help group-hover/header:text-foreground transition-colors">
-            {label}
-          </Label>
-        </div>
-      </HoverCardTrigger>
-      <HoverCardContent side="top" align="start" className="w-80 shadow-2xl border-border/40 bg-background/95 backdrop-blur-md rounded-[28px] p-5 overflow-hidden">
-        <div className="flex gap-4 items-start">
-          <div className="flex-none h-12 w-12 rounded-full bg-amber-500/10 dark:bg-amber-500/20 text-amber-600 dark:text-amber-400 flex items-center justify-center shadow-inner border border-amber-500/20">
-            <Lightbulb className="h-6 w-6" />
-          </div>
-          <div className="space-y-1.5 pt-1">
-            <h4 className="font-bold text-foreground text-sm uppercase tracking-tight">Tipp</h4>
-            <p className="text-sm leading-relaxed text-muted-foreground/90">{infoText}</p>
-          </div>
-        </div>
-      </HoverCardContent>
-    </HoverCard>
+    <>
+      <Label htmlFor={htmlFor} className="block sm:hidden text-xs font-medium text-muted-foreground uppercase tracking-wider">
+        {label}
+      </Label>
+      <div className="hidden sm:block">
+        <HoverCard openDelay={200} closeDelay={100}>
+          <HoverCardTrigger asChild>
+            <div
+              tabIndex={0}
+              role="button"
+              className="flex items-center gap-3 text-muted-foreground/70 cursor-help transition-colors hover:text-foreground/90 w-fit group/header focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:rounded-[4px]"
+            >
+              <Icon className="h-4 w-4 group-hover/header:text-primary transition-colors" />
+              <Label htmlFor={htmlFor} className="text-sm font-medium uppercase tracking-wider cursor-help group-hover/header:text-foreground transition-colors">
+                {label}
+              </Label>
+            </div>
+          </HoverCardTrigger>
+          <HoverCardContent side="top" align="start" className="w-80 shadow-2xl border-border/40 bg-background/95 backdrop-blur-md rounded-[28px] p-5 overflow-hidden">
+            <div className="flex gap-4 items-start">
+              <div className="flex-none h-12 w-12 rounded-full bg-amber-500/10 dark:bg-amber-500/20 text-amber-600 dark:text-amber-400 flex items-center justify-center shadow-inner border border-amber-500/20">
+                <Lightbulb className="h-6 w-6" />
+              </div>
+              <div className="space-y-1.5 pt-1">
+                <h4 className="font-bold text-foreground text-sm uppercase tracking-tight">Tipp</h4>
+                <p className="text-sm leading-relaxed text-muted-foreground/90">{infoText}</p>
+              </div>
+            </div>
+          </HoverCardContent>
+        </HoverCard>
+      </div>
+    </>
   );
 }
 
@@ -90,7 +95,6 @@ interface HouseEditModalProps {
 export function HouseEditModal(props: HouseEditModalProps) {
   const { serverAction } = props;
 
-  const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [automaticSize, setAutomaticSize] = useState(true);
   const [manualGroesse, setManualGroesse] = useState<string>('');
@@ -168,7 +172,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
       if (result.success) {
         toast({
           title: "Erfolg",
-          description: `Das Haus "${formData.name}" wurde erfolgreich gelöscht.`,
+          description: `Das Haus "${houseInitialData.name}" wurde erfolgreich gelöscht.`,
           variant: "success",
         });
         setHouseModalDirty(false);
@@ -299,18 +303,18 @@ export function HouseEditModal(props: HouseEditModalProps) {
 
         <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0">
           <ScrollArea className="flex-1">
-            <div className="max-w-[520px] mx-auto pt-20 pb-10 px-8 space-y-12">
+            <div className="max-w-[520px] mx-auto pt-14 sm:pt-20 pb-10 px-4 sm:px-8 space-y-6 sm:space-y-12">
               
               {/* Header Section */}
-              <div className="space-y-4">
+              <div className="space-y-3 sm:space-y-4">
                 <div className="text-primary/80">
-                  <Building2 className="h-10 w-10" />
+                  <Building2 className="h-8 w-8 sm:h-10 sm:w-10" />
                 </div>
                 <div className="space-y-1">
-                  <SheetTitle className="text-4xl font-bold tracking-tight">
+                  <SheetTitle className="text-2xl sm:text-4xl font-bold tracking-tight">
                     {houseInitialData ? formData.name || "Unbenanntes Haus" : "Haus hinzufügen"}
                   </SheetTitle>
-                  <SheetDescription className="text-base text-muted-foreground/80">
+                  <SheetDescription className="text-sm sm:text-base text-muted-foreground/80">
                     {houseInitialData 
                       ? "Bearbeiten Sie die Informationen für dieses Objekt." 
                       : "Legen Sie ein neues Haus in Ihrer Verwaltung an."}
@@ -319,9 +323,9 @@ export function HouseEditModal(props: HouseEditModalProps) {
               </div>
 
               {/* Properties Section */}
-              <div className="space-y-8">
+              <div className="space-y-4 sm:space-y-8">
                 {/* Name Property */}
-                <div className="space-y-2">
+                <div className="space-y-1.5 sm:space-y-2">
                   <PropertyHeader 
                     icon={Home}
                     label="Name"
@@ -335,18 +339,18 @@ export function HouseEditModal(props: HouseEditModalProps) {
                     onChange={handleInputChange}
                     placeholder="Einen Namen geben..."
                     disabled={isSubmitting}
-                    className="text-xl font-medium placeholder:opacity-30 h-auto py-2 rounded-xl border-primary/20 bg-primary/5 focus:bg-background transition-colors"
+                    className="text-base sm:text-xl font-medium placeholder:opacity-30 h-auto py-2 rounded-xl border-primary/20 bg-primary/5 focus:bg-background transition-colors"
                   />
                 </div>
 
                 {/* Address Section */}
-                <div className="space-y-6 pt-4 border-t border-border/40">
-                  <div className="flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
+                <div className="sm:space-y-6 sm:pt-4 sm:border-t sm:border-border/40">
+                  <div className="hidden sm:flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
                     Standort
                   </div>
                   
-                  <div className="grid gap-6">
-                    <div className="grid grid-cols-[140px_1fr] items-center gap-4">
+                  <div className="sm:grid sm:gap-6 space-y-3 sm:space-y-0">
+                    <div className="sm:grid sm:grid-cols-[140px_1fr] sm:items-center sm:gap-4 space-y-1 sm:space-y-0">
                       <PropertyHeader 
                         icon={MapPin}
                         label="Straße"
@@ -364,7 +368,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
                       />
                     </div>
 
-                    <div className="grid grid-cols-[140px_1fr] items-center gap-4">
+                    <div className="sm:grid sm:grid-cols-[140px_1fr] sm:items-center sm:gap-4 space-y-1 sm:space-y-0">
                       <PropertyHeader 
                         icon={MapPin}
                         label="Ort"
@@ -385,13 +389,13 @@ export function HouseEditModal(props: HouseEditModalProps) {
                 </div>
 
                 {/* Calculation Section */}
-                <div className="space-y-6 pt-4 border-t border-border/40">
-                  <div className="flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
+                <div className="sm:space-y-6 sm:pt-4 sm:border-t sm:border-border/40">
+                  <div className="hidden sm:flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
                     Kennzahlen
                   </div>
 
-                  <div className="grid gap-6">
-                    <div className="grid grid-cols-[140px_1fr] items-center gap-4">
+                  <div className="sm:grid sm:gap-6 space-y-3 sm:space-y-0">
+                    <div className="sm:grid sm:grid-cols-[140px_1fr] sm:items-center sm:gap-4 space-y-1 sm:space-y-0">
                       <PropertyHeader 
                         icon={Ruler}
                         label="Berechnung"
@@ -420,11 +424,8 @@ export function HouseEditModal(props: HouseEditModalProps) {
                     </div>
 
                     {!automaticSize && (
-                      <div className="grid grid-cols-[140px_1fr] items-center gap-4 animate-in fade-in slide-in-from-top-1">
-                        <div className="flex items-center gap-2 text-muted-foreground/70">
-                          <Ruler className="h-4 w-4 opacity-0" />
-                          <Label htmlFor="manualGroesse" className="text-sm">Fläche (m²)</Label>
-                        </div>
+                      <div className="sm:grid sm:grid-cols-[140px_1fr] sm:items-center sm:gap-4 space-y-1 sm:space-y-0 animate-in fade-in slide-in-from-top-1">
+                        <Label htmlFor="manualGroesse" className="text-sm text-muted-foreground/70">Fläche (m²)</Label>
                         <div className="relative">
                           <NumberInput
                             id="manualGroesse"
@@ -442,7 +443,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
                 </div>
 
                 {/* Additional Info / Description Style */}
-                <div className="space-y-4 pt-4 border-t border-border/40">
+                <div className="hidden sm:block space-y-4 pt-4 border-t border-border/40">
                   <div className="flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
                     Beschreibung
                   </div>
@@ -459,7 +460,7 @@ export function HouseEditModal(props: HouseEditModalProps) {
             </div>
           </ScrollArea>
 
-          <SheetFooter className="p-8 pt-4">
+          <SheetFooter className="px-4 pb-6 pt-2 sm:p-8 sm:pt-4">
             <div className="max-w-[520px] mx-auto w-full flex gap-3">
               <Button 
                 type="button" 
@@ -494,12 +495,12 @@ export function HouseEditModal(props: HouseEditModalProps) {
             <AlertDialogHeader>
               <AlertDialogTitle>Haus löschen?</AlertDialogTitle>
               <AlertDialogDescription>
-                Möchten Sie das Haus "{formData.name}" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.
+                Möchten Sie das Haus "{houseInitialData?.name || formData.name}" wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
               <AlertDialogCancel disabled={isDeleting}>Abbrechen</AlertDialogCancel>
-              <AlertDialogAction onClick={handleDelete} disabled={isDeleting} className="bg-red-600 hover:bg-red-700">
+              <AlertDialogAction onClick={(e) => { e.preventDefault(); handleDelete(); }} disabled={isDeleting} className="bg-red-600 hover:bg-red-700">
                 {isDeleting ? "Löschen..." : "Löschen"}
               </AlertDialogAction>
             </AlertDialogFooter>

--- a/components/mail-context-menu.tsx
+++ b/components/mail-context-menu.tsx
@@ -229,7 +229,7 @@ export function MailActionsDropdown({
     onDeletePermanently,
   });
 
-  const dropdownItemClass = "focus:bg-gray-200 focus:text-foreground hover:bg-gray-200 dark:context-menu-item";
+  const dropdownItemClass = "focus:bg-hover-bg focus:text-foreground hover:bg-hover-bg dark:context-menu-item";
 
   return (
     <>
@@ -238,7 +238,7 @@ export function MailActionsDropdown({
           <Button
             variant="ghost"
             size="icon"
-            className="h-7 w-7 p-0 hover:bg-gray-200"
+            className="h-7 w-7 p-0 hover:bg-hover-bg"
           >
             <span className="sr-only">Menü öffnen</span>
             <MoreVertical className="h-3.5 w-3.5" />

--- a/components/mail-context-menu.tsx
+++ b/components/mail-context-menu.tsx
@@ -229,7 +229,7 @@ export function MailActionsDropdown({
     onDeletePermanently,
   });
 
-  const dropdownItemClass = "focus:bg-gray-200 focus:text-foreground hover:bg-gray-100 hover:scale-[1.02] dark:context-menu-item";
+  const dropdownItemClass = "focus:bg-gray-200 focus:text-foreground hover:bg-gray-200 dark:context-menu-item";
 
   return (
     <>
@@ -238,7 +238,7 @@ export function MailActionsDropdown({
           <Button
             variant="ghost"
             size="icon"
-            className="h-7 w-7 p-0 hover:bg-gray-200 dark:hover:bg-gray-700"
+            className="h-7 w-7 p-0 hover:bg-gray-200"
           >
             <span className="sr-only">Menü öffnen</span>
             <MoreVertical className="h-3.5 w-3.5" />

--- a/components/settings/display-section.tsx
+++ b/components/settings/display-section.tsx
@@ -32,9 +32,9 @@ const DisplaySection = () => {
               <div className="flex flex-col gap-1">
                 <div className="flex items-center gap-2">
                   <Monitor className="size-4 text-muted-foreground" />
-                  <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                  <span className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
                     Design-Modus
-                  </label>
+                  </span>
                 </div>
                 <p className="text-xs text-muted-foreground">
                   Wählen Sie zwischen hellem, dunklem Design oder folgen Sie den Systemeinstellungen.
@@ -50,9 +50,9 @@ const DisplaySection = () => {
             <div className="flex flex-col gap-1">
               <div className="flex items-center gap-2">
                 <PanelLeft className="size-4 text-muted-foreground" />
-                <label className="text-sm font-medium leading-none">
+                <span className="text-sm font-medium leading-none">
                   Navigationsleiste
-                </label>
+                </span>
               </div>
               <p className="text-xs text-muted-foreground">
                 Wählen Sie, ob die Seitenleiste standardmäßig ausgeklappt, eingeklappt bleibt oder sich automatisch beim Drüberfahren (Hover) erweitert.
@@ -67,9 +67,9 @@ const DisplaySection = () => {
             <div className="flex flex-col gap-1 flex-1">
               <div className="flex items-center gap-2">
                 <Info className="size-4 text-muted-foreground" />
-                <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                <span className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
                   Anleitung auf Betriebskosten-Seite
-                </label>
+                </span>
               </div>
               <p className="text-xs text-muted-foreground">
                 Blendet die Schritt-für-Schritt Anleitung für die Betriebskostenabrechnung ein oder aus.
@@ -96,9 +96,9 @@ const DisplaySection = () => {
             <div className="flex flex-col gap-1">
               <div className="flex items-center gap-2">
                 <Play className="size-4 text-muted-foreground" />
-                <label className="text-sm font-medium leading-none">
+                <span className="text-sm font-medium leading-none">
                   Tutorial neu starten
-                </label>
+                </span>
               </div>
               <p className="text-xs text-muted-foreground">
                 Startet die interaktive Einführungstour erneut.
@@ -115,9 +115,9 @@ const DisplaySection = () => {
             <div className="flex flex-col gap-1">
               <div className="flex items-center gap-2">
                 <Maximize2 className="size-4 text-muted-foreground" />
-                <label className="text-sm font-medium leading-none">
+                <span className="text-sm font-medium leading-none">
                   Größe der Seitenfenster zurücksetzen
-                </label>
+                </span>
               </div>
               <p className="text-xs text-muted-foreground">
                 Setzt die manuell angepasste Breite des Haus-Bearbeitungsfensters auf die Standardgröße zurück.

--- a/components/settings/display-section.tsx
+++ b/components/settings/display-section.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react"
 import { useFeatureFlagEnabled } from 'posthog-js/react'
-import { Info, Monitor, PanelLeft, Play } from "lucide-react";
+import { Info, Monitor, PanelLeft, Play, Maximize2 } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
 import { getCookie, setCookie } from "@/utils/cookies";
 import { BETRIEBSKOSTEN_GUIDE_COOKIE, BETRIEBSKOSTEN_GUIDE_VISIBILITY_CHANGED } from "@/constants/guide";
@@ -11,6 +11,7 @@ import { SidebarSwitcherCards } from "@/components/common/sidebar-switcher-cards
 import { SettingsCard, SettingsSection } from "@/components/settings/shared";
 import { useOnboardingStore } from "@/hooks/use-onboarding-store";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/hooks/use-toast";
 
 const DisplaySection = () => {
   const darkModeEnabled = useFeatureFlagEnabled('dark-mode')
@@ -105,6 +106,39 @@ const DisplaySection = () => {
             </div>
             <Button variant="outline" size="sm" onClick={() => useOnboardingStore.getState().resetTour()}>
               Neustart
+            </Button>
+          </div>
+        </SettingsCard>
+
+        <SettingsCard>
+          <div className="flex items-center justify-between gap-6">
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center gap-2">
+                <Maximize2 className="size-4 text-muted-foreground" />
+                <label className="text-sm font-medium leading-none">
+                  Größe der Seitenfenster zurücksetzen
+                </label>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Setzt die manuell angepasste Breite des Haus-Bearbeitungsfensters auf die Standardgröße zurück.
+              </p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                localStorage.removeItem("house-modal-width");
+                if (typeof window !== 'undefined') {
+                  window.dispatchEvent(new CustomEvent("reset-house-modal-width"));
+                }
+                toast({
+                  title: "Zurückgesetzt",
+                  description: "Die Breite des Bearbeitungsfensters wurde auf die Standardgröße zurückgesetzt.",
+                  variant: "success",
+                });
+              }}
+            >
+              Zurücksetzen
             </Button>
           </div>
         </SettingsCard>

--- a/components/tenants/tenant-payment-bento.tsx
+++ b/components/tenants/tenant-payment-bento.tsx
@@ -40,7 +40,7 @@ export function TenantPaymentBento() {
           </div>
           <button
             type="button"
-            className="p-2 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors duration-150"
+            className="p-2 rounded-lg hover:bg-hover-bg transition-colors duration-150"
             onClick={() => openTenantPaymentOverviewModal()}
             title="Maximieren"
           >

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -13,10 +13,10 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-gray-200 hover:text-foreground dark:btn-outline-hover",
+          "border border-input bg-background hover:bg-hover-bg hover:text-foreground dark:btn-outline-hover",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-gray-200 hover:text-foreground dark:btn-ghost-hover",
+        ghost: "hover:bg-hover-bg hover:text-foreground dark:btn-ghost-hover",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/components/ui/context-menu.tsx
+++ b/components/ui/context-menu.tsx
@@ -80,7 +80,7 @@ const ContextMenuItem = React.forwardRef<
   <ContextMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-lg px-3 py-2 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-100 hover:scale-[1.01] data-disabled:pointer-events-none data-disabled:opacity-50 dark:context-menu-item",
+      "relative flex cursor-pointer select-none items-center rounded-lg px-3 py-2 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-200 data-disabled:pointer-events-none data-disabled:opacity-50 dark:context-menu-item",
       inset && "pl-8",
       className
     )}

--- a/components/ui/context-menu.tsx
+++ b/components/ui/context-menu.tsx
@@ -27,7 +27,7 @@ const ContextMenuSubTrigger = React.forwardRef<
   <ContextMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-lg px-2 py-1.5 text-sm outline-hidden focus:bg-gray-200 focus:text-foreground data-[state=open]:bg-gray-200 data-[state=open]:text-foreground dark:context-menu-subtrigger",
+      "flex cursor-default select-none items-center rounded-lg px-2 py-1.5 text-sm outline-hidden focus:bg-hover-bg focus:text-foreground data-[state=open]:bg-hover-bg data-[state=open]:text-foreground dark:context-menu-subtrigger",
       inset && "pl-8",
       className
     )}
@@ -80,7 +80,7 @@ const ContextMenuItem = React.forwardRef<
   <ContextMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-lg px-3 py-2 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-200 data-disabled:pointer-events-none data-disabled:opacity-50 dark:context-menu-item",
+      "relative flex cursor-pointer select-none items-center rounded-lg px-3 py-2 text-sm outline-hidden transition-all duration-150 focus:bg-hover-bg focus:text-foreground hover:bg-hover-bg data-disabled:pointer-events-none data-disabled:opacity-50 dark:context-menu-item",
       inset && "pl-8",
       className
     )}
@@ -96,7 +96,7 @@ const ContextMenuCheckboxItem = React.forwardRef<
   <ContextMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-lg py-1.5 pl-8 pr-2 text-sm outline-hidden focus:bg-gray-200 focus:text-foreground data-disabled:pointer-events-none data-disabled:opacity-50 dark:context-menu-checkbox",
+      "relative flex cursor-default select-none items-center rounded-lg py-1.5 pl-8 pr-2 text-sm outline-hidden focus:bg-hover-bg focus:text-foreground data-disabled:pointer-events-none data-disabled:opacity-50 dark:context-menu-checkbox",
       className
     )}
     checked={checked}
@@ -120,7 +120,7 @@ const ContextMenuRadioItem = React.forwardRef<
   <ContextMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-lg py-1.5 pl-8 pr-2 text-sm outline-hidden focus:bg-gray-200 focus:text-foreground data-disabled:pointer-events-none data-disabled:opacity-50 dark:context-menu-radio",
+      "relative flex cursor-default select-none items-center rounded-lg py-1.5 pl-8 pr-2 text-sm outline-hidden focus:bg-hover-bg focus:text-foreground data-disabled:pointer-events-none data-disabled:opacity-50 dark:context-menu-radio",
       className
     )}
     {...props}

--- a/components/ui/custom-combobox.tsx
+++ b/components/ui/custom-combobox.tsx
@@ -271,7 +271,7 @@ export function CustomCombobox({
                     option.disabled
                       ? "pointer-events-none opacity-50"
                       : [
-                        highlightedIndex === index ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+                        highlightedIndex === index ? "bg-gray-200 text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-gray-200"
                       ]
                   )}
                   onClick={() => {

--- a/components/ui/custom-combobox.tsx
+++ b/components/ui/custom-combobox.tsx
@@ -271,7 +271,7 @@ export function CustomCombobox({
                     option.disabled
                       ? "pointer-events-none opacity-50"
                       : [
-                        highlightedIndex === index ? "bg-gray-200 text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-gray-200"
+                        highlightedIndex === index ? "bg-hover-bg text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-hover-bg"
                       ]
                   )}
                   onClick={() => {

--- a/components/ui/custom-dropdown.tsx
+++ b/components/ui/custom-dropdown.tsx
@@ -52,14 +52,9 @@ export function CustomDropdown({ children, trigger, align = "end", className }: 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <div
-          role="button"
-          tabIndex={0}
-          className="cursor-pointer"
-          data-dropdown-trigger
-        >
+        <span className="cursor-pointer" data-dropdown-trigger>
           {trigger}
-        </div>
+        </span>
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align={align}

--- a/components/ui/custom-dropdown.tsx
+++ b/components/ui/custom-dropdown.tsx
@@ -52,9 +52,7 @@ export function CustomDropdown({ children, trigger, align = "end", className }: 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <span className="cursor-pointer" data-dropdown-trigger>
-          {trigger}
-        </span>
+        {trigger}
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align={align}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -160,7 +160,7 @@ const DialogContent = React.forwardRef<
             className="absolute right-3 top-3 rounded-full p-2 opacity-70 ring-offset-background transition-all duration-300 hover:opacity-100 hover:bg-gray-100 hover:scale-110 active:scale-95 hover:shadow-lg hover:rotate-90 dark:modal-close-hover focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground sm:right-4 sm:top-4 sm:p-2.5 md:right-6 md:top-6"
           >
             <X className="h-4 w-4" />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">Schließen</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Content>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -125,14 +125,19 @@ const DialogContent = React.forwardRef<
       <DialogPrimitive.Content
         ref={ref}
         className={cn(dialogContentVariants({ size }), className)}
-        onInteractOutside={handleInteraction} // Assign the correctly typed handler
+        onInteractOutside={handleInteraction}
+        onEscapeKeyDown={(e) => {
+          if (isDirty && onAttemptClose) {
+            e.preventDefault();
+            onAttemptClose();
+          }
+        }}
         onOpenAutoFocus={(e) => {
           // Prevent auto focus to allow combobox inputs to work
           e.preventDefault();
         }}
         onCloseAutoFocus={(e) => {
-          // Prevent auto focus on close
-          e.preventDefault();
+          // Intentionally empty: let Radix restore focus to the trigger element.
         }}
         onFocusOutside={(e) => {
           // Don't prevent focus from moving to combobox elements or when combobox is actively being used

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-pointer select-none items-center rounded-lg p-2 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-200 data-[state=open]:bg-gray-200",
+      "relative flex w-full cursor-pointer select-none items-center rounded-lg p-2 text-sm outline-hidden transition-all duration-150 focus:bg-hover-bg focus:text-foreground hover:bg-hover-bg data-[state=open]:bg-hover-bg",
       inset && "pl-8",
       className
     )}
@@ -83,7 +83,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-pointer select-none items-center gap-3 rounded-lg px-3 py-2 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-200 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex w-full cursor-pointer select-none items-center gap-3 rounded-lg px-3 py-2 text-sm outline-hidden transition-all duration-150 focus:bg-hover-bg focus:text-foreground hover:bg-hover-bg data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -99,7 +99,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-pointer select-none items-center rounded-lg p-2 pl-8 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-200 data-disabled:pointer-events-none data-disabled:opacity-50",
+      "relative flex w-full cursor-pointer select-none items-center rounded-lg p-2 pl-8 text-sm outline-hidden transition-all duration-150 focus:bg-hover-bg focus:text-foreground hover:bg-hover-bg data-disabled:pointer-events-none data-disabled:opacity-50",
       className
     )}
     checked={checked}
@@ -123,7 +123,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-pointer select-none items-center rounded-lg p-2 pl-8 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-200 data-disabled:pointer-events-none data-disabled:opacity-50",
+      "relative flex w-full cursor-pointer select-none items-center rounded-lg p-2 pl-8 text-sm outline-hidden transition-all duration-150 focus:bg-hover-bg focus:text-foreground hover:bg-hover-bg data-disabled:pointer-events-none data-disabled:opacity-50",
       className
     )}
     {...props}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-pointer select-none items-center rounded-lg p-2 text-sm outline-hidden transition-all duration-150 focus:bg-accent hover:bg-accent/50 data-[state=open]:bg-accent",
+      "relative flex w-full cursor-pointer select-none items-center rounded-lg p-2 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-100 data-[state=open]:bg-gray-200",
       inset && "pl-8",
       className
     )}
@@ -83,7 +83,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-pointer select-none items-center gap-3 rounded-lg px-3 py-2 text-sm outline-hidden transition-colors duration-150 focus:bg-accent focus:text-accent-foreground hover:bg-accent/50 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex w-full cursor-pointer select-none items-center gap-3 rounded-lg px-3 py-2 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-100 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -99,7 +99,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-pointer select-none items-center rounded-lg p-2 pl-8 text-sm outline-hidden transition-all duration-150 focus:bg-accent focus:text-accent-foreground hover:bg-accent/50 data-disabled:pointer-events-none data-disabled:opacity-50",
+      "relative flex w-full cursor-pointer select-none items-center rounded-lg p-2 pl-8 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-100 data-disabled:pointer-events-none data-disabled:opacity-50",
       className
     )}
     checked={checked}
@@ -123,7 +123,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-pointer select-none items-center rounded-lg p-2 pl-8 text-sm outline-hidden transition-all duration-150 focus:bg-accent focus:text-accent-foreground hover:bg-accent/50 data-disabled:pointer-events-none data-disabled:opacity-50",
+      "relative flex w-full cursor-pointer select-none items-center rounded-lg p-2 pl-8 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-100 data-disabled:pointer-events-none data-disabled:opacity-50",
       className
     )}
     {...props}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-pointer select-none items-center rounded-lg p-2 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-100 data-[state=open]:bg-gray-200",
+      "relative flex w-full cursor-pointer select-none items-center rounded-lg p-2 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-200 data-[state=open]:bg-gray-200",
       inset && "pl-8",
       className
     )}
@@ -83,7 +83,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-pointer select-none items-center gap-3 rounded-lg px-3 py-2 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-100 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex w-full cursor-pointer select-none items-center gap-3 rounded-lg px-3 py-2 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-200 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -99,7 +99,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-pointer select-none items-center rounded-lg p-2 pl-8 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-100 data-disabled:pointer-events-none data-disabled:opacity-50",
+      "relative flex w-full cursor-pointer select-none items-center rounded-lg p-2 pl-8 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-200 data-disabled:pointer-events-none data-disabled:opacity-50",
       className
     )}
     checked={checked}
@@ -123,7 +123,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-pointer select-none items-center rounded-lg p-2 pl-8 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-100 data-disabled:pointer-events-none data-disabled:opacity-50",
+      "relative flex w-full cursor-pointer select-none items-center rounded-lg p-2 pl-8 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-200 data-disabled:pointer-events-none data-disabled:opacity-50",
       className
     )}
     {...props}

--- a/components/ui/form-modal-shell.tsx
+++ b/components/ui/form-modal-shell.tsx
@@ -122,6 +122,11 @@ export function FormModalShell({
 }: FormModalShellProps) {
   const [deleteOpen, setDeleteOpen] = useState(false);
 
+  const handleFormSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit?.(e);
+  };
+
   const dropdownItems: DropdownEntry[] = [...actions];
   if (deleteConfig) {
     if (actions.length > 0) {
@@ -152,7 +157,7 @@ export function FormModalShell({
     >
       {dropdownItems.map((item, i) => {
         if (item.kind === "separator") {
-          return <CustomDropdownSeparator key="action-separator" />;
+          return <CustomDropdownSeparator key={"action-separator-" + i} />;
         }
         return (
           <CustomDropdownItem
@@ -214,7 +219,7 @@ export function FormModalShell({
                 {actionsDropdown}
               </div>
             )}
-            <form onSubmit={(e) => { e.preventDefault(); onSubmit?.(e); }} className="flex flex-col">
+            <form onSubmit={handleFormSubmit} className="flex flex-col">
               <DialogHeader>
                 <div className="flex items-start justify-between gap-4 pr-10">
                   <div>
@@ -277,7 +282,7 @@ export function FormModalShell({
               <div className="pointer-events-auto">{actionsDropdown}</div>
             </div>
           )}
-          <form onSubmit={onSubmit} className="flex flex-col flex-1 min-h-0">
+          <form onSubmit={handleFormSubmit} className="flex flex-col flex-1 min-h-0">
             <ScrollArea className="flex-1">
               <div className="max-w-[520px] mx-auto pt-20 pb-10 px-8 space-y-12">
                 {Icon && (

--- a/components/ui/form-modal-shell.tsx
+++ b/components/ui/form-modal-shell.tsx
@@ -38,11 +38,14 @@ import { MoreHorizontal, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export interface FormModalAction {
+  kind: "action";
   label: string;
   icon?: React.ComponentType<{ className?: string }>;
   onClick: () => void;
   destructive?: boolean;
 }
+
+type DropdownEntry = FormModalAction | { kind: "separator" };
 
 export interface FormModalDeleteConfig {
   onDelete: () => Promise<void>;
@@ -117,12 +120,13 @@ export function FormModalShell({
 }: FormModalShellProps) {
   const [deleteOpen, setDeleteOpen] = useState(false);
 
-  const dropdownItems = [...actions];
+  const dropdownItems: DropdownEntry[] = [...actions];
   if (deleteConfig) {
     if (actions.length > 0) {
-      dropdownItems.push({ label: "separator" } as any);
+      dropdownItems.push({ kind: "separator" });
     }
     dropdownItems.push({
+      kind: "action",
       label: "Löschen",
       icon: Trash2,
       onClick: () => setDeleteOpen(true),
@@ -144,8 +148,8 @@ export function FormModalShell({
       }
       align="end"
     >
-      {dropdownItems.map((item: any, i: number) => {
-        if (item.label === "separator") {
+      {dropdownItems.map((item, i) => {
+        if (item.kind === "separator") {
           return <CustomDropdownSeparator key={`sep-${i}`} />;
         }
         return (

--- a/components/ui/form-modal-shell.tsx
+++ b/components/ui/form-modal-shell.tsx
@@ -182,7 +182,10 @@ export function FormModalShell({
             Abbrechen
           </AlertDialogCancel>
           <AlertDialogAction
-            onClick={deleteConfig.onDelete}
+            onClick={(e) => {
+              e.preventDefault();
+              deleteConfig.onDelete().finally(() => setDeleteOpen(false));
+            }}
             disabled={deleteConfig.isDeleting}
             className="bg-red-600 hover:bg-red-700"
           >
@@ -199,7 +202,7 @@ export function FormModalShell({
         <Dialog open={open} onOpenChange={onOpenChange}>
           <DialogContent
             id={id}
-            size={size !== "lg" ? size : undefined}
+            size={size}
             className={contentClassName}
             isDirty={isDirty}
             onAttemptClose={onAttemptClose}
@@ -209,10 +212,15 @@ export function FormModalShell({
                 {actionsDropdown}
               </div>
             )}
-            <form onSubmit={onSubmit} className="flex flex-col">
+            <form onSubmit={(e) => { e.preventDefault(); onSubmit?.(e); }} className="flex flex-col">
               <DialogHeader>
                 <div className="flex items-start justify-between gap-4 pr-10">
                   <div>
+                    {Icon && (
+                      <div className="text-primary/80 mb-3">
+                        <Icon className="h-8 w-8" />
+                      </div>
+                    )}
                     <DialogTitle>{title}</DialogTitle>
                     {description && (
                       <DialogDescription>{description}</DialogDescription>
@@ -220,9 +228,11 @@ export function FormModalShell({
                   </div>
                 </div>
               </DialogHeader>
-              <div className="py-4 space-y-4">
-                {children}
-              </div>
+              <ScrollArea className="max-h-[60vh]">
+                <div className="py-4 space-y-4">
+                  {children}
+                </div>
+              </ScrollArea>
               <DialogFooter>
                 <Button
                   type="button"

--- a/components/ui/form-modal-shell.tsx
+++ b/components/ui/form-modal-shell.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import * as React from "react";
+import { useState } from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetDescription,
+  SheetFooter,
+} from "@/components/ui/sheet";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription as AlertDialogDesc,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle as AlertDialogTitle_,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  CustomDropdown,
+  CustomDropdownItem,
+  CustomDropdownSeparator,
+} from "@/components/ui/custom-dropdown";
+import { MoreHorizontal, Trash2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface FormModalAction {
+  label: string;
+  icon?: React.ComponentType<{ className?: string }>;
+  onClick: () => void;
+  destructive?: boolean;
+}
+
+export interface FormModalDeleteConfig {
+  onDelete: () => Promise<void>;
+  isDeleting: boolean;
+  itemName: string;
+  title?: string;
+}
+
+interface FormModalShellProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onAttemptClose?: () => void;
+  isDirty?: boolean;
+  title: string;
+  description?: string;
+  onCancel: () => void;
+  onSubmit?: (e: React.FormEvent) => void | Promise<void>;
+  isSubmitting: boolean;
+  submitLabel: string;
+  loadingLabel?: string;
+  children: React.ReactNode;
+  actions?: FormModalAction[];
+  deleteConfig?: FormModalDeleteConfig;
+  variant?: "sheet" | "dialog";
+  icon?: React.ComponentType<{ className?: string }>;
+  contentClassName?: string;
+  id?: string;
+  size?: "sm" | "md" | "lg" | "xl" | "full";
+}
+
+function SubmitContent({
+  isSubmitting,
+  submitLabel,
+  loadingLabel = "Wird gespeichert...",
+}: {
+  isSubmitting: boolean;
+  submitLabel: string;
+  loadingLabel?: string;
+}) {
+  if (!isSubmitting) return <>{submitLabel}</>;
+  return (
+    <span className="flex items-center gap-2">
+      <svg className="animate-spin h-5 w-5" style={{ animationDuration: "600ms" }} viewBox="0 0 24 24">
+        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+      </svg>
+      {loadingLabel}
+    </span>
+  );
+}
+
+export function FormModalShell({
+  open,
+  onOpenChange,
+  onAttemptClose,
+  isDirty,
+  title,
+  description,
+  onCancel,
+  onSubmit,
+  isSubmitting,
+  submitLabel,
+  loadingLabel,
+  children,
+  actions = [],
+  deleteConfig,
+  variant = "sheet",
+  icon: Icon,
+  contentClassName,
+  id,
+  size = "lg",
+}: FormModalShellProps) {
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const dropdownItems = [...actions];
+  if (deleteConfig) {
+    if (actions.length > 0) {
+      dropdownItems.push({ label: "separator" } as any);
+    }
+    dropdownItems.push({
+      label: "Löschen",
+      icon: Trash2,
+      onClick: () => setDeleteOpen(true),
+      destructive: true,
+    });
+  }
+
+  const actionsDropdown = dropdownItems.length > 0 && (
+    <CustomDropdown
+      trigger={
+        <Button
+          variant="ghost"
+          size="icon"
+          className="rounded-lg opacity-50 hover:opacity-100 hover:bg-hover-bg pointer-events-auto cursor-pointer h-8 w-8"
+        >
+          <MoreHorizontal className="h-5 w-5" />
+          <span className="sr-only">Aktionen</span>
+        </Button>
+      }
+      align="end"
+    >
+      {dropdownItems.map((item: any, i: number) => {
+        if (item.label === "separator") {
+          return <CustomDropdownSeparator key={`sep-${i}`} />;
+        }
+        return (
+          <CustomDropdownItem
+            key={item.label}
+            onClick={item.onClick}
+            className={item.destructive ? "text-red-600 focus:text-red-600" : undefined}
+          >
+            {item.icon && <item.icon className="h-4 w-4 mr-2" />}
+            <span>{item.label}</span>
+          </CustomDropdownItem>
+        );
+      })}
+    </CustomDropdown>
+  );
+
+  const deleteDialog = deleteConfig && (
+    <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle_>
+            {deleteConfig.title || "Eintrag löschen?"}
+          </AlertDialogTitle_>
+          <AlertDialogDesc>
+            Möchten Sie &ldquo;{deleteConfig.itemName}&rdquo; wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.
+          </AlertDialogDesc>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={deleteConfig.isDeleting}>
+            Abbrechen
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={deleteConfig.onDelete}
+            disabled={deleteConfig.isDeleting}
+            className="bg-red-600 hover:bg-red-700"
+          >
+            {deleteConfig.isDeleting ? "Löschen..." : "Löschen"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+
+  if (variant === "dialog") {
+    return (
+      <>
+        <Dialog open={open} onOpenChange={onOpenChange}>
+          <DialogContent
+            id={id}
+            size={size !== "lg" ? size : undefined}
+            className={contentClassName}
+            isDirty={isDirty}
+            onAttemptClose={onAttemptClose}
+          >
+            {actionsDropdown && (
+              <div className="absolute right-12 top-4 z-10">
+                {actionsDropdown}
+              </div>
+            )}
+            <form onSubmit={onSubmit} className="flex flex-col">
+              <DialogHeader>
+                <div className="flex items-start justify-between gap-4 pr-10">
+                  <div>
+                    <DialogTitle>{title}</DialogTitle>
+                    {description && (
+                      <DialogDescription>{description}</DialogDescription>
+                    )}
+                  </div>
+                </div>
+              </DialogHeader>
+              <div className="py-4 space-y-4">
+                {children}
+              </div>
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={onCancel}
+                  disabled={isSubmitting}
+                >
+                  Abbrechen
+                </Button>
+                <Button type="submit" disabled={isSubmitting}>
+                  <SubmitContent
+                    isSubmitting={isSubmitting}
+                    submitLabel={submitLabel}
+                    loadingLabel={loadingLabel}
+                  />
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+        {deleteDialog}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent
+          id={id}
+          className={cn(
+            "sm:max-w-[600px] flex flex-col h-full p-0 gap-0",
+            contentClassName,
+          )}
+          isDirty={isDirty}
+          onAttemptClose={onAttemptClose}
+        >
+          {actionsDropdown && (
+            <div className="absolute top-0 left-0 right-0 h-14 flex items-center justify-end px-4 z-10 pointer-events-none">
+              <div className="pointer-events-auto">{actionsDropdown}</div>
+            </div>
+          )}
+          <form onSubmit={onSubmit} className="flex flex-col flex-1 min-h-0">
+            <ScrollArea className="flex-1">
+              <div className="max-w-[520px] mx-auto pt-20 pb-10 px-8 space-y-12">
+                {Icon && (
+                  <div className="text-primary/80">
+                    <Icon className="h-10 w-10" />
+                  </div>
+                )}
+                <div className="space-y-1">
+                  <SheetTitle className="text-4xl font-bold tracking-tight">
+                    {title}
+                  </SheetTitle>
+                  {description && (
+                    <SheetDescription className="text-base text-muted-foreground/80">
+                      {description}
+                    </SheetDescription>
+                  )}
+                </div>
+                {children}
+              </div>
+            </ScrollArea>
+            <SheetFooter className="p-8 pt-4">
+              <div className="max-w-[520px] mx-auto w-full flex gap-3">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={onCancel}
+                  disabled={isSubmitting}
+                  className="flex-1 rounded-xl h-11 text-muted-foreground hover:text-foreground hover:scale-[1.005] active:scale-[0.995] hover:shadow-none"
+                >
+                  Abbrechen
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="flex-1 rounded-xl h-11 shadow-sm font-semibold hover:scale-[1.005] active:scale-[0.995] hover:shadow-sm"
+                >
+                  <SubmitContent
+                    isSubmitting={isSubmitting}
+                    submitLabel={submitLabel}
+                    loadingLabel={loadingLabel}
+                  />
+                </Button>
+              </div>
+            </SheetFooter>
+          </form>
+        </SheetContent>
+      </Sheet>
+      {deleteDialog}
+    </>
+  );
+}

--- a/components/ui/form-modal-shell.tsx
+++ b/components/ui/form-modal-shell.tsx
@@ -37,6 +37,8 @@ import {
 import { MoreHorizontal, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
+const EMPTY_ACTIONS: FormModalAction[] = [];
+
 export interface FormModalAction {
   kind: "action";
   label: string;
@@ -110,7 +112,7 @@ export function FormModalShell({
   submitLabel,
   loadingLabel,
   children,
-  actions = [],
+  actions = EMPTY_ACTIONS,
   deleteConfig,
   variant = "sheet",
   icon: Icon,
@@ -154,7 +156,7 @@ export function FormModalShell({
         }
         return (
           <CustomDropdownItem
-            key={item.label + "-" + i}
+            key={item.label}
             onClick={item.onClick}
             className={item.destructive ? "text-red-600 focus:text-red-600" : undefined}
           >

--- a/components/ui/form-modal-shell.tsx
+++ b/components/ui/form-modal-shell.tsx
@@ -152,7 +152,7 @@ export function FormModalShell({
     >
       {dropdownItems.map((item, i) => {
         if (item.kind === "separator") {
-          return <CustomDropdownSeparator key={`sep-${i}`} />;
+          return <CustomDropdownSeparator key="action-separator" />;
         }
         return (
           <CustomDropdownItem

--- a/components/ui/form-modal-shell.tsx
+++ b/components/ui/form-modal-shell.tsx
@@ -150,7 +150,7 @@ export function FormModalShell({
         }
         return (
           <CustomDropdownItem
-            key={item.label}
+            key={item.label + "-" + i}
             onClick={item.onClick}
             className={item.destructive ? "text-red-600 focus:text-red-600" : undefined}
           >

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -15,7 +15,7 @@ const SelectGroup = SelectPrimitive.Group
 const SelectValue = SelectPrimitive.Value
 
 const selectTriggerVariants = cva(
-  "flex h-10 w-full cursor-pointer items-center justify-between rounded-xl border border-input bg-background px-4 py-2 text-sm ring-offset-background transition-all duration-200 placeholder:text-muted-foreground focus:outline-hidden focus:ring-0 focus:ring-offset-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 hover:scale-[1.02] active:scale-[0.98] hover:shadow-md hover:bg-gray-200 hover:text-foreground dark:btn-outline-hover disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1"
+  "flex h-10 w-full cursor-pointer items-center justify-between rounded-xl border border-input bg-background px-4 py-2 text-sm ring-offset-background transition-all duration-200 placeholder:text-muted-foreground focus:outline-hidden focus:ring-0 focus:ring-offset-0 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 hover:scale-[1.02] active:scale-[0.98] hover:shadow-md hover:bg-hover-bg hover:text-foreground dark:btn-outline-hover disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1"
 )
 
 const SelectTrigger = React.forwardRef<
@@ -120,7 +120,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-pointer select-none items-center rounded-lg py-2 pl-8 pr-2 mb-1 last:mb-0 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-200 active:scale-[0.98] data-disabled:pointer-events-none data-disabled:opacity-50",
+      "relative flex w-full cursor-pointer select-none items-center rounded-lg py-2 pl-8 pr-2 mb-1 last:mb-0 text-sm outline-hidden transition-all duration-150 focus:bg-hover-bg focus:text-foreground hover:bg-hover-bg active:scale-[0.98] data-disabled:pointer-events-none data-disabled:opacity-50",
       className
     )}
     {...props}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -120,7 +120,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-pointer select-none items-center rounded-lg py-2 pl-8 pr-2 mb-1 last:mb-0 text-sm outline-hidden transition-all duration-150 focus:bg-accent focus:text-accent-foreground hover:bg-accent/50 active:scale-[0.98] data-disabled:pointer-events-none data-disabled:opacity-50",
+      "relative flex w-full cursor-pointer select-none items-center rounded-lg py-2 pl-8 pr-2 mb-1 last:mb-0 text-sm outline-hidden transition-all duration-150 focus:bg-gray-200 focus:text-foreground hover:bg-gray-200 active:scale-[0.98] data-disabled:pointer-events-none data-disabled:opacity-50",
       className
     )}
     {...props}

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -118,8 +118,7 @@ const SheetContent = React.forwardRef<
           e.preventDefault();
         }}
         onCloseAutoFocus={(e) => {
-          // Let focus return to trigger on normal close (accessibility).
-          // Only prevent when the sheet is closing because of navigation (submit success).
+          // Intentionally empty: let Radix restore focus to the trigger element.
         }}
         onFocusOutside={(e) => {
           // Don't prevent focus from moving to combobox elements or when combobox is actively being used

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -6,6 +6,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { ChevronsRight } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
 
 const Sheet = SheetPrimitive.Root
 
@@ -133,12 +134,11 @@ const SheetContent = React.forwardRef<
         {...props}
       >
         {children}
-        <SheetPrimitive.Close 
-          onClick={handleCloseButtonClick}
-          className="absolute left-4 top-4 rounded-full p-2 opacity-70 ring-offset-background transition-all hover:opacity-100 hover:bg-muted focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary"
-        >
-          <ChevronsRight className="h-5 w-5" />
-          <span className="sr-only">Close</span>
+        <SheetPrimitive.Close asChild onClick={handleCloseButtonClick}>
+          <Button variant="ghost" size="icon" className="absolute left-4 top-4 rounded-lg opacity-50 hover:opacity-100 hover:bg-gray-200 dark:hover:bg-gray-800 cursor-pointer h-8 w-8">
+            <ChevronsRight className="h-5 w-5" />
+            <span className="sr-only">Close</span>
+          </Button>
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>
     </SheetPortal>

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -79,8 +79,7 @@ const SheetContent = React.forwardRef<
       target?.closest('[role="listbox"]') ||
       target?.closest('[data-dialog-ignore-interaction]') ||
       target?.closest('[data-combobox-dropdown]') ||
-      target?.hasAttribute('data-combobox-input') ||
-      target?.tagName === 'INPUT' && target?.closest('[data-radix-popover-content]')) {
+      target?.hasAttribute('data-combobox-input')) {
       return;
     }
 

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -135,7 +135,7 @@ const SheetContent = React.forwardRef<
       >
         {children}
         <SheetPrimitive.Close asChild onClick={handleCloseButtonClick}>
-          <Button variant="ghost" size="icon" className="absolute left-4 top-4 rounded-lg opacity-50 hover:opacity-100 hover:bg-gray-200 cursor-pointer h-8 w-8">
+          <Button variant="ghost" size="icon" className="absolute left-4 top-4 rounded-lg opacity-50 hover:opacity-100 hover:bg-hover-bg cursor-pointer h-8 w-8">
             <ChevronsRight className="h-5 w-5" />
             <span className="sr-only">Close</span>
           </Button>

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -32,7 +32,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-500 data-[state=open]:duration-500",
   {
     variants: {
       side: {
@@ -135,7 +135,7 @@ const SheetContent = React.forwardRef<
       >
         {children}
         <SheetPrimitive.Close asChild onClick={handleCloseButtonClick}>
-          <Button variant="ghost" size="icon" className="absolute left-4 top-4 rounded-lg opacity-50 hover:opacity-100 hover:bg-gray-200 dark:hover:bg-gray-800 cursor-pointer h-8 w-8">
+          <Button variant="ghost" size="icon" className="absolute left-4 top-4 rounded-lg opacity-50 hover:opacity-100 hover:bg-gray-200 cursor-pointer h-8 w-8">
             <ChevronsRight className="h-5 w-5" />
             <span className="sr-only">Close</span>
           </Button>

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -107,13 +107,19 @@ const SheetContent = React.forwardRef<
         ref={ref}
         className={cn(sheetVariants({ side }), className)}
         onInteractOutside={handleInteraction}
+        onEscapeKeyDown={(e) => {
+          if (isDirty && onAttemptClose) {
+            e.preventDefault();
+            onAttemptClose();
+          }
+        }}
         onOpenAutoFocus={(e) => {
           // Prevent auto focus to allow combobox inputs to work
           e.preventDefault();
         }}
         onCloseAutoFocus={(e) => {
-          // Prevent auto focus on close
-          e.preventDefault();
+          // Let focus return to trigger on normal close (accessibility).
+          // Only prevent when the sheet is closing because of navigation (submit success).
         }}
         onFocusOutside={(e) => {
           // Don't prevent focus from moving to combobox elements or when combobox is actively being used
@@ -136,7 +142,7 @@ const SheetContent = React.forwardRef<
         <SheetPrimitive.Close asChild onClick={handleCloseButtonClick}>
           <Button variant="ghost" size="icon" className="absolute left-4 top-4 rounded-lg opacity-50 hover:opacity-100 hover:bg-hover-bg cursor-pointer h-8 w-8">
             <ChevronsRight className="h-5 w-5" />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">Schließen</span>
           </Button>
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -32,7 +32,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-500 data-[state=open]:duration-500",
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-500 data-[state=open]:duration-500 focus:outline-none",
   {
     variants: {
       side: {

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
 import { cva, type VariantProps } from "class-variance-authority"
-import { X } from "lucide-react"
+import { ChevronsRight } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
@@ -51,27 +51,99 @@ const sheetVariants = cva(
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+    VariantProps<typeof sheetVariants> {
+  isDirty?: boolean
+  onAttemptClose?: () => void
+}
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
-  <SheetPortal>
-    <SheetOverlay />
-    <SheetPrimitive.Content
-      ref={ref}
-      className={cn(sheetVariants({ side }), className)}
-      {...props}
-    >
-      {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="h-3 w-3" />
-        <span className="sr-only">Close</span>
-      </SheetPrimitive.Close>
-    </SheetPrimitive.Content>
-  </SheetPortal>
-))
+>(({ side = "right", className, children, isDirty, onAttemptClose, ...props }, ref) => {
+  const handleInteraction = (
+    event: Parameters<NonNullable<React.ComponentProps<typeof SheetPrimitive.Content>['onInteractOutside']>>[0]
+  ) => {
+    if (!event) return;
+
+    // Check if the interaction is with a combobox or popover element
+    const target = event.target as Element;
+
+    if (target?.closest('[data-radix-popover-content]') ||
+      target?.closest('[data-radix-popper-content-wrapper]') ||
+      target?.hasAttribute('cmdk-input') ||
+      target?.hasAttribute('cmdk-item') ||
+      target?.hasAttribute('cmdk-list') ||
+      target?.closest('[role="combobox"]') ||
+      target?.closest('[role="option"]') ||
+      target?.closest('[role="listbox"]') ||
+      target?.closest('[data-dialog-ignore-interaction]') ||
+      target?.closest('[data-combobox-dropdown]') ||
+      target?.hasAttribute('data-combobox-input') ||
+      target?.tagName === 'INPUT' && target?.closest('[data-radix-popover-content]')) {
+      return;
+    }
+
+    if (isDirty && onAttemptClose) {
+      event.preventDefault();
+      onAttemptClose();
+    } else if (props.onInteractOutside) {
+      props.onInteractOutside(event);
+    }
+  };
+
+  const handleCloseButtonClick = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    if (isDirty && onAttemptClose) {
+      event.preventDefault();
+      onAttemptClose();
+    }
+  }
+
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        ref={ref}
+        className={cn(sheetVariants({ side }), className)}
+        onInteractOutside={handleInteraction}
+        onOpenAutoFocus={(e) => {
+          // Prevent auto focus to allow combobox inputs to work
+          e.preventDefault();
+        }}
+        onCloseAutoFocus={(e) => {
+          // Prevent auto focus on close
+          e.preventDefault();
+        }}
+        onFocusOutside={(e) => {
+          // Don't prevent focus from moving to combobox elements or when combobox is actively being used
+          const target = e.target as Element;
+          const activeComboboxInput = document.querySelector('[data-combobox-active="true"]')
+
+          if (target?.hasAttribute('data-combobox-input') ||
+            target?.hasAttribute('data-combobox-active') ||
+            target?.closest('[data-dialog-ignore-interaction]') ||
+            target?.closest('[data-combobox-dropdown]') ||
+            target?.closest('[role="listbox"]') ||
+            target?.closest('[role="option"]') ||
+            activeComboboxInput) {
+            e.preventDefault();
+          }
+        }}
+        {...props}
+      >
+        {children}
+        <SheetPrimitive.Close 
+          onClick={handleCloseButtonClick}
+          className="absolute left-4 top-4 rounded-full p-2 opacity-70 ring-offset-background transition-all hover:opacity-100 hover:bg-muted focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary"
+        >
+          <ChevronsRight className="h-5 w-5" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+})
 SheetContent.displayName = SheetPrimitive.Content.displayName
 
 const SheetHeader = ({

--- a/e2e/business-flows.spec.ts
+++ b/e2e/business-flows.spec.ts
@@ -92,7 +92,7 @@ test.describe('Business Logic Flows', () => {
     await page.fill('#manualGroesse', '150');
 
     // Submit
-    await page.getByRole('button', { name: /Speichern|Aktualisieren/i }).click();
+    await page.getByRole('button', { name: /anlegen|speichern|aktualisieren/i }).click();
 
     // Wait for modal to close
     try {


### PR DESCRIPTION
- Transitioned HouseEditModal from centered dialog to right-aligned sidebar (Sheet)
- Enhanced Sheet component with dirty state checking and improved focus handling
- Implemented modern, icon-driven property layout inspired by minimalist dashboard designs
- Added 'Tipp' hover cards with fixed circular lightbulb icons for property headers
- Standardized input styling with high-visibility backgrounds and consistent border radii
- Moved sidebar navigation controls (collapse/actions) to a balanced top header