### PR TITLE
Update CTA badge icon to rocket

### DIFF
--- a/app/modern/components/cta.tsx
+++ b/app/modern/components/cta.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { motion } from "framer-motion"
-import { Sparkles } from "lucide-react"
+import { Rocket } from "lucide-react"
 import { CallToAction } from "./call-to-action"
 
 interface CTAProps {
@@ -62,7 +62,7 @@ export default function CTA({ onGetStarted }: CTAProps) {
           className="mb-8"
         >
           <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-card/80 border border-border backdrop-blur-xs mb-8">
-            <Sparkles className="w-4 h-4 text-primary" />
+            <Rocket className="w-4 h-4 text-primary" />
             <span className="text-sm text-muted-foreground">Bereit zur Vereinfachung?</span>
           </div>
         </motion.div>

--- a/components/ui/bottom-cta.tsx
+++ b/components/ui/bottom-cta.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { motion } from "framer-motion"
-import { Sparkles, ArrowRight, ExternalLink } from "lucide-react"
+import { Rocket, ArrowRight, ExternalLink } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   AlertDialog,
@@ -86,7 +86,7 @@ export default function BottomCTA({
           className="mb-8"
         >
           <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-card/80 border border-border backdrop-blur-xs mb-8">
-            <Sparkles className="w-4 h-4 text-primary" />
+            <Rocket className="w-4 h-4 text-primary" />
             <span className="text-sm text-muted-foreground">{badgeText}</span>
           </div>
         </motion.div>


### PR DESCRIPTION
Replaced `Sparkles` icon with `Rocket` icon in the `app/modern/components/cta.tsx` and `components/ui/bottom-cta.tsx` components near the footer as requested.

---
*PR created automatically by Jules for task [15090441632658533779](https://jules.google.com/task/15090441632658533779) started by @NtFelix*