### PR TITLE
feat(email): log Resend API calls to PostHog and add RESEND_FROM_EMAI…

### DIFF
--- a/lib/email/sendEinladungEmail.ts
+++ b/lib/email/sendEinladungEmail.ts
@@ -12,6 +12,13 @@
  * conflicts with react-dom/server internals (recentlyCreatedOwnerStacks).
  */
 
+import { posthogLogger } from "@/lib/posthog-logger";
+import crypto from "node:crypto";
+
+function hashEmail(email: string): string {
+  return crypto.createHash("sha256").update(email.toLowerCase().trim()).digest("hex");
+}
+
 export interface SendEinladungEmailOptions {
   /** Email address of the invitee */
   toEmail: string;
@@ -227,12 +234,11 @@ function escapeHtml(text: string): string {
     .replace(/'/g, "&#039;");
 }
 
-import { posthogLogger } from "@/lib/posthog-logger";
-
 export async function sendEinladungEmail(
   options: SendEinladungEmailOptions
 ): Promise<SendEmailResult> {
   const { toEmail, einladerName, organisationsName, rolle, token } = options;
+  const emailHash = hashEmail(toEmail);
 
   const apiKey = process.env.RESEND_API_KEY;
   if (!apiKey) {
@@ -270,7 +276,7 @@ export async function sendEinladungEmail(
       networkError instanceof Error ? networkError.message : String(networkError);
     posthogLogger.error("[sendEinladungEmail] Network error calling Resend API", {
       error: msg,
-      toEmail,
+      emailHash,
       organisationsName,
       component: "sendEinladungEmail",
     });
@@ -289,9 +295,9 @@ export async function sendEinladungEmail(
     posthogLogger.error("[sendEinladungEmail] Resend API returned non-OK status", {
       status: response.status,
       responseBody: body,
-      toEmail,
+      emailHash,
       organisationsName,
-      from: process.env.RESEND_FROM_EMAIL ?? "Mietevo <service@mietevo.de>",
+      from,
       component: "sendEinladungEmail",
     });
     return { sent: false, error: `Resend API returned ${response.status}` };
@@ -299,7 +305,7 @@ export async function sendEinladungEmail(
 
   const responseBody = await response.json().catch(() => ({}));
   posthogLogger.info("[sendEinladungEmail] Sent successfully", {
-    toEmail,
+    emailHash,
     organisationsName,
     tokenPrefix: token.slice(0, 8),
     resendId: responseBody.id,

--- a/lib/email/sendEinladungEmail.ts
+++ b/lib/email/sendEinladungEmail.ts
@@ -1,8 +1,7 @@
 /**
  * Sends an organisation invitation email via the Resend REST API.
  *
- * Uses native `fetch` instead of the Resend Node.js SDK so this module
- * is compatible with the Edge Runtime (where organisation-actions.ts runs).
+ * Uses native `fetch` instead of the Resend Node.js SDK to avoid SDK overhead.
  *
  * Design intent: fire-and-forget.  Errors are logged but NEVER propagate to
  * the caller – the invitation record in the DB is already the source of truth.
@@ -13,10 +12,13 @@
  */
 
 import { posthogLogger } from "@/lib/posthog-logger";
-import crypto from "node:crypto";
 
-function hashEmail(email: string): string {
-  return crypto.createHash("sha256").update(email.toLowerCase().trim()).digest("hex");
+async function hashEmail(email: string): Promise<string> {
+  const data = new TextEncoder().encode(email.toLowerCase().trim());
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 export interface SendEinladungEmailOptions {
@@ -238,7 +240,7 @@ export async function sendEinladungEmail(
   options: SendEinladungEmailOptions
 ): Promise<SendEmailResult> {
   const { toEmail, einladerName, organisationsName, rolle, token } = options;
-  const emailHash = hashEmail(toEmail);
+  const emailHash = await hashEmail(toEmail);
 
   const apiKey = process.env.RESEND_API_KEY;
   if (!apiKey) {

--- a/lib/email/sendEinladungEmail.ts
+++ b/lib/email/sendEinladungEmail.ts
@@ -227,6 +227,8 @@ function escapeHtml(text: string): string {
     .replace(/'/g, "&#039;");
 }
 
+import { posthogLogger } from "@/lib/posthog-logger";
+
 export async function sendEinladungEmail(
   options: SendEinladungEmailOptions
 ): Promise<SendEmailResult> {
@@ -235,7 +237,7 @@ export async function sendEinladungEmail(
   const apiKey = process.env.RESEND_API_KEY;
   if (!apiKey) {
     const msg = "RESEND_API_KEY is not set";
-    console.warn(`[sendEinladungEmail] ${msg} – skipping email.`);
+    posthogLogger.warn(`[sendEinladungEmail] ${msg} – skipping email.`);
     return { sent: false, error: msg };
   }
 
@@ -266,7 +268,12 @@ export async function sendEinladungEmail(
   } catch (networkError) {
     const msg =
       networkError instanceof Error ? networkError.message : String(networkError);
-    console.error("[sendEinladungEmail] Network error calling Resend API:", msg);
+    posthogLogger.error("[sendEinladungEmail] Network error calling Resend API", {
+      error: msg,
+      toEmail,
+      organisationsName,
+      component: "sendEinladungEmail",
+    });
     return { sent: false, error: `Network error: ${msg}` };
   } finally {
     clearTimeout(timeoutId);
@@ -279,15 +286,24 @@ export async function sendEinladungEmail(
     } catch {
       // ignore
     }
-    console.error(
-      `[sendEinladungEmail] Resend API returned ${response.status}: ${body}`
-    );
+    posthogLogger.error("[sendEinladungEmail] Resend API returned non-OK status", {
+      status: response.status,
+      responseBody: body,
+      toEmail,
+      organisationsName,
+      from: process.env.RESEND_FROM_EMAIL ?? "Mietevo <service@mietevo.de>",
+      component: "sendEinladungEmail",
+    });
     return { sent: false, error: `Resend API returned ${response.status}` };
   }
 
   const responseBody = await response.json().catch(() => ({}));
-  console.log(
-    `[sendEinladungEmail] Sent to ${toEmail} (org: ${organisationsName}, token: ${token.slice(0, 8)}…)`
-  );
+  posthogLogger.info("[sendEinladungEmail] Sent successfully", {
+    toEmail,
+    organisationsName,
+    tokenPrefix: token.slice(0, 8),
+    resendId: responseBody.id,
+    component: "sendEinladungEmail",
+  });
   return { sent: true, id: responseBody.id };
 }


### PR DESCRIPTION
## Description

Logs Resend API calls for organisation invitation emails to PostHog and adds the `RESEND_FROM_EMAIL` secret for configuring the sender address.

## Summary of Changes

- `lib/email/sendEinladungEmail.ts`: replaces console logging with the structured `posthogLogger` (info/warn/error with component + context properties)
- Recipient addresses are SHA-256 hashed (`hashEmail`) before being logged, so no raw PII reaches PostHog
- Success logs include the Resend message ID and token prefix; error logs include status and response body