### PR TITLE
chore(docker): pin npm and upgrade alpine packages to fix vulnerabili…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,19 @@ updates:
         dependency-type: "development"
         update-types:
           - "patch"
+
+  # Enable version updates for Docker images
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Dependencies
-FROM node:22.22-alpine AS deps
+FROM node:22-alpine AS deps
 WORKDIR /app
 
 COPY package.json package-lock.json ./
@@ -8,7 +8,7 @@ RUN --mount=type=cache,target=/root/.npm \
     npm ci
 
 # Stage 2: Build the source code
-FROM node:22.22-alpine AS builder
+FROM node:22-alpine AS builder
 WORKDIR /app
 
 # Required at build time: inlined into client bundles
@@ -53,7 +53,7 @@ RUN --mount=type=secret,id=POSTHOG_PERSONAL_API_KEY \
     npm run build
 
 # Stage 3: Production image
-FROM node:22.22-alpine AS runner
+FROM node:22-alpine AS runner
 RUN apk upgrade --no-cache && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN --mount=type=secret,id=POSTHOG_PERSONAL_API_KEY \
 
 # Stage 3: Production image
 FROM node:22.22-alpine AS runner
-RUN apk upgrade --no-cache && npm install -g npm@11.17.0
+RUN apk upgrade --no-cache && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx
 WORKDIR /app
 
 # Runtime environment variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN --mount=type=secret,id=POSTHOG_PERSONAL_API_KEY \
 
 # Stage 3: Production image
 FROM node:22.22-alpine AS runner
+RUN apk upgrade --no-cache && npm install -g npm@11.17.0
 WORKDIR /app
 
 # Runtime environment variables


### PR DESCRIPTION
## Description

Hardens the Docker image: pins the base image tag for Dependabot tracking and upgrades Alpine packages in the runner stage to fix vulnerabilities.

## Summary of Changes

- `Dockerfile`: `node:22.22-alpine` → `node:22-alpine` in all stages so Dependabot can track the moving minor tag; runner stage runs `apk upgrade --no-cache` and removes the bundled npm/npx binaries from the production image
- `dependabot.yml`: new `docker` package ecosystem (weekly, Monday 09:00 Europe/Berlin, max 3 open PRs, `dependencies`+`docker` labels)