### PR TITLE
feat(organisation): implement object scope and module permission edit…

### DIFF
--- a/app/(dashboard)/betriebskosten/client-wrapper.tsx
+++ b/app/(dashboard)/betriebskosten/client-wrapper.tsx
@@ -167,6 +167,7 @@ interface BetriebskostenClientViewProps {
   initialTenants?: any[];
   initialFinances?: any[];
   ownerName: string;
+  canCreate?: boolean;
 }
 
 export default function BetriebskostenClientView({
@@ -175,6 +176,7 @@ export default function BetriebskostenClientView({
   initialTenants = [],
   initialFinances = [],
   ownerName,
+  canCreate = true,
 }: BetriebskostenClientViewProps) {
   const [currentTab, setCurrentTab] = useState<"costs" | "overview">("costs");
   const [prognosisMode, setPrognosisMode] = useState<"real" | "goal">("goal");
@@ -1037,6 +1039,7 @@ export default function BetriebskostenClientView({
                     onTemplateClick={handleOpenDefaultTemplateModal}
                     className="flex-1"
                     buttonText="Neue Abrechnung erstellen"
+                    canCreate={canCreate}
                   />
                   <Button
                     variant="outline"
@@ -1065,6 +1068,7 @@ export default function BetriebskostenClientView({
                     onTemplateClick={handleOpenDefaultTemplateModal}
                     buttonText="Betriebskostenabrechnung erstellen"
                     className="sm:w-auto"
+                    canCreate={canCreate}
                   />
                 </div>
               </div>

--- a/app/(dashboard)/betriebskosten/page.tsx
+++ b/app/(dashboard)/betriebskosten/page.tsx
@@ -15,18 +15,16 @@ import { requirePermission, hasPermission } from "@/lib/permissions";
 export default async function BetriebskostenPage() {
   const { supabase, user } = await requireAuthenticatedUser();
   
-  const [_, canCreate] = await Promise.all([
-    requirePermission('betriebskosten', 'ansehen'),
-    hasPermission('betriebskosten', 'erstellen')
-  ]);
-  
-  // Fetch all necessary data in parallel
   const [
+    _,
+    canCreate,
     nebenkostenResult,
     haeuserData,
     tenantsData,
     financesData
   ] = await Promise.all([
+    requirePermission('betriebskosten', 'ansehen'),
+    hasPermission('betriebskosten', 'erstellen'),
     fetchNebenkostenListOptimized(),
     fetchHaeuserServer(supabase),
     fetchWithRpcFallback(

--- a/app/(dashboard)/betriebskosten/page.tsx
+++ b/app/(dashboard)/betriebskosten/page.tsx
@@ -10,10 +10,12 @@ import BetriebskostenClientView from "./client-wrapper"; // Import the default e
 // Types are still needed for data fetching
 import { Haus } from "../../../lib/data-fetching";
 import { OptimizedNebenkosten } from "@/types/optimized-betriebskosten";
+import { requirePermission } from "@/lib/permissions";
 // Server actions are fine to be imported by Server Components if needed, but not directly by client-wrapper
 
 export default async function BetriebskostenPage() {
   const { supabase, user } = await requireAuthenticatedUser();
+  await requirePermission('betriebskosten', 'ansehen');
   
   // Fetch all necessary data in parallel
   const [

--- a/app/(dashboard)/betriebskosten/page.tsx
+++ b/app/(dashboard)/betriebskosten/page.tsx
@@ -10,12 +10,12 @@ import BetriebskostenClientView from "./client-wrapper"; // Import the default e
 // Types are still needed for data fetching
 import { Haus } from "../../../lib/data-fetching";
 import { OptimizedNebenkosten } from "@/types/optimized-betriebskosten";
-import { requirePermission } from "@/lib/permissions";
-// Server actions are fine to be imported by Server Components if needed, but not directly by client-wrapper
+import { requirePermission, hasPermission } from "@/lib/permissions";
 
 export default async function BetriebskostenPage() {
   const { supabase, user } = await requireAuthenticatedUser();
   await requirePermission('betriebskosten', 'ansehen');
+  const canCreate = await hasPermission('betriebskosten', 'erstellen');
   
   // Fetch all necessary data in parallel
   const [
@@ -77,6 +77,7 @@ export default async function BetriebskostenPage() {
       initialTenants={tenants}
       initialFinances={finances}
       ownerName={ownerName}
+      canCreate={canCreate}
     />
   );
 }

--- a/app/(dashboard)/betriebskosten/page.tsx
+++ b/app/(dashboard)/betriebskosten/page.tsx
@@ -14,8 +14,11 @@ import { requirePermission, hasPermission } from "@/lib/permissions";
 
 export default async function BetriebskostenPage() {
   const { supabase, user } = await requireAuthenticatedUser();
-  await requirePermission('betriebskosten', 'ansehen');
-  const canCreate = await hasPermission('betriebskosten', 'erstellen');
+  
+  const [_, canCreate] = await Promise.all([
+    requirePermission('betriebskosten', 'ansehen'),
+    hasPermission('betriebskosten', 'erstellen')
+  ]);
   
   // Fetch all necessary data in parallel
   const [

--- a/app/(dashboard)/dateien/page.tsx
+++ b/app/(dashboard)/dateien/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react'
 import { CloudStorage } from "@/components/cloud-storage/cloud-storage"
 import { requireAuthenticatedUser } from "@/lib/server/route-access"
+import { requirePermission } from "@/lib/permissions"
 import { getFolderContents } from "./actions"
 import DateienLoading from './loading'
 
@@ -29,6 +30,7 @@ async function CloudStorageContent({ userId }: { userId: string }) {
 
 export default async function DateienPage() {
     const { user } = await requireAuthenticatedUser()
+    await requirePermission('dokumente', 'ansehen')
 
     return (
         <Suspense fallback={<DateienLoading />}>

--- a/app/(dashboard)/finanzen/client-wrapper.tsx
+++ b/app/(dashboard)/finanzen/client-wrapper.tsx
@@ -72,6 +72,7 @@ interface FinanzenClientWrapperProps {
   initialYear?: number;
   isUsingFallbackYear?: boolean;
   currentYear?: number;
+  canCreate?: boolean;
 }
 
 // Utility function to remove duplicates based on ID
@@ -106,7 +107,8 @@ export default function FinanzenClientWrapper({
   initialAvailableYears = [],
   initialYear,
   isUsingFallbackYear = false,
-  currentYear = new Date().getFullYear()
+  currentYear = new Date().getFullYear(),
+  canCreate = true,
 }: FinanzenClientWrapperProps) {
   const [currentTab, setCurrentTab] = useState<"finance" | "overview">("finance");
   const [finData, setFinData] = useState<Finanz[]>(() => deduplicateFinances(initialFinances));
@@ -1046,7 +1048,7 @@ export default function FinanzenClientWrapper({
                   <p className="text-sm text-muted-foreground mt-1 hidden sm:block">Verwalten Sie hier alle Ihre Einnahmen und Ausgaben</p>
                 </div>
                 <div className="mt-0 sm:mt-1">
-                  <ResponsiveButtonWithTooltip onClick={handleAddTransaction} icon={<PlusCircle className="size-4" />} shortText="Hinzufügen">
+                  <ResponsiveButtonWithTooltip onClick={handleAddTransaction} icon={<PlusCircle className="size-4" />} shortText="Hinzufügen" disabled={!canCreate} tooltip="Keine Berechtigung zum Erstellen" showTooltip={!canCreate}>
                     Transaktion hinzufügen
                   </ResponsiveButtonWithTooltip>
                 </div>

--- a/app/(dashboard)/finanzen/page.tsx
+++ b/app/(dashboard)/finanzen/page.tsx
@@ -6,6 +6,7 @@ import { requireAuthenticatedUser } from "@/lib/server/route-access";
 import { fetchWithRpcFallback } from "@/lib/data-fetching";
 import { calculateFinancialSummary, processRpcFinancialSummary, fetchAvailableFinanceYears } from "@/utils/financeCalculations";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { requirePermission } from "@/lib/permissions";
 
 
 import { PAGINATION } from "@/constants";
@@ -81,6 +82,7 @@ function determineInitialYear(
 
 export default async function FinanzenPage() {
   const { supabase } = await requireAuthenticatedUser();
+  await requirePermission('finanzen', 'ansehen');
 
   const currentYear = new Date().getFullYear();
 

--- a/app/(dashboard)/finanzen/page.tsx
+++ b/app/(dashboard)/finanzen/page.tsx
@@ -6,7 +6,7 @@ import { requireAuthenticatedUser } from "@/lib/server/route-access";
 import { fetchWithRpcFallback } from "@/lib/data-fetching";
 import { calculateFinancialSummary, processRpcFinancialSummary, fetchAvailableFinanceYears } from "@/utils/financeCalculations";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { requirePermission } from "@/lib/permissions";
+import { requirePermission, hasPermission } from "@/lib/permissions";
 
 
 import { PAGINATION } from "@/constants";
@@ -133,6 +133,8 @@ export default async function FinanzenPage() {
     summaryData = await getSummaryData(supabase, initialYear);
   }
 
+  const canCreate = await hasPermission('finanzen', 'erstellen');
+
   return <FinanzenClientWrapper
     finances={finances}
     wohnungen={wohnungen}
@@ -141,5 +143,6 @@ export default async function FinanzenPage() {
     initialYear={initialYear}
     isUsingFallbackYear={initialYear !== currentYear}
     currentYear={currentYear}
+    canCreate={canCreate}
   />;
 }

--- a/app/(dashboard)/haeuser/actions.ts
+++ b/app/(dashboard)/haeuser/actions.ts
@@ -87,13 +87,27 @@ export async function handleSubmit(id: string | null, formData: FormData): Promi
         return { success: false, error: { message: error.message } };
       }
     } else {
-      const { error: insertError } = await supabase
+      const { data: newHouse, error: insertError } = await supabase
         .from("Haeuser")
-        .insert(houseData);
+        .insert(houseData)
+        .select('id')
+        .single();
 
-      if (insertError) {
-        logAction(actionName, 'error', { house_name: houseName, error_message: insertError.message });
-        return { success: false, error: { message: insertError.message } };
+      if (insertError || !newHouse) {
+        logAction(actionName, 'error', { house_name: houseName, error_message: insertError?.message || 'No data returned' });
+        return { success: false, error: { message: insertError?.message || 'Fehler beim Erstellen des Hauses.' } };
+      }
+
+      // Auto-grant scope access for restricted members
+      const haeuserIds = await getAccessibleHaeuserIds();
+      if (haeuserIds !== null) {
+        // User has restricted scope → add the new house to their override
+        const { error: scopeError } = await supabase.rpc('add_house_to_member_scope', {
+          p_house_id: newHouse.id,
+        });
+        if (scopeError) {
+          console.error('Failed to auto-grant scope for new house:', scopeError);
+        }
       }
     }
     revalidatePath("/haeuser");

--- a/app/(dashboard)/haeuser/client-wrapper.tsx
+++ b/app/(dashboard)/haeuser/client-wrapper.tsx
@@ -48,7 +48,8 @@ const numberFormatter = new Intl.NumberFormat("de-DE");
 
 // Props for the main client view component
 interface HaeuserClientViewProps {
-  enrichedHaeuser: House[]; // Assuming enrichedHaeuser is an array of House
+  enrichedHaeuser: House[];
+  canCreate?: boolean;
 }
 
 
@@ -56,7 +57,7 @@ interface HaeuserClientViewProps {
 
 
 // This is the new main client component, combining logic from old HaeuserPageClientComponent and HaeuserClientWrapper
-export default function HaeuserClientView({ enrichedHaeuser }: HaeuserClientViewProps) {
+export default function HaeuserClientView({ enrichedHaeuser, canCreate = true }: HaeuserClientViewProps) {
   const router = useRouter();
   const [currentTab, setCurrentTab] = useState<"houses" | "overview">("houses");
   const [filter, setFilter] = useState("all");
@@ -387,6 +388,9 @@ export default function HaeuserClientView({ enrichedHaeuser }: HaeuserClientView
                     }}
                     icon={<PlusCircle className="size-4" />}
                     shortText="Hinzufügen"
+                    disabled={!canCreate}
+                    tooltip="Keine Berechtigung zum Erstellen"
+                    showTooltip={!canCreate}
                   >
                     Haus hinzufügen
                   </ResponsiveButtonWithTooltip>

--- a/app/(dashboard)/haeuser/page.tsx
+++ b/app/(dashboard)/haeuser/page.tsx
@@ -11,16 +11,12 @@ import { redirect } from "next/navigation";
 export default async function HaeuserPage() {
   const { supabase, user } = await requireAuthenticatedUser();
 
-  // Permission check with object-scope exception.
-  // get_accessible_haeuser_ids() returns:
-  //   null  = unrestricted (owner/admin) — always allow
-  //   []    = no object scope — deny if also no module permission
-  //   [ids] = scoped to specific houses — allow (data layer will filter)
-  const [canView, accessibleIdsResult] = await Promise.all([
+  const [canView, canCreate, accessibleIdsResult] = await Promise.all([
     hasPermission('haeuser', 'ansehen'),
+    hasPermission('haeuser', 'erstellen'),
     supabase.rpc('get_accessible_haeuser_ids'),
   ]);
-  const accessibleIds = accessibleIdsResult.data; // null | uuid[]
+  const accessibleIds = accessibleIdsResult.data;
   const hasObjectScopeAccess = accessibleIds === null || (Array.isArray(accessibleIds) && accessibleIds.length > 0);
   if (!canView && !hasObjectScopeAccess) {
     redirect('/unauthorized');
@@ -120,5 +116,5 @@ export default async function HaeuserPage() {
     };
   });
 
-  return <HaeuserClientView enrichedHaeuser={enrichedHaeuser} />;
+  return <HaeuserClientView enrichedHaeuser={enrichedHaeuser} canCreate={canCreate} />;
 }

--- a/app/(dashboard)/haeuser/page.tsx
+++ b/app/(dashboard)/haeuser/page.tsx
@@ -6,9 +6,26 @@ import { fetchWithRpcFallback } from "@/lib/data-fetching";
 import HaeuserClientView from "./client-wrapper"; // Import the default export client view
 import { formatNumber } from "@/utils/format";
 import { House } from "@/components/tables/house-table"; // Type for enrichedHaeuser
+import { hasPermission } from "@/lib/permissions";
+import { redirect } from "next/navigation";
 
 export default async function HaeuserPage() {
   const { supabase, user } = await requireAuthenticatedUser();
+
+  // Permission check with object-scope exception.
+  // get_accessible_haeuser_ids() returns:
+  //   null  = unrestricted (owner/admin) — always allow
+  //   []    = no object scope — deny if also no module permission
+  //   [ids] = scoped to specific houses — allow (data layer will filter)
+  const [canView, accessibleIdsResult] = await Promise.all([
+    hasPermission('haeuser', 'ansehen'),
+    supabase.rpc('get_accessible_haeuser_ids'),
+  ]);
+  const accessibleIds = accessibleIdsResult.data; // null | uuid[]
+  const hasObjectScopeAccess = accessibleIds === null || (Array.isArray(accessibleIds) && accessibleIds.length > 0);
+  if (!canView && !hasObjectScopeAccess) {
+    redirect('/unauthorized');
+  }
 
   // Load data in parallel
   const [

--- a/app/(dashboard)/haeuser/page.tsx
+++ b/app/(dashboard)/haeuser/page.tsx
@@ -2,7 +2,6 @@
 
 export const runtime = 'edge';
 import { requireAuthenticatedUser } from "@/lib/server/route-access";
-import { fetchWithRpcFallback } from "@/lib/data-fetching";
 import HaeuserClientView from "./client-wrapper"; // Import the default export client view
 import { formatNumber } from "@/utils/format";
 import { House } from "@/components/tables/house-table"; // Type for enrichedHaeuser
@@ -27,45 +26,56 @@ export default async function HaeuserPage() {
     redirect('/unauthorized');
   }
 
-  // Load data in parallel
+  // Load data in parallel with object-scope filtering.
+  // Direct queries are used instead of RPCs because the overview RPCs
+  // (get_haeuser_overview etc.) do not apply get_accessible_haeuser_ids().
+  // Using direct queries with scope filtering ensures restricted employees
+  // only see data they have object-level access to.
+  const fetchScopedHouses = async () => {
+    try {
+      let q = supabase.from('Haeuser').select('*');
+      if (accessibleIds !== null) q = q.in('id', accessibleIds);
+      const { data, error } = await q;
+      if (error) throw error;
+      return data;
+    } catch (e) {
+      console.error('Error fetching Haeuser with scope:', e);
+      return null;
+    }
+  };
+
+  const fetchScopedApartments = async () => {
+    try {
+      let q = supabase.from('Wohnungen').select('*');
+      if (accessibleIds !== null) q = q.in('haus_id', accessibleIds);
+      const { data, error } = await q;
+      if (error) throw error;
+      return data;
+    } catch (e) {
+      console.error('Error fetching Wohnungen with scope:', e);
+      return null;
+    }
+  };
+
+  const fetchScopedTenants = async () => {
+    try {
+      const { data, error } = await supabase.from('Mieter').select('wohnung_id,einzug,auszug');
+      if (error) throw error;
+      return data;
+    } catch (e) {
+      console.error('Error fetching Mieter:', e);
+      return null;
+    }
+  };
+
   const [
     housesData,
     apartmentsData,
     tenantsData
   ] = await Promise.all([
-    fetchWithRpcFallback(
-      supabase,
-      'get_haeuser_overview',
-      {},
-      async () => {
-        const { data, error } = await supabase.from('Haeuser').select('*');
-        if (error) throw error;
-        return data;
-      },
-      'haeuser_overview_houses'
-    ),
-    fetchWithRpcFallback(
-      supabase,
-      'get_haeuser_wohnungen_overview',
-      {},
-      async () => {
-        const { data, error } = await supabase.from('Wohnungen').select('*');
-        if (error) throw error;
-        return data;
-      },
-      'haeuser_overview_apartments'
-    ),
-    fetchWithRpcFallback(
-      supabase,
-      'get_haeuser_mieter_overview',
-      {},
-      async () => {
-        const { data, error } = await supabase.from('Mieter').select('wohnung_id,einzug,auszug');
-        if (error) throw error;
-        return data;
-      },
-      'haeuser_overview_tenants'
-    )
+    fetchScopedHouses(),
+    fetchScopedApartments(),
+    fetchScopedTenants(),
   ]);
 
   if (housesData === null) {

--- a/app/(dashboard)/mieter/client-wrapper.tsx
+++ b/app/(dashboard)/mieter/client-wrapper.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { motion } from "framer-motion";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ResponsiveButtonWithTooltip } from "@/components/ui/responsive-button";
+import { ButtonWithTooltip } from "@/components/ui/button-with-tooltip";
 import { ResponsiveFilterButton } from "@/components/ui/responsive-filter-button";
 import { useModalStore } from "@/hooks/use-modal-store";
 import { PlusCircle, Users, BadgeCheck, Euro, Search, Building2, BarChart3 } from "lucide-react";
@@ -77,11 +78,11 @@ const CustomNebenkostenTooltip = ({ active, payload }: any) => {
   return null;
 };
 
-// Props for the main client view component
 interface MieterClientViewProps {
   initialTenants: Tenant[];
   initialWohnungen: Wohnung[];
   serverAction: (formData: FormData) => Promise<{ success: boolean; error?: { message: string } }>;
+  canCreate?: boolean;
 }
 
 // Internal AddTenantButton (could be kept from previous step if preferred)
@@ -94,6 +95,7 @@ export default function MieterClientView({
   initialTenants,
   initialWohnungen,
   serverAction,
+  canCreate = true,
 }: MieterClientViewProps) {
   const router = useRouter()
   const [filter, setFilter] = useState<"current" | "previous" | "all">("current");
@@ -864,11 +866,11 @@ export default function MieterClientView({
                     {showApplicantsTab ? (
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
-                          <Button className="w-full sm:w-auto gap-2">
+                          <ButtonWithTooltip className="w-full sm:w-auto gap-2" disabled={!canCreate} tooltip="Keine Berechtigung zum Erstellen" showTooltip={!canCreate}>
                             <PlusCircle className="size-4" />
                             Hinzufügen
                             <ChevronDown className="size-4 opacity-50" />
-                          </Button>
+                          </ButtonWithTooltip>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end" className="w-64">
                           <DropdownMenuItem onClick={handleAddTenant} className="flex flex-col items-start gap-1 p-3 cursor-pointer">
@@ -892,10 +894,10 @@ export default function MieterClientView({
                         </DropdownMenuContent>
                       </DropdownMenu>
                     ) : (
-                      <Button onClick={handleAddTenant} className="w-full sm:w-auto gap-2">
+                      <ButtonWithTooltip onClick={handleAddTenant} className="w-full sm:w-auto gap-2" disabled={!canCreate} tooltip="Keine Berechtigung zum Erstellen" showTooltip={!canCreate}>
                         <PlusCircle className="size-4" />
                         Mieter hinzufügen
-                      </Button>
+                      </ButtonWithTooltip>
                     )}
                   </div>
                 </div>

--- a/app/(dashboard)/mieter/page.tsx
+++ b/app/(dashboard)/mieter/page.tsx
@@ -73,8 +73,19 @@ export default async function MieterPage() {
     )
   ]);
 
+  // Post-fetch application-level filtering to guarantee scoping
+  let filteredMieter = rawMieter || [];
+  let filteredWohnungen = rawWohnungen || [];
+
+  if (accessibleIds !== null) {
+    const { data: whgIds } = await supabase.from('Wohnungen').select('id').in('haus_id', accessibleIds);
+    const ids = new Set(whgIds?.map(w => w.id) ?? []);
+    filteredMieter = (rawMieter || []).filter((m: any) => !m.wohnung_id || ids.has(m.wohnung_id));
+    filteredWohnungen = (rawWohnungen || []).filter((w: any) => ids.has(w.id));
+  }
+
   const today = new Date();
-  const wohnungen: Wohnung[] = rawWohnungen ? rawWohnungen.map((apt: any) => {
+  const wohnungen: Wohnung[] = filteredWohnungen.map((apt: any) => {
     // If the data comes from our enriched RPC, it already has status and tenant
     if (apt.status && apt.tenant != null) {
       return {
@@ -84,7 +95,7 @@ export default async function MieterPage() {
     }
 
     // Fallback mapping logic
-    const tenant = rawMieter?.find((t: any) => t.wohnung_id === apt.id);
+    const tenant = filteredMieter.find((t: any) => t.wohnung_id === apt.id);
     let status: 'frei' | 'vermietet' = 'frei';
     if (tenant && (!tenant.auszug || new Date(tenant.auszug) > today)) {
       status = 'vermietet';
@@ -95,9 +106,9 @@ export default async function MieterPage() {
       status,
       tenant: tenant ? { id: tenant.id, name: tenant.name, einzug: tenant.einzug as string, auszug: tenant.auszug as string } : undefined,
     } as Wohnung;
-  }) : [];
+  });
 
-  const mieter: Tenant[] = rawMieter ? rawMieter.map(m => ({ ...m })) : [];
+  const mieter: Tenant[] = filteredMieter.map(m => ({ ...m }));
 
 
 

--- a/app/(dashboard)/mieter/page.tsx
+++ b/app/(dashboard)/mieter/page.tsx
@@ -7,12 +7,25 @@ import { requireAuthenticatedUser } from "@/lib/server/route-access";
 import { fetchWithRpcFallback } from "@/lib/data-fetching";
 import { handleSubmit as mieterServerAction } from "../../../app/mieter-actions";
 import MieterClientView from "./client-wrapper"; // Import the default export
+import { hasPermission } from "@/lib/permissions";
+import { redirect } from "next/navigation";
 
 import type { Tenant } from "@/types/Tenant";
 import type { Wohnung } from "@/types/Wohnung";
 
 export default async function MieterPage() {
   const { supabase } = await requireAuthenticatedUser();
+
+  // Object-scope exception: if user can access specific houses, they can see their tenants.
+  const [canView, accessibleIdsResult] = await Promise.all([
+    hasPermission('mieter', 'ansehen'),
+    supabase.rpc('get_accessible_haeuser_ids'),
+  ]);
+  const accessibleIds = accessibleIdsResult.data;
+  const hasObjectScopeAccess = accessibleIds === null || (Array.isArray(accessibleIds) && accessibleIds.length > 0);
+  if (!canView && !hasObjectScopeAccess) {
+    redirect('/unauthorized');
+  }
 
   // Load data in parallel to eliminate waterfalls
   const [

--- a/app/(dashboard)/mieter/page.tsx
+++ b/app/(dashboard)/mieter/page.tsx
@@ -17,8 +17,9 @@ export default async function MieterPage() {
   const { supabase } = await requireAuthenticatedUser();
 
   // Object-scope exception: if user can access specific houses, they can see their tenants.
-  const [canView, accessibleIdsResult] = await Promise.all([
+  const [canView, canCreate, accessibleIdsResult] = await Promise.all([
     hasPermission('mieter', 'ansehen'),
+    hasPermission('mieter', 'erstellen'),
     supabase.rpc('get_accessible_haeuser_ids'),
   ]);
   const accessibleIds = accessibleIdsResult.data;
@@ -37,7 +38,11 @@ export default async function MieterPage() {
       'get_mieter_wohnungen_overview',
       {},
       async () => {
-        const { data, error } = await supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id,Haeuser(name)');
+        let q = supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id,Haeuser(name)');
+        if (accessibleIds !== null && accessibleIds.length > 0) {
+          q = q.in('haus_id', accessibleIds);
+        }
+        const { data, error } = await q;
         if (error) {
           console.error('Fehler beim Laden der Wohnungen:', error);
           throw error;
@@ -51,7 +56,13 @@ export default async function MieterPage() {
       'get_mieter_details_overview',
       {},
       async () => {
-        const { data, error } = await supabase.from('Mieter').select('id,wohnung_id,einzug,auszug,name,nebenkosten,email,telefonnummer,notiz,kaution,status,bewerbung_score,bewerbung_metadaten,bewerbung_mail_id');
+        let q = supabase.from('Mieter').select('id,wohnung_id,einzug,auszug,name,nebenkosten,email,telefonnummer,notiz,kaution,status,bewerbung_score,bewerbung_metadaten,bewerbung_mail_id');
+        if (accessibleIds !== null && accessibleIds.length > 0) {
+          const { data: whgIds } = await supabase.from('Wohnungen').select('id').in('haus_id', accessibleIds);
+          const ids = whgIds?.map(w => w.id) ?? [];
+          q = ids.length > 0 ? q.in('wohnung_id', ids) : q;
+        }
+        const { data, error } = await q;
         if (error) {
           console.error('Fehler beim Laden der Mieter:', error);
           throw error;
@@ -95,6 +106,7 @@ export default async function MieterPage() {
       initialTenants={mieter}
       initialWohnungen={wohnungen}
       serverAction={mieterServerAction}
+      canCreate={canCreate}
     />
   );
 }

--- a/app/(dashboard)/organisation/client-wrapper.tsx
+++ b/app/(dashboard)/organisation/client-wrapper.tsx
@@ -353,7 +353,7 @@ function OrganisationMembersTable({
                       className={cn(
                         "cursor-pointer transition-colors duration-150",
                         isSelected
-                          ? "bg-zinc-100 dark:bg-zinc-800/80 hover:bg-zinc-150 dark:hover:bg-zinc-800"
+                          ? "bg-zinc-100 dark:bg-zinc-800/80 hover:bg-zinc-200 dark:hover:bg-zinc-800"
                           : "hover:bg-zinc-50/30 dark:hover:bg-zinc-900/30"
                       )}
                     >
@@ -560,6 +560,7 @@ function OrganisationMembersTab({
   inviteEmail,
   inviteRole,
   filteredMembers,
+  members,
   invitations,
   expiredInvitationIds,
   hasVerwaltenPermission,
@@ -585,6 +586,7 @@ function OrganisationMembersTab({
   inviteEmail: string;
   inviteRole: "admin" | "mitarbeiter";
   filteredMembers: Member[];
+  members: Member[];
   invitations: Invitation[];
   expiredInvitationIds: Set<string>;
   hasVerwaltenPermission: boolean;
@@ -604,7 +606,7 @@ function OrganisationMembersTab({
   onStatusChange: (memberId: string, name: string, newStatus: string) => void;
   onRemove: (memberId: string, name: string) => void;
 }) {
-  const selectedMember = filteredMembers.find(m => m.mitglied_id === selectedMemberId);
+  const selectedMember = members.find(m => m.mitglied_id === selectedMemberId);
 
   return (
     <div className="flex flex-col gap-8">
@@ -976,6 +978,7 @@ export default function OrganisationClientView({
           inviteEmail={uiState.inviteEmail}
           inviteRole={uiState.inviteRole}
           filteredMembers={filteredMembers}
+          members={members}
           invitations={invitations}
           expiredInvitationIds={expiredInvitationIds}
           hasVerwaltenPermission={hasVerwaltenPermission}

--- a/app/(dashboard)/organisation/client-wrapper.tsx
+++ b/app/(dashboard)/organisation/client-wrapper.tsx
@@ -40,6 +40,8 @@ import {
   removeMitgliedAction
 } from "@/app/organisation-actions";
 
+import { MitgliedPermissionDetail } from "@/components/organisation/mitglied-permission-detail";
+
 interface Member {
   mitglied_id: string;
   user_id: string;
@@ -83,6 +85,7 @@ type UiState = {
   statusFilter: string;
   inviteEmail: string;
   inviteRole: "admin" | "mitarbeiter";
+  selectedMemberId: string | null;
   pendingConfirm: {
     type: 'role' | 'status' | 'delete' | 'revoke';
     memberId?: string;
@@ -99,6 +102,7 @@ type UiAction =
   | { type: 'SET_STATUS_FILTER'; payload: string }
   | { type: 'SET_INVITE_EMAIL'; payload: string }
   | { type: 'SET_INVITE_ROLE'; payload: "admin" | "mitarbeiter" }
+  | { type: 'SET_SELECTED_MEMBER'; payload: string | null }
   | { type: 'SET_PENDING_CONFIRM'; payload: UiState['pendingConfirm'] }
   | { type: 'CLEAR_INVITE_EMAIL' }
   | { type: 'RESET_FILTERS' };
@@ -110,6 +114,7 @@ const initialUiState: UiState = {
   statusFilter: "all",
   inviteEmail: "",
   inviteRole: "mitarbeiter",
+  selectedMemberId: null,
   pendingConfirm: null,
 };
 
@@ -127,12 +132,14 @@ function uiReducer(state: UiState, action: UiAction): UiState {
       return { ...state, inviteEmail: action.payload };
     case 'SET_INVITE_ROLE':
       return { ...state, inviteRole: action.payload };
+    case 'SET_SELECTED_MEMBER':
+      return { ...state, selectedMemberId: action.payload };
     case 'SET_PENDING_CONFIRM':
       return { ...state, pendingConfirm: action.payload };
     case 'CLEAR_INVITE_EMAIL':
       return { ...state, inviteEmail: "" };
     case 'RESET_FILTERS':
-      return { ...state, searchQuery: "", roleFilter: "all", statusFilter: "all" };
+      return { ...state, searchQuery: "", roleFilter: "all", statusFilter: "all", selectedMemberId: null };
     default:
       return state;
   }
@@ -280,11 +287,14 @@ function OrganisationConfirmDialog({
     </AlertDialog>
   );
 }
+
 function OrganisationMembersTable({
   filteredMembers,
   hasVerwaltenPermission,
   isPending,
   currentUserId,
+  selectedMemberId,
+  onSelectMember,
   onRoleChange,
   onStatusChange,
   onRemove
@@ -293,6 +303,8 @@ function OrganisationMembersTable({
   hasVerwaltenPermission: boolean;
   isPending: boolean;
   currentUserId?: string;
+  selectedMemberId: string | null;
+  onSelectMember: (id: string | null) => void;
   onRoleChange: (memberId: string, name: string, newRole: string) => void;
   onStatusChange: (memberId: string, name: string, newStatus: string) => void;
   onRemove: (memberId: string, name: string) => void;
@@ -301,7 +313,7 @@ function OrganisationMembersTable({
     <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs overflow-hidden">
       <CardHeader className="pb-2">
         <CardTitle className="text-xl">Aktive &amp; Deaktivierte Mitglieder</CardTitle>
-        <CardDescription>Mitglieder, die Zugriff auf diese Organisation haben.</CardDescription>
+        <CardDescription>Mitglieder, die Zugriff auf diese Organisation haben. Klicken Sie auf ein Mitglied, um Berechtigungen zu bearbeiten.</CardDescription>
       </CardHeader>
       <CardContent className="p-0">
         <div className="overflow-x-auto">
@@ -332,9 +344,19 @@ function OrganisationMembersTable({
                     : member.email.charAt(0).toUpperCase();
                   const isCurrentUser = member.user_id === currentUserId;
                   const isOwnerRow = member.rolle === 'owner';
+                  const isSelected = selectedMemberId === member.mitglied_id;
 
                   return (
-                    <TableRow key={member.mitglied_id} className="hover:bg-zinc-50/30 dark:hover:bg-zinc-900/30">
+                    <TableRow
+                      key={member.mitglied_id}
+                      onClick={() => onSelectMember(isSelected ? null : member.mitglied_id)}
+                      className={cn(
+                        "cursor-pointer transition-colors duration-150",
+                        isSelected
+                          ? "bg-zinc-100 dark:bg-zinc-800/80 hover:bg-zinc-150 dark:hover:bg-zinc-800"
+                          : "hover:bg-zinc-50/30 dark:hover:bg-zinc-900/30"
+                      )}
+                    >
                       <TableCell className="py-4 pl-6 flex items-center gap-3">
                         <Avatar className="h-9 w-9 border border-zinc-200/20">
                           <AvatarFallback className="bg-primary/5 text-primary text-xs font-bold">{initials}</AvatarFallback>
@@ -347,7 +369,7 @@ function OrganisationMembersTable({
                           <span className="text-xs text-muted-foreground">{member.email}</span>
                         </div>
                       </TableCell>
-                      <TableCell className="py-4">
+                      <TableCell className="py-4" onClick={(e) => e.stopPropagation()}>
                         {hasVerwaltenPermission && !isOwnerRow && !isCurrentUser ? (
                           <Select defaultValue={member.rolle} onValueChange={(val) => onRoleChange(member.mitglied_id, fullName || member.email, val)} disabled={isPending}>
                             <SelectTrigger className="w-[130px] h-8 rounded-lg text-xs"><SelectValue /></SelectTrigger>
@@ -362,7 +384,7 @@ function OrganisationMembersTable({
                           </Badge>
                         )}
                       </TableCell>
-                      <TableCell className="py-4">
+                      <TableCell className="py-4" onClick={(e) => e.stopPropagation()}>
                         {hasVerwaltenPermission && !isOwnerRow && !isCurrentUser ? (
                           <Select defaultValue={member.status} onValueChange={(val) => onStatusChange(member.mitglied_id, fullName || member.email, val)} disabled={isPending}>
                             <SelectTrigger className="w-[120px] h-8 rounded-lg text-xs"><SelectValue /></SelectTrigger>
@@ -381,7 +403,7 @@ function OrganisationMembersTable({
                         {new Date(member.erstellt_am).toLocaleDateString("de-DE")}
                       </TableCell>
                       {hasVerwaltenPermission && (
-                        <TableCell className="py-4 pr-6 text-right">
+                        <TableCell className="py-4 pr-6 text-right" onClick={(e) => e.stopPropagation()}>
                           {!isOwnerRow && !isCurrentUser ? (
                             <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground hover:text-red-500 rounded-lg" onClick={() => onRemove(member.mitglied_id, fullName || member.email)} disabled={isPending} title="Mitglied entfernen">
                               <Trash2 className="size-4" />
@@ -544,6 +566,8 @@ function OrganisationMembersTab({
   isPending,
   isInviting,
   currentUserId,
+  selectedMemberId,
+  onSelectMember,
   onSearchChange,
   onRoleFilterChange,
   onStatusFilterChange,
@@ -567,6 +591,8 @@ function OrganisationMembersTab({
   isPending: boolean;
   isInviting: boolean;
   currentUserId?: string;
+  selectedMemberId: string | null;
+  onSelectMember: (id: string | null) => void;
   onSearchChange: (val: string) => void;
   onRoleFilterChange: (val: string) => void;
   onStatusFilterChange: (val: string) => void;
@@ -578,6 +604,8 @@ function OrganisationMembersTab({
   onStatusChange: (memberId: string, name: string, newStatus: string) => void;
   onRemove: (memberId: string, name: string) => void;
 }) {
+  const selectedMember = filteredMembers.find(m => m.mitglied_id === selectedMemberId);
+
   return (
     <div className="flex flex-col gap-8">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center justify-between">
@@ -605,13 +633,16 @@ function OrganisationMembersTab({
         </div>
       </div>
 
-      <div className="grid gap-8 lg:grid-cols-3 items-start">
-        <div className="lg:col-span-2 flex flex-col gap-6">
+      <div className="flex flex-col md:flex-row gap-6 items-start">
+        {/* Left/Middle Pane: Member tables & Invites */}
+        <div className={cn("flex flex-col gap-6", selectedMemberId ? "w-full md:w-1/2" : "w-full md:w-2/3")}>
           <OrganisationMembersTable
             filteredMembers={filteredMembers}
             hasVerwaltenPermission={hasVerwaltenPermission}
             isPending={isPending}
             currentUserId={currentUserId}
+            selectedMemberId={selectedMemberId}
+            onSelectMember={onSelectMember}
             onRoleChange={onRoleChange}
             onStatusChange={onStatusChange}
             onRemove={onRemove}
@@ -623,17 +654,37 @@ function OrganisationMembersTab({
             isPending={isPending}
             onRevoke={onRevoke}
           />
+          {hasVerwaltenPermission && (
+            <OrganisationInvitePanel
+              inviteEmail={inviteEmail}
+              inviteRole={inviteRole}
+              isInviting={isInviting}
+              onInviteEmailChange={onInviteEmailChange}
+              onInviteRoleChange={onInviteRoleChange}
+              onInvite={onInvite}
+            />
+          )}
         </div>
-        {hasVerwaltenPermission && (
-          <OrganisationInvitePanel
-            inviteEmail={inviteEmail}
-            inviteRole={inviteRole}
-            isInviting={isInviting}
-            onInviteEmailChange={onInviteEmailChange}
-            onInviteRoleChange={onInviteRoleChange}
-            onInvite={onInvite}
-          />
-        )}
+
+        {/* Right Pane: Permission Configuration */}
+        <div className={cn("w-full", selectedMemberId ? "md:w-1/2" : "md:w-1/3")}>
+          {selectedMember ? (
+            <MitgliedPermissionDetail
+              mitgliedId={selectedMember.mitglied_id}
+              rolle={selectedMember.rolle}
+              status={selectedMember.status}
+              memberName={
+                selectedMember.first_name || selectedMember.last_name
+                  ? `${selectedMember.first_name || ""} ${selectedMember.last_name || ""}`.trim()
+                  : selectedMember.email
+              }
+            />
+          ) : (
+            <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs p-6 text-center text-zinc-500">
+              <p className="text-sm">Klicken Sie auf ein Mitglied in der Tabelle, um dessen detaillierte Objekt- und Modulberechtigungen anzuzeigen und zu bearbeiten.</p>
+            </Card>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -931,6 +982,8 @@ export default function OrganisationClientView({
           isPending={isPending}
           isInviting={isInviting}
           currentUserId={currentUser?.id}
+          selectedMemberId={uiState.selectedMemberId}
+          onSelectMember={(id) => dispatch({ type: 'SET_SELECTED_MEMBER', payload: id })}
           onSearchChange={(val) => dispatch({ type: 'SET_SEARCH_QUERY', payload: val })}
           onRoleFilterChange={(val) => dispatch({ type: 'SET_ROLE_FILTER', payload: val })}
           onStatusFilterChange={(val) => dispatch({ type: 'SET_STATUS_FILTER', payload: val })}
@@ -959,3 +1012,4 @@ export default function OrganisationClientView({
     </LazyMotion>
   );
 }
+

--- a/app/(dashboard)/todos/client-wrapper.tsx
+++ b/app/(dashboard)/todos/client-wrapper.tsx
@@ -306,9 +306,10 @@ function SidebarTaskList({ tasks, setTasks, onTaskClick, onTaskToggle }: Sidebar
 
 interface TodosClientWrapperProps {
   tasks: TaskBoardTask[];
+  canCreate?: boolean;
 }
 
-export default function TodosClientWrapper({ tasks: initialTasks }: TodosClientWrapperProps) {
+export default function TodosClientWrapper({ tasks: initialTasks, canCreate = true }: TodosClientWrapperProps) {
   const [tasks, setTasks] = useState<TaskBoardTask[]>(initialTasks);
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
@@ -554,6 +555,9 @@ export default function TodosClientWrapper({ tasks: initialTasks }: TodosClientW
                   onClick={() => handleAddTask()}
                   icon={<PlusCircle className="size-4" />}
                   shortText="Hinzufügen"
+                  disabled={!canCreate}
+                  tooltip="Keine Berechtigung zum Erstellen"
+                  showTooltip={!canCreate}
                 >
                   Aufgabe hinzufügen
                 </ResponsiveButtonWithTooltip>

--- a/app/(dashboard)/todos/page.tsx
+++ b/app/(dashboard)/todos/page.tsx
@@ -3,13 +3,14 @@ export const dynamic = 'force-dynamic';
 
 import TodosClientWrapper from "./client-wrapper";
 import { requireAuthenticatedUser } from "@/lib/server/route-access";
-import { requirePermission } from "@/lib/permissions";
+import { requirePermission, hasPermission } from "@/lib/permissions";
 
 export default async function TodosPage() {
   const { supabase } = await requireAuthenticatedUser();
   await requirePermission('aufgaben', 'ansehen');
+  const canCreate = await hasPermission('aufgaben', 'erstellen');
   const { data: tasksData } = await supabase.from('Aufgaben').select('*');
   const tasks = tasksData ?? [];
 
-  return <TodosClientWrapper tasks={tasks} />;
+  return <TodosClientWrapper tasks={tasks} canCreate={canCreate} />;
 }

--- a/app/(dashboard)/todos/page.tsx
+++ b/app/(dashboard)/todos/page.tsx
@@ -7,9 +7,13 @@ import { requirePermission, hasPermission } from "@/lib/permissions";
 
 export default async function TodosPage() {
   const { supabase } = await requireAuthenticatedUser();
-  await requirePermission('aufgaben', 'ansehen');
-  const canCreate = await hasPermission('aufgaben', 'erstellen');
-  const { data: tasksData } = await supabase.from('Aufgaben').select('*');
+  
+  const [_, canCreate, { data: tasksData }] = await Promise.all([
+    requirePermission('aufgaben', 'ansehen'),
+    hasPermission('aufgaben', 'erstellen'),
+    supabase.from('Aufgaben').select('*')
+  ]);
+  
   const tasks = tasksData ?? [];
 
   return <TodosClientWrapper tasks={tasks} canCreate={canCreate} />;

--- a/app/(dashboard)/todos/page.tsx
+++ b/app/(dashboard)/todos/page.tsx
@@ -3,9 +3,11 @@ export const dynamic = 'force-dynamic';
 
 import TodosClientWrapper from "./client-wrapper";
 import { requireAuthenticatedUser } from "@/lib/server/route-access";
+import { requirePermission } from "@/lib/permissions";
 
 export default async function TodosPage() {
   const { supabase } = await requireAuthenticatedUser();
+  await requirePermission('aufgaben', 'ansehen');
   const { data: tasksData } = await supabase.from('Aufgaben').select('*');
   const tasks = tasksData ?? [];
 

--- a/app/(dashboard)/wohnungen/client.tsx
+++ b/app/(dashboard)/wohnungen/client.tsx
@@ -308,6 +308,12 @@ export default function WohnungenClientView({
 
   const handleEditWohnung = useCallback(async (apartment: ApartmentTableType) => {
     try {
+      const existingApt = apartments.find(a => a.id === apartment.id);
+      if (existingApt) {
+        openWohnungModal(existingApt, housesData, handleSuccess, serverApartmentCount, serverApartmentLimit, serverUserIsEligibleToAdd);
+        return;
+      }
+
       const supabase = createBrowserClient();
       const { data: aptToEdit, error } = await supabase.from('Wohnungen').select('*, Haeuser(name)').eq('id', apartment.id).single();
       if (error || !aptToEdit) {
@@ -319,7 +325,7 @@ export default function WohnungenClientView({
     } catch (error) {
       console.error('Fehler beim Laden der Wohnung für Bearbeitung:', error);
     }
-  }, [openWohnungModal, housesData, handleSuccess, serverApartmentCount, serverApartmentLimit, serverUserIsEligibleToAdd]);
+  }, [apartments, openWohnungModal, housesData, handleSuccess, serverApartmentCount, serverApartmentLimit, serverUserIsEligibleToAdd]);
 
   useEffect(() => {
     const handleEditApartmentListener = async (event: Event) => {
@@ -327,6 +333,12 @@ export default function WohnungenClientView({
       const apartmentId = customEvent.detail?.id;
       if (!apartmentId) return;
       try {
+        const existingApt = apartments.find(a => a.id === apartmentId);
+        if (existingApt) {
+          handleEditWohnung(existingApt);
+          return;
+        }
+
         const supabase = createBrowserClient();
         const { data: aptToEdit, error } = await supabase.from('Wohnungen').select('*, Haeuser(name)').eq('id', apartmentId).single();
         if (error || !aptToEdit) { console.error('Wohnung nicht gefunden oder Fehler:', error?.message); return; }
@@ -336,7 +348,7 @@ export default function WohnungenClientView({
     };
     window.addEventListener('edit-apartment', handleEditApartmentListener);
     return () => window.removeEventListener('edit-apartment', handleEditApartmentListener);
-  }, [handleEditWohnung]);
+  }, [apartments, handleEditWohnung]);
 
   return (
     <div className="flex flex-col gap-6 sm:gap-8 p-4 sm:p-8">

--- a/app/(dashboard)/wohnungen/client.tsx
+++ b/app/(dashboard)/wohnungen/client.tsx
@@ -327,15 +327,20 @@ export default function WohnungenClientView({
     }
   }, [apartments, openWohnungModal, housesData, handleSuccess, serverApartmentCount, serverApartmentLimit, serverUserIsEligibleToAdd]);
 
+  const handleEditWohnungRef = useRef(handleEditWohnung);
+  handleEditWohnungRef.current = handleEditWohnung;
+  const apartmentsRef = useRef(apartments);
+  apartmentsRef.current = apartments;
+
   useEffect(() => {
     const handleEditApartmentListener = async (event: Event) => {
       const customEvent = event as CustomEvent<{ id: string }>;
       const apartmentId = customEvent.detail?.id;
       if (!apartmentId) return;
       try {
-        const existingApt = apartments.find(a => a.id === apartmentId);
+        const existingApt = apartmentsRef.current.find(a => a.id === apartmentId);
         if (existingApt) {
-          handleEditWohnung(existingApt);
+          handleEditWohnungRef.current(existingApt);
           return;
         }
 
@@ -343,12 +348,12 @@ export default function WohnungenClientView({
         const { data: aptToEdit, error } = await supabase.from('Wohnungen').select('*, Haeuser(name)').eq('id', apartmentId).single();
         if (error || !aptToEdit) { console.error('Wohnung nicht gefunden oder Fehler:', error?.message); return; }
         const transformedApt = { ...aptToEdit, Haeuser: Array.isArray(aptToEdit.Haeuser) ? aptToEdit.Haeuser[0] : aptToEdit.Haeuser } as Wohnung;
-        handleEditWohnung(transformedApt);
+        handleEditWohnungRef.current(transformedApt);
       } catch (error) { console.error('Fehler beim Laden der Wohnung für Event-Edit:', error); }
     };
     window.addEventListener('edit-apartment', handleEditApartmentListener);
     return () => window.removeEventListener('edit-apartment', handleEditApartmentListener);
-  }, [apartments, handleEditWohnung]);
+  }, []);
 
   return (
     <div className="flex flex-col gap-6 sm:gap-8 p-4 sm:p-8">

--- a/app/(dashboard)/wohnungen/page.tsx
+++ b/app/(dashboard)/wohnungen/page.tsx
@@ -11,10 +11,23 @@ import { getPlanDetails } from '@/lib/stripe-server';
 import { isTestEnv } from '@/lib/test-utils';
 import WohnungenClientView from './client'; // Import the default export from client.tsx
 import type { Wohnung } from "@/types/Wohnung";
+import { hasPermission } from "@/lib/permissions";
+import { redirect } from "next/navigation";
 
 // Server Component: Fetches data and passes it to the Client Component
 export default async function WohnungenPage() {
   const { supabase, user } = await requireAuthenticatedUser();
+
+  // Permission check with object-scope exception (same as haeuser).
+  const [canView, accessibleIdsResult] = await Promise.all([
+    hasPermission('wohnungen', 'ansehen'),
+    supabase.rpc('get_accessible_haeuser_ids'),
+  ]);
+  const accessibleIds = accessibleIdsResult.data;
+  const hasObjectScopeAccess = accessibleIds === null || (Array.isArray(accessibleIds) && accessibleIds.length > 0);
+  if (!canView && !hasObjectScopeAccess) {
+    redirect('/unauthorized');
+  }
 
   let apartmentCount = 0;
   let userIsEligibleToAdd = false;

--- a/app/(dashboard)/wohnungen/page.tsx
+++ b/app/(dashboard)/wohnungen/page.tsx
@@ -34,7 +34,25 @@ export default async function WohnungenPage() {
   let effectiveApartmentLimit: number | typeof Infinity = 0;
   let limitReason: 'trial' | 'subscription' | 'none' = 'none';
 
-  // Load profile and main data in parallel to eliminate waterfalls
+  // Load profile and main data in parallel with object-scope filtering.
+  // The accessibleIds check restricts all queries to only houses/apartments
+  // the restricted employee has object-level access to.
+  const fetchScopedApartmentsCount = async () => {
+    let q = supabase.from('Wohnungen').select('*', { count: 'exact', head: true });
+    if (accessibleIds !== null) q = q.in('haus_id', accessibleIds);
+    return q;
+  };
+  const fetchScopedApartments = async () => {
+    let q = supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id,Haeuser(name)');
+    if (accessibleIds !== null) q = q.in('haus_id', accessibleIds);
+    return q;
+  };
+  const fetchScopedHaeuser = async () => {
+    let q = supabase.from('Haeuser').select('id,name');
+    if (accessibleIds !== null) q = q.in('id', accessibleIds);
+    return q;
+  };
+
   const [
     userProfile,
     countResult,
@@ -43,10 +61,12 @@ export default async function WohnungenPage() {
     housesResult
   ] = await Promise.all([
     fetchUserProfile(),
-    supabase.from('Wohnungen').select('*', { count: 'exact', head: true }),
-    supabase.from('Wohnungen').select('id,name,groesse,miete,haus_id,Haeuser(name)'),
+    fetchScopedApartmentsCount(),
+    fetchScopedApartments(),
+    // Tenants query is unscoped — tenantMap is only accessed by scoped apartment IDs,
+    // so extra tenant data is harmless.
     supabase.from('Mieter').select('id,wohnung_id,einzug,auszug,name'),
-    supabase.from('Haeuser').select('id,name')
+    fetchScopedHaeuser(),
   ]);
 
   if (userProfile) {

--- a/app/api/haeuser/route.ts
+++ b/app/api/haeuser/route.ts
@@ -37,7 +37,14 @@ export async function POST(request: Request) {
 
 export async function GET() {
   const supabase = await createClient()
-  const { data: houses, error: housesError } = await supabase.from('Haeuser').select("*")
+
+  // Apply object scope filtering
+  const { data: accessibleIds } = await supabase.rpc('get_accessible_haeuser_ids')
+  let q = supabase.from('Haeuser').select("*")
+  if (accessibleIds !== null && accessibleIds.length > 0) {
+    q = q.in('id', accessibleIds)
+  }
+  const { data: houses, error: housesError } = await q
   
   if (housesError) {
     return NextResponse.json({ error: housesError.message }, { 

--- a/components/abrechnung/create-abrechnung-dropdown.tsx
+++ b/components/abrechnung/create-abrechnung-dropdown.tsx
@@ -18,6 +18,7 @@ interface CreateAbrechnungDropdownProps {
   buttonText?: string;
   buttonVariant?: "default" | "outline" | "ghost" | "link";
   align?: "center" | "start" | "end";
+  canCreate?: boolean;
 }
 
 export function CreateAbrechnungDropdown({
@@ -28,6 +29,7 @@ export function CreateAbrechnungDropdown({
   buttonText = "Neue Abrechnung erstellen",
   buttonVariant,
   align = "end",
+  canCreate = true,
 }: CreateAbrechnungDropdownProps) {
   return (
     <DropdownMenu>
@@ -37,6 +39,9 @@ export function CreateAbrechnungDropdown({
           onClick={() => useOnboardingStore.getState().completeStep('create-bill-start')}
           className={className}
           variant={buttonVariant}
+          disabled={!canCreate}
+          tooltip="Keine Berechtigung zum Erstellen"
+          showTooltip={!canCreate}
         >
           <PlusCircle className="mr-2 h-4 w-4" />
           {buttonText}

--- a/components/common/mobile-bottom-navigation.tsx
+++ b/components/common/mobile-bottom-navigation.tsx
@@ -311,7 +311,7 @@ function useMobileNavigation(sidebarData: SidebarUserData | undefined, isRouteAc
     { id: 'houses', title: 'Häuser', href: '/haeuser', icon: Building2 },
     { id: 'apartments', title: 'Wohnungen', href: '/wohnungen', icon: Home },
     { id: 'operating-costs', title: 'Betriebskosten', href: '/betriebskosten', icon: FileSpreadsheet },
-    { id: 'organisation', title: 'Organisationen', href: '/organisation', icon: Building2, hidden: !sidebarData?.hasOrganisationPermission || sidebarData?.isOrganisationHidden },
+    { id: 'organisation', title: 'Organisationen', href: '/organisation', icon: Building2, hidden: !sidebarData?.hasOrganisationPermission || sidebarData?.isOrganisationHidden || (sidebarData?.modulePermissions !== null && !sidebarData?.modulePermissions.has('organisation')) },
     { id: 'tasks', title: 'Aufgaben', href: '/todos', icon: CheckSquare },
     { id: 'documents', title: 'Dokumente', href: '/dateien', icon: Folder, hidden: !documentsEnabled },
     { id: 'logout', title: 'Abmelden', icon: LogOut, onClick: handleLogout }

--- a/components/dashboard/dashboard-sidebar-navigation.test.tsx
+++ b/components/dashboard/dashboard-sidebar-navigation.test.tsx
@@ -38,6 +38,7 @@ const mockSidebarData: SidebarUserData = {
   apartmentLimit: 10,
   hasOrganisationPermission: true,
   isOrganisationHidden: false,
+  modulePermissions: null,
 }
 
 describe('DashboardSidebar Navigation', () => {

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -150,6 +150,20 @@ const sidebarNavGroups: SidebarNavGroupType[] = [
   }
 ];
 
+/**
+ * Maps sidebar item hrefs to the module key used in check_permission.
+ * Items without an entry are always visible (Dashboard, Suche, E-Mails, Organisation).
+ */
+const SIDEBAR_MODULE_MAP: Record<string, string> = {
+  '/haeuser': 'haeuser',
+  '/wohnungen': 'wohnungen',
+  '/mieter': 'mieter',
+  '/finanzen': 'finanzen',
+  '/betriebskosten': 'betriebskosten',
+  '/todos': 'aufgaben',
+  '/dateien': 'dokumente',
+};
+
 export function DashboardSidebar({ sidebarData }: { sidebarData: SidebarUserData }) {
   const pathname = usePathname()
   const [isOpen, setIsOpen] = useState(false)
@@ -511,6 +525,11 @@ function SidebarContent({
                 }
                 if (item.href === "/organisation") {
                   return sidebarData.hasOrganisationPermission && !sidebarData.isOrganisationHidden;
+                }
+                // Check module permissions if they are restricted (non-null Set).
+                const requiredModule = SIDEBAR_MODULE_MAP[item.href];
+                if (requiredModule && sidebarData.modulePermissions !== null) {
+                  return sidebarData.modulePermissions.has(requiredModule);
                 }
                 return true;
               }

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -162,6 +162,7 @@ const SIDEBAR_MODULE_MAP: Record<string, string> = {
   '/betriebskosten': 'betriebskosten',
   '/todos': 'aufgaben',
   '/dateien': 'dokumente',
+  '/organisation': 'organisation',
 };
 
 export function DashboardSidebar({ sidebarData }: { sidebarData: SidebarUserData }) {
@@ -522,9 +523,6 @@ function SidebarContent({
               item => {
                 if (featureFlags.has(item.href) && !featureFlags.get(item.href)) {
                   return false;
-                }
-                if (item.href === "/organisation") {
-                  return sidebarData.hasOrganisationPermission && !sidebarData.isOrganisationHidden;
                 }
                 // Check module permissions if they are restricted (non-null Set).
                 const requiredModule = SIDEBAR_MODULE_MAP[item.href];

--- a/components/organisation/mitglied-permission-detail.tsx
+++ b/components/organisation/mitglied-permission-detail.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+import React, { useState, useEffect, useTransition } from "react";
+import { MemberPermissions, HausWithWohnungen } from "@/lib/organisation-types";
+import { getMitgliedPermissionsAction, getOrgHaeuserAction, setMitgliedOverridesAction } from "@/lib/perms-actions";
+import { ObjectScopeEditor } from "./object-scope-editor";
+import { ModulePermissionEditor } from "./module-permission-editor";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { ShieldAlert, Lock, CheckCircle, RefreshCw, Save } from "lucide-react";
+import { toast } from "@/hooks/use-toast";
+
+interface Props {
+  mitgliedId: string;
+  rolle: "owner" | "admin" | "mitarbeiter";
+  status: "eingeladen" | "aktiv" | "deaktiviert";
+  memberName: string;
+}
+
+export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName }: Props) {
+  const [permissions, setPermissions] = useState<MemberPermissions | null>(null);
+  const [originalPermissions, setOriginalPermissions] = useState<MemberPermissions | null>(null);
+  const [haeuser, setHaeuser] = useState<HausWithWohnungen[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, startSavingTransition] = useTransition();
+
+  const isLocked = rolle === "owner" || rolle === "admin";
+
+  const fetchPermissions = async () => {
+    if (isLocked) return;
+    setLoading(true);
+    try {
+      const [perms, houses] = await Promise.all([
+        getMitgliedPermissionsAction(mitgliedId),
+        getOrgHaeuserAction(),
+      ]);
+      setPermissions(perms);
+      // Deep clone to keep track of dirty states
+      setOriginalPermissions(JSON.parse(JSON.stringify(perms)));
+      setHaeuser(houses);
+    } catch (error) {
+      console.error("Failed to load permissions:", error);
+      toast({
+        title: "Fehler beim Laden",
+        description: "Die Berechtigungen konnten nicht geladen werden.",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchPermissions();
+  }, [mitgliedId, rolle]);
+
+  // Compute stats for overview pane
+  const statsSummary = React.useMemo(() => {
+    if (!permissions) return null;
+    const isUnrestricted = permissions.objekte?.haeuser === null;
+    
+    // Count houses
+    const housesCount = isUnrestricted
+      ? haeuser.length
+      : permissions.objekte?.haeuser?.length || 0;
+
+    // Count apartments
+    const apartmentsCount = isUnrestricted
+      ? haeuser.reduce((sum, h) => sum + h.wohnungen.length, 0)
+      : permissions.objekte?.wohnungen?.length || 0;
+
+    // Count modules that have at least one permission
+    const activeModules = Object.values(permissions.module || {}).filter(arr => arr.length > 0).length;
+
+    return {
+      isUnrestricted,
+      housesCount,
+      apartmentsCount,
+      activeModules,
+    };
+  }, [permissions, haeuser]);
+
+  // Check if dirty
+  const isDirty = React.useMemo(() => {
+    if (!permissions || !originalPermissions) return false;
+    return JSON.stringify(permissions) !== JSON.stringify(originalPermissions);
+  }, [permissions, originalPermissions]);
+
+  const handleSave = () => {
+    if (!permissions || !isDirty) return;
+
+    startSavingTransition(async () => {
+      const payload = {
+        module: permissions.module || {},
+        objekte: permissions.objekte || { haeuser: null, wohnungen: null },
+      };
+
+      const res = await setMitgliedOverridesAction(mitgliedId, payload);
+      if (res.success) {
+        toast({
+          title: "Berechtigungen gespeichert",
+          description: `Die Berechtigungen für ${memberName} wurden erfolgreich aktualisiert.`,
+          variant: "success",
+        });
+        setOriginalPermissions(JSON.parse(JSON.stringify(permissions)));
+      } else {
+        toast({
+          title: "Fehler beim Speichern",
+          description: res.error || "Es gab ein Problem beim Speichern.",
+          variant: "destructive",
+        });
+      }
+    });
+  };
+
+  const handleReset = () => {
+    if (originalPermissions) {
+      setPermissions(JSON.parse(JSON.stringify(originalPermissions)));
+    }
+  };
+
+  const handleObjectScopeChange = (hausIds: string[] | null, wohnungIds: string[] | null) => {
+    if (!permissions) return;
+    setPermissions({
+      ...permissions,
+      objekte: {
+        haeuser: hausIds,
+        wohnungen: wohnungIds,
+      },
+    });
+  };
+
+  const handleModulePermissionsChange = (modulePerms: Record<string, string[]>) => {
+    if (!permissions) return;
+    setPermissions({
+      ...permissions,
+      module: modulePerms,
+    });
+  };
+
+  if (isLocked) {
+    return (
+      <div className="flex flex-col gap-6">
+        <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs overflow-hidden">
+          <CardHeader>
+            <CardTitle className="text-xl flex items-center gap-2">
+              <Lock className="size-5 text-indigo-500" />
+              Rollenbasierte Berechtigungen
+            </CardTitle>
+            <CardDescription>
+              Für diese Rolle sind Berechtigungen fest definiert.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="p-6 pt-0">
+            <Alert className="rounded-2xl bg-indigo-500/10 border-indigo-500/20 text-indigo-700 dark:text-indigo-400 [&>svg]:text-indigo-500">
+              <ShieldAlert className="size-4" />
+              <AlertTitle className="font-semibold">{rolle === "owner" ? "Eigentümer" : "Administrator"}</AlertTitle>
+              <AlertDescription className="text-xs mt-1">
+                {rolle === "owner" ? "Der Eigentümer" : "Administratoren"} der Organisation {rolle === "owner" ? "hat" : "haben"} vollumfänglichen Zugriff auf alle Objekte, Module und Einstellungen und {rolle === "owner" ? "kann" : "können"} nicht eingeschränkt werden.
+              </AlertDescription>
+            </Alert>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center p-12 border border-dashed border-zinc-200 dark:border-zinc-800 rounded-[2rem] min-h-[300px] gap-3">
+        <RefreshCw className="size-6 animate-spin text-muted-foreground" />
+        <span className="text-sm text-muted-foreground">Berechtigungen werden geladen...</span>
+      </div>
+    );
+  }
+
+  if (!permissions) {
+    return (
+      <div className="flex flex-col items-center justify-center p-12 border border-dashed border-zinc-200 dark:border-zinc-800 rounded-[2rem] min-h-[300px]">
+        <span className="text-sm text-muted-foreground">Wählen Sie ein Mitglied aus der Liste aus, um Berechtigungen anzuzeigen.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Top Save / Discard bar if dirty */}
+      {isDirty && (
+        <div className="flex items-center justify-between p-4 bg-amber-500/10 border border-amber-500/20 rounded-2xl animate-in fade-in slide-in-from-top-2 duration-250">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-semibold text-amber-700 dark:text-amber-400">
+              Ungespeicherte Änderungen an den Berechtigungen von {memberName}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              size="xs"
+              variant="ghost"
+              onClick={handleReset}
+              disabled={saving}
+              className="text-xs h-8 rounded-lg"
+            >
+              Verwerfen
+            </Button>
+            <Button
+              size="xs"
+              onClick={handleSave}
+              disabled={saving}
+              className="text-xs h-8 rounded-lg bg-amber-500 hover:bg-amber-600 text-white font-medium flex items-center gap-1.5"
+            >
+              {saving ? (
+                <>
+                  <RefreshCw className="size-3 animate-spin" />
+                  <span>Speichert...</span>
+                </>
+              ) : (
+                <>
+                  <Save className="size-3" />
+                  <span>Speichern</span>
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Permissions Stats Summary Bar */}
+      {statsSummary && (
+        <div className="grid grid-cols-3 gap-4 p-4 bg-zinc-50 dark:bg-zinc-900 border border-zinc-200/50 dark:border-zinc-800/50 rounded-2xl">
+          <div className="flex flex-col gap-0.5">
+            <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Objekt-Scope</span>
+            <span className="text-sm font-semibold text-zinc-800 dark:text-zinc-200">
+              {statsSummary.isUnrestricted
+                ? "Unbeschränkt"
+                : `${statsSummary.housesCount} Haus / ${statsSummary.apartmentsCount} Wohn.`}
+            </span>
+          </div>
+          <div className="flex flex-col gap-0.5 border-x border-zinc-200/80 dark:border-zinc-800/80 px-4">
+            <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Module</span>
+            <span className="text-sm font-semibold text-zinc-800 dark:text-zinc-200">
+              {statsSummary.activeModules} von 10 aktiv
+            </span>
+          </div>
+          <div className="flex flex-col gap-0.5 pl-4">
+            <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Status</span>
+            <span className="text-sm font-semibold text-zinc-800 dark:text-zinc-200 flex items-center gap-1">
+              <CheckCircle className="size-3.5 text-emerald-500" />
+              Konfiguriert
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* Accordion or Tabs for editors */}
+      <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg">Objekt-Scope (Zugriffsbeschränkung)</CardTitle>
+          <CardDescription className="text-xs">
+            Legen Sie fest, auf welche Häuser und Wohnungen dieser Mitarbeiter Zugriff erhalten soll.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <ObjectScopeEditor
+            haeuser={haeuser}
+            selectedHausIds={permissions.objekte?.haeuser}
+            selectedWohnungIds={permissions.objekte?.wohnungen}
+            onChange={handleObjectScopeChange}
+            disabled={saving}
+          />
+        </CardContent>
+      </Card>
+
+      <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg">Modul- und Aktionsberechtigungen</CardTitle>
+          <CardDescription className="text-xs">
+            Legen Sie fest, welche Aktionen in den jeweiligen Modulen ausgeführt werden dürfen.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-0 sm:px-6 sm:pb-6">
+          <ModulePermissionEditor
+            modulePermissions={permissions.module || {}}
+            onChange={handleModulePermissionsChange}
+            disabled={saving}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/organisation/mitglied-permission-detail.tsx
+++ b/components/organisation/mitglied-permission-detail.tsx
@@ -65,10 +65,12 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
       ? haeuser.length
       : permissions.objekte?.haeuser?.length || 0;
 
-    // Count apartments
+    // Count apartments (derived from selected houses — no per-wohnung scope)
     const apartmentsCount = isUnrestricted
       ? haeuser.reduce((sum, h) => sum + h.wohnungen.length, 0)
-      : permissions.objekte?.wohnungen?.length || 0;
+      : haeuser
+          .filter(h => permissions.objekte?.haeuser?.includes(h.id))
+          .reduce((sum, h) => sum + h.wohnungen.length, 0);
 
     // Count modules that have at least one permission
     const activeModules = Object.values(permissions.module || {}).filter(arr => arr.length > 0).length;
@@ -93,7 +95,7 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
     startSavingTransition(async () => {
       const payload = {
         module: permissions.module || {},
-        objekte: permissions.objekte || { haeuser: null, wohnungen: null },
+        objekte: { haeuser: permissions.objekte?.haeuser ?? null },
       };
 
       const res = await setMitgliedOverridesAction(mitgliedId, payload);
@@ -120,13 +122,12 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
     }
   };
 
-  const handleObjectScopeChange = (hausIds: string[] | null, wohnungIds: string[] | null) => {
+  const handleObjectScopeChange = (hausIds: string[] | null) => {
     if (!permissions) return;
     setPermissions({
       ...permissions,
       objekte: {
         haeuser: hausIds,
-        wohnungen: wohnungIds,
       },
     });
   };
@@ -264,7 +265,6 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
           <ObjectScopeEditor
             haeuser={haeuser}
             selectedHausIds={permissions.objekte?.haeuser}
-            selectedWohnungIds={permissions.objekte?.wohnungen}
             onChange={handleObjectScopeChange}
             disabled={saving}
           />

--- a/components/organisation/mitglied-permission-detail.tsx
+++ b/components/organisation/mitglied-permission-detail.tsx
@@ -27,33 +27,33 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
 
   const isLocked = rolle === "owner" || rolle === "admin";
 
-  const fetchPermissions = async () => {
-    if (isLocked) return;
-    setLoading(true);
-    try {
-      const [perms, houses] = await Promise.all([
-        getMitgliedPermissionsAction(mitgliedId),
-        getOrgHaeuserAction(),
-      ]);
-      setPermissions(perms);
-      // Deep clone to keep track of dirty states
-      setOriginalPermissions(JSON.parse(JSON.stringify(perms)));
-      setHaeuser(houses);
-    } catch (error) {
-      console.error("Failed to load permissions:", error);
-      toast({
-        title: "Fehler beim Laden",
-        description: "Die Berechtigungen konnten nicht geladen werden.",
-        variant: "destructive",
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
-
   useEffect(() => {
+    const fetchPermissions = async () => {
+      if (isLocked) return;
+      setLoading(true);
+      try {
+        const [perms, houses] = await Promise.all([
+          getMitgliedPermissionsAction(mitgliedId),
+          getOrgHaeuserAction(),
+        ]);
+        setPermissions(perms);
+        // Deep clone to keep track of dirty states
+        setOriginalPermissions(structuredClone(perms));
+        setHaeuser(houses);
+      } catch (error) {
+        console.error("Failed to load permissions:", error);
+        toast({
+          title: "Fehler beim Laden",
+          description: "Die Berechtigungen konnten nicht geladen werden.",
+          variant: "destructive",
+        });
+      } finally {
+        setLoading(false);
+      }
+    };
+
     fetchPermissions();
-  }, [mitgliedId, rolle]);
+  }, [mitgliedId, isLocked]);
 
   // Compute stats for overview pane
   const statsSummary = React.useMemo(() => {
@@ -105,7 +105,7 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
           description: `Die Berechtigungen für ${memberName} wurden erfolgreich aktualisiert.`,
           variant: "success",
         });
-        setOriginalPermissions(JSON.parse(JSON.stringify(permissions)));
+        setOriginalPermissions(structuredClone(permissions));
       } else {
         toast({
           title: "Fehler beim Speichern",
@@ -118,7 +118,7 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
 
   const handleReset = () => {
     if (originalPermissions) {
-      setPermissions(JSON.parse(JSON.stringify(originalPermissions)));
+      setPermissions(structuredClone(originalPermissions));
     }
   };
 
@@ -188,7 +188,7 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
     <div className="flex flex-col gap-6">
       {/* Top Save / Discard bar if dirty */}
       {isDirty && (
-        <div className="flex items-center justify-between p-4 bg-amber-500/10 border border-amber-500/20 rounded-2xl animate-in fade-in slide-in-from-top-2 duration-250">
+        <div className="flex items-center justify-between p-4 bg-amber-500/10 border border-amber-500/20 rounded-2xl animate-in fade-in slide-in-from-top-2 duration-200">
           <div className="flex items-center gap-2">
             <span className="text-xs font-semibold text-amber-700 dark:text-amber-400">
               Ungespeicherte Änderungen an den Berechtigungen von {memberName}

--- a/components/organisation/module-permission-editor.tsx
+++ b/components/organisation/module-permission-editor.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import React from "react";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+const MODULES = [
+  { key: "haeuser", label: "Häuser" },
+  { key: "wohnungen", label: "Wohnungen" },
+  { key: "mieter", label: "Mieter" },
+  { key: "zaehler", label: "Zähler" },
+  { key: "finanzen", label: "Finanzen" },
+  { key: "betriebskosten", label: "Betriebskosten" },
+  { key: "dokumente", label: "Dokumente" },
+  { key: "aufgaben", label: "Aufgaben" },
+  { key: "vorlagen", label: "Vorlagen" },
+  { key: "organisation", label: "Organisation" },
+] as const;
+
+const AKTIONEN = [
+  { key: "ansehen", label: "Ansehen" },
+  { key: "erstellen", label: "Erstellen" },
+  { key: "bearbeiten", label: "Bearbeiten" },
+  { key: "loeschen", label: "Löschen" },
+  { key: "verwalten", label: "Verwalten" },
+] as const;
+
+interface ModulePermissionEditorProps {
+  modulePermissions: Record<string, string[]>;
+  onChange: (permissions: Record<string, string[]>) => void;
+  disabled?: boolean;
+}
+
+export function ModulePermissionEditor({
+  modulePermissions,
+  onChange,
+  disabled = false,
+}: ModulePermissionEditorProps) {
+  const togglePermission = (moduleKey: string, aktionKey: string) => {
+    if (disabled) return;
+
+    const currentModulePerms = modulePermissions[moduleKey] || [];
+    let nextModulePerms: string[];
+
+    if (currentModulePerms.includes(aktionKey)) {
+      nextModulePerms = currentModulePerms.filter(a => a !== aktionKey);
+    } else {
+      nextModulePerms = [...currentModulePerms, aktionKey];
+    }
+
+    onChange({
+      ...modulePermissions,
+      [moduleKey]: nextModulePerms,
+    });
+  };
+
+  const handleSelectRowAll = (moduleKey: string) => {
+    if (disabled) return;
+    onChange({
+      ...modulePermissions,
+      [moduleKey]: AKTIONEN.map(a => a.key),
+    });
+  };
+
+  const handleDeselectRowAll = (moduleKey: string) => {
+    if (disabled) return;
+    onChange({
+      ...modulePermissions,
+      [moduleKey]: [],
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="overflow-x-auto border border-zinc-200 dark:border-zinc-800 rounded-2xl">
+        <Table>
+          <TableHeader className="bg-zinc-50/50 dark:bg-zinc-900/50">
+            <TableRow>
+              <TableHead className="w-[180px] font-semibold py-3 pl-6">Modul</TableHead>
+              {AKTIONEN.map(aktion => (
+                <TableHead key={aktion.key} className="text-center font-medium text-xs py-3">
+                  {aktion.label}
+                </TableHead>
+              ))}
+              {!disabled && <TableHead className="w-[140px] text-right py-3 pr-6">Aktionen</TableHead>}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {MODULES.map(mod => {
+              const currentPerms = modulePermissions[mod.key] || [];
+              const isRowEmpty = currentPerms.length === 0;
+              const isRowAllSelected = currentPerms.length === AKTIONEN.length;
+
+              return (
+                <TableRow key={mod.key} className="hover:bg-zinc-50/30 dark:hover:bg-zinc-900/30">
+                  <TableCell className="font-semibold text-sm py-3.5 pl-6 flex items-center gap-2">
+                    <span>{mod.label}</span>
+                    {isRowEmpty && (
+                      <Badge variant="outline" className="bg-red-50 text-red-700 border-red-200 text-[10px] py-0 px-1.5 rounded-full font-medium">
+                        Kein Zugriff
+                      </Badge>
+                    )}
+                  </TableCell>
+                  {AKTIONEN.map(aktion => {
+                    const isChecked = currentPerms.includes(aktion.key);
+                    return (
+                      <TableCell key={aktion.key} className="text-center py-3.5">
+                        <div className="flex justify-center">
+                          <Checkbox
+                            checked={isChecked}
+                            onCheckedChange={() => togglePermission(mod.key, aktion.key)}
+                            disabled={disabled}
+                            id={`perm-${mod.key}-${aktion.key}`}
+                            aria-label={`${mod.label} ${aktion.label}`}
+                          />
+                        </div>
+                      </TableCell>
+                    );
+                  })}
+                  {!disabled && (
+                    <TableCell className="text-right py-3.5 pr-6">
+                      <div className="flex justify-end gap-1.5">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="xs"
+                          onClick={() => {
+                            if (isRowAllSelected) {
+                              handleDeselectRowAll(mod.key);
+                            } else {
+                              handleSelectRowAll(mod.key);
+                            }
+                          }}
+                          className="h-7 text-xs rounded-lg px-2 hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                        >
+                          {isRowAllSelected ? "Zurücksetzen" : "Alle"}
+                        </Button>
+                      </div>
+                    </TableCell>
+                  )}
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/components/organisation/module-permission-editor.tsx
+++ b/components/organisation/module-permission-editor.tsx
@@ -15,7 +15,6 @@ const MODULES = [
   { key: "betriebskosten", label: "Betriebskosten" },
   { key: "dokumente", label: "Dokumente" },
   { key: "aufgaben", label: "Aufgaben" },
-  { key: "vorlagen", label: "Vorlagen" },
   { key: "organisation", label: "Organisation" },
 ] as const;
 

--- a/components/organisation/object-scope-editor.tsx
+++ b/components/organisation/object-scope-editor.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import React from "react";
+import { HausWithWohnungen } from "@/lib/organisation-types";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
+
+interface ObjectScopeEditorProps {
+  haeuser: HausWithWohnungen[];
+  selectedHausIds: string[] | null; // null = unrestricted
+  selectedWohnungIds: string[] | null;
+  onChange: (hausIds: string[] | null, wohnungIds: string[] | null) => void;
+  disabled?: boolean;
+}
+
+export function ObjectScopeEditor({
+  haeuser,
+  selectedHausIds,
+  selectedWohnungIds,
+  onChange,
+  disabled = false,
+}: ObjectScopeEditorProps) {
+  // Helpers to resolve current checked states
+  const isUnrestricted = selectedHausIds === null;
+
+  // Actual selected set for easier lookup
+  const activeHausIds = React.useMemo(() => new Set(selectedHausIds || []), [selectedHausIds]);
+  const activeWohnungIds = React.useMemo(() => new Set(selectedWohnungIds || []), [selectedWohnungIds]);
+
+  const totalHousesCount = haeuser.length;
+  const totalWohnungenCount = haeuser.reduce((sum, h) => sum + h.wohnungen.length, 0);
+
+  // Current selections
+  const selectedHousesCount = isUnrestricted ? totalHousesCount : haeuser.filter(h => activeHausIds.has(h.id)).length;
+  const selectedWohnungenCount = isUnrestricted
+    ? totalWohnungenCount
+    : haeuser.reduce((sum, h) => {
+        if (activeHausIds.has(h.id)) {
+          // If house is checked, count how many of its apartments are checked (or all if we default to all)
+          // Actually, our override jsonb only tracks selectedWohnungIds. Let's count them.
+          const houseWohnungIds = h.wohnungen.map(w => w.id);
+          const checkedInHouse = houseWohnungIds.filter(id => activeWohnungIds.has(id)).length;
+          return sum + checkedInHouse;
+        }
+        return sum;
+      }, 0);
+
+  const handleSelectAll = () => {
+    if (disabled) return;
+    onChange(null, null); // null = unrestricted
+  };
+
+  const handleDeselectAll = () => {
+    if (disabled) return;
+    // Set to concrete empty arrays to restrict completely
+    onChange([], []);
+  };
+
+  const toggleHaus = (hausId: string) => {
+    if (disabled) return;
+
+    let nextHausIds = isUnrestricted ? haeuser.map(h => h.id) : [...(selectedHausIds || [])];
+    let nextWohnungIds = isUnrestricted ? haeuser.flatMap(h => h.wohnungen.map(w => w.id)) : [...(selectedWohnungIds || [])];
+
+    const targetHaus = haeuser.find(h => h.id === hausId);
+    if (!targetHaus) return;
+
+    const targetWohnungIds = targetHaus.wohnungen.map(w => w.id);
+
+    if (isUnrestricted || activeHausIds.has(hausId)) {
+      // Remove house and all its apartments
+      nextHausIds = nextHausIds.filter(id => id !== hausId);
+      nextWohnungIds = nextWohnungIds.filter(id => !targetWohnungIds.includes(id));
+    } else {
+      // Add house and all its apartments
+      nextHausIds.push(hausId);
+      targetWohnungIds.forEach(id => {
+        if (!nextWohnungIds.includes(id)) {
+          nextWohnungIds.push(id);
+        }
+      });
+    }
+
+    // Check if everything is selected, if so set to null (unrestricted)
+    if (
+      nextHausIds.length === totalHousesCount &&
+      nextWohnungIds.length === totalWohnungenCount
+    ) {
+      onChange(null, null);
+    } else {
+      onChange(nextHausIds, nextWohnungIds);
+    }
+  };
+
+  const toggleWohnung = (hausId: string, wohnungId: string) => {
+    if (disabled) return;
+
+    let nextHausIds = isUnrestricted ? haeuser.map(h => h.id) : [...(selectedHausIds || [])];
+    let nextWohnungIds = isUnrestricted ? haeuser.flatMap(h => h.wohnungen.map(w => w.id)) : [...(selectedWohnungIds || [])];
+
+    if (isUnrestricted || activeWohnungIds.has(wohnungId)) {
+      // Remove apartment
+      nextWohnungIds = nextWohnungIds.filter(id => id !== wohnungId);
+      
+      // If no apartments of this house are checked anymore, remove house too
+      const targetHaus = haeuser.find(h => h.id === hausId);
+      if (targetHaus) {
+        const remainingChecked = targetHaus.wohnungen.filter(w => w.id !== wohnungId && nextWohnungIds.includes(w.id)).length;
+        if (remainingChecked === 0) {
+          nextHausIds = nextHausIds.filter(id => id !== hausId);
+        }
+      }
+    } else {
+      // Add apartment
+      nextWohnungIds.push(wohnungId);
+      // Ensure parent house is selected
+      if (!nextHausIds.includes(hausId)) {
+        nextHausIds.push(hausId);
+      }
+    }
+
+    // Check if everything is selected, if so set to null (unrestricted)
+    if (
+      nextHausIds.length === totalHousesCount &&
+      nextWohnungIds.length === totalWohnungenCount
+    ) {
+      onChange(null, null);
+    } else {
+      onChange(nextHausIds, nextWohnungIds);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Overview stats bar */}
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2 pb-3 border-b border-zinc-200 dark:border-zinc-800">
+        <div>
+          <span className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+            Zusammenfassung:
+          </span>{" "}
+          <span className="text-xs bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 px-2.5 py-1 rounded-full font-medium ml-1">
+            {isUnrestricted ? "Voller Zugriff" : `${selectedHousesCount} von ${totalHousesCount} Häusern`}
+          </span>
+          {!isUnrestricted && (
+            <span className="text-xs bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 px-2.5 py-1 rounded-full font-medium ml-2">
+              {selectedWohnungenCount} von ${totalWohnungenCount} Wohnungen
+            </span>
+          )}
+        </div>
+
+        {!disabled && (
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="xs"
+              onClick={handleSelectAll}
+              className="text-xs rounded-lg h-7"
+            >
+              Alle auswählen
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="xs"
+              onClick={handleDeselectAll}
+              className="text-xs rounded-lg h-7 text-red-500 hover:text-red-600"
+            >
+              Alle abwählen
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {isUnrestricted && (
+        <div className="bg-emerald-500/10 border border-emerald-500/20 text-emerald-700 dark:text-emerald-400 p-3 rounded-xl text-xs font-medium">
+          Keine Einschränkung — Mitarbeiter hat vollen Zugriff auf alle Häuser und Wohnungen.
+        </div>
+      )}
+
+      {/* Checkbox tree list */}
+      <div className="space-y-4 max-h-[350px] overflow-y-auto pr-1">
+        {haeuser.map(haus => {
+          const isHausChecked = isUnrestricted || activeHausIds.has(haus.id);
+          const hasApartments = haus.wohnungen.length > 0;
+
+          // Determine if indeterminate (some apartments checked but not all, or house checked but not all apartments)
+          const checkedApartmentsCount = haus.wohnungen.filter(w => activeWohnungIds.has(w.id)).length;
+          const isIndeterminate = !isUnrestricted && checkedApartmentsCount > 0 && checkedApartmentsCount < haus.wohnungen.length;
+
+          return (
+            <div
+              key={haus.id}
+              className={`p-3 border rounded-2xl transition-colors duration-200 ${
+                isHausChecked
+                  ? "bg-zinc-50/50 dark:bg-zinc-900/50 border-zinc-200 dark:border-zinc-800"
+                  : "bg-zinc-100/10 dark:bg-zinc-950/10 border-zinc-100 dark:border-zinc-900 opacity-60"
+              }`}
+            >
+              <div className="flex items-center gap-3">
+                <Checkbox
+                  id={`haus-${haus.id}`}
+                  checked={isIndeterminate ? "indeterminate" : isHausChecked}
+                  onCheckedChange={() => toggleHaus(haus.id)}
+                  disabled={disabled}
+                />
+                <label
+                  htmlFor={`haus-${haus.id}`}
+                  className="text-sm font-semibold cursor-pointer select-none text-zinc-800 dark:text-zinc-200 flex-1"
+                >
+                  {haus.name}
+                </label>
+              </div>
+
+              {hasApartments && (
+                <div className="mt-3 pl-7 pt-2 border-t border-zinc-200/50 dark:border-zinc-850/50 grid grid-cols-1 sm:grid-cols-2 gap-2.5">
+                  {haus.wohnungen.map(wohnung => {
+                    const isWohnungChecked = isUnrestricted || activeWohnungIds.has(wohnung.id);
+                    return (
+                      <div key={wohnung.id} className="flex items-center gap-2.5 py-0.5">
+                        <Checkbox
+                          id={`w-${wohnung.id}`}
+                          checked={isWohnungChecked}
+                          onCheckedChange={() => toggleWohnung(haus.id, wohnung.id)}
+                          disabled={disabled || (!isHausChecked && !isWohnungChecked)}
+                        />
+                        <label
+                          htmlFor={`w-${wohnung.id}`}
+                          className="text-xs cursor-pointer select-none text-zinc-600 dark:text-zinc-400 flex-1 truncate"
+                        >
+                          {wohnung.name}
+                        </label>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        {haeuser.length === 0 && (
+          <div className="text-center text-xs text-muted-foreground py-6">
+            Keine Häuser in dieser Organisation vorhanden.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/organisation/object-scope-editor.tsx
+++ b/components/organisation/object-scope-editor.tsx
@@ -8,125 +8,52 @@ import { Button } from "@/components/ui/button";
 interface ObjectScopeEditorProps {
   haeuser: HausWithWohnungen[];
   selectedHausIds: string[] | null; // null = unrestricted
-  selectedWohnungIds: string[] | null;
-  onChange: (hausIds: string[] | null, wohnungIds: string[] | null) => void;
+  onChange: (hausIds: string[] | null) => void;
   disabled?: boolean;
 }
 
 export function ObjectScopeEditor({
   haeuser,
   selectedHausIds,
-  selectedWohnungIds,
   onChange,
   disabled = false,
 }: ObjectScopeEditorProps) {
-  // Helpers to resolve current checked states
   const isUnrestricted = selectedHausIds === null;
 
-  // Actual selected set for easier lookup
   const activeHausIds = React.useMemo(() => new Set(selectedHausIds || []), [selectedHausIds]);
-  const activeWohnungIds = React.useMemo(() => new Set(selectedWohnungIds || []), [selectedWohnungIds]);
 
   const totalHousesCount = haeuser.length;
   const totalWohnungenCount = haeuser.reduce((sum, h) => sum + h.wohnungen.length, 0);
 
-  // Current selections
-  const selectedHousesCount = isUnrestricted ? totalHousesCount : haeuser.filter(h => activeHausIds.has(h.id)).length;
-  const selectedWohnungenCount = isUnrestricted
-    ? totalWohnungenCount
-    : haeuser.reduce((sum, h) => {
-        if (activeHausIds.has(h.id)) {
-          // If house is checked, count how many of its apartments are checked (or all if we default to all)
-          // Actually, our override jsonb only tracks selectedWohnungIds. Let's count them.
-          const houseWohnungIds = h.wohnungen.map(w => w.id);
-          const checkedInHouse = houseWohnungIds.filter(id => activeWohnungIds.has(id)).length;
-          return sum + checkedInHouse;
-        }
-        return sum;
-      }, 0);
+  const selectedHousesCount = isUnrestricted
+    ? totalHousesCount
+    : haeuser.filter(h => activeHausIds.has(h.id)).length;
 
   const handleSelectAll = () => {
     if (disabled) return;
-    onChange(null, null); // null = unrestricted
+    onChange(null); // null = unrestricted
   };
 
   const handleDeselectAll = () => {
     if (disabled) return;
-    // Set to concrete empty arrays to restrict completely
-    onChange([], []);
+    onChange([]);
   };
 
   const toggleHaus = (hausId: string) => {
     if (disabled) return;
 
     let nextHausIds = isUnrestricted ? haeuser.map(h => h.id) : [...(selectedHausIds || [])];
-    let nextWohnungIds = isUnrestricted ? haeuser.flatMap(h => h.wohnungen.map(w => w.id)) : [...(selectedWohnungIds || [])];
-
-    const targetHaus = haeuser.find(h => h.id === hausId);
-    if (!targetHaus) return;
-
-    const targetWohnungIds = targetHaus.wohnungen.map(w => w.id);
 
     if (isUnrestricted || activeHausIds.has(hausId)) {
-      // Remove house and all its apartments
       nextHausIds = nextHausIds.filter(id => id !== hausId);
-      nextWohnungIds = nextWohnungIds.filter(id => !targetWohnungIds.includes(id));
     } else {
-      // Add house and all its apartments
       nextHausIds.push(hausId);
-      targetWohnungIds.forEach(id => {
-        if (!nextWohnungIds.includes(id)) {
-          nextWohnungIds.push(id);
-        }
-      });
     }
 
-    // Check if everything is selected, if so set to null (unrestricted)
-    if (
-      nextHausIds.length === totalHousesCount &&
-      nextWohnungIds.length === totalWohnungenCount
-    ) {
-      onChange(null, null);
+    if (nextHausIds.length === totalHousesCount) {
+      onChange(null);
     } else {
-      onChange(nextHausIds, nextWohnungIds);
-    }
-  };
-
-  const toggleWohnung = (hausId: string, wohnungId: string) => {
-    if (disabled) return;
-
-    let nextHausIds = isUnrestricted ? haeuser.map(h => h.id) : [...(selectedHausIds || [])];
-    let nextWohnungIds = isUnrestricted ? haeuser.flatMap(h => h.wohnungen.map(w => w.id)) : [...(selectedWohnungIds || [])];
-
-    if (isUnrestricted || activeWohnungIds.has(wohnungId)) {
-      // Remove apartment
-      nextWohnungIds = nextWohnungIds.filter(id => id !== wohnungId);
-      
-      // If no apartments of this house are checked anymore, remove house too
-      const targetHaus = haeuser.find(h => h.id === hausId);
-      if (targetHaus) {
-        const remainingChecked = targetHaus.wohnungen.filter(w => w.id !== wohnungId && nextWohnungIds.includes(w.id)).length;
-        if (remainingChecked === 0) {
-          nextHausIds = nextHausIds.filter(id => id !== hausId);
-        }
-      }
-    } else {
-      // Add apartment
-      nextWohnungIds.push(wohnungId);
-      // Ensure parent house is selected
-      if (!nextHausIds.includes(hausId)) {
-        nextHausIds.push(hausId);
-      }
-    }
-
-    // Check if everything is selected, if so set to null (unrestricted)
-    if (
-      nextHausIds.length === totalHousesCount &&
-      nextWohnungIds.length === totalWohnungenCount
-    ) {
-      onChange(null, null);
-    } else {
-      onChange(nextHausIds, nextWohnungIds);
+      onChange(nextHausIds);
     }
   };
 
@@ -139,13 +66,13 @@ export function ObjectScopeEditor({
             Zusammenfassung:
           </span>{" "}
           <span className="text-xs bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 px-2.5 py-1 rounded-full font-medium ml-1">
-            {isUnrestricted ? "Voller Zugriff" : `${selectedHousesCount} von ${totalHousesCount} Häusern`}
+            {isUnrestricted
+              ? `Voller Zugriff (${totalHousesCount} Häuser)`
+              : `${selectedHousesCount} von ${totalHousesCount} Häusern`}
           </span>
-          {!isUnrestricted && (
-            <span className="text-xs bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 px-2.5 py-1 rounded-full font-medium ml-2">
-              {selectedWohnungenCount} von ${totalWohnungenCount} Wohnungen
-            </span>
-          )}
+          <span className="text-xs text-muted-foreground ml-2">
+            ({totalWohnungenCount} Wohnungen aus Haus-Scope abgeleitet)
+          </span>
         </div>
 
         {!disabled && (
@@ -178,63 +105,34 @@ export function ObjectScopeEditor({
         </div>
       )}
 
-      {/* Checkbox tree list */}
-      <div className="space-y-4 max-h-[350px] overflow-y-auto pr-1">
+      {/* House checkbox list */}
+      <div className="space-y-3 max-h-[350px] overflow-y-auto pr-1">
         {haeuser.map(haus => {
           const isHausChecked = isUnrestricted || activeHausIds.has(haus.id);
-          const hasApartments = haus.wohnungen.length > 0;
-
-          // Determine if indeterminate (some apartments checked but not all, or house checked but not all apartments)
-          const checkedApartmentsCount = haus.wohnungen.filter(w => activeWohnungIds.has(w.id)).length;
-          const isIndeterminate = !isUnrestricted && checkedApartmentsCount > 0 && checkedApartmentsCount < haus.wohnungen.length;
-
           return (
             <div
               key={haus.id}
-              className={`p-3 border rounded-2xl transition-colors duration-200 ${
+              className={`p-3 border rounded-2xl transition-colors duration-200 flex items-center gap-3 ${
                 isHausChecked
                   ? "bg-zinc-50/50 dark:bg-zinc-900/50 border-zinc-200 dark:border-zinc-800"
                   : "bg-zinc-100/10 dark:bg-zinc-950/10 border-zinc-100 dark:border-zinc-900 opacity-60"
               }`}
             >
-              <div className="flex items-center gap-3">
-                <Checkbox
-                  id={`haus-${haus.id}`}
-                  checked={isIndeterminate ? "indeterminate" : isHausChecked}
-                  onCheckedChange={() => toggleHaus(haus.id)}
-                  disabled={disabled}
-                />
-                <label
-                  htmlFor={`haus-${haus.id}`}
-                  className="text-sm font-semibold cursor-pointer select-none text-zinc-800 dark:text-zinc-200 flex-1"
-                >
-                  {haus.name}
-                </label>
-              </div>
-
-              {hasApartments && (
-                <div className="mt-3 pl-7 pt-2 border-t border-zinc-200/50 dark:border-zinc-850/50 grid grid-cols-1 sm:grid-cols-2 gap-2.5">
-                  {haus.wohnungen.map(wohnung => {
-                    const isWohnungChecked = isUnrestricted || activeWohnungIds.has(wohnung.id);
-                    return (
-                      <div key={wohnung.id} className="flex items-center gap-2.5 py-0.5">
-                        <Checkbox
-                          id={`w-${wohnung.id}`}
-                          checked={isWohnungChecked}
-                          onCheckedChange={() => toggleWohnung(haus.id, wohnung.id)}
-                          disabled={disabled || (!isHausChecked && !isWohnungChecked)}
-                        />
-                        <label
-                          htmlFor={`w-${wohnung.id}`}
-                          className="text-xs cursor-pointer select-none text-zinc-600 dark:text-zinc-400 flex-1 truncate"
-                        >
-                          {wohnung.name}
-                        </label>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
+              <Checkbox
+                id={`haus-${haus.id}`}
+                checked={isHausChecked}
+                onCheckedChange={() => toggleHaus(haus.id)}
+                disabled={disabled}
+              />
+              <label
+                htmlFor={`haus-${haus.id}`}
+                className="text-sm font-semibold cursor-pointer select-none text-zinc-800 dark:text-zinc-200 flex-1"
+              >
+                {haus.name}
+              </label>
+              <span className="text-[10px] text-muted-foreground bg-zinc-100 dark:bg-zinc-800 px-2 py-0.5 rounded-full">
+                {haus.wohnungen.length} Wohn.
+              </span>
             </div>
           );
         })}

--- a/components/organisation/object-scope-editor.tsx
+++ b/components/organisation/object-scope-editor.tsx
@@ -3,7 +3,6 @@
 import React from "react";
 import { HausWithWohnungen } from "@/lib/organisation-types";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Button } from "@/components/ui/button";
 
 interface ObjectScopeEditorProps {
   haeuser: HausWithWohnungen[];
@@ -29,38 +28,32 @@ export function ObjectScopeEditor({
     ? totalHousesCount
     : haeuser.filter(h => activeHausIds.has(h.id)).length;
 
-  const handleSelectAll = () => {
-    if (disabled) return;
-    onChange(null); // null = unrestricted
-  };
-
-  const handleDeselectAll = () => {
-    if (disabled) return;
-    onChange([]);
-  };
+  const isLastHouse = !isUnrestricted && selectedHousesCount === 1;
 
   const toggleHaus = (hausId: string) => {
     if (disabled) return;
 
-    let nextHausIds = isUnrestricted ? haeuser.map(h => h.id) : [...(selectedHausIds || [])];
+    if (isUnrestricted) {
+      const nextHausIds = haeuser.map(h => h.id).filter(id => id !== hausId);
+      onChange(nextHausIds.length > 0 ? nextHausIds : null);
+      return;
+    }
 
-    if (isUnrestricted || activeHausIds.has(hausId)) {
+    let nextHausIds = [...(selectedHausIds || [])];
+
+    if (activeHausIds.has(hausId)) {
+      if (isLastHouse) return;
       nextHausIds = nextHausIds.filter(id => id !== hausId);
     } else {
       nextHausIds.push(hausId);
     }
 
-    if (nextHausIds.length === totalHousesCount) {
-      onChange(null);
-    } else {
-      onChange(nextHausIds);
-    }
+    onChange(nextHausIds.length === totalHousesCount ? null : nextHausIds);
   };
 
   return (
     <div className="flex flex-col gap-4">
-      {/* Overview stats bar */}
-      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2 pb-3 border-b border-zinc-200 dark:border-zinc-800">
+      <div className="flex items-center justify-between pb-3 border-b border-zinc-200 dark:border-zinc-800">
         <div>
           <span className="text-sm font-semibold text-zinc-700 dark:text-zinc-300">
             Zusammenfassung:
@@ -71,31 +64,18 @@ export function ObjectScopeEditor({
               : `${selectedHousesCount} von ${totalHousesCount} Häusern`}
           </span>
           <span className="text-xs text-muted-foreground ml-2">
-            ({totalWohnungenCount} Wohnungen aus Haus-Scope abgeleitet)
+            ({totalWohnungenCount} Wohnungen)
           </span>
         </div>
 
-        {!disabled && (
-          <div className="flex items-center gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="xs"
-              onClick={handleSelectAll}
-              className="text-xs rounded-lg h-7"
-            >
-              Alle auswählen
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="xs"
-              onClick={handleDeselectAll}
-              className="text-xs rounded-lg h-7 text-red-500 hover:text-red-600"
-            >
-              Alle abwählen
-            </Button>
-          </div>
+        {!isUnrestricted && !disabled && (
+          <button
+            type="button"
+            onClick={() => onChange(null)}
+            className="text-xs font-semibold text-indigo-600 dark:text-indigo-400 hover:text-indigo-700"
+          >
+            Alle auswählen
+          </button>
         )}
       </div>
 
@@ -105,30 +85,39 @@ export function ObjectScopeEditor({
         </div>
       )}
 
-      {/* House checkbox list */}
       <div className="space-y-3 max-h-[350px] overflow-y-auto pr-1">
         {haeuser.map(haus => {
-          const isHausChecked = isUnrestricted || activeHausIds.has(haus.id);
+          const isSelected = isUnrestricted || activeHausIds.has(haus.id);
+          const isLocked = isLastHouse && activeHausIds.has(haus.id);
           return (
             <div
               key={haus.id}
-              className={`p-3 border rounded-2xl transition-colors duration-200 flex items-center gap-3 ${
-                isHausChecked
+              className={`p-3 border rounded-2xl flex items-center gap-3 ${
+                isSelected
                   ? "bg-zinc-50/50 dark:bg-zinc-900/50 border-zinc-200 dark:border-zinc-800"
                   : "bg-zinc-100/10 dark:bg-zinc-950/10 border-zinc-100 dark:border-zinc-900 opacity-60"
               }`}
             >
               <Checkbox
                 id={`haus-${haus.id}`}
-                checked={isHausChecked}
+                checked={isSelected}
                 onCheckedChange={() => toggleHaus(haus.id)}
-                disabled={disabled}
+                disabled={disabled || isLocked}
               />
               <label
                 htmlFor={`haus-${haus.id}`}
-                className="text-sm font-semibold cursor-pointer select-none text-zinc-800 dark:text-zinc-200 flex-1"
+                className={`text-sm font-semibold select-none flex-1 ${
+                  isLocked
+                    ? "text-zinc-400 dark:text-zinc-600 cursor-not-allowed"
+                    : "text-zinc-800 dark:text-zinc-200 cursor-pointer"
+                }`}
               >
                 {haus.name}
+                {isLocked && (
+                  <span className="text-[10px] text-zinc-400 dark:text-zinc-500 ml-2 font-normal">
+                    (mindestens eines erforderlich)
+                  </span>
+                )}
               </label>
               <span className="text-[10px] text-muted-foreground bg-zinc-100 dark:bg-zinc-800 px-2 py-0.5 rounded-full">
                 {haus.wohnungen.length} Wohn.

--- a/components/organisation/object-scope-editor.tsx
+++ b/components/organisation/object-scope-editor.tsx
@@ -34,7 +34,10 @@ export function ObjectScopeEditor({
     if (disabled) return;
 
     if (isUnrestricted) {
-      const nextHausIds = haeuser.map(h => h.id).filter(id => id !== hausId);
+      const nextHausIds = haeuser.reduce<string[]>((acc, h) => {
+        if (h.id !== hausId) acc.push(h.id);
+        return acc;
+      }, []);
       onChange(nextHausIds.length > 0 ? nextHausIds : null);
       return;
     }

--- a/components/settings/user-settings-progress.test.tsx
+++ b/components/settings/user-settings-progress.test.tsx
@@ -62,6 +62,7 @@ describe('UserSettings with Progress Bar', () => {
     apartmentLimit: null,
     hasOrganisationPermission: true,
     isOrganisationHidden: false,
+    modulePermissions: null,
   }
 
   const setupMocks = (apartmentCount: number, apartmentLimit: number | null) => {

--- a/lib/object-scope.ts
+++ b/lib/object-scope.ts
@@ -61,8 +61,6 @@ export async function getAccessibleWohnungIds(): Promise<string[] | null> {
  * Otherwise, filters the specified column to match only the provided ids.
  */
 export function applyHaeuserScope<T>(query: T, column: string, ids: string[] | null): T {
-  if (ids === null) {
-    return query;
-  }
+  if (ids === null || ids.length === 0) return query;
   return (query as any).in(column, ids);
 }

--- a/lib/organisation-types.ts
+++ b/lib/organisation-types.ts
@@ -2,7 +2,6 @@ export interface MemberBerechtigungen {
   module?: Record<string, string[]>;
   objekte?: {
     haeuser?: string[] | null;
-    wohnungen?: string[] | null;
   };
 }
 
@@ -12,7 +11,6 @@ export interface MemberPermissions {
   module: Record<string, string[]> | null;
   objekte: {
     haeuser: string[] | null;
-    wohnungen: string[] | null;
   };
   is_restricted: boolean;
 }

--- a/lib/organisation-types.ts
+++ b/lib/organisation-types.ts
@@ -1,0 +1,24 @@
+export interface MemberBerechtigungen {
+  module?: Record<string, string[]>;
+  objekte?: {
+    haeuser?: string[] | null;
+    wohnungen?: string[] | null;
+  };
+}
+
+export interface MemberPermissions {
+  rolle: 'owner' | 'admin' | 'mitarbeiter';
+  status: 'eingeladen' | 'aktiv' | 'deaktiviert';
+  module: Record<string, string[]> | null;
+  objekte: {
+    haeuser: string[] | null;
+    wohnungen: string[] | null;
+  };
+  is_restricted: boolean;
+}
+
+export interface HausWithWohnungen {
+  id: string;
+  name: string;
+  wohnungen: { id: string; name: string }[];
+}

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -23,16 +23,6 @@ export async function hasPermission(modul: Modul, aktion: Aktion): Promise<boole
   try {
     const { supabase } = await ensureAuth();
     
-    // Any active member of an organization has read access ('ansehen') to the organization page
-    if (modul === 'organisation' && aktion === 'ansehen') {
-      const { data: orgId, error: orgIdError } = await supabase.rpc('current_organisation_id');
-      if (orgIdError) {
-        console.error("Error fetching current_organisation_id in hasPermission:", orgIdError);
-        return false;
-      }
-      return orgId !== null;
-    }
-
     const { data, error } = await supabase.rpc('check_permission', {
       p_modul: modul,
       p_aktion: aktion,

--- a/lib/perms-actions.ts
+++ b/lib/perms-actions.ts
@@ -5,55 +5,17 @@ import { requirePermission } from "@/lib/permissions";
 import { revalidatePath } from "next/cache";
 import { MemberPermissions, HausWithWohnungen, MemberBerechtigungen } from "@/lib/organisation-types";
 
-const ALL_AKTIONEN = ["ansehen", "erstellen", "bearbeiten", "loeschen", "verwalten"] as const;
-
 /**
- * Converts the UI's array format to the DB's boolean-map format.
- * UI:  { haeuser: ["ansehen", "erstellen"] }
- * DB:  { haeuser: { "ansehen": true, "erstellen": true, "bearbeiten": false, ... } }
- */
-function moduleArrayToDbBooleanMap(
-  uiModule: Record<string, string[]> | undefined
-): Record<string, Record<string, boolean>> | undefined {
-  if (!uiModule) return undefined;
-  const result: Record<string, Record<string, boolean>> = {};
-  for (const [modKey, aktionen] of Object.entries(uiModule)) {
-    result[modKey] = {};
-    for (const aktion of ALL_AKTIONEN) {
-      result[modKey][aktion] = aktionen.includes(aktion);
-    }
-  }
-  return result;
-}
-
-/**
- * Converts the DB's boolean-map format back to the UI's array format.
- * DB:  { haeuser: { "ansehen": true, "erstellen": true, "bearbeiten": false } }
- * UI:  { haeuser: ["ansehen", "erstellen"] }
+ * Fetches the permissions for a specific member (owner/admin only).
  *
- * Also handles the legacy array format in case the DB stored it directly.
+ * The returned `module` object uses the canonical array format:
+ *   { haeuser: ["ansehen", "erstellen"], mieter: ["ansehen"] }
+ * This matches exactly what get_mitglied_permissions returns and what the UI
+ * ModulePermissionEditor and ObjectScopeEditor consume.
+ *
+ * No conversion needed — the DB stores and returns the array format natively.
+ * check_permission() (fixed in migration 20260619000020) correctly reads this format.
  */
-function moduleDbBooleanMapToArray(
-  dbModule: Record<string, Record<string, boolean> | string[]> | null | undefined
-): Record<string, string[]> | null {
-  if (!dbModule) return null;
-  const result: Record<string, string[]> = {};
-  for (const [modKey, value] of Object.entries(dbModule)) {
-    if (Array.isArray(value)) {
-      // Legacy: already in array format
-      result[modKey] = value as string[];
-    } else if (value && typeof value === "object") {
-      // Boolean map format (canonical DB format)
-      result[modKey] = Object.entries(value)
-        .filter(([, granted]) => granted === true)
-        .map(([aktion]) => aktion);
-    } else {
-      result[modKey] = [];
-    }
-  }
-  return result;
-}
-
 export async function getMitgliedPermissionsAction(mitgliedId: string): Promise<MemberPermissions> {
   const supabase = await createClient();
   await requirePermission('organisation', 'ansehen');
@@ -64,12 +26,7 @@ export async function getMitgliedPermissionsAction(mitgliedId: string): Promise<
     console.error("Error in get_mitglied_permissions RPC:", error);
     throw error;
   }
-  const raw = data as any;
-  return {
-    ...raw,
-    // Normalize module format from DB boolean-map → UI array format
-    module: moduleDbBooleanMapToArray(raw?.module),
-  } as MemberPermissions;
+  return data as MemberPermissions;
 }
 
 export async function getOrgHaeuserAction(): Promise<HausWithWohnungen[]> {
@@ -83,6 +40,13 @@ export async function getOrgHaeuserAction(): Promise<HausWithWohnungen[]> {
   return (data ?? []) as HausWithWohnungen[];
 }
 
+/**
+ * Saves per-member permission overrides (owner/admin only).
+ *
+ * The `berechtigungen` argument uses the canonical array format:
+ *   { module: { haeuser: ["ansehen", "erstellen"] }, objekte: { haeuser: [uuid, ...] } }
+ * Passed directly to set_mitglied_overrides without any conversion.
+ */
 export async function setMitgliedOverridesAction(
   mitgliedId: string,
   berechtigungen: MemberBerechtigungen
@@ -90,18 +54,9 @@ export async function setMitgliedOverridesAction(
   try {
     const supabase = await createClient();
     await requirePermission('organisation', 'verwalten');
-
-    // Convert UI array format → DB boolean-map format before saving
-    const dbBerechtigungen = {
-      ...berechtigungen,
-      module: berechtigungen.module
-        ? moduleArrayToDbBooleanMap(berechtigungen.module)
-        : undefined,
-    };
-
     const { error } = await supabase.rpc('set_mitglied_overrides', {
       p_mitglied_id: mitgliedId,
-      p_berechtigungen: dbBerechtigungen,
+      p_berechtigungen: berechtigungen,
     });
     if (error) {
       console.error("Error in set_mitglied_overrides RPC:", error);

--- a/lib/perms-actions.ts
+++ b/lib/perms-actions.ts
@@ -14,7 +14,7 @@ import { MemberPermissions, HausWithWohnungen, MemberBerechtigungen } from "@/li
  * ModulePermissionEditor and ObjectScopeEditor consume.
  *
  * No conversion needed — the DB stores and returns the array format natively.
- * check_permission() (fixed in migration 20260619000020) correctly reads this format.
+ * check_permission() correctly reads this format (uses JSONB array containment).
  */
 export async function getMitgliedPermissionsAction(mitgliedId: string): Promise<MemberPermissions> {
   const supabase = await createClient();

--- a/lib/perms-actions.ts
+++ b/lib/perms-actions.ts
@@ -1,0 +1,53 @@
+"use server";
+
+import { createClient } from "@/utils/supabase/server";
+import { requirePermission } from "@/lib/permissions";
+import { revalidatePath } from "next/cache";
+import { MemberPermissions, HausWithWohnungen, MemberBerechtigungen } from "@/lib/organisation-types";
+
+export async function getMitgliedPermissionsAction(mitgliedId: string): Promise<MemberPermissions> {
+  const supabase = await createClient();
+  await requirePermission('organisation', 'ansehen');
+  const { data, error } = await supabase.rpc('get_mitglied_permissions', {
+    p_mitglied_id: mitgliedId,
+  });
+  if (error) {
+    console.error("Error in get_mitglied_permissions RPC:", error);
+    throw error;
+  }
+  return data as MemberPermissions;
+}
+
+export async function getOrgHaeuserAction(): Promise<HausWithWohnungen[]> {
+  const supabase = await createClient();
+  await requirePermission('organisation', 'ansehen');
+  const { data, error } = await supabase.rpc('get_org_haeuser_mit_wohnungen');
+  if (error) {
+    console.error("Error in get_org_haeuser_mit_wohnungen RPC:", error);
+    throw error;
+  }
+  return (data ?? []) as HausWithWohnungen[];
+}
+
+export async function setMitgliedOverridesAction(
+  mitgliedId: string,
+  berechtigungen: MemberBerechtigungen
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const supabase = await createClient();
+    await requirePermission('organisation', 'verwalten');
+    const { error } = await supabase.rpc('set_mitglied_overrides', {
+      p_mitglied_id: mitgliedId,
+      p_berechtigungen: berechtigungen,
+    });
+    if (error) {
+      console.error("Error in set_mitglied_overrides RPC:", error);
+      return { success: false, error: error.message };
+    }
+    revalidatePath('/organisation');
+    return { success: true };
+  } catch (err: any) {
+    console.error("Exception in setMitgliedOverridesAction:", err);
+    return { success: false, error: err.message || "Unbekannter Fehler" };
+  }
+}

--- a/lib/perms-actions.ts
+++ b/lib/perms-actions.ts
@@ -5,6 +5,55 @@ import { requirePermission } from "@/lib/permissions";
 import { revalidatePath } from "next/cache";
 import { MemberPermissions, HausWithWohnungen, MemberBerechtigungen } from "@/lib/organisation-types";
 
+const ALL_AKTIONEN = ["ansehen", "erstellen", "bearbeiten", "loeschen", "verwalten"] as const;
+
+/**
+ * Converts the UI's array format to the DB's boolean-map format.
+ * UI:  { haeuser: ["ansehen", "erstellen"] }
+ * DB:  { haeuser: { "ansehen": true, "erstellen": true, "bearbeiten": false, ... } }
+ */
+function moduleArrayToDbBooleanMap(
+  uiModule: Record<string, string[]> | undefined
+): Record<string, Record<string, boolean>> | undefined {
+  if (!uiModule) return undefined;
+  const result: Record<string, Record<string, boolean>> = {};
+  for (const [modKey, aktionen] of Object.entries(uiModule)) {
+    result[modKey] = {};
+    for (const aktion of ALL_AKTIONEN) {
+      result[modKey][aktion] = aktionen.includes(aktion);
+    }
+  }
+  return result;
+}
+
+/**
+ * Converts the DB's boolean-map format back to the UI's array format.
+ * DB:  { haeuser: { "ansehen": true, "erstellen": true, "bearbeiten": false } }
+ * UI:  { haeuser: ["ansehen", "erstellen"] }
+ *
+ * Also handles the legacy array format in case the DB stored it directly.
+ */
+function moduleDbBooleanMapToArray(
+  dbModule: Record<string, Record<string, boolean> | string[]> | null | undefined
+): Record<string, string[]> | null {
+  if (!dbModule) return null;
+  const result: Record<string, string[]> = {};
+  for (const [modKey, value] of Object.entries(dbModule)) {
+    if (Array.isArray(value)) {
+      // Legacy: already in array format
+      result[modKey] = value as string[];
+    } else if (value && typeof value === "object") {
+      // Boolean map format (canonical DB format)
+      result[modKey] = Object.entries(value)
+        .filter(([, granted]) => granted === true)
+        .map(([aktion]) => aktion);
+    } else {
+      result[modKey] = [];
+    }
+  }
+  return result;
+}
+
 export async function getMitgliedPermissionsAction(mitgliedId: string): Promise<MemberPermissions> {
   const supabase = await createClient();
   await requirePermission('organisation', 'ansehen');
@@ -15,7 +64,12 @@ export async function getMitgliedPermissionsAction(mitgliedId: string): Promise<
     console.error("Error in get_mitglied_permissions RPC:", error);
     throw error;
   }
-  return data as MemberPermissions;
+  const raw = data as any;
+  return {
+    ...raw,
+    // Normalize module format from DB boolean-map → UI array format
+    module: moduleDbBooleanMapToArray(raw?.module),
+  } as MemberPermissions;
 }
 
 export async function getOrgHaeuserAction(): Promise<HausWithWohnungen[]> {
@@ -36,9 +90,18 @@ export async function setMitgliedOverridesAction(
   try {
     const supabase = await createClient();
     await requirePermission('organisation', 'verwalten');
+
+    // Convert UI array format → DB boolean-map format before saving
+    const dbBerechtigungen = {
+      ...berechtigungen,
+      module: berechtigungen.module
+        ? moduleArrayToDbBooleanMap(berechtigungen.module)
+        : undefined,
+    };
+
     const { error } = await supabase.rpc('set_mitglied_overrides', {
       p_mitglied_id: mitgliedId,
-      p_berechtigungen: berechtigungen,
+      p_berechtigungen: dbBerechtigungen,
     });
     if (error) {
       console.error("Error in set_mitglied_overrides RPC:", error);

--- a/lib/server/user-data.ts
+++ b/lib/server/user-data.ts
@@ -89,11 +89,12 @@ export async function getSidebarUserData(
       supabase.rpc('check_permission', { p_modul: 'betriebskosten', p_aktion: 'ansehen' }),
       supabase.rpc('check_permission', { p_modul: 'aufgaben', p_aktion: 'ansehen' }),
       supabase.rpc('check_permission', { p_modul: 'dokumente', p_aktion: 'ansehen' }),
+      supabase.rpc('check_permission', { p_modul: 'organisation', p_aktion: 'ansehen' }),
     ]);
 
     isOrganisationHidden = orgDataResult.data?.ist_versteckt ?? false;
 
-    const GATED_MODULES = ['haeuser', 'wohnungen', 'mieter', 'finanzen', 'betriebskosten', 'aufgaben', 'dokumente'] as const;
+    const GATED_MODULES = ['haeuser', 'wohnungen', 'mieter', 'finanzen', 'betriebskosten', 'aufgaben', 'dokumente', 'organisation'] as const;
     const allAllowed = permChecks.every(r => r.data === true);
 
     if (!allAllowed) {

--- a/lib/server/user-data.ts
+++ b/lib/server/user-data.ts
@@ -3,6 +3,13 @@ import { User, SupabaseClient } from "@supabase/supabase-js"
 import { getUserDisplayData } from "@/lib/utils/user"
 import { getEffectiveApartmentLimit } from "@/lib/utils/subscription"
 
+/**
+ * Modules that are gated by permissions in the sidebar.
+ * `null` = unrestricted (owner/admin or personal account).
+ * A Set means only the listed modules are visible to this user.
+ */
+export type SidebarModulePermissions = Set<string> | null;
+
 export interface SidebarUserData {
   user: User | null;
   userName: string;
@@ -12,6 +19,8 @@ export interface SidebarUserData {
   apartmentLimit: number | typeof Infinity | null;
   hasOrganisationPermission: boolean;
   isOrganisationHidden: boolean;
+  /** null = no restrictions (personal account or owner/admin). Set = allowed modules. */
+  modulePermissions: SidebarModulePermissions;
 }
 
 /**
@@ -32,6 +41,7 @@ export async function getSidebarUserData(
       apartmentLimit: Infinity, // Guest users = unlimited (consistent with normalizeApartmentLimit)
       hasOrganisationPermission: false,
       isOrganisationHidden: false,
+      modulePermissions: null,
     }
   }
 
@@ -56,14 +66,39 @@ export async function getSidebarUserData(
   const orgId = orgIdResult.data;
   const hasOrganisationPermission = orgId !== null;
   let isOrganisationHidden = false;
+  let modulePermissions: SidebarModulePermissions = null;
 
   if (orgId) {
-    const { data: orgData } = await supabase
-      .from('Organisation')
-      .select('ist_versteckt')
-      .eq('id', orgId)
-      .maybeSingle();
-    isOrganisationHidden = orgData?.ist_versteckt ?? false;
+    const [orgDataResult, ...permChecks] = await Promise.all([
+      supabase
+        .from('Organisation')
+        .select('ist_versteckt')
+        .eq('id', orgId)
+        .maybeSingle(),
+      // Check 'ansehen' permission for each sidebar-gated module in parallel.
+      // Owners/admins → check_permission returns true for all.
+      // Restricted members → only returns true for explicitly granted modules.
+      supabase.rpc('check_permission', { p_modul: 'haeuser', p_aktion: 'ansehen' }),
+      supabase.rpc('check_permission', { p_modul: 'wohnungen', p_aktion: 'ansehen' }),
+      supabase.rpc('check_permission', { p_modul: 'mieter', p_aktion: 'ansehen' }),
+      supabase.rpc('check_permission', { p_modul: 'finanzen', p_aktion: 'ansehen' }),
+      supabase.rpc('check_permission', { p_modul: 'betriebskosten', p_aktion: 'ansehen' }),
+      supabase.rpc('check_permission', { p_modul: 'aufgaben', p_aktion: 'ansehen' }),
+      supabase.rpc('check_permission', { p_modul: 'dokumente', p_aktion: 'ansehen' }),
+    ]);
+
+    isOrganisationHidden = orgDataResult.data?.ist_versteckt ?? false;
+
+    const GATED_MODULES = ['haeuser', 'wohnungen', 'mieter', 'finanzen', 'betriebskosten', 'aufgaben', 'dokumente'] as const;
+    const allAllowed = permChecks.every(r => r.data === true);
+
+    if (!allAllowed) {
+      // At least one module is restricted — build a specific allow-set.
+      modulePermissions = new Set(
+        GATED_MODULES.filter((_, i) => permChecks[i].data === true)
+      );
+    }
+    // If allAllowed === true, modulePermissions stays null (= unrestricted).
   }
 
   let apartmentLimit: number | typeof Infinity | null = null;
@@ -97,5 +132,6 @@ export async function getSidebarUserData(
     apartmentLimit,
     hasOrganisationPermission,
     isOrganisationHidden,
+    modulePermissions,
   }
 }

--- a/lib/server/user-data.ts
+++ b/lib/server/user-data.ts
@@ -69,12 +69,16 @@ export async function getSidebarUserData(
   let modulePermissions: SidebarModulePermissions = null;
 
   if (orgId) {
-    const [orgDataResult, ...permChecks] = await Promise.all([
+    const [orgDataResult, accessibleHaeuserResult, ...permChecks] = await Promise.all([
       supabase
         .from('Organisation')
         .select('ist_versteckt')
         .eq('id', orgId)
         .maybeSingle(),
+      // Fetch object-scope house IDs to handle the "object-scope exception":
+      // If a member has no module.haeuser permission but has specific house IDs
+      // in their object scope, they can still access /haeuser (with filtered data).
+      supabase.rpc('get_accessible_haeuser_ids'),
       // Check 'ansehen' permission for each sidebar-gated module in parallel.
       // Owners/admins → check_permission returns true for all.
       // Restricted members → only returns true for explicitly granted modules.
@@ -97,9 +101,20 @@ export async function getSidebarUserData(
       modulePermissions = new Set(
         GATED_MODULES.filter((_, i) => permChecks[i].data === true)
       );
+
+      // Object-scope exception: if the user has specific house IDs in their object scope
+      // (non-empty array from get_accessible_haeuser_ids), grant access to haeuser and
+      // wohnungen pages even without the module permission. The data RPCs will filter by scope.
+      const accessibleIds = accessibleHaeuserResult.data;
+      const hasObjectScopedHouses = Array.isArray(accessibleIds) && accessibleIds.length > 0;
+      if (hasObjectScopedHouses) {
+        modulePermissions.add('haeuser');
+        modulePermissions.add('wohnungen');
+      }
     }
     // If allAllowed === true, modulePermissions stays null (= unrestricted).
   }
+
 
   let apartmentLimit: number | typeof Infinity | null = null;
   const activeProfile = profile || secondaryProfileResult.data;

--- a/lib/server/user-data.ts
+++ b/lib/server/user-data.ts
@@ -103,13 +103,13 @@ export async function getSidebarUserData(
       );
 
       // Object-scope exception: if the user has specific house IDs in their object scope
-      // (non-empty array from get_accessible_haeuser_ids), grant access to haeuser and
-      // wohnungen pages even without the module permission. The data RPCs will filter by scope.
+      // (non-empty array from get_accessible_haeuser_ids), grant access to the haeuser
+      // page even without the module permission. The data RPCs will further filter by scope.
+      // wohnungen is NOT added here — it only appears if the user has explicit module permission.
       const accessibleIds = accessibleHaeuserResult.data;
       const hasObjectScopedHouses = Array.isArray(accessibleIds) && accessibleIds.length > 0;
       if (hasObjectScopedHouses) {
         modulePermissions.add('haeuser');
-        modulePermissions.add('wohnungen');
       }
     }
     // If allAllowed === true, modulePermissions stays null (= unrestricted).


### PR DESCRIPTION
## Description

Implements the object scope and module permission editor UI in the organisation settings: clicking a member opens a detail pane to configure their module permissions and per-house object scope.

## Summary of Changes

- Organisation members tab: rows are clickable and open `MitgliedPermissionDetail` in a split-view right pane
- New `lib/perms-actions.ts`: `getMitgliedPermissionsAction`, `getOrgHaeuserAction`, `setMitgliedOverridesAction` (array permission format, no conversion)
- New `lib/organisation-types.ts`: `MemberBerechtigungen`, `MemberPermissions`, `HausWithWohnungen`
- `ModulePermissionEditor` / `ObjectScopeEditor` components for editing module rights and house scope (with at-least-one-house locking)
- Sidebar: `modulePermissions` allow-set computed per user (gated modules + object-scope exception for haeuser)
- `lib/permissions.ts`: removes the organisation-ansehen special case; `applyHaeuserScope` treats empty scope as unrestricted