### PR TITLE
Style/modal improvements

### DIFF
--- a/components/apartments/wohnung-edit-modal.tsx
+++ b/components/apartments/wohnung-edit-modal.tsx
@@ -150,7 +150,7 @@ function TopBar({
           <Button
             variant="ghost"
             size="icon"
-            className="rounded-lg opacity-50 hover:opacity-100 hover:bg-hover-bg pointer-events-auto cursor-pointer h-8 w-8"
+            className="rounded-lg opacity-50 hover:opacity-100 hover:bg-hover-bg pointer-events-auto cursor-pointer h-8 w-8 active:scale-[0.995]"
           >
             <MoreHorizontal className="h-5 w-5" />
             <span className="sr-only">Aktionen</span>

--- a/components/apartments/wohnung-edit-modal.tsx
+++ b/components/apartments/wohnung-edit-modal.tsx
@@ -69,15 +69,15 @@ function PropertyHeader({ icon: Icon, label, infoText, htmlFor }: { icon: Lucide
       <div className="hidden sm:block">
         <HoverCard openDelay={200} closeDelay={100}>
           <HoverCardTrigger asChild>
-            <button
-              type="button"
+            <Label
+              htmlFor={htmlFor}
               className="flex items-center gap-3 text-muted-foreground/70 cursor-help transition-colors hover:text-foreground/90 w-fit group/header focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:rounded-[4px]"
             >
               <Icon className="h-4 w-4 group-hover/header:text-primary transition-colors" />
-              <Label htmlFor={htmlFor} className="text-sm font-medium uppercase tracking-wider cursor-help group-hover/header:text-foreground transition-colors">
+              <span className="text-sm font-medium uppercase tracking-wider cursor-help group-hover/header:text-foreground transition-colors">
                 {label}
-              </Label>
-            </button>
+              </span>
+            </Label>
           </HoverCardTrigger>
           <HoverCardContent side="top" align="start" className="w-80 shadow-2xl border-border/40 bg-background/95 backdrop-blur-md rounded-[28px] p-5 overflow-hidden">
             <div className="flex gap-3 items-start">

--- a/components/apartments/wohnung-edit-modal.tsx
+++ b/components/apartments/wohnung-edit-modal.tsx
@@ -134,11 +134,11 @@ function ResizeHandle({
 
 function TopBar({
   wohnungInitialData,
-  onOverviewClick,
+  onMeterClick,
   onDeleteRequest,
 }: {
   wohnungInitialData: any;
-  onOverviewClick: () => void;
+  onMeterClick: () => void;
   onDeleteRequest: () => void;
 }) {
   if (!wohnungInitialData) return null;
@@ -158,9 +158,9 @@ function TopBar({
         }
         align="end"
       >
-        <CustomDropdownItem onClick={onOverviewClick}>
-          <Eye className="h-4 w-4 mr-2" />
-          <span>Übersicht</span>
+        <CustomDropdownItem onClick={onMeterClick}>
+          <Gauge className="h-4 w-4 mr-2" />
+          <span>Zähler verwalten</span>
         </CustomDropdownItem>
         <CustomDropdownSeparator />
         <CustomDropdownItem onClick={onDeleteRequest} className="text-red-600 focus:text-red-600">
@@ -188,7 +188,7 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
     wohnungModalOnSuccess,
     isWohnungModalDirty,
     setWohnungModalDirty,
-    openWohnungOverviewModal,
+    openZaehlerModal,
   } = useModalStore();
 
   const router = useRouter();
@@ -489,7 +489,12 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
 
         <TopBar
           wohnungInitialData={wohnungInitialData}
-          onOverviewClick={() => wohnungInitialData && openWohnungOverviewModal(wohnungInitialData.id)}
+          onMeterClick={() => {
+            if (wohnungInitialData) {
+              useOnboardingStore.getState().completeStep('create-meter-select');
+              openZaehlerModal(wohnungInitialData.id, wohnungInitialData.name);
+            }
+          }}
           onDeleteRequest={() => setDeleteDialogOpen(true)}
         />
 

--- a/components/apartments/wohnung-edit-modal.tsx
+++ b/components/apartments/wohnung-edit-modal.tsx
@@ -1,49 +1,48 @@
 "use client";
 
-import React, { useState, useEffect, FormEvent } from "react";
+import React, { useState, useEffect, useRef, FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-} from "@/components/ui/dialog";
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetDescription,
+  SheetFooter,
+} from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { NumberInput } from "@/components/ui/number-input";
 import { Label } from "@/components/ui/label";
-import { LabelWithTooltip } from "@/components/ui/label-with-tooltip";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
 import { CustomCombobox, ComboboxOption } from "@/components/ui/custom-combobox";
-import { toast } from "@/hooks/use-toast"; // Changed import
-import { createClient } from "@/utils/supabase/client";
+import { toast } from "@/hooks/use-toast";
 import { useModalStore } from "@/hooks/use-modal-store";
 import { useOnboardingStore } from "@/hooks/use-onboarding-store";
-
-// Define interfaces based on expected data structure
-interface Wohnung {
-  id: string;
-  name: string;
-  groesse: number;
-  miete: number;
-  haus_id?: string | null;
-  // Add other fields if necessary, e.g., created_at
-}
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Home, Ruler, Coins, Building2, MoreHorizontal, Lightbulb, Eye, Trash2, Info, type LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { CustomDropdown, CustomDropdownItem, CustomDropdownSeparator } from "@/components/ui/custom-dropdown";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { loescheWohnung } from "@/app/(dashboard)/wohnungen/actions";
 
 interface Haus {
   id: string;
   name: string;
 }
 
-// Define the payload type for the server action, matching WohnungServerAction's expectation
 interface WohnungServerActionPayload {
   name: string;
   groesse: number;
@@ -52,28 +51,130 @@ interface WohnungServerActionPayload {
 }
 
 interface WohnungEditModalProps {
-  // open: boolean; // Now from store
-  // onOpenChange: (open: boolean) => void; // Now from store
-  // initialData?: Wohnung; // Now from store
-  // initialHaeuser?: Haus[]; // Now from store
   serverAction: (
     id: string | null,
     payload: WohnungServerActionPayload
   ) => Promise<{ success: boolean; error?: any; data?: any }>;
-  // onSuccess?: (data: any) => void; // Now from store
   currentApartmentLimitFromProps?: number | typeof Infinity;
   isActiveSubscriptionFromProps?: boolean;
   currentApartmentCountFromProps?: number | undefined;
 }
 
+function PropertyHeader({ icon: Icon, label, infoText, htmlFor }: { icon: LucideIcon, label: string, infoText: string, htmlFor: string }) {
+  return (
+    <>
+      <Label htmlFor={htmlFor} className="block sm:hidden text-xs font-medium text-muted-foreground uppercase tracking-wider">
+        {label}
+      </Label>
+      <div className="hidden sm:block">
+        <HoverCard openDelay={200} closeDelay={100}>
+          <HoverCardTrigger asChild>
+            <button
+              type="button"
+              className="flex items-center gap-3 text-muted-foreground/70 cursor-help transition-colors hover:text-foreground/90 w-fit group/header focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:rounded-[4px]"
+            >
+              <Icon className="h-4 w-4 group-hover/header:text-primary transition-colors" />
+              <Label htmlFor={htmlFor} className="text-sm font-medium uppercase tracking-wider cursor-help group-hover/header:text-foreground transition-colors">
+                {label}
+              </Label>
+            </button>
+          </HoverCardTrigger>
+          <HoverCardContent side="top" align="start" className="w-80 shadow-2xl border-border/40 bg-background/95 backdrop-blur-md rounded-[28px] p-5 overflow-hidden">
+            <div className="flex gap-3 items-start">
+              <div className="flex-none h-8 w-8 rounded-full bg-amber-500/10 dark:bg-amber-500/20 text-amber-600 dark:text-amber-400 flex items-center justify-center shadow-inner border border-amber-500/20">
+                <Lightbulb className="h-4 w-4" />
+              </div>
+              <div className="space-y-1.5 pt-1">
+                <h4 className="font-bold text-foreground text-sm uppercase tracking-tight">Tipp</h4>
+                <p className="text-sm leading-relaxed text-muted-foreground/90">{infoText}</p>
+              </div>
+            </div>
+          </HoverCardContent>
+        </HoverCard>
+      </div>
+    </>
+  );
+}
+
+function ResizeHandle({
+  isResizing,
+  setWidth,
+  onMouseDown,
+}: {
+  isResizing: boolean;
+  setWidth: React.Dispatch<React.SetStateAction<number>>;
+  onMouseDown: (e: React.MouseEvent) => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label="Panelgröße anpassen"
+      onMouseDown={onMouseDown}
+      onKeyDown={(e) => {
+        if (e.key === 'ArrowLeft') {
+          e.preventDefault();
+          setWidth(prev => Math.max(360, prev - 20));
+        } else if (e.key === 'ArrowRight') {
+          e.preventDefault();
+          setWidth(prev => Math.min(window.innerWidth * 0.9, prev + 20));
+        }
+      }}
+      className={cn(
+        "absolute -left-1 top-0 bottom-0 w-2 cursor-ew-resize z-50 select-none group/resize-handle hidden sm:block appearance-none bg-transparent border-none p-0",
+        isResizing ? "cursor-ew-resize" : ""
+      )}
+    >
+      <div className={cn(
+        "absolute inset-y-0 left-1/2 w-[2px] -translate-x-1/2 transition-all duration-150 ease-in-out",
+        isResizing ? "bg-primary" : "bg-transparent group-hover/resize-handle:bg-primary/40"
+      )} />
+    </button>
+  );
+}
+
+function TopBar({
+  wohnungInitialData,
+  onOverviewClick,
+  onDeleteRequest,
+}: {
+  wohnungInitialData: any;
+  onOverviewClick: () => void;
+  onDeleteRequest: () => void;
+}) {
+  if (!wohnungInitialData) return null;
+
+  return (
+    <div className="absolute top-0 left-0 right-0 h-14 flex items-center justify-end px-4 z-10 pointer-events-none">
+      <CustomDropdown
+        trigger={
+          <Button
+            variant="ghost"
+            size="icon"
+            className="rounded-lg opacity-50 hover:opacity-100 hover:bg-hover-bg pointer-events-auto cursor-pointer h-8 w-8"
+          >
+            <MoreHorizontal className="h-5 w-5" />
+            <span className="sr-only">Aktionen</span>
+          </Button>
+        }
+        align="end"
+      >
+        <CustomDropdownItem onClick={onOverviewClick}>
+          <Eye className="h-4 w-4 mr-2" />
+          <span>Übersicht</span>
+        </CustomDropdownItem>
+        <CustomDropdownSeparator />
+        <CustomDropdownItem onClick={onDeleteRequest} className="text-red-600 focus:text-red-600">
+          <Trash2 className="h-4 w-4 mr-2" />
+          <span>Löschen</span>
+        </CustomDropdownItem>
+      </CustomDropdown>
+    </div>
+  );
+}
+
 export function WohnungEditModal(props: WohnungEditModalProps) {
   const {
-    // open, // from store
-    // onOpenChange, // from store
-    // initialData, // from store
-    // initialHaeuser = [], // from store
     serverAction,
-    // onSuccess, // from store
     currentApartmentLimitFromProps,
     isActiveSubscriptionFromProps,
     currentApartmentCountFromProps,
@@ -87,19 +188,26 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
     wohnungModalOnSuccess,
     isWohnungModalDirty,
     setWohnungModalDirty,
-  } = useModalStore(); // Assuming you will import useModalStore
+    openWohnungOverviewModal,
+  } = useModalStore();
 
   const router = useRouter();
   const [formData, setFormData] = useState({
-    name: wohnungInitialData?.name || "",
-    groesse: wohnungInitialData?.groesse?.toString() || "",
-    miete: wohnungInitialData?.miete?.toString() || "",
-    haus_id: wohnungInitialData?.haus_id || "",
+    name: "",
+    groesse: "",
+    miete: "",
+    haus_id: "",
   });
 
-  const [internalHaeuser, setInternalHaeuser] = useState<Haus[]>([]); // Initialize empty, effect will populate
-  const [isLoadingHaeuser, setIsLoadingHaeuser] = useState(false);
+  const [internalHaeuser, setInternalHaeuser] = useState<Haus[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const isPending = isSubmitting || isDeleting;
+
+  const [width, setWidth] = useState(600);
+  const [isResizing, setIsResizing] = useState(false);
+  const widthRef = useRef(width);
 
   // New state variables for context fetching
   const [isLoadingContext, setIsLoadingContext] = useState(false);
@@ -107,37 +215,99 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
   const [contextualSaveMessage, setContextualSaveMessage] = useState("");
 
   const houseOptions: ComboboxOption[] = internalHaeuser.map(h => ({ value: h.id, label: h.name }));
+  const isAddNewMode = !wohnungInitialData;
 
-  const isAddNewMode = !wohnungInitialData; // Use store data
+  useEffect(() => {
+    widthRef.current = width;
+  }, [width]);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const savedWidth = localStorage.getItem("apartment-modal-width");
+      if (savedWidth) {
+        const parsed = parseInt(savedWidth, 10);
+        if (!isNaN(parsed)) {
+          setWidth(parsed);
+        }
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const handleResetWidth = () => {
+        setWidth(600);
+      };
+      window.addEventListener("reset-apartment-modal-width", handleResetWidth);
+      return () => {
+        window.removeEventListener("reset-apartment-modal-width", handleResetWidth);
+      };
+    }
+  }, []);
+
+  const startResizing = (mouseDownEvent: React.MouseEvent) => {
+    mouseDownEvent.preventDefault();
+    setIsResizing(true);
+  };
+
+  useEffect(() => {
+    if (!isResizing) return;
+
+    document.body.style.cursor = "ew-resize";
+    document.body.style.userSelect = "none";
+
+    const handleMouseMove = (mouseMoveEvent: MouseEvent) => {
+      const newWidth = window.innerWidth - mouseMoveEvent.clientX;
+      const minWidth = 360;
+      const maxWidth = window.innerWidth * 0.9;
+      setWidth(Math.max(minWidth, Math.min(newWidth, maxWidth)));
+    };
+
+    const handleMouseUp = () => {
+      setIsResizing(false);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      const finalWidth = widthRef.current;
+      if (typeof finalWidth === "number" && !isNaN(finalWidth) && finalWidth >= 360) {
+        localStorage.setItem("apartment-modal-width", String(finalWidth));
+      }
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [isResizing]);
 
   useEffect(() => {
     if (isWohnungModalOpen) {
-      setFormData({
-        name: wohnungInitialData?.name || "",
-        groesse: wohnungInitialData?.groesse?.toString() || "",
-        miete: wohnungInitialData?.miete?.toString() || "",
-        haus_id: wohnungInitialData?.haus_id || "",
-      });
-      setWohnungModalDirty(false); // Reset dirty state
-      // internalHaeuser is now wohnungModalHaeuser from the store, no need to fetch here
-      // if (wohnungModalHaeuser && wohnungModalHaeuser.length > 0) {
-      //   setInternalHaeuser(wohnungModalHaeuser);
-      // } else {
-      //   // Potentially fetch if store didn't provide them, though ideally store should.
-      // }
+      if (wohnungInitialData) {
+        setFormData({
+          name: wohnungInitialData.name || "",
+          groesse: wohnungInitialData.groesse?.toString() || "",
+          miete: wohnungInitialData.miete?.toString() || "",
+          haus_id: wohnungInitialData.haus_id || "",
+        });
+      } else {
+        setFormData({
+          name: "",
+          groesse: "",
+          miete: "",
+          haus_id: "",
+        });
+      }
+      setWohnungModalDirty(false);
     }
-  }, [wohnungInitialData, isWohnungModalOpen, setWohnungModalDirty]); // Removed wohnungModalHaeuser if it's guaranteed by openWohnungModal
+  }, [wohnungInitialData, isWohnungModalOpen, setWohnungModalDirty]);
 
-  // useEffect for fetching Haeuser (if not provided by store) is removed for now,
-  // assuming wohnungModalHaeuser is populated by openWohnungModal.
-
-  // Sync internalHaeuser with store's wohnungModalHaeuser
   useEffect(() => {
-    if (isWohnungModalOpen) { // Only run if modal is open
+    if (isWohnungModalOpen) {
       setInternalHaeuser(wohnungModalHaeuser || []);
-      // If there's a need to fetch Haeuser because wohnungModalHaeuser is empty,
-      // that logic would go here, perhaps setting setIsLoadingHaeuser.
-      // For now, we assume openWohnungModal provides the necessary haeuser list.
     }
   }, [isWohnungModalOpen, wohnungModalHaeuser]);
 
@@ -147,10 +317,8 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
       let determinedDisabled = false;
       setContextualSaveMessage("");
       setIsSaveDisabledByLimitsOrSubscriptionState(false);
-      setIsLoadingContext(true); // Start loading context
+      setIsLoadingContext(true);
 
-      // Directly use props for limits and subscription status
-      // These are passed from layout, which gets them from useModalStore's specific wohnung... fields
       const count = currentApartmentCountFromProps;
       const limit = currentApartmentLimitFromProps;
       const isActiveSub = isActiveSubscriptionFromProps;
@@ -161,22 +329,11 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
       } else if (isAddNewMode && limit !== undefined && count !== undefined && limit !== Infinity && count >= limit) {
         determinedMessage = `Sie haben die maximale Anzahl an Wohnungen (${limit}) für Ihr Abonnement erreicht.`;
         determinedDisabled = true;
-      } else if (!isAddNewMode && limit !== undefined && count !== undefined && limit !== Infinity && count > limit && wohnungInitialData?.id) {
-        // This case is tricky: if editing and already over limit.
-        // The original logic for EDIT mode: count > limit.
-        // This assumes `count` reflects total BEFORE this edit might save (which is fine for blocking).
-        // Let's refine: if editing, the concern is less about *this* apartment
-        // unless policies strictly block any interaction. Usually, "add new" is the primary block.
-        // The original logic: `else if (initialData && count > limit)`
-        // For simplicity, if adding is blocked, that's the main use case for these props.
-        // If editing while over limit should also be blocked, this needs careful consideration
-        // of whether `count` includes the current apartment being edited.
-        // For now, focusing on "add new" block as per original intent.
       }
 
       setContextualSaveMessage(determinedMessage);
       setIsSaveDisabledByLimitsOrSubscriptionState(determinedDisabled);
-      setIsLoadingContext(false); // Finished context check
+      setIsLoadingContext(false);
     } else {
       setContextualSaveMessage("");
       setIsSaveDisabledByLimitsOrSubscriptionState(false);
@@ -184,38 +341,76 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
     }
   }, [
     isWohnungModalOpen,
-    isAddNewMode, // Derived from wohnungInitialData
+    isAddNewMode,
     isActiveSubscriptionFromProps,
     currentApartmentLimitFromProps,
     currentApartmentCountFromProps,
-    wohnungInitialData?.id // Added to re-evaluate if mode changes
+    wohnungInitialData?.id
   ]);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormData({ ...formData, [e.target.name]: e.target.value });
-    setWohnungModalDirty(true);
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+    if (!isWohnungModalDirty) setWohnungModalDirty(true);
   };
 
   const handleSelectChange = (name: string, value: string) => {
-    setFormData({ ...formData, [name]: value });
-    setWohnungModalDirty(true);
+    setFormData(prev => ({ ...prev, [name]: value }));
+    if (!isWohnungModalDirty) setWohnungModalDirty(true);
   };
 
   const attemptClose = () => {
-    closeWohnungModal(); // For outside clicks / X button
+    closeWohnungModal();
   };
 
   const handleCancelClick = () => {
-    closeWohnungModal({ force: true }); // For "Abbrechen" button
+    closeWohnungModal({ force: true });
+  };
+
+  const handleDelete = async () => {
+    if (!wohnungInitialData || isPending) return;
+    try {
+      setIsDeleting(true);
+      const result = await loescheWohnung(wohnungInitialData.id);
+
+      if (result.success) {
+        toast({
+          title: "Erfolg",
+          description: `Die Wohnung "${wohnungInitialData.name}" wurde erfolgreich gelöscht.`,
+          variant: "success",
+        });
+        setWohnungModalDirty(false);
+        closeWohnungModal();
+        if (wohnungModalOnSuccess) {
+          wohnungModalOnSuccess({ deleted: true, id: wohnungInitialData.id });
+        }
+      } else {
+        toast({
+          title: "Fehler",
+          description: result.error || "Die Wohnung konnte nicht gelöscht werden.",
+          variant: "destructive",
+        });
+      }
+    } catch (error) {
+      console.error("Unerwarteter Fehler beim Löschen der Wohnung:", error);
+      toast({
+        title: "Systemfehler",
+        description: "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es später erneut.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsDeleting(false);
+      setDeleteDialogOpen(false);
+    }
   };
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    setIsSubmitting(true);
+    if (isPending) return;
 
     if (!formData.name || !formData.groesse || !formData.miete) {
       toast({ title: "Fehlende Angaben", description: "Bitte füllen Sie alle Pflichtfelder aus.", variant: "destructive" });
-      setIsSubmitting(false); return;
+      return;
     }
 
     const groesseNum = parseFloat(formData.groesse);
@@ -223,12 +418,14 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
 
     if (isNaN(groesseNum) || groesseNum <= 0) {
       toast({ title: "Ungültige Größe", description: "Die Größe muss eine positive Zahl sein.", variant: "destructive" });
-      setIsSubmitting(false); return;
+      return;
     }
     if (isNaN(mieteNum) || mieteNum < 0) {
       toast({ title: "Ungültige Miete", description: "Die Miete darf nicht negativ sein.", variant: "destructive" });
-      setIsSubmitting(false); return;
+      return;
     }
+
+    setIsSubmitting(true);
 
     const payload: WohnungServerActionPayload = {
       name: formData.name,
@@ -251,7 +448,7 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
         if (wohnungModalOnSuccess) {
           const successData = result.data || {
             ...payload,
-            id: wohnungInitialData?.id || result.data?.id || '', // Ensure ID is present
+            id: wohnungInitialData?.id || result.data?.id || '',
             haus_name: (wohnungModalHaeuser || []).find(h => h.id === formData.haus_id)?.name || ''
           };
           wohnungModalOnSuccess(successData);
@@ -262,7 +459,6 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
         throw new Error(result.error?.message || "Ein unbekannter Fehler ist aufgetreten.");
       }
     } catch (error) {
-      // Don't re-set dirty on error - form still has unsaved changes
       toast({
         title: "Fehler",
         description: error instanceof Error ? error.message : "Ein unbekannter Fehler ist aufgetreten.",
@@ -274,97 +470,202 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
   };
 
   return (
-    <Dialog open={isWohnungModalOpen} onOpenChange={(openValue) => !openValue && attemptClose()}>
-      <DialogContent
+    <Sheet open={isWohnungModalOpen} onOpenChange={(open) => !open && attemptClose()}>
+      <SheetContent
         id="wohnung-form-container"
-        className="sm:max-w-[500px]"
+        className="w-full sm:w-[var(--sheet-width)] sm:max-w-none flex flex-col h-full p-0 gap-0"
+        style={{
+          "--sheet-width": `${width}px`,
+          transition: isResizing ? "none" : undefined
+        } as React.CSSProperties}
         isDirty={isWohnungModalDirty}
         onAttemptClose={attemptClose}
       >
-        <DialogHeader>
-          <DialogTitle>{wohnungInitialData?.id ? "Wohnung bearbeiten" : "Neue Wohnung erstellen"}</DialogTitle>
-          <DialogDescription>
-            {wohnungInitialData?.id ? "Aktualisieren Sie die Details dieser Wohnung." : "Füllen Sie die Details der neuen Wohnung aus."}
-          </DialogDescription>
-        </DialogHeader>
-        <form onSubmit={handleSubmit} className="grid gap-4 pt-4 pb-2">
-          <div className="space-y-2">
-            <LabelWithTooltip htmlFor="name" infoText="Eindeutiger Name für die Wohnung (z.B. 'EG Links' oder '1. OG rechts')">
-              Name der Wohnung
-            </LabelWithTooltip>
-            <Input
-              id="name"
-              name="name"
-              value={formData.name}
-              onChange={handleChange}
-              placeholder="z.B. Wohnung 1 OG Links"
-              required
-              disabled={isSubmitting || isLoadingContext}
-            />
-          </div>
-          <div className="space-y-2">
-            <LabelWithTooltip htmlFor="groesse" infoText="Wohnfläche in Quadratmetern (z.B. 65.5 für 65,5 m²)">
-              Größe (m²)
-            </LabelWithTooltip>
-            <NumberInput
-              id="groesse"
-              name="groesse"
-              value={formData.groesse}
-              onChange={handleChange}
-              placeholder="z.B. 65"
-              required
-              min="0"
-              step="0.01"
-              disabled={isSubmitting || isLoadingContext}
-            />
-          </div>
-          <div className="space-y-2">
-            <LabelWithTooltip htmlFor="miete" infoText="Monatliche Miete in Euro (z.B. 650.50 für 650,50 €)">
-              Miete (€)
-            </LabelWithTooltip>
-            <NumberInput
-              id="miete"
-              name="miete"
-              value={formData.miete}
-              onChange={handleChange}
-              placeholder="z.B. 650.50"
-              required
-              min="0"
-              step="0.01"
-              disabled={isSubmitting || isLoadingContext}
-            />
-          </div>
-          <div className="space-y-2">
-            <LabelWithTooltip htmlFor="haus_id" infoText="Zugeordnetes Haus (z.B. 'Haus A' oder 'Haus B')">
-              Zugehöriges Haus
-            </LabelWithTooltip>
-            <CustomCombobox
-              width="w-full"
-              options={houseOptions}
-              value={formData.haus_id}
-              onChange={(value) => handleSelectChange("haus_id", value || "")}
-              placeholder={isLoadingHaeuser ? "Häuser laden..." : "Haus auswählen"}
-              searchPlaceholder="Haus suchen..."
-              emptyText="Kein Haus gefunden."
-              disabled={isLoadingHaeuser || isSubmitting || isLoadingContext}
-            />
-          </div>
-          {contextualSaveMessage && (
-            <p className="text-sm text-red-500 mb-2 text-center">{contextualSaveMessage}</p>
-          )}
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={handleCancelClick} disabled={isSubmitting}>
-              Abbrechen
-            </Button>
-            <Button
-              type="submit"
-              disabled={isSubmitting || isLoadingHaeuser || isLoadingContext || isSaveDisabledByLimitsOrSubscriptionState}
-            >
-              {isSubmitting ? (wohnungInitialData?.id ? "Wird aktualisiert..." : "Wird erstellt...") : (wohnungInitialData?.id ? "Änderungen speichern" : "Wohnung erstellen")}
-            </Button>
-          </DialogFooter>
+        <ResizeHandle
+          isResizing={isResizing}
+          setWidth={setWidth}
+          onMouseDown={startResizing}
+        />
+
+        <TopBar
+          wohnungInitialData={wohnungInitialData}
+          onOverviewClick={() => wohnungInitialData && openWohnungOverviewModal(wohnungInitialData.id)}
+          onDeleteRequest={() => setDeleteDialogOpen(true)}
+        />
+
+        <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0">
+          <ScrollArea className="flex-1">
+            <div className="max-w-[90%] mx-auto pt-10 sm:pt-14 pb-6 px-4 sm:px-8 space-y-4 sm:space-y-8">
+              <div className="space-y-2 sm:space-y-3">
+                <div className="text-primary/80">
+                  <Home className="h-8 w-8 sm:h-10 sm:w-10" />
+                </div>
+                <div className="space-y-1">
+                  <SheetTitle className="sr-only">
+                    {wohnungInitialData ? "Wohnung bearbeiten" : "Wohnung hinzufügen"}
+                  </SheetTitle>
+                  <input
+                    type="text"
+                    id="name"
+                    name="name"
+                    value={formData.name}
+                    onChange={handleInputChange}
+                    placeholder={wohnungInitialData ? "Unbenannte Wohnung" : "Wohnung hinzufügen"}
+                    disabled={isPending || isLoadingContext}
+                    aria-label={wohnungInitialData ? "Name der Wohnung" : "Name der neuen Wohnung"}
+                    className="text-2xl sm:text-4xl font-bold tracking-tight w-full bg-transparent border-none outline-none focus:outline-none focus:ring-0 p-0 text-foreground placeholder:opacity-30 placeholder:text-muted-foreground/50 cursor-text"
+                  />
+                  <SheetDescription className="text-sm sm:text-base text-muted-foreground/80">
+                    {wohnungInitialData
+                      ? "Bearbeiten Sie die Informationen für dieses Objekt."
+                      : "Legen Sie eine neue Wohnung in Ihrer Verwaltung an."}
+                  </SheetDescription>
+                </div>
+              </div>
+
+              <div className="space-y-3 sm:space-y-6">
+                <div className="sm:space-y-4 sm:pt-3 sm:border-t sm:border-border/40">
+                  <div className="hidden sm:flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
+                    Kennzahlen & Details
+                  </div>
+
+                  <div className="sm:grid sm:gap-4 space-y-2 sm:space-y-0">
+                    <div className="sm:grid sm:grid-cols-[140px_1fr] sm:items-center sm:gap-4 space-y-1 sm:space-y-0">
+                      <PropertyHeader
+                        icon={Ruler}
+                        label="Größe"
+                        htmlFor="groesse"
+                        infoText="Geben Sie die Wohnfläche in Quadratmetern an. Dieser Wert wird zur anteiligen Berechnung der Betriebskosten verwendet."
+                      />
+                      <NumberInput
+                        id="groesse"
+                        name="groesse"
+                        value={formData.groesse}
+                        onChange={handleInputChange}
+                        placeholder="z.B. 65"
+                        required
+                        min="0"
+                        step="0.01"
+                        disabled={isPending || isLoadingContext}
+                        className="bg-transparent border-none shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 hover:bg-muted/10 focus:bg-muted/20 px-2 py-1 -mx-2 rounded-lg transition-all h-auto text-sm focus-visible:scale-100 hover:border-transparent focus:border-transparent"
+                      />
+                    </div>
+
+                    <div className="sm:grid sm:grid-cols-[140px_1fr] sm:items-center sm:gap-4 space-y-1 sm:space-y-0">
+                      <PropertyHeader
+                        icon={Coins}
+                        label="Miete (€)"
+                        htmlFor="miete"
+                        infoText="Geben Sie die monatliche Kaltmiete der Wohnung in Euro an."
+                      />
+                      <NumberInput
+                        id="miete"
+                        name="miete"
+                        value={formData.miete}
+                        onChange={handleInputChange}
+                        placeholder="z.B. 650.50"
+                        required
+                        min="0"
+                        step="0.01"
+                        disabled={isPending || isLoadingContext}
+                        className="bg-transparent border-none shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 hover:bg-muted/10 focus:bg-muted/20 px-2 py-1 -mx-2 rounded-lg transition-all h-auto text-sm focus-visible:scale-100 hover:border-transparent focus:border-transparent"
+                      />
+                    </div>
+
+                    <div className="sm:grid sm:grid-cols-[140px_1fr] sm:items-center sm:gap-4 space-y-1 sm:space-y-0">
+                      <PropertyHeader
+                        icon={Building2}
+                        label="Haus"
+                        htmlFor="haus_id"
+                        infoText="Wählen Sie das Haus aus, zu dem diese Wohnung gehört."
+                      />
+                      <div className="relative">
+                        <CustomCombobox
+                          width="w-full"
+                          options={houseOptions}
+                          value={formData.haus_id}
+                          onChange={(value) => handleSelectChange("haus_id", value || "")}
+                          placeholder="Haus auswählen"
+                          searchPlaceholder="Haus suchen..."
+                          emptyText="Kein Haus gefunden."
+                          disabled={isPending || isLoadingContext}
+                          triggerClassName="hover:scale-100 active:scale-[0.995] shadow-none hover:shadow-none hover:bg-hover-bg hover:text-foreground"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="hidden sm:block space-y-3 pt-3 border-t border-border/40">
+                  <div className="flex items-center gap-2 text-xs font-bold text-muted-foreground/50 uppercase tracking-widest">
+                    Beschreibung
+                  </div>
+                  <div className="bg-muted/20 rounded-xl p-4 text-sm text-muted-foreground/80 leading-relaxed border border-border/50">
+                    <div className="flex gap-2 items-start">
+                      <Info className="h-4 w-4 mt-0.5 shrink-0 opacity-40" />
+                      <p>
+                        Diese Wohneinheit kann Mietern zugeordnet werden, um automatische Abrechnungen, Zahlungsströme und Mietverträge zu verwalten.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {contextualSaveMessage && (
+                <div className="bg-red-500/10 border border-red-500/20 rounded-xl p-4 text-sm text-red-600 dark:text-red-400">
+                  <p>{contextualSaveMessage}</p>
+                </div>
+              )}
+            </div>
+          </ScrollArea>
+
+          <SheetFooter className="px-4 pb-8 pt-2 sm:p-8 sm:pb-14 sm:pt-4">
+            <div className="max-w-[90%] mx-auto w-full flex gap-3">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={handleCancelClick}
+                disabled={isPending}
+                className="flex-1 rounded-xl h-11 text-muted-foreground hover:text-foreground hover:scale-[1.005] active:scale-[0.995] hover:shadow-none"
+              >
+                Abbrechen
+              </Button>
+              <Button
+                type="submit"
+                disabled={isPending || isLoadingContext || isSaveDisabledByLimitsOrSubscriptionState}
+                className="flex-1 rounded-xl h-11 shadow-sm font-semibold hover:scale-[1.005] active:scale-[0.995] hover:shadow-sm"
+              >
+                {isSubmitting ? (
+                  <span className="flex items-center gap-2">
+                    <svg className="animate-spin h-5 w-5" style={{ animationDuration: "600ms" }} viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                    </svg>
+                    Wird gespeichert...
+                  </span>
+                ) : (wohnungInitialData ? "Änderungen speichern" : "Wohnung erstellen")}
+              </Button>
+            </div>
+          </SheetFooter>
         </form>
-      </DialogContent>
-    </Dialog>
+
+        <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Wohnung löschen?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Möchten Sie die Wohnung &ldquo;{wohnungInitialData?.name || formData.name}&rdquo; wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isDeleting}>Abbrechen</AlertDialogCancel>
+              <AlertDialogAction onClick={(e) => { e.preventDefault(); handleDelete(); }} disabled={isDeleting} className="bg-red-600 hover:bg-red-700">
+                {isDeleting ? "Löschen..." : "Löschen"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/components/apartments/wohnung-edit-modal.tsx
+++ b/components/apartments/wohnung-edit-modal.tsx
@@ -23,7 +23,7 @@ import { toast } from "@/hooks/use-toast";
 import { useModalStore } from "@/hooks/use-modal-store";
 import { useOnboardingStore } from "@/hooks/use-onboarding-store";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Home, Ruler, Coins, Building2, MoreHorizontal, Lightbulb, Eye, Trash2, Info, type LucideIcon } from "lucide-react";
+import { Home, Ruler, Coins, Building2, MoreHorizontal, Lightbulb, Eye, Trash2, Info, Gauge, type LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CustomDropdown, CustomDropdownItem, CustomDropdownSeparator } from "@/components/ui/custom-dropdown";
 import {

--- a/components/apartments/wohnung-edit-modal.tsx
+++ b/components/apartments/wohnung-edit-modal.tsx
@@ -205,33 +205,42 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
   const [isDeleting, setIsDeleting] = useState(false);
   const isPending = isSubmitting || isDeleting;
 
-  const [width, setWidth] = useState(600);
-  const [isResizing, setIsResizing] = useState(false);
-  const widthRef = useRef(width);
-
-  // New state variables for context fetching
-  const [isLoadingContext, setIsLoadingContext] = useState(false);
-  const [isSaveDisabledByLimitsOrSubscriptionState, setIsSaveDisabledByLimitsOrSubscriptionState] = useState(false);
-  const [contextualSaveMessage, setContextualSaveMessage] = useState("");
-
-  const houseOptions: ComboboxOption[] = internalHaeuser.map(h => ({ value: h.id, label: h.name }));
-  const isAddNewMode = !wohnungInitialData;
-
-  useEffect(() => {
-    widthRef.current = width;
-  }, [width]);
-
-  useEffect(() => {
+  const [width, setWidth] = useState<number>(() => {
     if (typeof window !== "undefined") {
       const savedWidth = localStorage.getItem("apartment-modal-width");
       if (savedWidth) {
         const parsed = parseInt(savedWidth, 10);
-        if (!isNaN(parsed)) {
-          setWidth(parsed);
-        }
+        if (!isNaN(parsed)) return parsed;
       }
     }
-  }, []);
+    return 600;
+  });
+  const [isResizing, setIsResizing] = useState(false);
+  const widthRef = useRef(width);
+
+  const houseOptions: ComboboxOption[] = internalHaeuser.map(h => ({ value: h.id, label: h.name }));
+  const isAddNewMode = !wohnungInitialData;
+
+  const count = currentApartmentCountFromProps;
+  const limit = currentApartmentLimitFromProps;
+  const isActiveSub = isActiveSubscriptionFromProps;
+
+  let contextualSaveMessage = "";
+  let isSaveDisabledByLimitsOrSubscriptionState = false;
+
+  if (isWohnungModalOpen) {
+    if (isActiveSub === false) {
+      contextualSaveMessage = "Ein aktives Abonnement ist erforderlich.";
+      isSaveDisabledByLimitsOrSubscriptionState = true;
+    } else if (isAddNewMode && limit !== undefined && count !== undefined && limit !== Infinity && count >= limit) {
+      contextualSaveMessage = `Sie haben die maximale Anzahl an Wohnungen (${limit}) für Ihr Abonnement erreicht.`;
+      isSaveDisabledByLimitsOrSubscriptionState = true;
+    }
+  }
+
+  useEffect(() => {
+    widthRef.current = width;
+  }, [width]);
 
   useEffect(() => {
     if (typeof window !== "undefined") {
@@ -311,42 +320,7 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
     }
   }, [isWohnungModalOpen, wohnungModalHaeuser]);
 
-  useEffect(() => {
-    if (isWohnungModalOpen) {
-      let determinedMessage = "";
-      let determinedDisabled = false;
-      setContextualSaveMessage("");
-      setIsSaveDisabledByLimitsOrSubscriptionState(false);
-      setIsLoadingContext(true);
-
-      const count = currentApartmentCountFromProps;
-      const limit = currentApartmentLimitFromProps;
-      const isActiveSub = isActiveSubscriptionFromProps;
-
-      if (isActiveSub === false) {
-        determinedMessage = "Ein aktives Abonnement ist erforderlich.";
-        determinedDisabled = true;
-      } else if (isAddNewMode && limit !== undefined && count !== undefined && limit !== Infinity && count >= limit) {
-        determinedMessage = `Sie haben die maximale Anzahl an Wohnungen (${limit}) für Ihr Abonnement erreicht.`;
-        determinedDisabled = true;
-      }
-
-      setContextualSaveMessage(determinedMessage);
-      setIsSaveDisabledByLimitsOrSubscriptionState(determinedDisabled);
-      setIsLoadingContext(false);
-    } else {
-      setContextualSaveMessage("");
-      setIsSaveDisabledByLimitsOrSubscriptionState(false);
-      setIsLoadingContext(false);
-    }
-  }, [
-    isWohnungModalOpen,
-    isAddNewMode,
-    isActiveSubscriptionFromProps,
-    currentApartmentLimitFromProps,
-    currentApartmentCountFromProps,
-    wohnungInitialData?.id
-  ]);
+  // Context settings (determined directly in render phase)
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -516,7 +490,7 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
                     value={formData.name}
                     onChange={handleInputChange}
                     placeholder={wohnungInitialData ? "Unbenannte Wohnung" : "Wohnung hinzufügen"}
-                    disabled={isPending || isLoadingContext}
+                    disabled={isPending}
                     aria-label={wohnungInitialData ? "Name der Wohnung" : "Name der neuen Wohnung"}
                     className="text-2xl sm:text-4xl font-bold tracking-tight w-full bg-transparent border-none outline-none focus:outline-none focus:ring-0 p-0 text-foreground placeholder:opacity-30 placeholder:text-muted-foreground/50 cursor-text"
                   />
@@ -551,7 +525,7 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
                         required
                         min="0"
                         step="0.01"
-                        disabled={isPending || isLoadingContext}
+                        disabled={isPending}
                         className="bg-transparent border-none shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 hover:bg-muted/10 focus:bg-muted/20 px-2 py-1 -mx-2 rounded-lg transition-all h-auto text-sm focus-visible:scale-100 hover:border-transparent focus:border-transparent"
                       />
                     </div>
@@ -572,7 +546,7 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
                         required
                         min="0"
                         step="0.01"
-                        disabled={isPending || isLoadingContext}
+                        disabled={isPending}
                         className="bg-transparent border-none shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 hover:bg-muted/10 focus:bg-muted/20 px-2 py-1 -mx-2 rounded-lg transition-all h-auto text-sm focus-visible:scale-100 hover:border-transparent focus:border-transparent"
                       />
                     </div>
@@ -593,7 +567,7 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
                           placeholder="Haus auswählen"
                           searchPlaceholder="Haus suchen..."
                           emptyText="Kein Haus gefunden."
-                          disabled={isPending || isLoadingContext}
+                          disabled={isPending}
                           triggerClassName="hover:scale-100 active:scale-[0.995] shadow-none hover:shadow-none hover:bg-hover-bg hover:text-foreground"
                         />
                       </div>
@@ -637,7 +611,7 @@ export function WohnungEditModal(props: WohnungEditModalProps) {
               </Button>
               <Button
                 type="submit"
-                disabled={isPending || isLoadingContext || isSaveDisabledByLimitsOrSubscriptionState}
+                disabled={isPending || isSaveDisabledByLimitsOrSubscriptionState}
                 className="flex-1 rounded-xl h-11 shadow-sm font-semibold hover:scale-[1.005] active:scale-[0.995] hover:shadow-sm"
               >
                 {isSubmitting ? (

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -150,7 +150,7 @@ function TopBar({
           <Button
             variant="ghost"
             size="icon"
-            className="rounded-lg opacity-50 hover:opacity-100 hover:bg-hover-bg pointer-events-auto cursor-pointer h-8 w-8"
+            className="rounded-lg opacity-50 hover:opacity-100 hover:bg-hover-bg pointer-events-auto cursor-pointer h-8 w-8 active:scale-[0.995]"
           >
             <MoreHorizontal className="h-5 w-5" />
             <span className="sr-only">Aktionen</span>

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -69,15 +69,15 @@ function PropertyHeader({ icon: Icon, label, infoText, htmlFor }: { icon: Lucide
       <div className="hidden sm:block">
         <HoverCard openDelay={200} closeDelay={100}>
           <HoverCardTrigger asChild>
-            <button
-              type="button"
+            <Label
+              htmlFor={htmlFor}
               className="flex items-center gap-3 text-muted-foreground/70 cursor-help transition-colors hover:text-foreground/90 w-fit group/header focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:rounded-[4px]"
             >
               <Icon className="h-4 w-4 group-hover/header:text-primary transition-colors" />
-              <Label htmlFor={htmlFor} className="text-sm font-medium uppercase tracking-wider cursor-help group-hover/header:text-foreground transition-colors">
+              <span className="text-sm font-medium uppercase tracking-wider cursor-help group-hover/header:text-foreground transition-colors">
                 {label}
-              </Label>
-            </button>
+              </span>
+            </Label>
           </HoverCardTrigger>
           <HoverCardContent side="top" align="start" className="w-80 shadow-2xl border-border/40 bg-background/95 backdrop-blur-md rounded-[28px] p-5 overflow-hidden">
             <div className="flex gap-3 items-start">

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -424,25 +424,22 @@ export function HouseEditModal(props: HouseEditModalProps) {
   const [isDeleting, setIsDeleting] = useState(false);
   const isPending = isSubmitting || isDeleting;
 
-  const [width, setWidth] = useState(600);
+  const [width, setWidth] = useState<number>(() => {
+    if (typeof window !== "undefined") {
+      const savedWidth = localStorage.getItem("house-modal-width");
+      if (savedWidth) {
+        const parsed = parseInt(savedWidth, 10);
+        if (!isNaN(parsed)) return parsed;
+      }
+    }
+    return 600;
+  });
   const [isResizing, setIsResizing] = useState(false);
   const widthRef = useRef(width);
 
   useEffect(() => {
     widthRef.current = width;
   }, [width]);
-
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      const savedWidth = localStorage.getItem("house-modal-width");
-      if (savedWidth) {
-        const parsed = parseInt(savedWidth, 10);
-        if (!isNaN(parsed)) {
-          setWidth(parsed);
-        }
-      }
-    }
-  }, []);
 
   useEffect(() => {
     if (typeof window !== "undefined") {

--- a/components/houses/house-edit-modal.tsx
+++ b/components/houses/house-edit-modal.tsx
@@ -80,9 +80,9 @@ function PropertyHeader({ icon: Icon, label, infoText, htmlFor }: { icon: Lucide
             </button>
           </HoverCardTrigger>
           <HoverCardContent side="top" align="start" className="w-80 shadow-2xl border-border/40 bg-background/95 backdrop-blur-md rounded-[28px] p-5 overflow-hidden">
-            <div className="flex gap-4 items-start">
-              <div className="flex-none h-12 w-12 rounded-full bg-amber-500/10 dark:bg-amber-500/20 text-amber-600 dark:text-amber-400 flex items-center justify-center shadow-inner border border-amber-500/20">
-                <Lightbulb className="h-6 w-6" />
+            <div className="flex gap-3 items-start">
+              <div className="flex-none h-8 w-8 rounded-full bg-amber-500/10 dark:bg-amber-500/20 text-amber-600 dark:text-amber-400 flex items-center justify-center shadow-inner border border-amber-500/20">
+                <Lightbulb className="h-4 w-4" />
               </div>
               <div className="space-y-1.5 pt-1">
                 <h4 className="font-bold text-foreground text-sm uppercase tracking-tight">Tipp</h4>
@@ -350,7 +350,7 @@ function FormActions({
   houseInitialData: House | null;
 }) {
   return (
-    <SheetFooter className="px-4 pb-6 pt-2 sm:p-8 sm:pt-4">
+    <SheetFooter className="px-4 pb-8 pt-2 sm:p-8 sm:pb-14 sm:pt-4">
       <div className="max-w-[90%] mx-auto w-full flex gap-3">
         <Button
           type="button"

--- a/components/ui/custom-combobox.tsx
+++ b/components/ui/custom-combobox.tsx
@@ -27,6 +27,7 @@ interface CustomComboboxProps {
   width?: string; // e.g., "w-[200px]", "w-full"
   disabled?: boolean; // For disabling the entire combobox
   id?: string; // For accessibility - connects with Label htmlFor
+  triggerClassName?: string; // Custom styling for the trigger button
 }
 
 export function CustomCombobox({
@@ -39,6 +40,7 @@ export function CustomCombobox({
   width = "w-[200px]",
   disabled = false,
   id,
+  triggerClassName,
 }: CustomComboboxProps) {
   const [open, setOpen] = React.useState(false)
   const [inputValue, setInputValue] = React.useState("")
@@ -190,7 +192,7 @@ export function CustomCombobox({
           aria-expanded={open}
           aria-haspopup="listbox"
           aria-label={id ? undefined : (selectedOption ? `Selected: ${selectedOption.label}` : placeholder)}
-          className={cn("justify-between px-3 min-h-[40px] h-auto cursor-pointer", width, !value && "text-muted-foreground")}
+          className={cn("justify-between px-3 min-h-[40px] h-auto cursor-pointer", width, !value && "text-muted-foreground", triggerClassName)}
           disabled={disabled}
           id={id}
           data-dropdown-trigger

--- a/components/ui/custom-combobox.tsx
+++ b/components/ui/custom-combobox.tsx
@@ -46,6 +46,7 @@ export function CustomCombobox({
   const [inputValue, setInputValue] = React.useState("")
   const [highlightedIndex, setHighlightedIndex] = React.useState(-1)
   const [isKeyboardNavigation, setIsKeyboardNavigation] = React.useState(false)
+  const [portalContainer, setPortalContainer] = React.useState<HTMLElement | null>(null)
 
   const closeCombobox = React.useCallback(() => {
     setOpen(false)
@@ -53,6 +54,20 @@ export function CustomCombobox({
   const buttonRef = React.useRef<HTMLButtonElement>(null)
   const inputRef = React.useRef<HTMLInputElement>(null)
   const optionRefs = React.useRef<(HTMLDivElement | null)[]>([])
+
+  React.useEffect(() => {
+    if (open && buttonRef.current) {
+      // Find the closest ancestor dialog or sheet
+      const dialogContent = buttonRef.current.closest('[role="dialog"], [data-sheet-content="true"], [data-dialog-content="true"]') as HTMLElement | null
+      if (dialogContent) {
+        setPortalContainer(dialogContent)
+      } else {
+        setPortalContainer(null)
+      }
+    } else {
+      setPortalContainer(null)
+    }
+  }, [open])
 
   const selectedOption = options.find((option) => option.value === value)
 
@@ -120,6 +135,49 @@ export function CustomCombobox({
     }
   }, [filteredOptions, highlightedIndex, value, onChange, closeCombobox])
 
+  // Global keydown listener to support keyboard navigation when open
+  React.useEffect(() => {
+    if (!open) return
+
+    const handleGlobalKeyDown = (e: KeyboardEvent) => {
+      const navigationKeys = ['ArrowDown', 'ArrowUp', 'Enter', 'Escape', 'Home', 'End', 'Tab']
+      if (navigationKeys.includes(e.key)) {
+        // Handle navigation if the focus is on the input or the trigger button
+        if (
+          document.activeElement === inputRef.current ||
+          document.activeElement === buttonRef.current ||
+          buttonRef.current?.contains(document.activeElement)
+        ) {
+          // Tab shouldn't prevent default browser behavior
+          if (e.key !== 'Tab') {
+            e.preventDefault()
+          }
+          handleNavigationKey(e.key, e)
+        }
+      } else if (
+        e.key.length === 1 &&
+        !e.ctrlKey &&
+        !e.metaKey &&
+        !e.altKey &&
+        (document.activeElement === buttonRef.current || (document.activeElement === inputRef.current && inputRef.current.value === ""))
+      ) {
+        // Redirect printable character typing to search input when trigger button is focused
+        e.preventDefault()
+        if (inputRef.current) {
+          inputRef.current.focus()
+          setInputValue(e.key)
+          setIsKeyboardNavigation(true)
+          setHighlightedIndex(0)
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleGlobalKeyDown, true)
+    return () => {
+      document.removeEventListener('keydown', handleGlobalKeyDown, true)
+    }
+  }, [open, handleNavigationKey])
+
   // Effect 1: Handle Open/Close state and input focus
   React.useEffect(() => {
     if (!open) {
@@ -131,13 +189,11 @@ export function CustomCombobox({
       // Start in mouse mode by default
       setIsKeyboardNavigation(false)
 
-      // Focus the input
-      // Use requestAnimationFrame to ensure the element is mounted and ready
-      requestAnimationFrame(() => {
-        if (inputRef.current) {
-          inputRef.current.focus({ preventScroll: true })
-        }
-      })
+      // Focus the input after the popover content has mounted
+      const timer = setTimeout(() => {
+        inputRef.current?.focus({ preventScroll: true })
+      }, 0)
+      return () => clearTimeout(timer)
     }
   }, [open])
 
@@ -182,7 +238,7 @@ export function CustomCombobox({
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen} modal={true}>
+    <Popover open={open} onOpenChange={setOpen} modal={false}>
       <PopoverTrigger asChild>
         <Button
           ref={buttonRef}
@@ -196,26 +252,47 @@ export function CustomCombobox({
           disabled={disabled}
           id={id}
           data-dropdown-trigger
+          onKeyDown={(e) => {
+            if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              if (!open) {
+                setOpen(true)
+              }
+            }
+          }}
         >
           <span className="truncate">{selectedOption ? selectedOption.label : placeholder}</span>
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent
+       <PopoverContent
+        container={portalContainer}
         className={cn("p-2 border border-border rounded-2xl shadow-2xl backdrop-blur-xs bg-popover z-100", width)}
         align="start"
         sideOffset={8}
-        // Removed onOpenAutoFocus prevention to allow natural focus behavior
-        // Also added data attribute for dialog interaction handling
+        onOpenAutoFocus={(e) => {
+          // Prevent Radix from stealing focus — we focus the input ourselves in the effect
+          e.preventDefault()
+          // Focus input immediately
+          setTimeout(() => {
+            inputRef.current?.focus({ preventScroll: true })
+          }, 0)
+        }}
+        onCloseAutoFocus={(e) => {
+          // Prevent Radix from returning focus to trigger — we handle this ourselves
+          e.preventDefault()
+          buttonRef.current?.focus({ preventScroll: true })
+        }}
         data-combobox-dropdown=""
       >
         <div className="flex flex-col gap-2">
-          {/* Custom search input with aggressive focus management */}
+          {/* Custom search input */}
           <div className="flex items-center gap-2 rounded-lg border border-border bg-popover px-2 mx-1 mt-1">
             <input
               ref={inputRef}
               type="text"
               role="searchbox"
+              data-combobox-input=""
               aria-label="Search options"
               placeholder={searchPlaceholder}
               value={inputValue}
@@ -225,17 +302,6 @@ export function CustomCombobox({
                 // Reset highlighted index when searching and enable keyboard navigation
                 setIsKeyboardNavigation(true)
                 setHighlightedIndex(0)
-              }}
-              onKeyDown={(e) => {
-                // Handle navigation keys using shared helper
-                const navigationKeys = ['ArrowDown', 'ArrowUp', 'Enter', 'Escape', 'Home', 'End', 'Tab']
-
-                if (navigationKeys.includes(e.key)) {
-                  // Stop propagation to prevent the global handler from also processing this event
-                  e.stopPropagation()
-                  handleNavigationKey(e.key, e)
-                }
-                // For all other keys, let the browser handle them naturally
               }}
               className="flex h-9 w-full rounded-md bg-transparent px-2 py-2 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
               autoComplete="off"
@@ -247,6 +313,7 @@ export function CustomCombobox({
 
           {/* Custom options list with proper scrolling */}
           <div
+            role="listbox"
             className="flex max-h-[300px] flex-col gap-1 overflow-y-auto p-1 custom-scrollbar"
             style={{ overscrollBehavior: 'contain' }}
           >
@@ -273,7 +340,7 @@ export function CustomCombobox({
                     option.disabled
                       ? "pointer-events-none opacity-50"
                       : [
-                        highlightedIndex === index ? "bg-hover-bg text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-hover-bg"
+                        highlightedIndex === index ? "bg-hover-bg text-foreground" : "text-foreground hover:bg-hover-bg"
                       ]
                   )}
                   onClick={() => {

--- a/components/ui/custom-combobox.tsx
+++ b/components/ui/custom-combobox.tsx
@@ -14,7 +14,7 @@ import {
 export interface ComboboxOption {
   value: string;
   label: string;
-  disabled?: boolean; // Added to allow disabling specific options
+  disabled?: boolean;
 }
 
 interface CustomComboboxProps {
@@ -24,10 +24,181 @@ interface CustomComboboxProps {
   placeholder?: string;
   searchPlaceholder?: string;
   emptyText?: string;
-  width?: string; // e.g., "w-[200px]", "w-full"
-  disabled?: boolean; // For disabling the entire combobox
-  id?: string; // For accessibility - connects with Label htmlFor
-  triggerClassName?: string; // Custom styling for the trigger button
+  width?: string;
+  disabled?: boolean;
+  id?: string;
+  triggerClassName?: string;
+}
+
+interface ComboboxState {
+  open: boolean;
+  inputValue: string;
+  highlightedIndex: number;
+  isKeyboardNavigation: boolean;
+  portalContainer: HTMLElement | null;
+}
+
+type ComboboxAction =
+  | { type: 'OPEN'; portalContainer: HTMLElement | null; selectedIndex: number }
+  | { type: 'CLOSE' }
+  | { type: 'SET_INPUT_VALUE'; value: string }
+  | { type: 'SET_HIGHLIGHTED_INDEX'; index: number; isKeyboard?: boolean }
+  | { type: 'RESET_KEYBOARD_NAV' }
+
+function comboboxReducer(state: ComboboxState, action: ComboboxAction): ComboboxState {
+  switch (action.type) {
+    case 'OPEN':
+      return {
+        ...state,
+        open: true,
+        portalContainer: action.portalContainer,
+        highlightedIndex: action.selectedIndex >= 0 ? action.selectedIndex : 0,
+        isKeyboardNavigation: false,
+      }
+    case 'CLOSE':
+      return {
+        ...state,
+        open: false,
+        inputValue: "",
+        highlightedIndex: -1,
+        isKeyboardNavigation: false,
+        portalContainer: null,
+      }
+    case 'SET_INPUT_VALUE':
+      return {
+        ...state,
+        inputValue: action.value,
+        highlightedIndex: 0,
+        isKeyboardNavigation: true,
+      }
+    case 'SET_HIGHLIGHTED_INDEX':
+      return {
+        ...state,
+        highlightedIndex: action.index,
+        isKeyboardNavigation: action.isKeyboard !== undefined ? action.isKeyboard : state.isKeyboardNavigation,
+      }
+    case 'RESET_KEYBOARD_NAV':
+      return {
+        ...state,
+        isKeyboardNavigation: false,
+      }
+    default:
+      return state
+  }
+}
+
+// Subcomponent: Search Input
+interface ComboboxSearchInputProps {
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  inputValue: string;
+  searchPlaceholder: string;
+  onChange: (value: string) => void;
+}
+
+function ComboboxSearchInput({
+  inputRef,
+  inputValue,
+  searchPlaceholder,
+  onChange,
+}: ComboboxSearchInputProps) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-border bg-popover px-2 mx-1 mt-1">
+      <input
+        ref={inputRef}
+        type="text"
+        role="searchbox"
+        data-combobox-input=""
+        aria-label="Search options"
+        placeholder={searchPlaceholder}
+        value={inputValue}
+        onChange={(e) => {
+          e.stopPropagation()
+          onChange(e.target.value)
+        }}
+        className="flex h-9 w-full rounded-md bg-transparent px-2 py-2 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck="false"
+      />
+    </div>
+  )
+}
+
+// Subcomponent: Options List
+interface ComboboxOptionsListProps {
+  filteredOptions: ComboboxOption[];
+  value: string | null;
+  highlightedIndex: number;
+  optionRefs: React.MutableRefObject<(HTMLDivElement | null)[]>;
+  emptyText: string;
+  onSelect: (val: string) => void;
+  onMouseEnter: (index: number) => void;
+  onMouseMove: () => void;
+}
+
+function ComboboxOptionsList({
+  filteredOptions,
+  value,
+  highlightedIndex,
+  optionRefs,
+  emptyText,
+  onSelect,
+  onMouseEnter,
+  onMouseMove,
+}: ComboboxOptionsListProps) {
+  return (
+    <div
+      role="listbox"
+      className="flex max-h-[300px] flex-col gap-1 overflow-y-auto p-1 custom-scrollbar"
+      style={{ overscrollBehavior: 'contain' }}
+    >
+      {filteredOptions.length === 0 ? (
+        <div
+          className="rounded-lg px-4 py-6 text-center text-sm text-muted-foreground font-medium"
+          role="option"
+          aria-disabled="true"
+        >
+          {emptyText}
+        </div>
+      ) : (
+        filteredOptions.map((option, index) => (
+          <div
+            key={option.value}
+            ref={(el) => {
+              optionRefs.current[index] = el
+            }}
+            role="option"
+            aria-selected={value === option.value}
+            aria-disabled={option.disabled}
+            className={cn(
+              "relative flex w-full cursor-pointer select-none items-center gap-2 rounded-lg p-2 text-sm outline-hidden transition-all duration-150 active:scale-[0.98]",
+              option.disabled
+                ? "pointer-events-none opacity-50"
+                : [
+                  highlightedIndex === index ? "bg-hover-bg text-foreground" : "text-foreground hover:bg-hover-bg"
+                ]
+            )}
+            onClick={() => {
+              if (!option.disabled) {
+                onSelect(option.value)
+              }
+            }}
+            onMouseEnter={() => onMouseEnter(index)}
+            onMouseMove={onMouseMove}
+          >
+            <Check
+              className={cn(
+                "h-4 w-4 transition-all duration-200",
+                value === option.value ? "opacity-100 scale-100" : "opacity-0 scale-50"
+              )}
+            />
+            <span className="truncate">{option.label}</span>
+          </div>
+        ))
+      )}
+    </div>
+  )
 }
 
 export function CustomCombobox({
@@ -42,32 +213,19 @@ export function CustomCombobox({
   id,
   triggerClassName,
 }: CustomComboboxProps) {
-  const [open, setOpen] = React.useState(false)
-  const [inputValue, setInputValue] = React.useState("")
-  const [highlightedIndex, setHighlightedIndex] = React.useState(-1)
-  const [isKeyboardNavigation, setIsKeyboardNavigation] = React.useState(false)
-  const [portalContainer, setPortalContainer] = React.useState<HTMLElement | null>(null)
+  const [state, dispatch] = React.useReducer(comboboxReducer, {
+    open: false,
+    inputValue: "",
+    highlightedIndex: -1,
+    isKeyboardNavigation: false,
+    portalContainer: null,
+  })
 
-  const closeCombobox = React.useCallback(() => {
-    setOpen(false)
-  }, [])
+  const { open, inputValue, highlightedIndex, isKeyboardNavigation, portalContainer } = state
+
   const buttonRef = React.useRef<HTMLButtonElement>(null)
   const inputRef = React.useRef<HTMLInputElement>(null)
   const optionRefs = React.useRef<(HTMLDivElement | null)[]>([])
-
-  React.useEffect(() => {
-    if (open && buttonRef.current) {
-      // Find the closest ancestor dialog or sheet
-      const dialogContent = buttonRef.current.closest('[role="dialog"], [data-sheet-content="true"], [data-dialog-content="true"]') as HTMLElement | null
-      if (dialogContent) {
-        setPortalContainer(dialogContent)
-      } else {
-        setPortalContainer(null)
-      }
-    } else {
-      setPortalContainer(null)
-    }
-  }, [open])
 
   const selectedOption = options.find((option) => option.value === value)
 
@@ -78,34 +236,47 @@ export function CustomCombobox({
     ), [options, inputValue]
   )
 
-  // Shared keyboard navigation logic used by both global handler and input handler
-  // This eliminates code duplication and ensures consistent navigation behavior
+  const handleOpenChange = React.useCallback((nextOpen: boolean) => {
+    if (nextOpen) {
+      const dialogContent = buttonRef.current?.closest('[role="dialog"], [data-sheet-content="true"], [data-dialog-content="true"]') as HTMLElement | null
+      const selectedIndex = filteredOptions.findIndex(option => option.value === value)
+      dispatch({ type: 'OPEN', portalContainer: dialogContent, selectedIndex })
+    } else {
+      dispatch({ type: 'CLOSE' })
+    }
+  }, [filteredOptions, value])
+
+  const closeCombobox = React.useCallback(() => {
+    handleOpenChange(false)
+  }, [handleOpenChange])
+
+  // Shared keyboard navigation logic
   const handleNavigationKey = React.useCallback((key: string, event: KeyboardEvent | React.KeyboardEvent) => {
     switch (key) {
       case 'ArrowDown':
         event.preventDefault()
-        setIsKeyboardNavigation(true)
-        setHighlightedIndex(prev => {
-          const nextIndex = prev < filteredOptions.length - 1 ? prev + 1 : 0
-          return nextIndex
+        dispatch({
+          type: 'SET_HIGHLIGHTED_INDEX',
+          index: highlightedIndex < filteredOptions.length - 1 ? highlightedIndex + 1 : 0,
+          isKeyboard: true
         })
         break
 
       case 'ArrowUp':
         event.preventDefault()
-        setIsKeyboardNavigation(true)
-        setHighlightedIndex(prev => {
-          const nextIndex = prev > 0 ? prev - 1 : filteredOptions.length - 1
-          return nextIndex
+        dispatch({
+          type: 'SET_HIGHLIGHTED_INDEX',
+          index: highlightedIndex > 0 ? highlightedIndex - 1 : filteredOptions.length - 1,
+          isKeyboard: true
         })
         break
 
       case 'Enter':
         event.preventDefault()
         if (highlightedIndex >= 0 && highlightedIndex < filteredOptions.length) {
-          const selectedOption = filteredOptions[highlightedIndex]
-          if (!selectedOption.disabled) {
-            onChange(selectedOption.value === value ? null : selectedOption.value)
+          const opt = filteredOptions[highlightedIndex]
+          if (!opt.disabled) {
+            onChange(opt.value === value ? null : opt.value)
             closeCombobox()
           }
         }
@@ -118,22 +289,25 @@ export function CustomCombobox({
 
       case 'Home':
         event.preventDefault()
-        setIsKeyboardNavigation(true)
-        setHighlightedIndex(0)
+        dispatch({ type: 'SET_HIGHLIGHTED_INDEX', index: 0, isKeyboard: true })
         break
 
       case 'End':
         event.preventDefault()
-        setIsKeyboardNavigation(true)
-        setHighlightedIndex(filteredOptions.length - 1)
+        dispatch({ type: 'SET_HIGHLIGHTED_INDEX', index: filteredOptions.length - 1, isKeyboard: true })
         break
 
       case 'Tab':
-        // Allow tab to close dropdown and move focus
         closeCombobox()
         break
     }
   }, [filteredOptions, highlightedIndex, value, onChange, closeCombobox])
+
+  // Ref-based useEffectEvent simulation to avoid global keydown re-subscriptions
+  const handleNavigationKeyRef = React.useRef(handleNavigationKey)
+  React.useEffect(() => {
+    handleNavigationKeyRef.current = handleNavigationKey
+  }, [handleNavigationKey])
 
   // Global keydown listener to support keyboard navigation when open
   React.useEffect(() => {
@@ -142,32 +316,27 @@ export function CustomCombobox({
     const handleGlobalKeyDown = (e: KeyboardEvent) => {
       const navigationKeys = ['ArrowDown', 'ArrowUp', 'Enter', 'Escape', 'Home', 'End', 'Tab']
       if (navigationKeys.includes(e.key)) {
-        // Handle navigation if the focus is on the input or the trigger button
         if (
           document.activeElement === inputRef.current ||
           document.activeElement === buttonRef.current ||
           buttonRef.current?.contains(document.activeElement)
         ) {
-          // Tab shouldn't prevent default browser behavior
           if (e.key !== 'Tab') {
             e.preventDefault()
           }
-          handleNavigationKey(e.key, e)
+          handleNavigationKeyRef.current(e.key, e)
         }
       } else if (
         e.key.length === 1 &&
         !e.ctrlKey &&
         !e.metaKey &&
         !e.altKey &&
-        (document.activeElement === buttonRef.current || (document.activeElement === inputRef.current && inputRef.current.value === ""))
+        (document.activeElement === buttonRef.current || (inputRef.current && document.activeElement === inputRef.current && inputRef.current.value === ""))
       ) {
-        // Redirect printable character typing to search input when trigger button is focused
         e.preventDefault()
         if (inputRef.current) {
           inputRef.current.focus()
-          setInputValue(e.key)
-          setIsKeyboardNavigation(true)
-          setHighlightedIndex(0)
+          dispatch({ type: 'SET_INPUT_VALUE', value: e.key })
         }
       }
     }
@@ -176,41 +345,7 @@ export function CustomCombobox({
     return () => {
       document.removeEventListener('keydown', handleGlobalKeyDown, true)
     }
-  }, [open, handleNavigationKey])
-
-  // Effect 1: Handle Open/Close state and input focus
-  React.useEffect(() => {
-    if (!open) {
-      setInputValue("")
-      setHighlightedIndex(-1)
-      setIsKeyboardNavigation(false)
-    } else {
-      // When opening:
-      // Start in mouse mode by default
-      setIsKeyboardNavigation(false)
-
-      // Focus the input after the popover content has mounted
-      const timer = setTimeout(() => {
-        inputRef.current?.focus({ preventScroll: true })
-      }, 0)
-      return () => clearTimeout(timer)
-    }
   }, [open])
-
-  // Effect 2: Handle Highlighting synchronization
-  React.useEffect(() => {
-    if (open) {
-      // Only update highlight based on value if we are NOT actively searching (inputValue is empty)
-      // If the user is typing (inputValue !== ""), the onChange handler takes care of setting the index to 0 (top result)
-      // and we shouldn't override that with the currently selected value's index.
-      if (inputValue === "") {
-        const currentIndex = filteredOptions.findIndex(option => option.value === value)
-        setHighlightedIndex(currentIndex >= 0 ? currentIndex : 0)
-      }
-    }
-  }, [open, value, filteredOptions, inputValue])
-
-
 
   // Scroll highlighted option into view
   React.useEffect(() => {
@@ -222,23 +357,8 @@ export function CustomCombobox({
     }
   }, [highlightedIndex, open])
 
-  // Handle mouse hover to update highlighted index
-  const handleOptionMouseEnter = (index: number) => {
-    // Only update highlight on mouse hover if we're not in keyboard navigation mode
-    if (!isKeyboardNavigation) {
-      setHighlightedIndex(index)
-    }
-  }
-
-  // Reset keyboard navigation mode when mouse moves
-  const handleOptionMouseMove = () => {
-    if (isKeyboardNavigation) {
-      setIsKeyboardNavigation(false)
-    }
-  }
-
   return (
-    <Popover open={open} onOpenChange={setOpen} modal={false}>
+    <Popover open={open} onOpenChange={handleOpenChange} modal={false}>
       <PopoverTrigger asChild>
         <Button
           ref={buttonRef}
@@ -256,7 +376,7 @@ export function CustomCombobox({
             if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Enter' || e.key === ' ') {
               e.preventDefault()
               if (!open) {
-                setOpen(true)
+                handleOpenChange(true)
               }
             }
           }}
@@ -265,104 +385,52 @@ export function CustomCombobox({
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-       <PopoverContent
+      <PopoverContent
         container={portalContainer}
         className={cn("p-2 border border-border rounded-2xl shadow-2xl backdrop-blur-xs bg-popover z-100", width)}
         align="start"
         sideOffset={8}
         onOpenAutoFocus={(e) => {
-          // Prevent Radix from stealing focus — we focus the input ourselves in the effect
           e.preventDefault()
-          // Focus input immediately
           setTimeout(() => {
             inputRef.current?.focus({ preventScroll: true })
           }, 0)
         }}
         onCloseAutoFocus={(e) => {
-          // Prevent Radix from returning focus to trigger — we handle this ourselves
           e.preventDefault()
           buttonRef.current?.focus({ preventScroll: true })
         }}
         data-combobox-dropdown=""
       >
         <div className="flex flex-col gap-2">
-          {/* Custom search input */}
-          <div className="flex items-center gap-2 rounded-lg border border-border bg-popover px-2 mx-1 mt-1">
-            <input
-              ref={inputRef}
-              type="text"
-              role="searchbox"
-              data-combobox-input=""
-              aria-label="Search options"
-              placeholder={searchPlaceholder}
-              value={inputValue}
-              onChange={(e) => {
-                e.stopPropagation()
-                setInputValue(e.target.value)
-                // Reset highlighted index when searching and enable keyboard navigation
-                setIsKeyboardNavigation(true)
-                setHighlightedIndex(0)
-              }}
-              className="flex h-9 w-full rounded-md bg-transparent px-2 py-2 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
-              autoComplete="off"
-              autoCorrect="off"
-              autoCapitalize="off"
-              spellCheck="false"
-            />
-          </div>
+          <ComboboxSearchInput
+            inputRef={inputRef}
+            inputValue={inputValue}
+            searchPlaceholder={searchPlaceholder}
+            onChange={(val) => dispatch({ type: 'SET_INPUT_VALUE', value: val })}
+          />
 
-          {/* Custom options list with proper scrolling */}
-          <div
-            role="listbox"
-            className="flex max-h-[300px] flex-col gap-1 overflow-y-auto p-1 custom-scrollbar"
-            style={{ overscrollBehavior: 'contain' }}
-          >
-            {filteredOptions.length === 0 ? (
-              <div
-                className="rounded-lg px-4 py-6 text-center text-sm text-muted-foreground font-medium"
-                role="option"
-                aria-disabled="true"
-              >
-                {emptyText}
-              </div>
-            ) : (
-              filteredOptions.map((option, index) => (
-                <div
-                  key={option.value}
-                  ref={(el) => {
-                    optionRefs.current[index] = el
-                  }}
-                  role="option"
-                  aria-selected={value === option.value}
-                  aria-disabled={option.disabled}
-                  className={cn(
-                    "relative flex w-full cursor-pointer select-none items-center gap-2 rounded-lg p-2 text-sm outline-hidden transition-all duration-150 active:scale-[0.98]",
-                    option.disabled
-                      ? "pointer-events-none opacity-50"
-                      : [
-                        highlightedIndex === index ? "bg-hover-bg text-foreground" : "text-foreground hover:bg-hover-bg"
-                      ]
-                  )}
-                  onClick={() => {
-                    if (!option.disabled) {
-                      onChange(option.value === value ? null : option.value)
-                      closeCombobox()
-                    }
-                  }}
-                  onMouseEnter={() => handleOptionMouseEnter(index)}
-                  onMouseMove={handleOptionMouseMove}
-                >
-                  <Check
-                    className={cn(
-                      "h-4 w-4 transition-all duration-200",
-                      value === option.value ? "opacity-100 scale-100" : "opacity-0 scale-50"
-                    )}
-                  />
-                  <span className="truncate">{option.label}</span>
-                </div>
-              ))
-            )}
-          </div>
+          <ComboboxOptionsList
+            filteredOptions={filteredOptions}
+            value={value}
+            highlightedIndex={highlightedIndex}
+            optionRefs={optionRefs}
+            emptyText={emptyText}
+            onSelect={(val) => {
+              onChange(val === value ? null : val)
+              closeCombobox()
+            }}
+            onMouseEnter={(idx) => {
+              if (!isKeyboardNavigation) {
+                dispatch({ type: 'SET_HIGHLIGHTED_INDEX', index: idx })
+              }
+            }}
+            onMouseMove={() => {
+              if (isKeyboardNavigation) {
+                dispatch({ type: 'RESET_KEYBOARD_NAV' })
+              }
+            }}
+          />
         </div>
       </PopoverContent>
     </Popover>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -125,6 +125,7 @@ const DialogContent = React.forwardRef<
       <DialogPrimitive.Content
         ref={ref}
         className={cn(dialogContentVariants({ size }), className)}
+        data-dialog-content="true"
         onInteractOutside={handleInteraction}
         onEscapeKeyDown={(e) => {
           if (isDirty && onAttemptClose) {

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -9,11 +9,16 @@ const Popover = PopoverPrimitive.Root
 
 const PopoverTrigger = PopoverPrimitive.Trigger
 
+interface PopoverContentProps
+  extends React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> {
+  container?: HTMLElement | null
+}
+
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, style, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
+  PopoverContentProps
+>(({ className, align = "center", sideOffset = 4, style, container, ...props }, ref) => (
+  <PopoverPrimitive.Portal container={container}>
     <PopoverPrimitive.Content
       ref={ref}
       align={align}

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -139,7 +139,7 @@ const SheetContent = React.forwardRef<
       >
         {children}
         <SheetPrimitive.Close asChild onClick={handleCloseButtonClick}>
-          <Button variant="ghost" size="icon" className="absolute left-4 top-4 rounded-lg opacity-50 hover:opacity-100 hover:bg-hover-bg cursor-pointer h-8 w-8">
+          <Button variant="ghost" size="icon" className="absolute left-4 top-4 rounded-lg opacity-50 hover:opacity-100 hover:bg-hover-bg cursor-pointer h-8 w-8 active:scale-[0.995]">
             <ChevronsRight className="h-5 w-5" />
             <span className="sr-only">Schließen</span>
           </Button>

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -106,6 +106,7 @@ const SheetContent = React.forwardRef<
       <SheetPrimitive.Content
         ref={ref}
         className={cn(sheetVariants({ side }), className)}
+        data-sheet-content="true"
         onInteractOutside={handleInteraction}
         onEscapeKeyDown={(e) => {
           if (isDirty && onAttemptClose) {
@@ -121,19 +122,11 @@ const SheetContent = React.forwardRef<
           // Intentionally empty: let Radix restore focus to the trigger element.
         }}
         onFocusOutside={(e) => {
-          // Don't prevent focus from moving to combobox elements or when combobox is actively being used
-          const target = e.target as Element;
-          const activeComboboxInput = document.querySelector('[data-combobox-active="true"]')
-
-          if (target?.hasAttribute('data-combobox-input') ||
-            target?.hasAttribute('data-combobox-active') ||
-            target?.closest('[data-dialog-ignore-interaction]') ||
-            target?.closest('[data-combobox-dropdown]') ||
-            target?.closest('[role="listbox"]') ||
-            target?.closest('[role="option"]') ||
-            activeComboboxInput) {
-            e.preventDefault();
-          }
+          // Always prevent Radix Dialog from re-trapping focus.
+          // This allows focus to move to Popover portal content (e.g. combobox search input)
+          // which renders outside the Dialog's DOM tree.
+          // The sheet remains visually modal via the overlay; close button and Escape still work.
+          e.preventDefault()
         }}
         {...props}
       >


### PR DESCRIPTION
## Description

Modal style improvements: migrates the wohnung edit modal from Dialog to a resizable Sheet and polishes the shared combobox/dialog/sheet primitives.

## Summary of Changes

- `wohnung-edit-modal.tsx`: Dialog → Sheet rewrite (~720 changes) — large inline title input, resizable width persisted in localStorage, TopBar with meter/delete actions, PropertyHeader hovercards with tips, integrated delete flow
- `custom-combobox.tsx`: refactored into `ComboboxSearchInput`/`ComboboxOptionsList` subcomponents, portal `container` support, improved focus management (keyboard open, autofocus search, focus restore)
- `dialog.tsx` / `sheet.tsx`: `data-*` markers, sheet `onFocusOutside` always prevented so focus can move into popover portals (combobox search)
- `popover.tsx`: optional portal `container` prop