### PR TITLE
fix(tenants): prevent crash when tenant has no assigned apartment

### DIFF
--- a/components/tenants/tenant-payment-bento.tsx
+++ b/components/tenants/tenant-payment-bento.tsx
@@ -142,7 +142,7 @@ export function TenantPaymentBento() {
                     <button
                       type="button"
                       className="flex-1 px-2 py-1 rounded-full text-xs font-medium border transition-colors duration-150 bg-gray-50 dark:bg-gray-900/30 text-gray-700 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-900/50 flex items-center justify-center gap-1"
-                      disabled={updatingStatus === tenant.id}
+                      disabled={updatingStatus === tenant.id || !tenant.apartmentId}
                       onClick={() => openTenantPaymentEditModal({
                         id: tenant.id,
                         tenant: tenant.tenant,
@@ -168,7 +168,7 @@ export function TenantPaymentBento() {
                             : 'bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300 border-green-200 dark:border-green-700 hover:bg-green-100 dark:hover:bg-green-900/50'
                         }`
                       }
-                      disabled={updatingStatus === tenant.id}
+                      disabled={updatingStatus === tenant.id || !tenant.apartmentId}
                       onClick={() => toggleRentPayment(tenant)}
                     >
                       {updatingStatus === tenant.id ? (

--- a/components/tenants/tenant-payment-edit-modal.tsx
+++ b/components/tenants/tenant-payment-edit-modal.tsx
@@ -287,7 +287,7 @@ export default function TenantPaymentEditModal() {
     setTenantPaymentEditModalDirty(true)
   }
 
-  if (!isTenantPaymentEditModalOpen || !tenantPaymentEditInitialData) {
+  if (!isTenantPaymentEditModalOpen || !tenantPaymentEditInitialData || !tenantPaymentEditInitialData.apartmentId) {
     return null
   }
 

--- a/components/tenants/tenant-payment-overview-modal.tsx
+++ b/components/tenants/tenant-payment-overview-modal.tsx
@@ -248,7 +248,7 @@ export default function TenantPaymentOverviewModal() {
                       <button
                         type="button"
                         className="flex-1 px-2 py-1.5 rounded-xl text-xs font-medium border transition-colors duration-150 bg-gray-50 dark:bg-gray-900/30 text-gray-700 dark:text-gray-300 border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-900/50 flex items-center justify-center gap-1"
-                        disabled={updatingStatus === tenant.id}
+                        disabled={updatingStatus === tenant.id || !tenant.apartmentId}
                         onClick={() => openTenantPaymentEditModal({
                           id: tenant.id,
                           tenant: tenant.tenant,
@@ -274,7 +274,7 @@ export default function TenantPaymentOverviewModal() {
                             ? 'bg-orange-50 dark:bg-orange-900/20 text-orange-700 dark:text-orange-300 border-orange-200 dark:border-orange-800 hover:bg-orange-100 dark:hover:bg-orange-900/30'
                             : 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300 border-green-200 dark:border-green-800 hover:bg-green-100 dark:hover:bg-green-900/30'
                           }`}
-                        disabled={updatingStatus === tenant.id}
+                        disabled={updatingStatus === tenant.id || !tenant.apartmentId}
                         onClick={() => toggleRentPayment(tenant)}
                       >
                         {updatingStatus === tenant.id ? (

--- a/hooks/use-tenant-payments.ts
+++ b/hooks/use-tenant-payments.ts
@@ -76,6 +76,15 @@ export function useTenantPayments() {
     const toggleRentPayment = async (tenant: TenantBentoItem) => {
         if (updatingStatus === tenant.id) return
 
+        if (!tenant.apartmentId) {
+            toast({
+                title: "Keine Wohnung zugeordnet",
+                description: `Für ${tenant.tenant} ist keine Wohnung hinterlegt. Mietzahlungen können nur für Mieter mit zugeordneter Wohnung verwaltet werden.`,
+                variant: "destructive",
+            })
+            return
+        }
+
         const originalData = [...data]
         setUpdatingStatus(tenant.id)
 

--- a/hooks/use-tenant-payments.ts
+++ b/hooks/use-tenant-payments.ts
@@ -42,14 +42,14 @@ export function useTenantPayments() {
             )
 
             const formattedData: TenantBentoItem[] = activeTenants.map((mieter: any) => {
-                const mieteRaw = Number(mieter.Wohnungen.miete) || 0
+                const mieteRaw = Number(mieter.Wohnungen?.miete) || 0
                 const nebenkostenRaw = getLatestNebenkostenAmount(mieter.nebenkosten)
 
                 return {
                     id: mieter.id,
                     tenant: mieter.name,
-                    apartment: mieter.Wohnungen.name,
-                    apartmentId: mieter.Wohnungen.id,
+                    apartment: mieter.Wohnungen?.name || 'Keine Wohnung',
+                    apartmentId: mieter.Wohnungen?.id || '',
                     mieteRaw,
                     nebenkostenRaw,
                     actualRent: mieter.actualRent || 0,

--- a/types/tenant-payment.ts
+++ b/types/tenant-payment.ts
@@ -28,9 +28,9 @@ export type MieterData = {
     einzug: string | null
     auszug: string | null
     nebenkosten?: NebenkostenEntry[] | null
-    Wohnungen: {
+    Wohnungen?: {
         id: string
         name: string
         miete: number
-    }
+    } | null
 }


### PR DESCRIPTION
## Description

Prevents crashes in the tenant payment components when a tenant has no assigned apartment.

## Summary of Changes

- `use-tenant-payments.ts`: optional chaining on `mieter.Wohnungen`, "Keine Wohnung" fallback label, and a guard in `toggleRentPayment` that shows a destructive toast instead of firing the request when no apartment is assigned
- `tenant-payment-bento.tsx` / `tenant-payment-overview-modal.tsx`: payment buttons disabled when `tenant.apartmentId` is missing
- `tenant-payment-edit-modal.tsx`: does not render when `apartmentId` is missing
- `types/tenant-payment.ts`: `Wohnungen` is now optional/nullable