### PR TITLE
Fix GitHub Actions run-shell-injection vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,19 @@ jobs:
 
       - name: Get changed files
         id: changed-files
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          GITHUB_SHA: ${{ github.sha }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE_SHA="$PR_BASE_SHA"
+            HEAD_SHA="$PR_HEAD_SHA"
           else
-            BASE_SHA="${{ github.event.before }}"
-            HEAD_SHA="${{ github.sha }}"
+            BASE_SHA="$EVENT_BEFORE"
+            HEAD_SHA="$GITHUB_SHA"
 
             if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
               BASE_SHA=$(git rev-parse HEAD~1 2>/dev/null || echo "")
@@ -83,19 +89,23 @@ jobs:
 
       - name: Check visual review scope
         id: visual
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             echo "should-run-visual=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+          if [[ "$EVENT_NAME" != "pull_request" ]]; then
             echo "should-run-visual=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          BASE_SHA="$PR_BASE_SHA"
+          HEAD_SHA="$PR_HEAD_SHA"
 
           CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -E \
             '^(app|components|lib|hooks|public|styles|playwright)/|\.css$|playwright\.config\.ts$' \
@@ -109,17 +119,21 @@ jobs:
 
       - name: Check Lighthouse audit scope
         id: lighthouse
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
+          EVENT_ACTION: ${{ github.event.action }}
         run: |
           FULL_MATRIX='["mobile", "desktop", "tablet"]'
           DESKTOP_ONLY='["desktop"]'
 
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             echo "should-run-lighthouse=true" >> $GITHUB_OUTPUT
             echo "device-matrix=$FULL_MATRIX" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+          elif [[ "$EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
             echo "should-run-lighthouse=true" >> $GITHUB_OUTPUT
             echo "device-matrix=$FULL_MATRIX" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "pull_request" && ("${{ github.event.action }}" == "opened" || "${{ github.event.action }}" == "reopened") ]]; then
+          elif [[ "$EVENT_NAME" == "pull_request" && ("$EVENT_ACTION" == "opened" || "$EVENT_ACTION" == "reopened") ]]; then
             echo "should-run-lighthouse=true" >> $GITHUB_OUTPUT
             echo "device-matrix=$FULL_MATRIX" >> $GITHUB_OUTPUT
           else
@@ -129,8 +143,10 @@ jobs:
 
       - name: Check E2E scope
         id: e2e
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request" || "$EVENT_NAME" == "push" || "$EVENT_NAME" == "workflow_dispatch" ]]; then
             echo "should-run-e2e=true" >> $GITHUB_OUTPUT
           else
             echo "should-run-e2e=false" >> $GITHUB_OUTPUT
@@ -138,6 +154,9 @@ jobs:
 
       - name: Discover & Filter Test Files
         id: tests
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           ALL_TEST_FILES=$(find . -type f \( -name "*.test.ts" -o -name "*.test.tsx" \) \
             -not -path "./node_modules/*" \
@@ -151,7 +170,7 @@ jobs:
           TOTAL_ALL_FILES=${#ALL_FILES_ARRAY[@]}
 
           IS_FULL_RUN=false
-          if [ "${{ github.ref }}" = "refs/heads/main" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$GITHUB_REF" = "refs/heads/main" ] || [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             IS_FULL_RUN=true
           fi
 
@@ -237,12 +256,17 @@ jobs:
 
       - name: Check deployment scope
         id: deploy
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          IS_MAIN_BRANCH=$([[ "${{ github.ref }}" == "refs/heads/main" ]] && echo "true" || echo "false")
-          IS_PR=$([[ "${{ github.event_name }}" == "pull_request" ]] && echo "true" || echo "false")
+          IS_MAIN_BRANCH=$([[ "$GITHUB_REF" == "refs/heads/main" ]] && echo "true" || echo "false")
+          IS_PR=$([[ "$EVENT_NAME" == "pull_request" ]] && echo "true" || echo "false")
           
           if [[ "$IS_PR" == "true" ]]; then
-            APP_CHANGED=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" 2>/dev/null | grep -E '^(app|components|lib|hooks|public|styles|playwright|types|utils|supabase)/|\.css$|\.js$|\.tsx?$|package.*\.json|next\.config.*|tailwind\.config.*|Dockerfile|\.github/workflows' || true)
+            APP_CHANGED=$(git diff --name-only "$PR_BASE_SHA" "$PR_HEAD_SHA" 2>/dev/null | grep -E '^(app|components|lib|hooks|public|styles|playwright|types|utils|supabase)/|\.css$|\.js$|\.tsx?$|package.*\.json|next\.config.*|tailwind\.config.*|Dockerfile|\.github/workflows' || true)
           else
             APP_CHANGED="true"
           fi
@@ -335,6 +359,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL || secrets.DISCORD_WEBHOOK_LIGHTHOUSE_REPORTS }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
         with:
           script: |
             const fs = require('fs').promises;
@@ -349,7 +374,7 @@ jobs:
             console.log('Running React Doctor scan for Discord payload...');
             let report;
             try {
-              execSync('npx react-doctor@latest . --diff ${{ github.base_ref }} --json > react-doctor-report.json || true');
+              execSync(`npx react-doctor@latest . --diff ${process.env.GITHUB_BASE_REF} --json > react-doctor-report.json || true`);
               const rawData = await fs.readFile('react-doctor-report.json', 'utf8');
               report = JSON.parse(rawData);
             } catch (error) {
@@ -562,14 +587,19 @@ jobs:
 
       - name: Set Image Name & Tag
         id: image
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           IMAGE_BASE="europe-west1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/mietevo/mietevo"
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            TAG="pr-${{ github.event.pull_request.number }}"
-          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            TAG="pr-$PR_NUMBER"
+          elif [ "$GITHUB_REF" = "refs/heads/main" ]; then
             TAG="latest"
           else
-            TAG="branch-${{ github.ref_name }}"
+            TAG="branch-$GITHUB_REF_NAME"
           fi
           echo "full_name=$IMAGE_BASE:$TAG" >> $GITHUB_OUTPUT
           echo "tag=$TAG" >> $GITHUB_OUTPUT
@@ -1928,14 +1958,17 @@ jobs:
       - name: Create PostHog Visual Review run
         if: always()
         id: vr-run
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          PR_ARGS: ${{ github.event_name == 'pull_request' && format('--pr {0}', github.event.pull_request.number) || '' }}
         run: |
           RUN_ID=$(npx tsx /tmp/posthog/products/visual_review/cli/src/index.ts run create \
             --type playwright \
             --baseline playwright/snapshots.yml \
             --token ${{ secrets.POSTHOG_VR_TOKEN }} \
-            --branch ${{ github.event.pull_request.head.ref || github.ref_name }} \
+            --branch "$BRANCH_NAME" \
             --commit $(git rev-parse HEAD) \
-            ${{ github.event_name == 'pull_request' && format('--pr {0}', github.event.pull_request.number) || '' }})
+            $PR_ARGS)
           echo "run-id=$RUN_ID" >> $GITHUB_OUTPUT
           echo "Created PostHog VR run: $RUN_ID"
 

--- a/.github/workflows/lighthouse-report.yaml
+++ b/.github/workflows/lighthouse-report.yaml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - name: Determine audit scope
         id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
+          EVENT_ACTION: ${{ github.event.action }}
         run: |
           # Determine which jobs to run:
           # - Build: Always runs on valid events (validates code compiles)
@@ -30,22 +34,22 @@ jobs:
           FULL_MATRIX='["mobile", "desktop", "tablet"]'
           DESKTOP_ONLY='["desktop"]'
           
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             echo "should-run-build=true" >> $GITHUB_OUTPUT
             echo "should-run-lighthouse=true" >> $GITHUB_OUTPUT
             echo "device-matrix=$FULL_MATRIX" >> $GITHUB_OUTPUT
             echo "Reason: Manual trigger - running build + all devices"
-          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+          elif [[ "$EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
             echo "should-run-build=true" >> $GITHUB_OUTPUT
             echo "should-run-lighthouse=true" >> $GITHUB_OUTPUT
             echo "device-matrix=$FULL_MATRIX" >> $GITHUB_OUTPUT
             echo "Reason: Push to main - running build + all devices"
-          elif [[ "${{ github.event_name }}" == "pull_request" && ("${{ github.event.action }}" == "opened" || "${{ github.event.action }}" == "reopened") ]]; then
+          elif [[ "$EVENT_NAME" == "pull_request" && ("$EVENT_ACTION" == "opened" || "$EVENT_ACTION" == "reopened") ]]; then
             echo "should-run-build=true" >> $GITHUB_OUTPUT
             echo "should-run-lighthouse=true" >> $GITHUB_OUTPUT
             echo "device-matrix=$FULL_MATRIX" >> $GITHUB_OUTPUT
             echo "Reason: PR opened/reopened - running build + all devices"
-          elif [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.action }}" == "synchronize" ]]; then
+          elif [[ "$EVENT_NAME" == "pull_request" && "$EVENT_ACTION" == "synchronize" ]]; then
             echo "should-run-build=true" >> $GITHUB_OUTPUT
             echo "should-run-lighthouse=false" >> $GITHUB_OUTPUT
             echo "device-matrix=$DESKTOP_ONLY" >> $GITHUB_OUTPUT

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -30,16 +30,20 @@ jobs:
 
       - name: Remove Preview and Merged Branch Tags
         if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
         run: |
-          PR_TAG="pr-${{ github.event.pull_request.number }}"
-          BRANCH_TAG=$(printf '%s' "branch-${{ github.event.pull_request.head.ref }}" \
+          PR_TAG="pr-$PR_NUMBER"
+          BRANCH_TAG=$(printf '%s' "branch-$PR_HEAD_REF" \
             | tr '[:upper:]' '[:lower:]' \
             | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g' \
             | cut -c1-63 \
             | sed -E 's/-+$//')
 
           TAGS=("$PR_TAG")
-          if [ "${{ github.event.pull_request.merged }}" = "true" ] && [ -n "$BRANCH_TAG" ]; then
+          if [ "$PR_MERGED" = "true" ] && [ -n "$BRANCH_TAG" ]; then
             TAGS+=("$BRANCH_TAG")
           fi
 
@@ -53,6 +57,8 @@ jobs:
       - name: Delete Docker Image from Artifact Registry
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # Use safer pipe handling
           set -o pipefail
@@ -60,15 +66,15 @@ jobs:
           REPO="europe-west1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/mietevo/mietevo"
 
           # 1. Delete the specific PR image (fast path if triggered by PR close)
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            PR_TAG="pr-${{ github.event.pull_request.number }}"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            PR_TAG="pr-$PR_NUMBER"
             echo "Deleting image for PR: $PR_TAG"
             gcloud artifacts docker images delete "$REPO:$PR_TAG" --quiet || echo "PR Image $PR_TAG not found or permission denied"
           fi
 
           # 2. Cleanup: Delete all untagged images (orphaned versions)
           # ONLY RUN ON MANUAL DISPATCH - too broad for every PR close
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             echo "Cleaning up all untagged images (Manual Dispatch)..."
             gcloud artifacts docker images delete "$REPO" --filter='-tags:*' --quiet || echo "No untagged images found"
           fi

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -157,15 +157,21 @@ jobs:
       # Get changed files for PR or push
       - name: Get changed files
         id: changed-files
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          GITHUB_SHA: ${{ github.sha }}
         run: |
           # Determine if this is a PR or a push
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE_SHA="$PR_BASE_SHA"
+            HEAD_SHA="$PR_HEAD_SHA"
           else
             # For push events, compare with the previous commit
-            BASE_SHA="${{ github.event.before }}"
-            HEAD_SHA="${{ github.sha }}"
+            BASE_SHA="$EVENT_BEFORE"
+            HEAD_SHA="$GITHUB_SHA"
             
             # If before is empty (first push), use parent commit
             if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
@@ -206,6 +212,9 @@ jobs:
 
       - name: Find and filter test files
         id: set-matrix
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           # Find all test files
           ALL_TEST_FILES=$(find . -type f \( -name "*.test.ts" -o -name "*.test.tsx" \) \
@@ -225,7 +234,7 @@ jobs:
           IS_MAIN_BRANCH=false
           IS_FULL_RUN=false
           
-          if [ "${{ github.ref }}" = "refs/heads/main" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$GITHUB_REF" = "refs/heads/main" ] || [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             IS_MAIN_BRANCH=true
             IS_FULL_RUN=true
             echo "Main branch or manual trigger - running ALL tests"


### PR DESCRIPTION
Fixes multiple "run-shell-injection" security warnings across `.github/workflows/ci.yml`, `lighthouse-report.yaml`, `preview-cleanup.yml`, and `run-tests.yml`.

Vulnerabilities occurred where untrusted GitHub context data (like `github.event.pull_request.head.ref`, `github.sha`, etc.) was interpolated directly into `run` blocks using `${{ ... }}`.

The fix maps these variables to `env:` blocks within the respective steps and references the environment variables dynamically within the scripts, which safely prevents shell injection.

---
*PR created automatically by Jules for task [985720061051868800](https://jules.google.com/task/985720061051868800) started by @NtFelix*