### PR TITLE
Update pricing cards layout to match design

### DIFF
--- a/app/modern/components/pricing.tsx
+++ b/app/modern/components/pricing.tsx
@@ -617,10 +617,10 @@ export default function Pricing({
               return (
                 <Card
                   key={group.productName}
-                  className={`relative flex flex-col rounded-[2.5rem] bg-[#141414] border-white/10 ${group.popular ? "border-white/30 shadow-lg scale-105" : "border-white/5"}`}
+                  className={`relative flex flex-col rounded-[2.5rem] bg-[#141414] ${group.popular ? "border-white/30 shadow-lg scale-105" : "border-white/5"}`}
                 >
                   {group.popular && (
-                    <Badge variant="secondary" className="absolute -top-3 left-1/2 transform -translate-x-1/2 bg-[#EAEAEA] text-black hover:bg-white border-0 font-medium">Am beliebtesten</Badge>
+                    <Badge variant="secondary" className="absolute -top-3 left-1/2 transform -translate-x-1/2 bg-[#EAEAEA] text-black hover:bg-white font-medium">Am beliebtesten</Badge>
                   )}
 
                   <CardHeader className="text-center pb-8">
@@ -633,7 +633,7 @@ export default function Pricing({
                         {billingCycle === "monthly" ? "/Monat" : "/Jahr"}
                       </span>
                     </div>
-                    <CardDescription className="mt-4 min-h-[72px] text-sm text-[#A1A1AA] leading-relaxed px-4"> {/* Added fixed height and overflow for description consistency */}
+                    <CardDescription className="mt-4 min-h-[72px] text-sm text-[#A1A1AA] leading-relaxed px-4">
                       {group.description || `Unser ${group.productName} Plan.`} {/* Use group's description */}
                     </CardDescription>
                   </CardHeader>
@@ -651,15 +651,15 @@ export default function Pricing({
                         )
                         onSelectPlan(planToDisplay.priceId)
                       }}
-                      className={`w-full rounded-full border-0 font-medium ${group.popular ? "bg-[#EAEAEA] text-black hover:bg-white" : "bg-white/5 text-white hover:bg-white/10"}`}
-                      variant="outline"
+                      className={`w-full rounded-full font-medium ${group.popular ? "bg-[#EAEAEA] text-black hover:bg-white" : "bg-white/5 text-white hover:bg-white/10"}`}
+                      variant="ghost"
                       size="lg"
                       disabled={getButtonTextAndState(planToDisplay.priceId).disabled}
                     >
                       {getButtonTextAndState(planToDisplay.priceId).text}
                     </Button>
                   </div>
-                  <CardContent className="grow pt-0">
+                  <CardContent className="grow">
                     <ul className="space-y-3">
                       {group.features.map((feature, featureIndex) => (
                         <li key={featureIndex} className="flex items-center gap-3">

--- a/app/modern/components/pricing.tsx
+++ b/app/modern/components/pricing.tsx
@@ -617,10 +617,10 @@ export default function Pricing({
               return (
                 <Card
                   key={group.productName}
-                  className={`relative flex flex-col rounded-[2.5rem] ${group.popular ? "border-primary shadow-lg scale-105" : "border-border"}`}
+                  className={`relative flex flex-col rounded-[2.5rem] bg-[#141414] border-white/10 ${group.popular ? "border-white/30 shadow-lg scale-105" : "border-white/5"}`}
                 >
                   {group.popular && (
-                    <Badge className="absolute -top-3 left-1/2 transform -translate-x-1/2">Am beliebtesten</Badge>
+                    <Badge variant="secondary" className="absolute -top-3 left-1/2 transform -translate-x-1/2 bg-[#EAEAEA] text-black hover:bg-white border-0 font-medium">Am beliebtesten</Badge>
                   )}
 
                   <CardHeader className="text-center pb-8">
@@ -633,23 +633,13 @@ export default function Pricing({
                         {billingCycle === "monthly" ? "/Monat" : "/Jahr"}
                       </span>
                     </div>
-                    <CardDescription className="mt-2 h-12 overflow-hidden"> {/* Added fixed height and overflow for description consistency */}
+                    <CardDescription className="mt-4 min-h-[72px] text-sm text-[#A1A1AA] leading-relaxed px-4"> {/* Added fixed height and overflow for description consistency */}
                       {group.description || `Unser ${group.productName} Plan.`} {/* Use group's description */}
                     </CardDescription>
                   </CardHeader>
 
-                  <CardContent className="grow">
-                    <ul className="space-y-3">
-                      {group.features.map((feature, featureIndex) => (
-                        <li key={featureIndex} className="flex items-center gap-3">
-                          <Check className="h-4 w-4 text-primary shrink-0" />
-                          <span className="text-sm">{feature}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  </CardContent>
+                  <div className="px-6 pb-8">
 
-                  <CardFooter className="mt-auto py-6">
                     <Button
                       onClick={() => {
                         trackPricingPlanSelected(
@@ -661,14 +651,26 @@ export default function Pricing({
                         )
                         onSelectPlan(planToDisplay.priceId)
                       }}
-                      className="w-full rounded-xl"
-                      variant={group.popular ? "default" : "outline"}
+                      className={`w-full rounded-full border-0 font-medium ${group.popular ? "bg-[#EAEAEA] text-black hover:bg-white" : "bg-white/5 text-white hover:bg-white/10"}`}
+                      variant="outline"
                       size="lg"
                       disabled={getButtonTextAndState(planToDisplay.priceId).disabled}
                     >
                       {getButtonTextAndState(planToDisplay.priceId).text}
                     </Button>
-                  </CardFooter>
+                  </div>
+                  <CardContent className="grow pt-0">
+                    <ul className="space-y-3">
+                      {group.features.map((feature, featureIndex) => (
+                        <li key={featureIndex} className="flex items-center gap-3">
+                          <Check className="h-4 w-4 text-[#A1A1AA] shrink-0" />
+                          <span className="text-sm">{feature}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </CardContent>
+
+
                 </Card>
               );
             })}


### PR DESCRIPTION
This PR updates the layout and styling of the pricing cards in `app/modern/components/pricing.tsx` to precisely match the provided design.

Changes include:
- Changing the card background color to slightly lighter than pitch black (`bg-[#141414]`) and adjusting the border colors (`border-white/10`).
- Updating the "Am beliebtesten" badge to use a white/light gray background (`bg-[#EAEAEA]`) with black text and rounded-full shape without borders.
- Modifying the text color for the `CardDescription` and the Checkmarks (`Check` icons) to a lighter gray (`text-[#A1A1AA]`).
- Moving the "Kostenlos testen" Button from `CardFooter` (at the bottom) to be located above the features list (between `CardHeader` and `CardContent`).
- Modifying the Button styles:
  - Popular button: Light gray/white background with black text.
  - Non-popular buttons: Dark, slightly transparent background (`bg-white/5`) with white text.

No functional changes have been introduced. The build and linters execute flawlessly.

---
*PR created automatically by Jules for task [9897713176691639475](https://jules.google.com/task/9897713176691639475) started by @NtFelix*