### PR TITLE
ci: skip deploy and push for dependabot-triggered workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -805,7 +805,7 @@ jobs:
           echo "✓ Container runs as non-root user: **$USER**"
 
       - name: Push Docker image to Artifact Registry
-        if: success()
+        if: success() && github.actor != 'dependabot[bot]'
         run: |
           echo "Pushing ${{ steps.image.outputs.full_name }}..."
           docker push ${{ steps.image.outputs.full_name }}
@@ -1990,7 +1990,7 @@ jobs:
     name: Deploy Preview
     runs-on: ubuntu-latest
     needs: [docker-build, check-runs]
-    if: needs.check-runs.outputs.should-run-deploy-preview == 'true'
+    if: needs.check-runs.outputs.should-run-deploy-preview == 'true' && github.actor != 'dependabot[bot]'
     permissions:
       contents: read
       pull-requests: write
@@ -2129,7 +2129,7 @@ jobs:
     name: Deploy to Production
     runs-on: ubuntu-latest
     needs: [docker-build, check-runs]
-    if: needs.check-runs.outputs.should-run-deploy-production == 'true'
+    if: needs.check-runs.outputs.should-run-deploy-production == 'true' && github.actor != 'dependabot[bot]'
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Description

Skips Docker push and deployment jobs for workflows triggered by Dependabot, avoiding failing/superfluous deploys on dependency PRs.

## Summary of Changes

- `ci.yml`: add `github.actor != 'dependabot[bot]'` condition to
  - "Push Docker image to Artifact Registry"
  - "Deploy Preview" job
  - "Deploy to Production" job