### PR TITLE
feat: replace auto-redirect with manage screen for already-authorized…

### DIFF
--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -234,32 +234,114 @@ export default function ConsentUI({
         fetchCustomScopes();
     }, [authDetails]);
 
-    // Smart client logo detection based on name or ID
+    // Smart client logo detection based on name, ID, or redirect URI
     const getSmartClientConfig = (id?: string, name?: string, providedUri?: string, redirectTarget?: string) => {
         const lowerName = (name || '').toLowerCase();
 
-        // 1. Check known IDs first
+        // 1. Check known Mietevo IDs first
         if (id === OAUTH_CLIENT_IDS.MIETEVO) return { name: 'Mietevo', icon: LOGO_URL };
         if (id === OAUTH_CLIENT_IDS.MIETEVO_PUBLIC_MCP) return { name: 'Mietevo Public MCP', icon: LOGO_URL };
 
-        // 2. Use provided URI if it exists
+        // 2. Use provided URI if it exists (from Supabase client.logo_uri)
         if (providedUri) return { name: name || 'Unbekannte Anwendung', icon: providedUri };
 
-        // 3. Smart guess based on popular tools you might integrate
-        if (lowerName.includes('notion')) return { name: name || 'Notion', icon: 'https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png' };
-        if (lowerName.includes('claude') || lowerName.includes('anthropic')) return { name: name || 'Claude', icon: 'https://upload.wikimedia.org/wikipedia/commons/1/14/Claude_AI_logo.svg' };
-        if (lowerName.includes('chatgpt') || lowerName.includes('openai')) return { name: name || 'ChatGPT', icon: 'https://upload.wikimedia.org/wikipedia/commons/0/04/ChatGPT_logo.svg' };
-
-        // 4. Guess from the redirect/callback URL (the target application the user is connecting from)
-        if (redirectTarget) {
-            const lowerRedirect = redirectTarget.toLowerCase();
-            if (lowerRedirect.includes('notion.so')) return { name: name || 'Notion', icon: 'https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png' };
-            if (lowerRedirect.includes('perplexity')) return { name: name || 'Perplexity', icon: null };
+        // 3. Extract client identity from CIMD URL (client_id is often an HTTPS URL)
+        // Client ID Metadata Documents use HTTPS URLs as client_id
+        // e.g., https://claude.ai/oauth/claude-code-client-metadata
+        // The host identifies the client platform
+        if (id && id.startsWith('https://')) {
+            try {
+                const clientIdUrl = new URL(id);
+                const host = clientIdUrl.hostname.toLowerCase();
+                const cimdConfig = getClientConfigFromHost(host);
+                if (cimdConfig) return { name: name || cimdConfig.name, icon: cimdConfig.icon };
+            } catch {
+                // Invalid URL, fall through
+            }
         }
 
-        // 5. Default fallback
+        // 4. Detect from redirect URI (cloud clients use their domain as callback)
+        // e.g., https://claude.ai/callback, https://www.notion.so/workflows/mcp/oauth/callback
+        if (redirectTarget) {
+            try {
+                const redirectUrl = new URL(redirectTarget);
+                const host = redirectUrl.hostname.toLowerCase();
+                const redirectConfig = getClientConfigFromHost(host);
+                if (redirectConfig) return { name: name || redirectConfig.name, icon: redirectConfig.icon };
+            } catch {
+                // Invalid URL, fall through
+            }
+        }
+
+        // 5. Smart guess based on popular tool names (from client.name)
+        if (lowerName.includes('notion')) return { name: name || 'Notion', icon: 'https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png' };
+        if (lowerName.includes('claude') || lowerName.includes('anthropic')) return { name: name || 'Claude', icon: 'https://upload.wikimedia.org/wikipedia/commons/1/14/Claude_AI_logo.svg' };
+        if (lowerName.includes('chatgpt') || lowerName.includes('openai') || lowerName.includes('codex')) return { name: name || 'ChatGPT', icon: 'https://upload.wikimedia.org/wikipedia/commons/0/04/ChatGPT_logo.svg' };
+        if (lowerName.includes('perplexity')) return { name: name || 'Perplexity', icon: 'https://www.perplexity.ai/favicon.ico' };
+        if (lowerName.includes('cursor')) return { name: name || 'Cursor', icon: 'https://cursor.com/favicon.ico' };
+        if (lowerName.includes('gemini') || lowerName.includes('google')) return { name: name || 'Gemini', icon: 'https://www.google.com/favicon.ico' };
+        if (lowerName.includes('windsurf') || lowerName.includes('codeium')) return { name: name || 'Windsurf', icon: 'https://windsurf.com/favicon.ico' };
+
+        // 6. Default fallback
         return { name: name || initialClientName || 'Unbekannte Anwendung', icon: initialClientIcon || null };
     };
+
+    // Map known OAuth client hosts to display names and icons
+    // Based on Client ID Metadata Document (CIMD) hosts and redirect URI hosts
+    function getClientConfigFromHost(host: string): { name: string; icon: string } | null {
+        const normalizedHost = host.replace(/^www\./, ''); // Normalize www subdomain
+
+        const knownClients: Record<string, { name: string; icon: string }> = {
+            // Notion
+            'notion.so': { name: 'Notion', icon: 'https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png' },
+            'api.notion.com': { name: 'Notion', icon: 'https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png' },
+
+            // Anthropic / Claude
+            'claude.ai': { name: 'Claude', icon: 'https://upload.wikimedia.org/wikipedia/commons/1/14/Claude_AI_logo.svg' },
+            'anthropic.com': { name: 'Claude', icon: 'https://upload.wikimedia.org/wikipedia/commons/1/14/Claude_AI_logo.svg' },
+
+            // OpenAI / ChatGPT / Codex
+            'chatgpt.com': { name: 'ChatGPT', icon: 'https://upload.wikimedia.org/wikipedia/commons/0/04/ChatGPT_logo.svg' },
+            'openai.com': { name: 'ChatGPT', icon: 'https://upload.wikimedia.org/wikipedia/commons/0/04/ChatGPT_logo.svg' },
+            'api.openai.com': { name: 'ChatGPT', icon: 'https://upload.wikimedia.org/wikipedia/commons/0/04/ChatGPT_logo.svg' },
+
+            // Perplexity
+            'perplexity.ai': { name: 'Perplexity', icon: 'https://www.perplexity.ai/favicon.ico' },
+            'api.perplexity.ai': { name: 'Perplexity', icon: 'https://www.perplexity.ai/favicon.ico' },
+
+            // Cursor (uses mcp-remote)
+            'cursor.com': { name: 'Cursor', icon: 'https://cursor.com/favicon.ico' },
+            'cursor.sh': { name: 'Cursor', icon: 'https://cursor.com/favicon.ico' },
+
+            // Google / Gemini
+            'google.com': { name: 'Gemini', icon: 'https://www.google.com/favicon.ico' },
+            'vertexaisearch.cloud.google.com': { name: 'Gemini', icon: 'https://www.google.com/favicon.ico' },
+            'generativelanguage.googleapis.com': { name: 'Gemini', icon: 'https://www.google.com/favicon.ico' },
+
+            // Windsurf / Codeium
+            'windsurf.com': { name: 'Windsurf', icon: 'https://windsurf.com/favicon.ico' },
+            'codeium.com': { name: 'Windsurf', icon: 'https://windsurf.com/favicon.ico' },
+
+            // Replit
+            'replit.com': { name: 'Replit', icon: 'https://replit.com/favicon.ico' },
+
+            // Sourcegraph / Cody
+            'sourcegraph.com': { name: 'Cody', icon: 'https://sourcegraph.com/favicon.ico' },
+            'cody.dev': { name: 'Cody', icon: 'https://sourcegraph.com/favicon.ico' },
+        };
+
+        // Exact match
+        if (knownClients[normalizedHost]) return knownClients[normalizedHost];
+
+        // Subdomain match (e.g., api.notion.com -> notion.so)
+        for (const [knownHost, config] of Object.entries(knownClients)) {
+            if (normalizedHost === knownHost || normalizedHost.endsWith('.' + knownHost)) {
+                return config;
+            }
+        }
+
+        return null;
+    }
 
     const clientId = authDetails?.client?.id;
     const redirectUri = authDetails?.redirect_uri || initialRedirectUri;
@@ -267,10 +349,10 @@ export default function ConsentUI({
         clientId,
         authDetails?.client?.name || initialClientName,
         authDetails?.client?.logo_uri,
-		redirectUri || autoRedirectUrl
-	);
+        redirectUri || autoRedirectUrl
+    );
 
-	// Merge Supabase scopes with our custom stashed scopes
+    // Merge Supabase scopes with our custom stashed scopes
     const rawSupabaseScopes = typeof authDetails?.scopes === 'string' ? authDetails.scopes.split(' ') : (authDetails?.scopes || []);
     const mergedScopes = Array.from(new Set([...rawSupabaseScopes, ...customScopes, ...(initialScopes || [])])).filter(s => s !== 'offline_access');
     const scopes = mergedScopes.length > 0 ? mergedScopes : ['openid', 'email'];

--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -66,6 +66,161 @@ import { LOGO_URL, BRAND_NAME, OAUTH_CLIENT_IDS, MIETEVO_MCP_URL } from '@/lib/c
 
 import { isValidRedirect, isValidSupabaseRedirect } from '@/lib/oauth-utils';
 
+// Logo header — logos, arrow, and labels shared between manage and consent screens
+function OriginProductLogos({ clientIcon, clientName }: { clientIcon: string | null; clientName: string }) {
+    return (
+        <>
+            <div className="flex items-center justify-center gap-4 mb-8">
+                <motion.div
+                    initial={{ x: -20, opacity: 0 }}
+                    animate={{ x: 0, opacity: 1 }}
+                    transition={{ delay: 0.2, duration: 0.5 }}
+                    className="relative"
+                >
+                    <div className="absolute inset-0 bg-primary/10 dark:bg-primary/20 blur-xl rounded-full" />
+                    {clientIcon ? (
+                        <div className="w-16 h-16 rounded-4xl bg-white border border-border/40 dark:border-border/50 shadow-md dark:shadow-xl flex items-center justify-center overflow-hidden shrink-0 relative z-10">
+                            <div className="absolute inset-0 bg-linear-to-tr from-black/5 to-transparent mix-blend-multiply dark:mix-blend-normal dark:from-white/10 dark:to-transparent" />
+                            <img src={clientIcon} alt={clientName} className="w-10 h-10 object-contain drop-shadow-xs relative z-10" />
+                        </div>
+                    ) : (
+                        <div className="w-16 h-16 rounded-4xl bg-card border border-border/40 dark:border-border/70 shadow-md dark:shadow-xl flex items-center justify-center shrink-0 relative overflow-hidden z-10">
+                            <div className="absolute inset-0 bg-primary/5 dark:bg-primary/10" />
+                            <ShieldAlert className="w-7 h-7 text-primary relative z-10" />
+                        </div>
+                    )}
+                </motion.div>
+
+                <motion.div
+                    initial={{ scale: 0.95, opacity: 0 }}
+                    animate={{ scale: 1, opacity: 1 }}
+                    transition={{ delay: 0.4, type: "spring" }}
+                    className="flex items-center justify-center text-muted-foreground/60"
+                >
+                    <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4-4 4m-6-8v12" />
+                    </svg>
+                </motion.div>
+
+                <motion.div
+                    initial={{ x: 20, opacity: 0 }}
+                    animate={{ x: 0, opacity: 1 }}
+                    transition={{ delay: 0.3, duration: 0.5 }}
+                    className="relative"
+                >
+                    <div className="absolute inset-0 bg-primary/10 dark:bg-primary/20 blur-xl rounded-full" />
+                    <div className="w-16 h-16 rounded-4xl bg-card border border-border/40 dark:border-border/70 shadow-md dark:shadow-xl flex items-center justify-center shrink-0 relative overflow-hidden z-10">
+                        <div className="absolute inset-0 bg-linear-to-tr from-black/5 dark:from-black/20 to-transparent" />
+                        <img src={LOGO_URL} alt={BRAND_NAME} className="w-10 h-10 object-contain relative z-10 dark:brightness-110" />
+                    </div>
+                </motion.div>
+            </div>
+
+            <div className="flex justify-center gap-4 mb-6">
+                <div className="flex flex-col items-center">
+                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Ursprung</span>
+                    <span className="text-sm font-semibold text-foreground">{clientName}</span>
+                </div>
+                <div className="flex flex-col items-center text-muted-foreground/60">
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4-4 4m-6-8v12" />
+                    </svg>
+                </div>
+                <div className="flex flex-col items-center">
+                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Produkt</span>
+                    <span className="text-sm font-semibold text-primary">Mietevo MCP</span>
+                </div>
+            </div>
+        </>
+    );
+}
+
+// Map known OAuth client hosts to display names and icons
+// Based on Client ID Metadata Document (CIMD) hosts and redirect URI hosts
+function getClientConfigFromHost(host: string): { name: string; icon: string } | null {
+    const normalizedHost = host.replace(/^www\./, '');
+
+    const knownClients: Record<string, { name: string; icon: string }> = {
+        'notion.so': { name: 'Notion', icon: 'https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png' },
+        'api.notion.com': { name: 'Notion', icon: 'https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png' },
+        'claude.ai': { name: 'Claude', icon: 'https://upload.wikimedia.org/wikipedia/commons/1/14/Claude_AI_logo.svg' },
+        'anthropic.com': { name: 'Claude', icon: 'https://upload.wikimedia.org/wikipedia/commons/1/14/Claude_AI_logo.svg' },
+        'chatgpt.com': { name: 'ChatGPT', icon: 'https://upload.wikimedia.org/wikipedia/commons/0/04/ChatGPT_logo.svg' },
+        'openai.com': { name: 'ChatGPT', icon: 'https://upload.wikimedia.org/wikipedia/commons/0/04/ChatGPT_logo.svg' },
+        'api.openai.com': { name: 'ChatGPT', icon: 'https://upload.wikimedia.org/wikipedia/commons/0/04/ChatGPT_logo.svg' },
+        'perplexity.ai': { name: 'Perplexity', icon: 'https://www.perplexity.ai/favicon.ico' },
+        'api.perplexity.ai': { name: 'Perplexity', icon: 'https://www.perplexity.ai/favicon.ico' },
+        'cursor.com': { name: 'Cursor', icon: 'https://cursor.com/favicon.ico' },
+        'cursor.sh': { name: 'Cursor', icon: 'https://cursor.com/favicon.ico' },
+        'google.com': { name: 'Gemini', icon: 'https://www.google.com/favicon.ico' },
+        'vertexaisearch.cloud.google.com': { name: 'Gemini', icon: 'https://www.google.com/favicon.ico' },
+        'generativelanguage.googleapis.com': { name: 'Gemini', icon: 'https://www.google.com/favicon.ico' },
+        'windsurf.com': { name: 'Windsurf', icon: 'https://windsurf.com/favicon.ico' },
+        'codeium.com': { name: 'Windsurf', icon: 'https://windsurf.com/favicon.ico' },
+        'replit.com': { name: 'Replit', icon: 'https://replit.com/favicon.ico' },
+        'sourcegraph.com': { name: 'Cody', icon: 'https://sourcegraph.com/favicon.ico' },
+        'cody.dev': { name: 'Cody', icon: 'https://sourcegraph.com/favicon.ico' },
+    };
+
+    if (knownClients[normalizedHost]) return knownClients[normalizedHost];
+
+    for (const [knownHost, config] of Object.entries(knownClients)) {
+        if (normalizedHost === knownHost || normalizedHost.endsWith('.' + knownHost)) {
+            return config;
+        }
+    }
+
+    return null;
+}
+
+function getSmartClientConfig(
+    id: string | undefined,
+    name: string | undefined,
+    providedUri: string | undefined,
+    redirectTarget: string | undefined,
+    defaultName: string | undefined,
+    defaultIcon: string | null | undefined
+): { name: string; icon: string | null } {
+    const lowerName = (name || '').toLowerCase();
+
+    if (id === OAUTH_CLIENT_IDS.MIETEVO) return { name: 'Mietevo', icon: LOGO_URL };
+    if (id === OAUTH_CLIENT_IDS.MIETEVO_PUBLIC_MCP) return { name: 'Mietevo Public MCP', icon: LOGO_URL };
+
+    if (providedUri) return { name: name || 'Unbekannte Anwendung', icon: providedUri };
+
+    if (id && id.startsWith('https://')) {
+        try {
+            const clientIdUrl = new URL(id);
+            const host = clientIdUrl.hostname.toLowerCase();
+            const cimdConfig = getClientConfigFromHost(host);
+            if (cimdConfig) return { name: name || cimdConfig.name, icon: cimdConfig.icon };
+        } catch {
+            // Invalid URL, fall through
+        }
+    }
+
+    if (redirectTarget) {
+        try {
+            const redirectUrl = new URL(redirectTarget);
+            const host = redirectUrl.hostname.toLowerCase();
+            const redirectConfig = getClientConfigFromHost(host);
+            if (redirectConfig) return { name: name || redirectConfig.name, icon: redirectConfig.icon };
+        } catch {
+            // Invalid URL, fall through
+        }
+    }
+
+    if (lowerName.includes('notion')) return { name: name || 'Notion', icon: 'https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png' };
+    if (lowerName.includes('claude') || lowerName.includes('anthropic')) return { name: name || 'Claude', icon: 'https://upload.wikimedia.org/wikipedia/commons/1/14/Claude_AI_logo.svg' };
+    if (lowerName.includes('chatgpt') || lowerName.includes('openai') || lowerName.includes('codex')) return { name: name || 'ChatGPT', icon: 'https://upload.wikimedia.org/wikipedia/commons/0/04/ChatGPT_logo.svg' };
+    if (lowerName.includes('perplexity')) return { name: name || 'Perplexity', icon: 'https://www.perplexity.ai/favicon.ico' };
+    if (lowerName.includes('cursor')) return { name: name || 'Cursor', icon: 'https://cursor.com/favicon.ico' };
+    if (lowerName.includes('gemini') || lowerName.includes('google')) return { name: name || 'Gemini', icon: 'https://www.google.com/favicon.ico' };
+    if (lowerName.includes('windsurf') || lowerName.includes('codeium')) return { name: name || 'Windsurf', icon: 'https://windsurf.com/favicon.ico' };
+
+    return { name: name || defaultName || 'Unbekannte Anwendung', icon: defaultIcon || null };
+}
+
 /**
  * Validates a redirect URL before navigating to it.
  * Only HTTPS URLs whose origin is in the allowlist or the project's Supabase instance are accepted.
@@ -234,122 +389,15 @@ export default function ConsentUI({
         fetchCustomScopes();
     }, [authDetails]);
 
-    // Smart client logo detection based on name, ID, or redirect URI
-    const getSmartClientConfig = (id?: string, name?: string, providedUri?: string, redirectTarget?: string) => {
-        const lowerName = (name || '').toLowerCase();
-
-        // 1. Check known Mietevo IDs first
-        if (id === OAUTH_CLIENT_IDS.MIETEVO) return { name: 'Mietevo', icon: LOGO_URL };
-        if (id === OAUTH_CLIENT_IDS.MIETEVO_PUBLIC_MCP) return { name: 'Mietevo Public MCP', icon: LOGO_URL };
-
-        // 2. Use provided URI if it exists (from Supabase client.logo_uri)
-        if (providedUri) return { name: name || 'Unbekannte Anwendung', icon: providedUri };
-
-        // 3. Extract client identity from CIMD URL (client_id is often an HTTPS URL)
-        // Client ID Metadata Documents use HTTPS URLs as client_id
-        // e.g., https://claude.ai/oauth/claude-code-client-metadata
-        // The host identifies the client platform
-        if (id && id.startsWith('https://')) {
-            try {
-                const clientIdUrl = new URL(id);
-                const host = clientIdUrl.hostname.toLowerCase();
-                const cimdConfig = getClientConfigFromHost(host);
-                if (cimdConfig) return { name: name || cimdConfig.name, icon: cimdConfig.icon };
-            } catch {
-                // Invalid URL, fall through
-            }
-        }
-
-        // 4. Detect from redirect URI (cloud clients use their domain as callback)
-        // e.g., https://claude.ai/callback, https://www.notion.so/workflows/mcp/oauth/callback
-        if (redirectTarget) {
-            try {
-                const redirectUrl = new URL(redirectTarget);
-                const host = redirectUrl.hostname.toLowerCase();
-                const redirectConfig = getClientConfigFromHost(host);
-                if (redirectConfig) return { name: name || redirectConfig.name, icon: redirectConfig.icon };
-            } catch {
-                // Invalid URL, fall through
-            }
-        }
-
-        // 5. Smart guess based on popular tool names (from client.name)
-        if (lowerName.includes('notion')) return { name: name || 'Notion', icon: 'https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png' };
-        if (lowerName.includes('claude') || lowerName.includes('anthropic')) return { name: name || 'Claude', icon: 'https://upload.wikimedia.org/wikipedia/commons/1/14/Claude_AI_logo.svg' };
-        if (lowerName.includes('chatgpt') || lowerName.includes('openai') || lowerName.includes('codex')) return { name: name || 'ChatGPT', icon: 'https://upload.wikimedia.org/wikipedia/commons/0/04/ChatGPT_logo.svg' };
-        if (lowerName.includes('perplexity')) return { name: name || 'Perplexity', icon: 'https://www.perplexity.ai/favicon.ico' };
-        if (lowerName.includes('cursor')) return { name: name || 'Cursor', icon: 'https://cursor.com/favicon.ico' };
-        if (lowerName.includes('gemini') || lowerName.includes('google')) return { name: name || 'Gemini', icon: 'https://www.google.com/favicon.ico' };
-        if (lowerName.includes('windsurf') || lowerName.includes('codeium')) return { name: name || 'Windsurf', icon: 'https://windsurf.com/favicon.ico' };
-
-        // 6. Default fallback
-        return { name: name || initialClientName || 'Unbekannte Anwendung', icon: initialClientIcon || null };
-    };
-
-    // Map known OAuth client hosts to display names and icons
-    // Based on Client ID Metadata Document (CIMD) hosts and redirect URI hosts
-    function getClientConfigFromHost(host: string): { name: string; icon: string } | null {
-        const normalizedHost = host.replace(/^www\./, ''); // Normalize www subdomain
-
-        const knownClients: Record<string, { name: string; icon: string }> = {
-            // Notion
-            'notion.so': { name: 'Notion', icon: 'https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png' },
-            'api.notion.com': { name: 'Notion', icon: 'https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png' },
-
-            // Anthropic / Claude
-            'claude.ai': { name: 'Claude', icon: 'https://upload.wikimedia.org/wikipedia/commons/1/14/Claude_AI_logo.svg' },
-            'anthropic.com': { name: 'Claude', icon: 'https://upload.wikimedia.org/wikipedia/commons/1/14/Claude_AI_logo.svg' },
-
-            // OpenAI / ChatGPT / Codex
-            'chatgpt.com': { name: 'ChatGPT', icon: 'https://upload.wikimedia.org/wikipedia/commons/0/04/ChatGPT_logo.svg' },
-            'openai.com': { name: 'ChatGPT', icon: 'https://upload.wikimedia.org/wikipedia/commons/0/04/ChatGPT_logo.svg' },
-            'api.openai.com': { name: 'ChatGPT', icon: 'https://upload.wikimedia.org/wikipedia/commons/0/04/ChatGPT_logo.svg' },
-
-            // Perplexity
-            'perplexity.ai': { name: 'Perplexity', icon: 'https://www.perplexity.ai/favicon.ico' },
-            'api.perplexity.ai': { name: 'Perplexity', icon: 'https://www.perplexity.ai/favicon.ico' },
-
-            // Cursor (uses mcp-remote)
-            'cursor.com': { name: 'Cursor', icon: 'https://cursor.com/favicon.ico' },
-            'cursor.sh': { name: 'Cursor', icon: 'https://cursor.com/favicon.ico' },
-
-            // Google / Gemini
-            'google.com': { name: 'Gemini', icon: 'https://www.google.com/favicon.ico' },
-            'vertexaisearch.cloud.google.com': { name: 'Gemini', icon: 'https://www.google.com/favicon.ico' },
-            'generativelanguage.googleapis.com': { name: 'Gemini', icon: 'https://www.google.com/favicon.ico' },
-
-            // Windsurf / Codeium
-            'windsurf.com': { name: 'Windsurf', icon: 'https://windsurf.com/favicon.ico' },
-            'codeium.com': { name: 'Windsurf', icon: 'https://windsurf.com/favicon.ico' },
-
-            // Replit
-            'replit.com': { name: 'Replit', icon: 'https://replit.com/favicon.ico' },
-
-            // Sourcegraph / Cody
-            'sourcegraph.com': { name: 'Cody', icon: 'https://sourcegraph.com/favicon.ico' },
-            'cody.dev': { name: 'Cody', icon: 'https://sourcegraph.com/favicon.ico' },
-        };
-
-        // Exact match
-        if (knownClients[normalizedHost]) return knownClients[normalizedHost];
-
-        // Subdomain match (e.g., api.notion.com -> notion.so)
-        for (const [knownHost, config] of Object.entries(knownClients)) {
-            if (normalizedHost === knownHost || normalizedHost.endsWith('.' + knownHost)) {
-                return config;
-            }
-        }
-
-        return null;
-    }
-
     const clientId = authDetails?.client?.id;
     const redirectUri = authDetails?.redirect_uri || initialRedirectUri;
     const { name: clientName, icon: clientIcon } = getSmartClientConfig(
         clientId,
         authDetails?.client?.name || initialClientName,
         authDetails?.client?.logo_uri,
-        redirectUri || autoRedirectUrl
+        redirectUri || autoRedirectUrl,
+        initialClientName,
+        initialClientIcon
     );
 
     // Merge Supabase scopes with our custom stashed scopes
@@ -526,78 +574,7 @@ export default function ConsentUI({
 
                     <Card className="relative border-border/50 dark:border-border/30 bg-background/80 dark:bg-background/60 backdrop-blur-2xl shadow-xl dark:shadow-2xl rounded-[2.5rem] overflow-hidden">
                         <CardHeader className="text-center pt-10 px-8">
-                            <div className="flex items-center justify-center gap-4 mb-8">
-                                <motion.div
-                                    initial={{ x: -20, opacity: 0 }}
-                                    animate={{ x: 0, opacity: 1 }}
-                                    transition={{ delay: 0.2, duration: 0.5 }}
-                                    className="relative"
-                                >
-                                    <div className="absolute inset-0 bg-primary/10 dark:bg-primary/20 blur-xl rounded-full" />
-                                    {clientIcon ? (
-                                        <div className="w-16 h-16 rounded-4xl bg-white border border-border/40 dark:border-border/50 shadow-md dark:shadow-xl flex items-center justify-center overflow-hidden shrink-0 relative z-10">
-                                            <div className="absolute inset-0 bg-linear-to-tr from-black/5 to-transparent mix-blend-multiply dark:mix-blend-normal dark:from-white/10 dark:to-transparent" />
-                                            <img
-                                                src={clientIcon}
-                                                alt={clientName}
-                                                className="w-10 h-10 object-contain drop-shadow-xs relative z-10"
-                                            />
-                                        </div>
-                                    ) : (
-                                        <div className="w-16 h-16 rounded-4xl bg-card border border-border/40 dark:border-border/70 shadow-md dark:shadow-xl flex items-center justify-center shrink-0 relative overflow-hidden z-10">
-                                            <div className="absolute inset-0 bg-primary/5 dark:bg-primary/10" />
-                                            <ShieldAlert className="w-7 h-7 text-primary relative z-10" />
-                                        </div>
-                                    )}
-                                </motion.div>
-
-                                {/* Arrow between origin and product */}
-                                <motion.div
-                                    initial={{ scale: 0, opacity: 0 }}
-                                    animate={{ scale: 1, opacity: 1 }}
-                                    transition={{ delay: 0.4, type: "spring" }}
-                                    className="flex items-center justify-center text-muted-foreground/60"
-                                >
-                                    <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                                        <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4-4 4m-6-8v12" />
-                                    </svg>
-                                </motion.div>
-
-                                <motion.div
-                                    initial={{ x: 20, opacity: 0 }}
-                                    animate={{ x: 0, opacity: 1 }}
-                                    transition={{ delay: 0.3, duration: 0.5 }}
-                                    className="relative"
-                                >
-                                    <div className="absolute inset-0 bg-primary/10 dark:bg-primary/20 blur-xl rounded-full" />
-                                    <div className="w-16 h-16 rounded-4xl bg-card border border-border/40 dark:border-border/70 shadow-md dark:shadow-xl flex items-center justify-center shrink-0 relative overflow-hidden z-10">
-                                        <div className="absolute inset-0 bg-linear-to-tr from-black/5 dark:from-black/20 to-transparent" />
-                                        <img
-                                            src={LOGO_URL}
-                                            alt={BRAND_NAME}
-                                            className="w-10 h-10 object-contain relative z-10 dark:brightness-110"
-                                        />
-                                    </div>
-                                </motion.div>
-                            </div>
-
-                            {/* Origin / Product labels */}
-                            <div className="flex justify-center gap-4 mb-6">
-                                <div className="flex flex-col items-center">
-                                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Ursprung</span>
-                                    <span className="text-sm font-semibold text-foreground">{clientName}</span>
-                                </div>
-                                <div className="flex flex-col items-center text-muted-foreground/60">
-                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                                        <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4-4 4m-6-8v12" />
-                                    </svg>
-                                </div>
-                                <div className="flex flex-col items-center">
-                                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Produkt</span>
-                                    <span className="text-sm font-semibold text-primary">Mietevo MCP</span>
-                                </div>
-                            </div>
-
+                            <OriginProductLogos clientIcon={clientIcon} clientName={clientName} />
                             <CardTitle className="text-2xl md:text-3xl font-extrabold tracking-tight leading-tight bg-clip-text text-transparent bg-linear-to-br from-foreground to-muted-foreground pb-1">
                                 Bereits verbunden
                             </CardTitle>
@@ -714,79 +691,7 @@ export default function ConsentUI({
 
                 <Card className="relative border-border/50 dark:border-border/30 bg-background/80 dark:bg-background/60 backdrop-blur-2xl shadow-xl dark:shadow-2xl rounded-[2.5rem] overflow-hidden">
                         <CardHeader className="text-center pt-10 px-8">
-                            {/* App logos with origin → product flow */}
-                            <div className="flex items-center justify-center gap-4 mb-8">
-                                <motion.div
-                                    initial={{ x: -20, opacity: 0 }}
-                                    animate={{ x: 0, opacity: 1 }}
-                                    transition={{ delay: 0.2, duration: 0.5 }}
-                                    className="relative"
-                                >
-                                    <div className="absolute inset-0 bg-primary/10 dark:bg-primary/20 blur-xl rounded-full" />
-                                    {clientIcon ? (
-                                        <div className="w-16 h-16 rounded-4xl bg-white border border-border/40 dark:border-border/50 shadow-md dark:shadow-xl flex items-center justify-center overflow-hidden shrink-0 relative z-10">
-                                            <div className="absolute inset-0 bg-linear-to-tr from-black/5 to-transparent mix-blend-multiply dark:mix-blend-normal dark:from-white/10 dark:to-transparent" />
-                                            <img
-                                                src={clientIcon}
-                                                alt={clientName}
-                                                className="w-10 h-10 object-contain drop-shadow-xs relative z-10"
-                                            />
-                                        </div>
-                                    ) : (
-                                        <div className="w-16 h-16 rounded-4xl bg-card border border-border/40 dark:border-border/70 shadow-md dark:shadow-xl flex items-center justify-center shrink-0 relative overflow-hidden z-10">
-                                            <div className="absolute inset-0 bg-primary/5 dark:bg-primary/10" />
-                                            <ShieldAlert className="w-7 h-7 text-primary relative z-10" />
-                                        </div>
-                                    )}
-                                </motion.div>
-
-                                {/* Arrow between origin and product */}
-                                <motion.div
-                                    initial={{ scale: 0, opacity: 0 }}
-                                    animate={{ scale: 1, opacity: 1 }}
-                                    transition={{ delay: 0.4, type: "spring" }}
-                                    className="flex items-center justify-center text-muted-foreground/60"
-                                >
-                                    <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                                        <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4-4 4m-6-8v12" />
-                                    </svg>
-                                </motion.div>
-
-                                <motion.div
-                                    initial={{ x: 20, opacity: 0 }}
-                                    animate={{ x: 0, opacity: 1 }}
-                                    transition={{ delay: 0.3, duration: 0.5 }}
-                                    className="relative"
-                                >
-                                    <div className="absolute inset-0 bg-primary/10 dark:bg-primary/20 blur-xl rounded-full" />
-                                    <div className="w-16 h-16 rounded-4xl bg-card border border-border/40 dark:border-border/70 shadow-md dark:shadow-xl flex items-center justify-center shrink-0 relative overflow-hidden z-10">
-                                        <div className="absolute inset-0 bg-linear-to-tr from-black/5 dark:from-black/20 to-transparent" />
-                                        <img
-                                            src={LOGO_URL}
-                                            alt={BRAND_NAME}
-                                            className="w-10 h-10 object-contain relative z-10 dark:brightness-110"
-                                        />
-                                    </div>
-                                </motion.div>
-                            </div>
-
-                            {/* Origin / Product labels */}
-                            <div className="flex justify-center gap-4 mb-6">
-                                <div className="flex flex-col items-center">
-                                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Ursprung</span>
-                                    <span className="text-sm font-semibold text-foreground">{clientName}</span>
-                                </div>
-                                <div className="flex flex-col items-center text-muted-foreground/60">
-                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                                        <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4-4 4m-6-8v12" />
-                                    </svg>
-                                </div>
-                                <div className="flex flex-col items-center">
-                                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Produkt</span>
-                                    <span className="text-sm font-semibold text-primary">Mietevo MCP</span>
-                                </div>
-                            </div>
-
+                            <OriginProductLogos clientIcon={clientIcon} clientName={clientName} />
                             <CardTitle className="text-2xl md:text-3xl font-extrabold tracking-tight leading-tight bg-clip-text text-transparent bg-linear-to-br from-foreground to-muted-foreground pb-1">
                                 Verbindung autorisieren
                             </CardTitle>

--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -49,7 +49,7 @@ const getScopeDetails = (scope: string) => {
 };
 
 interface ConsentUIProps {
-    type: 'consent' | 'error' | 'loading' | 'success';
+    type: 'consent' | 'error' | 'loading' | 'success' | 'manage';
     error?: string;
     authorizationId?: string;
     clientName?: string;
@@ -59,6 +59,7 @@ interface ConsentUIProps {
     isDemo?: boolean;
     initialData?: AuthorizationDetails;
     initialError?: string;
+    autoRedirectUrl?: string;
 }
 
 import { LOGO_URL, BRAND_NAME, OAUTH_CLIENT_IDS, MIETEVO_MCP_URL } from '@/lib/constants';
@@ -129,7 +130,8 @@ export default function ConsentUI({
     scopes: initialScopes = [],
     isDemo = false,
     initialData,
-    initialError
+    initialError,
+    autoRedirectUrl
 }: ConsentUIProps) {
     const [isProcessing, setIsProcessing] = useState(false);
     const [processError, setProcessError] = useState<string | null>(null);
@@ -233,7 +235,7 @@ export default function ConsentUI({
     }, [authDetails]);
 
     // Smart client logo detection based on name or ID
-    const getSmartClientConfig = (id?: string, name?: string, providedUri?: string) => {
+    const getSmartClientConfig = (id?: string, name?: string, providedUri?: string, redirectTarget?: string) => {
         const lowerName = (name || '').toLowerCase();
 
         // 1. Check known IDs first
@@ -248,20 +250,27 @@ export default function ConsentUI({
         if (lowerName.includes('claude') || lowerName.includes('anthropic')) return { name: name || 'Claude', icon: 'https://upload.wikimedia.org/wikipedia/commons/1/14/Claude_AI_logo.svg' };
         if (lowerName.includes('chatgpt') || lowerName.includes('openai')) return { name: name || 'ChatGPT', icon: 'https://upload.wikimedia.org/wikipedia/commons/0/04/ChatGPT_logo.svg' };
 
-        // 4. Default fallback
+        // 4. Guess from the redirect/callback URL (the target application the user is connecting from)
+        if (redirectTarget) {
+            const lowerRedirect = redirectTarget.toLowerCase();
+            if (lowerRedirect.includes('notion.so')) return { name: name || 'Notion', icon: 'https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png' };
+            if (lowerRedirect.includes('perplexity')) return { name: name || 'Perplexity', icon: null };
+        }
+
+        // 5. Default fallback
         return { name: name || initialClientName || 'Unbekannte Anwendung', icon: initialClientIcon || null };
     };
 
     const clientId = authDetails?.client?.id;
+    const redirectUri = authDetails?.redirect_uri || initialRedirectUri;
     const { name: clientName, icon: clientIcon } = getSmartClientConfig(
         clientId,
         authDetails?.client?.name || initialClientName,
-        authDetails?.client?.logo_uri
-    );
+        authDetails?.client?.logo_uri,
+		redirectUri || autoRedirectUrl
+	);
 
-    const redirectUri = authDetails?.redirect_uri || initialRedirectUri;
-
-    // Merge Supabase scopes with our custom stashed scopes
+	// Merge Supabase scopes with our custom stashed scopes
     const rawSupabaseScopes = typeof authDetails?.scopes === 'string' ? authDetails.scopes.split(' ') : (authDetails?.scopes || []);
     const mergedScopes = Array.from(new Set([...rawSupabaseScopes, ...customScopes, ...(initialScopes || [])])).filter(s => s !== 'offline_access');
     const scopes = mergedScopes.length > 0 ? mergedScopes : ['openid', 'email'];
@@ -415,6 +424,158 @@ export default function ConsentUI({
                         </div>
                     </CardContent>
                 </Card>
+            </FullScreenLayout>
+        );
+    }
+
+    // Manage screen — app was previously authorized, show details + continue/manage actions
+    if (type === 'manage') {
+        return (
+            <FullScreenLayout
+                showGlow
+                motionProps={{
+                    initial: { opacity: 0, y: 30, scale: 0.95 },
+                    animate: { opacity: 1, y: 0, scale: 1 },
+                    transition: { duration: 0.6, type: "spring", bounce: 0.4 }
+                }}
+            >
+                <div className="relative group">
+                    <div className="absolute -inset-0.5 bg-linear-to-br from-primary/30 to-primary/0 dark:from-primary/40 dark:to-primary/5 rounded-[2.5rem] blur-md opacity-30 dark:opacity-50 group-hover:opacity-60 dark:group-hover:opacity-80 transition duration-1000 group-hover:duration-300" />
+
+                    <Card className="relative border-border/50 dark:border-border/30 bg-background/80 dark:bg-background/60 backdrop-blur-2xl shadow-xl dark:shadow-2xl rounded-[2.5rem] overflow-hidden">
+                        <CardHeader className="text-center pt-10 px-8">
+                            <div className="flex items-center justify-center gap-6 mb-8">
+                                <motion.div
+                                    initial={{ x: -20, opacity: 0 }}
+                                    animate={{ x: 0, opacity: 1 }}
+                                    transition={{ delay: 0.2, duration: 0.5 }}
+                                    className="relative"
+                                >
+                                    <div className="absolute inset-0 bg-primary/10 dark:bg-primary/20 blur-xl rounded-full" />
+                                    {clientIcon ? (
+                                        <div className="w-16 h-16 rounded-4xl bg-white border border-border/40 dark:border-border/50 shadow-md dark:shadow-xl flex items-center justify-center overflow-hidden shrink-0 relative z-10">
+                                            <div className="absolute inset-0 bg-linear-to-tr from-black/5 to-transparent mix-blend-multiply dark:mix-blend-normal dark:from-white/10 dark:to-transparent" />
+                                            <img
+                                                src={clientIcon}
+                                                alt={clientName}
+                                                className="w-10 h-10 object-contain drop-shadow-xs relative z-10"
+                                            />
+                                        </div>
+                                    ) : (
+                                        <div className="w-16 h-16 rounded-4xl bg-card border border-border/40 dark:border-border/70 shadow-md dark:shadow-xl flex items-center justify-center shrink-0 relative overflow-hidden z-10">
+                                            <div className="absolute inset-0 bg-primary/5 dark:bg-primary/10" />
+                                            <ShieldAlert className="w-7 h-7 text-primary relative z-10" />
+                                        </div>
+                                    )}
+                                </motion.div>
+
+                                <motion.div
+                                    initial={{ scale: 0, opacity: 0 }}
+                                    animate={{ scale: 1, opacity: 1 }}
+                                    transition={{ delay: 0.4, type: "spring" }}
+                                >
+                                    <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-green-500/10 border border-green-500/20 shadow-xs">
+                                        <Check className="w-3.5 h-3.5 text-green-500" />
+                                        <span className="text-xs font-medium text-green-600 dark:text-green-400">Verbunden</span>
+                                    </div>
+                                </motion.div>
+
+                                <motion.div
+                                    initial={{ x: 20, opacity: 0 }}
+                                    animate={{ x: 0, opacity: 1 }}
+                                    transition={{ delay: 0.3, duration: 0.5 }}
+                                    className="relative"
+                                >
+                                    <div className="absolute inset-0 bg-primary/10 dark:bg-primary/20 blur-xl rounded-full" />
+                                    <div className="w-16 h-16 rounded-4xl bg-card border border-border/40 dark:border-border/70 shadow-md dark:shadow-xl flex items-center justify-center shrink-0 relative overflow-hidden z-10">
+                                        <div className="absolute inset-0 bg-linear-to-tr from-black/5 dark:from-black/20 to-transparent" />
+                                        <img
+                                            src={LOGO_URL}
+                                            alt={BRAND_NAME}
+                                            className="w-10 h-10 object-contain relative z-10 dark:brightness-110"
+                                        />
+                                    </div>
+                                </motion.div>
+                            </div>
+
+                            <CardTitle className="text-2xl md:text-3xl font-extrabold tracking-tight leading-tight bg-clip-text text-transparent bg-linear-to-br from-foreground to-muted-foreground pb-1">
+                                Bereits verbunden
+                            </CardTitle>
+                            <CardDescription className="text-base mt-2 max-w-sm mx-auto text-muted-foreground">
+                                <span className="font-semibold text-foreground">{clientName}</span> ist bereits mit Ihrem {BRAND_NAME}-Konto verbunden.
+                            </CardDescription>
+                        </CardHeader>
+
+                        <CardContent className="px-8 pb-4">
+                            {scopes.length > 0 && (
+                                <div className="mb-6">
+                                    <h3 className="text-sm font-medium text-muted-foreground mb-4 text-center">
+                                        Aktuelle Berechtigungen:
+                                    </h3>
+                                    <div className="rounded-2xl border border-border/40 bg-muted/30 dark:bg-background/50 overflow-hidden shadow-inner backdrop-blur-xs p-3 space-y-2">
+                                        {scopes.map((scope, index) => {
+                                            const details = getScopeDetails(scope);
+                                            return (
+                                                <motion.div
+                                                    initial={{ opacity: 0, x: -10 }}
+                                                    animate={{ opacity: 1, x: 0 }}
+                                                    transition={{ delay: 0.1 * index }}
+                                                    key={scope}
+                                                    className="flex items-start gap-4 p-3.5 rounded-xl bg-card border border-border/40 hover:border-primary/30 dark:border-border/30 dark:hover:border-border/80 transition-all duration-300"
+                                                >
+                                                    <div className="w-8 h-8 rounded-full bg-green-500/10 flex items-center justify-center shrink-0 mt-0.5">
+                                                        <Check className="w-4 h-4 text-green-500" />
+                                                    </div>
+                                                    <div className="flex-1 min-w-0">
+                                                        <p className="text-sm font-semibold text-foreground mb-0.5">
+                                                            {details.title}
+                                                        </p>
+                                                        <p className="text-xs text-muted-foreground leading-relaxed">
+                                                            {details.description}
+                                                        </p>
+                                                    </div>
+                                                </motion.div>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
+                            )}
+
+                            {processError && (
+                                <Alert variant="destructive" className="rounded-xl mb-4 bg-destructive/10 text-destructive border-destructive/20">
+                                    <AlertDescription>{processError}</AlertDescription>
+                                </Alert>
+                            )}
+                        </CardContent>
+
+                        <CardFooter className="flex flex-col gap-3 px-8 pb-8">
+                            <Button
+                                onClick={() => autoRedirectUrl ? safeRedirect(autoRedirectUrl) : window.close()}
+                                disabled={isProcessing}
+                                className="w-full h-12 rounded-xl text-base font-semibold border-none bg-primary text-primary-foreground hover:bg-primary/90 shadow-[0_4px_14px_rgba(var(--primary),0.2)] dark:shadow-[0_0_20px_rgba(var(--primary),0.3)] hover:shadow-[0_6px_20px_rgba(var(--primary),0.3)] dark:hover:shadow-[0_0_25px_rgba(var(--primary),0.5)] transition-all duration-300"
+                            >
+                                <Check className="w-5 h-5 mr-2" />
+                                Verbinden
+                            </Button>
+                            <Button
+                                variant="outline"
+                                onClick={() => window.open('/', '_blank')}
+                                className="w-full h-12 rounded-xl text-base font-medium"
+                            >
+                                <ShieldAlert className="w-4 h-4 mr-2" />
+                                Verwalten
+                            </Button>
+                            <Button
+                                variant="ghost"
+                                onClick={() => window.close()}
+                                className="w-full h-12 rounded-xl text-base font-medium hover:bg-destructive/10 hover:text-destructive transition-colors"
+                            >
+                                <X className="w-4 h-4 mr-2" />
+                                Schließen
+                            </Button>
+                        </CardFooter>
+                    </Card>
+                </div>
             </FullScreenLayout>
         );
     }

--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -444,7 +444,7 @@ export default function ConsentUI({
 
                     <Card className="relative border-border/50 dark:border-border/30 bg-background/80 dark:bg-background/60 backdrop-blur-2xl shadow-xl dark:shadow-2xl rounded-[2.5rem] overflow-hidden">
                         <CardHeader className="text-center pt-10 px-8">
-                            <div className="flex items-center justify-center gap-6 mb-8">
+                            <div className="flex items-center justify-center gap-4 mb-8">
                                 <motion.div
                                     initial={{ x: -20, opacity: 0 }}
                                     animate={{ x: 0, opacity: 1 }}
@@ -469,15 +469,16 @@ export default function ConsentUI({
                                     )}
                                 </motion.div>
 
+                                {/* Arrow between origin and product */}
                                 <motion.div
                                     initial={{ scale: 0, opacity: 0 }}
                                     animate={{ scale: 1, opacity: 1 }}
                                     transition={{ delay: 0.4, type: "spring" }}
+                                    className="flex items-center justify-center text-muted-foreground/60"
                                 >
-                                    <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-green-500/10 border border-green-500/20 shadow-xs">
-                                        <Check className="w-3.5 h-3.5 text-green-500" />
-                                        <span className="text-xs font-medium text-green-600 dark:text-green-400">Verbunden</span>
-                                    </div>
+                                    <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                                        <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4-4 4m-6-8v12" />
+                                    </svg>
                                 </motion.div>
 
                                 <motion.div
@@ -498,11 +499,28 @@ export default function ConsentUI({
                                 </motion.div>
                             </div>
 
+                            {/* Origin / Product labels */}
+                            <div className="flex justify-center gap-4 mb-6">
+                                <div className="flex flex-col items-center">
+                                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Ursprung</span>
+                                    <span className="text-sm font-semibold text-foreground">{clientName}</span>
+                                </div>
+                                <div className="flex flex-col items-center text-muted-foreground/60">
+                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                                        <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4-4 4m-6-8v12" />
+                                    </svg>
+                                </div>
+                                <div className="flex flex-col items-center">
+                                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Produkt</span>
+                                    <span className="text-sm font-semibold text-primary">Mietevo MCP</span>
+                                </div>
+                            </div>
+
                             <CardTitle className="text-2xl md:text-3xl font-extrabold tracking-tight leading-tight bg-clip-text text-transparent bg-linear-to-br from-foreground to-muted-foreground pb-1">
                                 Bereits verbunden
                             </CardTitle>
                             <CardDescription className="text-base mt-2 max-w-sm mx-auto text-muted-foreground">
-                                <span className="font-semibold text-foreground">{clientName}</span> ist bereits mit Ihrem {BRAND_NAME}-Konto verbunden.
+                                <span className="font-semibold text-foreground">{clientName}</span> ist bereits mit <span className="font-semibold text-primary">Mietevo MCP</span> verbunden.
                             </CardDescription>
                         </CardHeader>
 
@@ -613,70 +631,87 @@ export default function ConsentUI({
                 <div className="absolute -inset-0.5 bg-linear-to-br from-primary/30 to-primary/0 dark:from-primary/40 dark:to-primary/5 rounded-[2.5rem] blur-md opacity-30 dark:opacity-50 group-hover:opacity-60 dark:group-hover:opacity-80 transition duration-1000 group-hover:duration-300" />
 
                 <Card className="relative border-border/50 dark:border-border/30 bg-background/80 dark:bg-background/60 backdrop-blur-2xl shadow-xl dark:shadow-2xl rounded-[2.5rem] overflow-hidden">
-                    <CardHeader className="text-center pt-10 px-8">
-                        {/* App logos */}
-                        <div className="flex items-center justify-center gap-6 mb-8">
-                            <motion.div
-                                initial={{ x: -20, opacity: 0 }}
-                                animate={{ x: 0, opacity: 1 }}
-                                transition={{ delay: 0.2, duration: 0.5 }}
-                                className="relative"
-                            >
-                                <div className="absolute inset-0 bg-primary/10 dark:bg-primary/20 blur-xl rounded-full" />
-                                {clientIcon ? (
-                                    <div className="w-16 h-16 rounded-4xl bg-white border border-border/40 dark:border-border/50 shadow-md dark:shadow-xl flex items-center justify-center overflow-hidden shrink-0 relative z-10">
-                                        <div className="absolute inset-0 bg-linear-to-tr from-black/5 to-transparent mix-blend-multiply dark:mix-blend-normal dark:from-white/10 dark:to-transparent" />
+                        <CardHeader className="text-center pt-10 px-8">
+                            {/* App logos with origin → product flow */}
+                            <div className="flex items-center justify-center gap-4 mb-8">
+                                <motion.div
+                                    initial={{ x: -20, opacity: 0 }}
+                                    animate={{ x: 0, opacity: 1 }}
+                                    transition={{ delay: 0.2, duration: 0.5 }}
+                                    className="relative"
+                                >
+                                    <div className="absolute inset-0 bg-primary/10 dark:bg-primary/20 blur-xl rounded-full" />
+                                    {clientIcon ? (
+                                        <div className="w-16 h-16 rounded-4xl bg-white border border-border/40 dark:border-border/50 shadow-md dark:shadow-xl flex items-center justify-center overflow-hidden shrink-0 relative z-10">
+                                            <div className="absolute inset-0 bg-linear-to-tr from-black/5 to-transparent mix-blend-multiply dark:mix-blend-normal dark:from-white/10 dark:to-transparent" />
+                                            <img
+                                                src={clientIcon}
+                                                alt={clientName}
+                                                className="w-10 h-10 object-contain drop-shadow-xs relative z-10"
+                                            />
+                                        </div>
+                                    ) : (
+                                        <div className="w-16 h-16 rounded-4xl bg-card border border-border/40 dark:border-border/70 shadow-md dark:shadow-xl flex items-center justify-center shrink-0 relative overflow-hidden z-10">
+                                            <div className="absolute inset-0 bg-primary/5 dark:bg-primary/10" />
+                                            <ShieldAlert className="w-7 h-7 text-primary relative z-10" />
+                                        </div>
+                                    )}
+                                </motion.div>
+
+                                {/* Arrow between origin and product */}
+                                <motion.div
+                                    initial={{ scale: 0, opacity: 0 }}
+                                    animate={{ scale: 1, opacity: 1 }}
+                                    transition={{ delay: 0.4, type: "spring" }}
+                                    className="flex items-center justify-center text-muted-foreground/60"
+                                >
+                                    <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                                        <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4-4 4m-6-8v12" />
+                                    </svg>
+                                </motion.div>
+
+                                <motion.div
+                                    initial={{ x: 20, opacity: 0 }}
+                                    animate={{ x: 0, opacity: 1 }}
+                                    transition={{ delay: 0.3, duration: 0.5 }}
+                                    className="relative"
+                                >
+                                    <div className="absolute inset-0 bg-primary/10 dark:bg-primary/20 blur-xl rounded-full" />
+                                    <div className="w-16 h-16 rounded-4xl bg-card border border-border/40 dark:border-border/70 shadow-md dark:shadow-xl flex items-center justify-center shrink-0 relative overflow-hidden z-10">
+                                        <div className="absolute inset-0 bg-linear-to-tr from-black/5 dark:from-black/20 to-transparent" />
                                         <img
-                                            src={clientIcon}
-                                            alt={clientName}
-                                            className="w-10 h-10 object-contain drop-shadow-xs relative z-10"
+                                            src={LOGO_URL}
+                                            alt={BRAND_NAME}
+                                            className="w-10 h-10 object-contain relative z-10 dark:brightness-110"
                                         />
                                     </div>
-                                ) : (
-                                    <div className="w-16 h-16 rounded-4xl bg-card border border-border/40 dark:border-border/70 shadow-md dark:shadow-xl flex items-center justify-center shrink-0 relative overflow-hidden z-10">
-                                        <div className="absolute inset-0 bg-primary/5 dark:bg-primary/10" />
-                                        <ShieldAlert className="w-7 h-7 text-primary relative z-10" />
-                                    </div>
-                                )}
-                            </motion.div>
+                                </motion.div>
+                            </div>
 
-                            <motion.div
-                                initial={{ scale: 0, opacity: 0 }}
-                                animate={{ scale: 1, opacity: 1 }}
-                                transition={{ delay: 0.4, type: "spring" }}
-                                className="flex flex-col items-center justify-center"
-                            >
-                                <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-muted dark:bg-secondary/50 border border-border/30 dark:border-border/50 shadow-xs dark:shadow-inner">
-                                    <div className="w-1.5 h-1.5 rounded-full bg-primary/80 animate-pulse" />
-                                    <div className="w-1.5 h-1.5 rounded-full bg-primary/50 animate-pulse" style={{ animationDelay: '200ms' }} />
-                                    <div className="w-1.5 h-1.5 rounded-full bg-primary/30 animate-pulse" style={{ animationDelay: '400ms' }} />
+                            {/* Origin / Product labels */}
+                            <div className="flex justify-center gap-4 mb-6">
+                                <div className="flex flex-col items-center">
+                                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Ursprung</span>
+                                    <span className="text-sm font-semibold text-foreground">{clientName}</span>
                                 </div>
-                            </motion.div>
+                                <div className="flex flex-col items-center text-muted-foreground/60">
+                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                                        <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4-4 4m-6-8v12" />
+                                    </svg>
+                                </div>
+                                <div className="flex flex-col items-center">
+                                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Produkt</span>
+                                    <span className="text-sm font-semibold text-primary">Mietevo MCP</span>
+                                </div>
+                            </div>
 
-                            <motion.div
-                                initial={{ x: 20, opacity: 0 }}
-                                animate={{ x: 0, opacity: 1 }}
-                                transition={{ delay: 0.3, duration: 0.5 }}
-                                className="relative"
-                            >
-                                <div className="absolute inset-0 bg-primary/10 dark:bg-primary/20 blur-xl rounded-full" />
-                                <div className="w-16 h-16 rounded-4xl bg-card border border-border/40 dark:border-border/70 shadow-md dark:shadow-xl flex items-center justify-center shrink-0 relative overflow-hidden z-10">
-                                    <div className="absolute inset-0 bg-linear-to-tr from-black/5 dark:from-black/20 to-transparent" />
-                                    <img
-                                        src={LOGO_URL}
-                                        alt={BRAND_NAME}
-                                        className="w-10 h-10 object-contain relative z-10 dark:brightness-110"
-                                    />
-                                </div>
-                            </motion.div>
-                        </div>
-                        <CardTitle className="text-2xl md:text-3xl font-extrabold tracking-tight leading-tight bg-clip-text text-transparent bg-linear-to-br from-foreground to-muted-foreground pb-1">
-                            Verknüpfung erlauben
-                        </CardTitle>
-                        <CardDescription className="text-base mt-2 max-w-sm mx-auto text-muted-foreground">
-                            <span className="font-semibold text-foreground">{clientName}</span> fordert Zugriff auf Ihr {BRAND_NAME}-Konto an.
-                        </CardDescription>
-                    </CardHeader>
+                            <CardTitle className="text-2xl md:text-3xl font-extrabold tracking-tight leading-tight bg-clip-text text-transparent bg-linear-to-br from-foreground to-muted-foreground pb-1">
+                                Verbindung autorisieren
+                            </CardTitle>
+                            <CardDescription className="text-base mt-2 max-w-sm mx-auto text-muted-foreground">
+                                <span className="font-semibold text-foreground">{clientName}</span> möchte sich mit <span className="font-semibold text-primary">Mietevo MCP</span> verbinden.
+                            </CardDescription>
+                        </CardHeader>
                     <CardContent className="px-8 pb-4">
                         {scopes.length > 0 && (
                             <div className="mb-8">

--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -550,7 +550,20 @@ export default function ConsentUI({
 
                         <CardFooter className="flex flex-col gap-3 px-8 pb-8">
                             <Button
-                                onClick={() => autoRedirectUrl ? safeRedirect(autoRedirectUrl) : window.close()}
+                                onClick={() => {
+                                    if (autoRedirectUrl) {
+                                        if (isValidRedirect(autoRedirectUrl) || isValidSupabaseRedirect(autoRedirectUrl)) {
+                                            safeRedirect(autoRedirectUrl);
+                                        } else {
+                                            setProcessError('Ungültige Weiterleitungs-URL. Zugriff verweigert aus Sicherheitsgründen.');
+                                        }
+                                    } else {
+                                        window.close();
+                                        setTimeout(() => {
+                                            window.location.href = '/';
+                                        }, 100);
+                                    }
+                                }}
                                 disabled={isProcessing}
                                 className="w-full h-12 rounded-xl text-base font-semibold border-none bg-primary text-primary-foreground hover:bg-primary/90 shadow-[0_4px_14px_rgba(var(--primary),0.2)] dark:shadow-[0_0_20px_rgba(var(--primary),0.3)] hover:shadow-[0_6px_20px_rgba(var(--primary),0.3)] dark:hover:shadow-[0_0_25px_rgba(var(--primary),0.5)] transition-all duration-300"
                             >
@@ -559,7 +572,7 @@ export default function ConsentUI({
                             </Button>
                             <Button
                                 variant="outline"
-                                onClick={() => window.open('/', '_blank')}
+                                onClick={() => window.open('/einstellungen', '_blank')}
                                 className="w-full h-12 rounded-xl text-base font-medium"
                             >
                                 <ShieldAlert className="w-4 h-4 mr-2" />
@@ -567,7 +580,12 @@ export default function ConsentUI({
                             </Button>
                             <Button
                                 variant="ghost"
-                                onClick={() => window.close()}
+                                onClick={() => {
+                                    window.close();
+                                    setTimeout(() => {
+                                        window.location.href = '/';
+                                    }, 100);
+                                }}
                                 className="w-full h-12 rounded-xl text-base font-medium hover:bg-destructive/10 hover:text-destructive transition-colors"
                             >
                                 <X className="w-4 h-4 mr-2" />

--- a/app/oauth/consent/ConsentUI.tsx
+++ b/app/oauth/consent/ConsentUI.tsx
@@ -91,16 +91,25 @@ function OriginProductLogos({ clientIcon, clientName }: { clientIcon: string | n
                     )}
                 </motion.div>
 
-                <motion.div
-                    initial={{ scale: 0.95, opacity: 0 }}
-                    animate={{ scale: 1, opacity: 1 }}
-                    transition={{ delay: 0.4, type: "spring" }}
-                    className="flex items-center justify-center text-muted-foreground/60"
-                >
-                    <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4-4 4m-6-8v12" />
-                    </svg>
-                </motion.div>
+                <div className="flex items-center gap-[2px]">
+                    {[0, 1, 2, 3, 4].map((i) => (
+                        <motion.div
+                            key={i}
+                            initial={{ scale: 0, opacity: 0 }}
+                            animate={{
+                                scale: [0.3, 1.2, 0.3],
+                                opacity: [0.15, 0.9, 0.15],
+                            }}
+                            transition={{
+                                repeat: Infinity,
+                                duration: 1.6,
+                                delay: 0.5 + i * 0.12,
+                                ease: "easeInOut",
+                            }}
+                            className="w-1.5 h-1.5 rounded-full bg-primary/60"
+                        />
+                    ))}
+                </div>
 
                 <motion.div
                     initial={{ x: 20, opacity: 0 }}
@@ -120,11 +129,6 @@ function OriginProductLogos({ clientIcon, clientName }: { clientIcon: string | n
                 <div className="flex flex-col items-center">
                     <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Ursprung</span>
                     <span className="text-sm font-semibold text-foreground">{clientName}</span>
-                </div>
-                <div className="flex flex-col items-center text-muted-foreground/60">
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M17 8l4 4-4 4m-6-8v12" />
-                    </svg>
                 </div>
                 <div className="flex flex-col items-center">
                     <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Produkt</span>

--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -2,8 +2,8 @@ import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import ConsentUI from './ConsentUI';
-import { getAuthorizationDetailsAction } from './actions';
-import { safeServerRedirect } from '@/lib/oauth-utils';
+import { getAuthorizationDetailsAction, type AuthorizationDetails } from './actions';
+
 
 export const runtime = 'edge';
 
@@ -83,25 +83,21 @@ export default async function ConsentPage({ searchParams }: PageProps) {
         return <ConsentUI type="success" />;
     }
 
-    // Detect auto-approval: Supabase successfully returned a payload without client details
-    const autoRedirectUrl = data?.redirect_url || data?.redirect_to;
+    // Detect auto-approval: Supabase successfully returned a payload without client details.
+    // Instead of auto-redirecting (which silently completes the flow without user awareness),
+    // show a manage screen where the user can review the app, manage it, or continue.
+    const autoRedirectUrl = (data?.redirect_url || data?.redirect_to) as string | undefined;
     const isAutoApproved = success && !data?.client;
 
     if (isAutoApproved) {
-        console.info('[OAuth SSR] auto_approved detected', {
-            authorizationId,
-            redirect_to: data?.redirect_to,
-            redirect_url: data?.redirect_url,
-            resolved: autoRedirectUrl,
-        });
-
-        if (autoRedirectUrl) {
-            safeServerRedirect(autoRedirectUrl as string);
-        }
-
-        // auto_approved but no redirect url — redirect to a user-friendly error page
-        // instead of silently rendering the consent UI which would cause a 400 on approve.
-        redirect(`/oauth/consent?error=true&message=${encodeURIComponent('Automatische Autorisierung fehlgeschlagen: Kein Weiterleitungs-Link gefunden.')}`);
+        return (
+            <ConsentUI
+                type="manage"
+                authorizationId={authorizationId}
+                initialData={data as AuthorizationDetails}
+                autoRedirectUrl={autoRedirectUrl}
+            />
+        );
     }
 
     return (

--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -90,6 +90,14 @@ export default async function ConsentPage({ searchParams }: PageProps) {
     const isAutoApproved = success && !data?.client;
 
     if (isAutoApproved) {
+        if (!autoRedirectUrl) {
+            return (
+                <ConsentUI
+                    type="error"
+                    error="Automatische Autorisierung fehlgeschlagen: Kein Weiterleitungs-Link gefunden."
+                />
+            );
+        }
         return (
             <ConsentUI
                 type="manage"


### PR DESCRIPTION
## Description

Replaces the silent auto-redirect for already-authorized OAuth apps with a manage screen, giving users visibility into what is happening. Instead of silently redirecting when an OAuth authorization is auto-approved (previously authorized app), the user can now review and choose an action.

## Summary of Changes

- Show app details and scopes on the manage screen
- "Verbinden" completes the connection
- "Verwalten" opens the dashboard settings
- "Schließen" closes the popup