### PR TITLE
Update landing page tag icons

### DIFF
--- a/app/modern/components/feature-sections.tsx
+++ b/app/modern/components/feature-sections.tsx
@@ -2,7 +2,7 @@
 
 import { motion } from "framer-motion"
 import {
-  Sparkles, ListTodo, FileText, Download, ShieldCheck,
+  Sparkles, Hammer, ListTodo, FileText, Download, ShieldCheck,
   FolderOpen, FileSpreadsheet, History, CheckCircle2, Server
 } from "lucide-react"
 import Image from "next/image"
@@ -180,7 +180,7 @@ export default function FeatureSections() {
               transition={{ duration: 0.5 }}
               className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/5 border border-primary/10 backdrop-blur-xs mb-6"
             >
-              <Sparkles className="w-4 h-4 text-primary" />
+              <Hammer className="w-4 h-4 text-primary" />
               <span className="text-sm font-medium text-primary">Mehr Features</span>
             </motion.div>
 

--- a/app/modern/components/product-showcase.tsx
+++ b/app/modern/components/product-showcase.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import { motion, AnimatePresence } from "framer-motion"
-import { Sparkles, Home, Receipt, BarChart3, Maximize2, X } from "lucide-react"
+import { Sparkles, Layers, Home, Receipt, BarChart3, Maximize2, X } from "lucide-react"
 import Image from "next/image"
 import { cn } from "@/lib/utils"
 
@@ -59,7 +59,7 @@ export default function ProductShowcase() {
                         transition={{ duration: 0.5 }}
                         className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/5 border border-primary/10 backdrop-blur-xs mb-6"
                     >
-                        <Sparkles className="w-4 h-4 text-primary" />
+                        <Layers className="w-4 h-4 text-primary" />
                         <span className="text-sm font-medium text-primary">Plattform</span>
                     </motion.div>
 


### PR DESCRIPTION
Fixes an issue where the generic Sparkles icon was used for multiple tags on the landing page. Replaced the Sparkles icon with more descriptive icons (Hammer and Layers) for the "Mehr Features" and "Plattform" tags respectively, per user request.

---
*PR created automatically by Jules for task [14861962237167552847](https://jules.google.com/task/14861962237167552847) started by @NtFelix*