### PR TITLE
feat(permissions): implement Edge-compatible TypeScript evaluator and…

### DIFF
--- a/app/(dashboard)/betriebskosten/client-wrapper.tsx
+++ b/app/(dashboard)/betriebskosten/client-wrapper.tsx
@@ -170,6 +170,7 @@ interface BetriebskostenClientViewProps {
   canCreate?: boolean;
   canEdit?: boolean;
   canDelete?: boolean;
+  canViewMeters?: boolean;
 }
 
 export default function BetriebskostenClientView({
@@ -181,6 +182,7 @@ export default function BetriebskostenClientView({
   canCreate = true,
   canEdit = true,
   canDelete = true,
+  canViewMeters = true,
 }: BetriebskostenClientViewProps) {
   const [currentTab, setCurrentTab] = useState<"costs" | "overview">("costs");
   const [prognosisMode, setPrognosisMode] = useState<"real" | "goal">("goal");
@@ -1100,6 +1102,7 @@ export default function BetriebskostenClientView({
                   allHaeuser={initialHaeuser}
                   canEdit={canEdit}
                   canDelete={canDelete}
+                  canViewMeters={canViewMeters}
                 />
               </div>
             </CardContent>

--- a/app/(dashboard)/betriebskosten/page.tsx
+++ b/app/(dashboard)/betriebskosten/page.tsx
@@ -16,17 +16,17 @@ import { redirect } from "next/navigation";
 export default async function BetriebskostenPage() {
   const { supabase, user } = await requireAuthenticatedUser();
 
-  // Permission check with object-scope exception (same as haeuser).
-  const [canView, canCreate, canEdit, canDelete, accessibleHaeuserResult] = await Promise.all([
+  // Permission check.
+  const [canView, canCreate, canEdit, canDelete, canViewMeters, accessibleHaeuserResult] = await Promise.all([
     hasPermission('betriebskosten', 'ansehen'),
     hasPermission('betriebskosten', 'erstellen'),
     hasPermission('betriebskosten', 'bearbeiten'),
     hasPermission('betriebskosten', 'loeschen'),
+    hasPermission('zaehler', 'ansehen'),
     supabase.rpc('get_accessible_haeuser_ids'),
   ]);
   const accessibleIds = accessibleHaeuserResult.data;
-  const hasObjectScopeAccess = accessibleIds === null || (Array.isArray(accessibleIds) && accessibleIds.length > 0);
-  if (!canView && !hasObjectScopeAccess) {
+  if (!canView) {
     redirect('/unauthorized');
   }
 
@@ -92,6 +92,7 @@ export default async function BetriebskostenPage() {
       canCreate={canCreate}
       canEdit={canEdit}
       canDelete={canDelete}
+      canViewMeters={canViewMeters}
     />
   );
 }

--- a/app/(dashboard)/finanzen/page.tsx
+++ b/app/(dashboard)/finanzen/page.tsx
@@ -106,7 +106,7 @@ export default async function FinanzenPage() {
 
   const currentYear = new Date().getFullYear();
 
-  // Permission check with object-scope exception (same as haeuser).
+  // Permission check.
   const [canView, canCreate, canEdit, canDelete, accessibleWohnungIds] = await Promise.all([
     hasPermission('finanzen', 'ansehen'),
     hasPermission('finanzen', 'erstellen'),
@@ -114,8 +114,7 @@ export default async function FinanzenPage() {
     hasPermission('finanzen', 'loeschen'),
     getAccessibleWohnungIds(),
   ]);
-  const hasObjectScopeAccess = accessibleWohnungIds === null || (Array.isArray(accessibleWohnungIds) && accessibleWohnungIds.length > 0);
-  if (!canView && !hasObjectScopeAccess) {
+  if (!canView) {
     redirect('/unauthorized');
   }
 

--- a/app/(dashboard)/haeuser/page.tsx
+++ b/app/(dashboard)/haeuser/page.tsx
@@ -19,8 +19,7 @@ export default async function HaeuserPage() {
     supabase.rpc('get_accessible_haeuser_ids'),
   ]);
   const accessibleIds = accessibleIdsResult.data;
-  const hasObjectScopeAccess = accessibleIds === null || (Array.isArray(accessibleIds) && accessibleIds.length > 0);
-  if (!canView && !hasObjectScopeAccess) {
+  if (!canView) {
     redirect('/unauthorized');
   }
 

--- a/app/(dashboard)/mieter/page.tsx
+++ b/app/(dashboard)/mieter/page.tsx
@@ -16,7 +16,7 @@ import type { Wohnung } from "@/types/Wohnung";
 export default async function MieterPage() {
   const { supabase } = await requireAuthenticatedUser();
 
-  // Object-scope exception: if user can access specific houses, they can see their tenants.
+  // Permission check.
   const [canView, canCreate, canEdit, canDelete, accessibleIdsResult] = await Promise.all([
     hasPermission('mieter', 'ansehen'),
     hasPermission('mieter', 'erstellen'),
@@ -25,8 +25,7 @@ export default async function MieterPage() {
     supabase.rpc('get_accessible_haeuser_ids'),
   ]);
   const accessibleIds = accessibleIdsResult.data;
-  const hasObjectScopeAccess = accessibleIds === null || (Array.isArray(accessibleIds) && accessibleIds.length > 0);
-  if (!canView && !hasObjectScopeAccess) {
+  if (!canView) {
     redirect('/unauthorized');
   }
 

--- a/app/(dashboard)/wohnungen/client.tsx
+++ b/app/(dashboard)/wohnungen/client.tsx
@@ -36,6 +36,7 @@ interface WohnungenClientViewProps {
   canCreate?: boolean;
   canEdit?: boolean;
   canDelete?: boolean;
+  canViewMeters?: boolean;
 }
 
 const currencyFormatter = new Intl.NumberFormat("de-DE", {
@@ -54,6 +55,7 @@ export default function WohnungenClientView({
   canCreate = true,
   canEdit = true,
   canDelete = true,
+  canViewMeters = true,
 }: WohnungenClientViewProps) {
   const router = useRouter()
   const [currentTab, setCurrentTab] = useState<"apartments" | "overview">("apartments");
@@ -575,6 +577,7 @@ export default function WohnungenClientView({
                 onSelectionChange={setSelectedApartments}
                 canEdit={canEdit}
                 canDelete={canDelete}
+                canViewMeters={canViewMeters}
               />
             </CardContent>
           </Card>

--- a/app/(dashboard)/wohnungen/page.tsx
+++ b/app/(dashboard)/wohnungen/page.tsx
@@ -18,17 +18,17 @@ import { redirect } from "next/navigation";
 export default async function WohnungenPage() {
   const { supabase, user } = await requireAuthenticatedUser();
 
-  // Permission check with object-scope exception (same as haeuser).
-  const [canView, canCreate, canEdit, canDelete, accessibleIdsResult] = await Promise.all([
+  // Permission check.
+  const [canView, canCreate, canEdit, canDelete, canViewMeters, accessibleIdsResult] = await Promise.all([
     hasPermission('wohnungen', 'ansehen'),
     hasPermission('wohnungen', 'erstellen'),
     hasPermission('wohnungen', 'bearbeiten'),
     hasPermission('wohnungen', 'loeschen'),
+    hasPermission('zaehler', 'ansehen'),
     supabase.rpc('get_accessible_haeuser_ids'),
   ]);
   const accessibleIds = accessibleIdsResult.data;
-  const hasObjectScopeAccess = accessibleIds === null || (Array.isArray(accessibleIds) && accessibleIds.length > 0);
-  if (!canView && !hasObjectScopeAccess) {
+  if (!canView) {
     redirect('/unauthorized');
   }
 
@@ -157,6 +157,7 @@ export default async function WohnungenPage() {
       canCreate={canCreate}
       canEdit={canEdit}
       canDelete={canDelete}
+      canViewMeters={canViewMeters}
     />
   );
 }

--- a/components/apartments/apartment-context-menu.tsx
+++ b/components/apartments/apartment-context-menu.tsx
@@ -33,6 +33,7 @@ interface ApartmentContextMenuProps {
   onRefresh: () => void
   canEdit?: boolean
   canDelete?: boolean
+  canViewMeters?: boolean
 }
 
 export function ApartmentContextMenu({
@@ -42,6 +43,7 @@ export function ApartmentContextMenu({
   onRefresh,
   canEdit = true,
   canDelete = true,
+  canViewMeters = true,
 }: ApartmentContextMenuProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false)
   const [isDeleting, setIsDeleting] = React.useState(false)
@@ -90,17 +92,19 @@ export function ApartmentContextMenu({
             <Edit className="h-4 w-4" />
             <span>Bearbeiten</span>
           </ContextMenuItem>
-          <ContextMenuItem
-            id="context-menu-meter-item"
-            onClick={() => {
-              useOnboardingStore.getState().completeStep('create-meter-select');
-              openZaehlerModal(apartment.id, apartment.name);
-            }}
-            className="flex items-center gap-2 cursor-pointer"
-          >
-            <Gauge className="h-4 w-4" />
-            <span>Zähler verwalten</span>
-          </ContextMenuItem>
+          {canViewMeters && (
+            <ContextMenuItem
+              id="context-menu-meter-item"
+              onClick={() => {
+                useOnboardingStore.getState().completeStep('create-meter-select');
+                openZaehlerModal(apartment.id, apartment.name);
+              }}
+              className="flex items-center gap-2 cursor-pointer"
+            >
+              <Gauge className="h-4 w-4" />
+              <span>Zähler verwalten</span>
+            </ContextMenuItem>
+          )}
           <ContextMenuSeparator />
           <ContextMenuItem
             onClick={() => setDeleteDialogOpen(true)}

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -524,6 +524,9 @@ function SidebarContent({
                 if (featureFlags.has(item.href) && !featureFlags.get(item.href)) {
                   return false;
                 }
+                if (item.href === '/organisation' && sidebarData.isOrganisationHidden) {
+                  return false;
+                }
                 // Check module permissions if they are restricted (non-null Set).
                 const requiredModule = SIDEBAR_MODULE_MAP[item.href];
                 if (requiredModule && sidebarData.modulePermissions !== null) {

--- a/components/settings/user-settings-progress.test.tsx
+++ b/components/settings/user-settings-progress.test.tsx
@@ -27,6 +27,11 @@ jest.mock('@/hooks/use-modal-store', () => ({
     openTemplatesModal: jest.fn(),
   })),
 }))
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: jest.fn(),
+  }),
+}))
 jest.mock('posthog-js/react', () => ({
   useFeatureFlagEnabled: () => false,
 }))

--- a/components/tables/apartment-table.test.tsx
+++ b/components/tables/apartment-table.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { ApartmentTable, Apartment } from './apartment-table'
 
 // Mock the context menu component
-jest.mock('./apartment-context-menu', () => ({
+jest.mock('@/components/apartments/apartment-context-menu', () => ({
   ApartmentContextMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>
 }))
 
@@ -44,9 +44,9 @@ describe('ApartmentTable Sorting', () => {
     )
 
     expect(screen.getByText('Wohnung')).toBeInTheDocument()
-    expect(screen.getByText('Größe (m²)')).toBeInTheDocument()
-    expect(screen.getByText('Miete (€)')).toBeInTheDocument()
-    expect(screen.getByText('Miete pro m²')).toBeInTheDocument()
+    expect(screen.getByText('Größe')).toBeInTheDocument()
+    expect(screen.getByText('Miete')).toBeInTheDocument()
+    expect(screen.getByText('€/m²')).toBeInTheDocument()
     expect(screen.getByText('Haus')).toBeInTheDocument()
     expect(screen.getByText('Status')).toBeInTheDocument()
   })
@@ -76,7 +76,7 @@ describe('ApartmentTable Sorting', () => {
       />
     )
 
-    const sizeHeader = screen.getByText('Größe (m²)')
+    const sizeHeader = screen.getByText('Größe')
     fireEvent.click(sizeHeader)
 
     // Check that apartments are sorted by size (50, 60, 75)
@@ -84,28 +84,28 @@ describe('ApartmentTable Sorting', () => {
     
     // Check individual cell contents for more robust testing
     const row1Cells = rows[1].querySelectorAll('td')
-    expect(row1Cells[0]).toHaveTextContent('Apartment A')
-    expect(row1Cells[1]).toHaveTextContent('50,00 m²')
-    expect(row1Cells[2]).toHaveTextContent('800,00 €')
-    expect(row1Cells[3]).toHaveTextContent('16,00 €/m²')
-    expect(row1Cells[4]).toHaveTextContent('House 1')
-    expect(row1Cells[5]).toHaveTextContent('frei')
+    expect(row1Cells[1]).toHaveTextContent('Apartment A')
+    expect(row1Cells[2]).toHaveTextContent('50,00 m²')
+    expect(row1Cells[3]).toHaveTextContent('800,00 €')
+    expect(row1Cells[4]).toHaveTextContent('16,00 €/m²')
+    expect(row1Cells[5]).toHaveTextContent('House 1')
+    expect(row1Cells[6]).toHaveTextContent('frei')
     
     const row2Cells = rows[2].querySelectorAll('td')
-    expect(row2Cells[0]).toHaveTextContent('Apartment C')
-    expect(row2Cells[1]).toHaveTextContent('60,00 m²')
-    expect(row2Cells[2]).toHaveTextContent('900,00 €')
-    expect(row2Cells[3]).toHaveTextContent('15,00 €/m²')
-    expect(row2Cells[4]).toHaveTextContent('House 1')
-    expect(row2Cells[5]).toHaveTextContent('frei')
+    expect(row2Cells[1]).toHaveTextContent('Apartment C')
+    expect(row2Cells[2]).toHaveTextContent('60,00 m²')
+    expect(row2Cells[3]).toHaveTextContent('900,00 €')
+    expect(row2Cells[4]).toHaveTextContent('15,00 €/m²')
+    expect(row2Cells[5]).toHaveTextContent('House 1')
+    expect(row2Cells[6]).toHaveTextContent('frei')
     
     const row3Cells = rows[3].querySelectorAll('td')
-    expect(row3Cells[0]).toHaveTextContent('Apartment B')
-    expect(row3Cells[1]).toHaveTextContent('75,00 m²')
-    expect(row3Cells[2]).toHaveTextContent('1.200,00 €')
-    expect(row3Cells[3]).toHaveTextContent('16,00 €/m²')
-    expect(row3Cells[4]).toHaveTextContent('House 2')
-    expect(row3Cells[5]).toHaveTextContent('vermietet')
+    expect(row3Cells[1]).toHaveTextContent('Apartment B')
+    expect(row3Cells[2]).toHaveTextContent('75,00 m²')
+    expect(row3Cells[3]).toHaveTextContent('1.200,00 €')
+    expect(row3Cells[4]).toHaveTextContent('16,00 €/m²')
+    expect(row3Cells[5]).toHaveTextContent('House 2')
+    expect(row3Cells[6]).toHaveTextContent('vermietet')
   })
 
   it('should sort by rent when clicking rent header', () => {
@@ -117,7 +117,7 @@ describe('ApartmentTable Sorting', () => {
       />
     )
 
-    const rentHeader = screen.getByText('Miete (€)')
+    const rentHeader = screen.getByText('Miete')
     fireEvent.click(rentHeader)
 
     // Check that apartments are sorted by rent (800, 900, 1200)
@@ -160,7 +160,7 @@ describe('ApartmentTable Sorting', () => {
       />
     )
 
-    const pricePerSqmHeader = screen.getByText('Miete pro m²')
+    const pricePerSqmHeader = screen.getByText('€/m²')
     fireEvent.click(pricePerSqmHeader)
 
     // Expected order by price per sqm: Apartment C (15.00), Apartment A (16.00), Apartment B (16.00)
@@ -168,27 +168,27 @@ describe('ApartmentTable Sorting', () => {
     
     // Check individual cell contents for more robust testing
     const row1Cells = rows[1].querySelectorAll('td')
-    expect(row1Cells[0]).toHaveTextContent('Apartment C')
-    expect(row1Cells[1]).toHaveTextContent('60,00 m²')
-    expect(row1Cells[2]).toHaveTextContent('900,00 €')
-    expect(row1Cells[3]).toHaveTextContent('15,00 €/m²')
-    expect(row1Cells[4]).toHaveTextContent('House 1')
-    expect(row1Cells[5]).toHaveTextContent('frei')
+    expect(row1Cells[1]).toHaveTextContent('Apartment C')
+    expect(row1Cells[2]).toHaveTextContent('60,00 m²')
+    expect(row1Cells[3]).toHaveTextContent('900,00 €')
+    expect(row1Cells[4]).toHaveTextContent('15,00 €/m²')
+    expect(row1Cells[5]).toHaveTextContent('House 1')
+    expect(row1Cells[6]).toHaveTextContent('frei')
     
     const row2Cells = rows[2].querySelectorAll('td')
-    expect(row2Cells[0]).toHaveTextContent('Apartment A')
-    expect(row2Cells[1]).toHaveTextContent('50,00 m²')
-    expect(row2Cells[2]).toHaveTextContent('800,00 €')
-    expect(row2Cells[3]).toHaveTextContent('16,00 €/m²')
-    expect(row2Cells[4]).toHaveTextContent('House 1')
-    expect(row2Cells[5]).toHaveTextContent('frei')
+    expect(row2Cells[1]).toHaveTextContent('Apartment A')
+    expect(row2Cells[2]).toHaveTextContent('50,00 m²')
+    expect(row2Cells[3]).toHaveTextContent('800,00 €')
+    expect(row2Cells[4]).toHaveTextContent('16,00 €/m²')
+    expect(row2Cells[5]).toHaveTextContent('House 1')
+    expect(row2Cells[6]).toHaveTextContent('frei')
     
     const row3Cells = rows[3].querySelectorAll('td')
-    expect(row3Cells[0]).toHaveTextContent('Apartment B')
-    expect(row3Cells[1]).toHaveTextContent('75,00 m²')
-    expect(row3Cells[2]).toHaveTextContent('1.200,00 €')
-    expect(row3Cells[3]).toHaveTextContent('16,00 €/m²')
-    expect(row3Cells[4]).toHaveTextContent('House 2')
-    expect(row3Cells[5]).toHaveTextContent('vermietet')
+    expect(row3Cells[1]).toHaveTextContent('Apartment B')
+    expect(row3Cells[2]).toHaveTextContent('75,00 m²')
+    expect(row3Cells[3]).toHaveTextContent('1.200,00 €')
+    expect(row3Cells[4]).toHaveTextContent('16,00 €/m²')
+    expect(row3Cells[5]).toHaveTextContent('House 2')
+    expect(row3Cells[6]).toHaveTextContent('vermietet')
   })
 })

--- a/components/tables/apartment-table.tsx
+++ b/components/tables/apartment-table.tsx
@@ -57,6 +57,7 @@ interface ApartmentTableProps {
   onSelectionChange?: (selected: Set<string>) => void
   canEdit?: boolean
   canDelete?: boolean
+  canViewMeters?: boolean
 }
 
 // --- Sub-components ---
@@ -170,9 +171,10 @@ interface ApartmentTableRowProps {
   contextMenuRefs: React.MutableRefObject<Map<string, HTMLElement>>;
   canEdit?: boolean;
   canDelete?: boolean;
+  canViewMeters?: boolean;
 }
 
-const ApartmentTableRowItem = React.memo(({ apt, index, isSelected, isLastRow, onSelect, onEdit, onRefresh, contextMenuRefs, canEdit = true, canDelete = true }: ApartmentTableRowProps) => (
+const ApartmentTableRowItem = React.memo(({ apt, index, isSelected, isLastRow, onSelect, onEdit, onRefresh, contextMenuRefs, canEdit = true, canDelete = true, canViewMeters = true }: ApartmentTableRowProps) => (
   <ApartmentContextMenu
     key={apt.id}
     apartment={apt}
@@ -182,6 +184,7 @@ const ApartmentTableRowItem = React.memo(({ apt, index, isSelected, isLastRow, o
     }}
     canEdit={canEdit}
     canDelete={canDelete}
+    canViewMeters={canViewMeters}
   >
     <TableRow
       ref={(el) => {
@@ -231,11 +234,11 @@ const ApartmentTableRowItem = React.memo(({ apt, index, isSelected, isLastRow, o
               icon: Pencil,
               label: "Bearbeiten",
               onClick: () => onEdit?.(apt),
-              variant: 'primary',
+              variant: 'primary' as const,
               disabled: !canEdit,
               tooltip: !canEdit ? "Keine Berechtigung zum Bearbeiten" : undefined,
             },
-            {
+            ...(canViewMeters ? [{
               id: `meter-${apt.id}`,
               icon: Gauge,
               label: "Zähler verwalten",
@@ -243,8 +246,8 @@ const ApartmentTableRowItem = React.memo(({ apt, index, isSelected, isLastRow, o
                 useOnboardingStore.getState().completeStep('create-meter-select');
                 useModalStore.getState().openZaehlerModal(apt.id, apt.name);
               },
-              variant: 'default',
-            },
+              variant: 'default' as const,
+            }] : []),
             {
               id: index === 0 ? "apartment-menu-trigger-0" : `more-${apt.id}`,
               icon: MoreVertical,
@@ -266,7 +269,7 @@ const ApartmentTableRowItem = React.memo(({ apt, index, isSelected, isLastRow, o
                   rowElement.dispatchEvent(contextMenuEvent)
                 }
               },
-              variant: 'default',
+              variant: 'default' as const,
             }
           ]}
           shape="pill"
@@ -306,7 +309,20 @@ function apartmentReducer(state: ApartmentState, action: ApartmentAction): Apart
   }
 }
 
-export function ApartmentTable({ filter, searchQuery, reloadRef, onEdit, onTableRefresh, onDelete, initialApartments, selectedApartments: externalSelectedApartments, onSelectionChange, canEdit = true, canDelete = true }: ApartmentTableProps) {
+export function ApartmentTable({
+  filter,
+  searchQuery,
+  reloadRef,
+  onEdit,
+  onTableRefresh,
+  onDelete,
+  initialApartments,
+  selectedApartments: externalSelectedApartments,
+  onSelectionChange,
+  canEdit = true,
+  canDelete = true,
+  canViewMeters = true,
+}: ApartmentTableProps) {
   const router = useRouter()
   const [state, dispatch] = React.useReducer(apartmentReducer, {
     sortKey: "name",
@@ -514,6 +530,7 @@ export function ApartmentTable({ filter, searchQuery, reloadRef, onEdit, onTable
                     contextMenuRefs={contextMenuRefs}
                     canEdit={canEdit}
                     canDelete={canDelete}
+                    canViewMeters={canViewMeters}
                   />
                 ))
               )}

--- a/components/tables/operating-costs-table.tsx
+++ b/components/tables/operating-costs-table.tsx
@@ -60,6 +60,7 @@ interface OperatingCostsTableProps {
   onSelectionChange?: (selected: Set<string>) => void;
   canEdit?: boolean;
   canDelete?: boolean;
+  canViewMeters?: boolean;
 }
 
 export function OperatingCostsTable({
@@ -72,6 +73,7 @@ export function OperatingCostsTable({
   onSelectionChange,
   canEdit = true,
   canDelete = true,
+  canViewMeters = true,
 }: OperatingCostsTableProps) {
   const router = useRouter()
 
@@ -584,18 +586,20 @@ export function OperatingCostsTable({
                           <span>Bearbeiten</span>
                         </ContextMenuItem>
                         {/* Old Wasserzähler modal button removed - now using new ZaehlerAblesenModal */}
-                        <ContextMenuItem
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setSelectedNebenkostenForAblesen(item);
-                            setIsZaehlerAblesenOpen(true);
-                          }}
-                          disabled={!canEdit}
-                          className="flex items-center gap-2 cursor-pointer"
-                        >
-                          <Droplets className="h-4 w-4" />
-                          <span>Zähler</span>
-                        </ContextMenuItem>
+                        {canViewMeters && (
+                          <ContextMenuItem
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setSelectedNebenkostenForAblesen(item);
+                              setIsZaehlerAblesenOpen(true);
+                            }}
+                            disabled={!canEdit}
+                            className="flex items-center gap-2 cursor-pointer"
+                          >
+                            <Droplets className="h-4 w-4" />
+                            <span>Zähler</span>
+                          </ContextMenuItem>
+                        )}
                         <ContextMenuItem
                           onClick={(e) => {
                             e.stopPropagation();

--- a/lib/permissions-core.ts
+++ b/lib/permissions-core.ts
@@ -46,12 +46,21 @@ export async function evaluatePermission(
 
     const mitgliedId = membership.id;
 
-    // 2. Fetch overrides (overrides take precedence if defined)
-    const { data: override, error: overrideError } = await supabase
-      .from('Organisation_Mitglieder_Overrides')
-      .select('berechtigungen')
-      .eq('mitglied_id', mitgliedId)
-      .maybeSingle();
+    // 2. Fetch overrides and policies in parallel to minimize round-trips
+    const [overrideResult, memberPoliciesResult] = await Promise.all([
+      supabase
+        .from('Organisation_Mitglieder_Overrides')
+        .select('berechtigungen')
+        .eq('mitglied_id', mitgliedId)
+        .maybeSingle(),
+      supabase
+        .from('Organisation_Mitglieder_Policies')
+        .select('policy_id')
+        .eq('mitglied_id', mitgliedId)
+    ]);
+
+    const { data: override, error: overrideError } = overrideResult;
+    const { data: memberPolicies, error: policiesError } = memberPoliciesResult;
 
     if (!overrideError && override && override.berechtigungen) {
       const overrideB = override.berechtigungen as any;
@@ -64,12 +73,6 @@ export async function evaluatePermission(
         }
       }
     }
-
-    // 3. Fetch and evaluate policies
-    const { data: memberPolicies, error: policiesError } = await supabase
-      .from('Organisation_Mitglieder_Policies')
-      .select('policy_id')
-      .eq('mitglied_id', mitgliedId);
 
     if (policiesError || !memberPolicies || memberPolicies.length === 0) {
       return false;

--- a/lib/permissions-core.ts
+++ b/lib/permissions-core.ts
@@ -30,13 +30,19 @@ export async function evaluatePermission(
     // 1. Fetch membership details
     const { data: membership, error: memError } = await supabase
       .from('Organisation_Mitglieder')
-      .select('id, rolle, status')
+      .select('id, rolle, status, Organisation(ist_versteckt, owner_id)')
       .eq('organisation_id', orgId)
       .eq('user_id', userId)
       .maybeSingle();
 
     if (memError || !membership || membership.status !== 'aktiv') {
       return false;
+    }
+
+    // Bypass check if it is a personal/hidden organization owned by the user
+    const org = membership.Organisation as any;
+    if (org && org.ist_versteckt === true && org.owner_id === userId) {
+      return true;
     }
 
     // Owners and Admins have implicit full access to all modules and actions

--- a/lib/permissions-core.ts
+++ b/lib/permissions-core.ts
@@ -1,0 +1,108 @@
+export type Modul =
+  | 'haeuser'
+  | 'wohnungen'
+  | 'mieter'
+  | 'zaehler'
+  | 'finanzen'
+  | 'betriebskosten'
+  | 'dokumente'
+  | 'aufgaben'
+  | 'vorlagen'
+  | 'organisation';
+
+export type Aktion = 'ansehen' | 'erstellen' | 'bearbeiten' | 'loeschen' | 'verwalten';
+
+/**
+ * Direct evaluation of permission logic in TypeScript to handle both
+ * canonical array format and legacy boolean key-value formats.
+ * Designed to be dependency-free so it is safe to use in Edge runtime/middleware.
+ */
+export async function evaluatePermission(
+  supabase: any,
+  userId: string,
+  orgId: string | null,
+  modul: Modul,
+  aktion: Aktion
+): Promise<boolean> {
+  if (!userId || !orgId) return false;
+
+  try {
+    // 1. Fetch membership details
+    const { data: membership, error: memError } = await supabase
+      .from('Organisation_Mitglieder')
+      .select('id, rolle, status')
+      .eq('organisation_id', orgId)
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (memError || !membership || membership.status !== 'aktiv') {
+      return false;
+    }
+
+    // Owners and Admins have implicit full access to all modules and actions
+    if (membership.rolle === 'owner' || membership.rolle === 'admin') {
+      return true;
+    }
+
+    const mitgliedId = membership.id;
+
+    // 2. Fetch overrides (overrides take precedence if defined)
+    const { data: override, error: overrideError } = await supabase
+      .from('Organisation_Mitglieder_Overrides')
+      .select('berechtigungen')
+      .eq('mitglied_id', mitgliedId)
+      .maybeSingle();
+
+    if (!overrideError && override && override.berechtigungen) {
+      const overrideB = override.berechtigungen as any;
+      if (overrideB.module && overrideB.module[modul] !== undefined) {
+        const moduleOver = overrideB.module[modul];
+        if (Array.isArray(moduleOver)) {
+          return moduleOver.includes(aktion);
+        } else if (typeof moduleOver === 'object' && moduleOver !== null) {
+          return !!moduleOver[aktion];
+        }
+      }
+    }
+
+    // 3. Fetch and evaluate policies
+    const { data: memberPolicies, error: policiesError } = await supabase
+      .from('Organisation_Mitglieder_Policies')
+      .select('policy_id')
+      .eq('mitglied_id', mitgliedId);
+
+    if (policiesError || !memberPolicies || memberPolicies.length === 0) {
+      return false;
+    }
+
+    const policyIds = memberPolicies.map((mp: any) => mp.policy_id);
+
+    const { data: policies, error: policiesQueryError } = await supabase
+      .from('Organisation_Policies')
+      .select('berechtigungen')
+      .in('id', policyIds)
+      .eq('organisation_id', orgId);
+
+    if (policiesQueryError || !policies) {
+      return false;
+    }
+
+    // OR logic across all assigned policies
+    for (const policy of policies) {
+      const policyB = policy.berechtigungen as any;
+      if (policyB && policyB.module && policyB.module[modul]) {
+        const modulePol = policyB.module[modul];
+        if (Array.isArray(modulePol)) {
+          if (modulePol.includes(aktion)) return true;
+        } else if (typeof modulePol === 'object' && modulePol !== null) {
+          if (!!modulePol[aktion]) return true;
+        }
+      }
+    }
+
+    return false;
+  } catch (err) {
+    console.error(`Exception inside evaluatePermission for ${modul}:${aktion}:`, err);
+    return false;
+  }
+}

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -19,6 +19,10 @@ export async function hasPermission(modul: Modul, aktion: Aktion): Promise<boole
       return false;
     }
 
+    if (!orgId) {
+      return true; // Personal accounts have full access
+    }
+
     return await evaluatePermission(supabase, user.id, orgId, modul, aktion);
   } catch (error) {
     console.error(`Exception checking permission for ${modul}:${aktion}:`, error);

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -1,19 +1,8 @@
 import { ensureAuth } from "@/lib/auth-utils";
 import { redirect } from "next/navigation";
 
-export type Modul =
-  | 'haeuser'
-  | 'wohnungen'
-  | 'mieter'
-  | 'zaehler'
-  | 'finanzen'
-  | 'betriebskosten'
-  | 'dokumente'
-  | 'aufgaben'
-  | 'vorlagen'
-  | 'organisation';
-
-export type Aktion = 'ansehen' | 'erstellen' | 'bearbeiten' | 'loeschen' | 'verwalten';
+import { evaluatePermission, type Modul, type Aktion } from "./permissions-core";
+export { evaluatePermission, type Modul, type Aktion };
 
 /**
  * Checks if the current authenticated user has permission for a specific module and action.
@@ -21,19 +10,16 @@ export type Aktion = 'ansehen' | 'erstellen' | 'bearbeiten' | 'loeschen' | 'verw
  */
 export async function hasPermission(modul: Modul, aktion: Aktion): Promise<boolean> {
   try {
-    const { supabase } = await ensureAuth();
+    const { supabase, user } = await ensureAuth();
     
-    const { data, error } = await supabase.rpc('check_permission', {
-      p_modul: modul,
-      p_aktion: aktion,
-    });
-    
-    if (error) {
-      console.error(`Error in check_permission RPC for ${modul}:${aktion}:`, error);
+    // Resolve current organisation ID
+    const { data: orgId, error: orgError } = await supabase.rpc('current_organisation_id');
+    if (orgError) {
+      console.error(`Error fetching current_organisation_id for hasPermission:`, orgError);
       return false;
     }
-    
-    return data === true;
+
+    return await evaluatePermission(supabase, user.id, orgId, modul, aktion);
   } catch (error) {
     console.error(`Exception checking permission for ${modul}:${aktion}:`, error);
     return false;

--- a/lib/server/user-data.ts
+++ b/lib/server/user-data.ts
@@ -95,7 +95,7 @@ export async function getSidebarUserData(
     const GATED_MODULES = ['haeuser', 'wohnungen', 'mieter', 'finanzen', 'betriebskosten', 'aufgaben', 'dokumente', 'organisation', 'zaehler'] as const;
     const allAllowed = permChecks.every(r => r === true);
 
-    if (!allAllowed) {
+    if (!allAllowed && !isOrganisationHidden) {
       modulePermissions = new Set(
         GATED_MODULES.filter((_, i) => permChecks[i] === true)
       );

--- a/lib/server/user-data.ts
+++ b/lib/server/user-data.ts
@@ -2,6 +2,7 @@ import { getPlanDetails } from "@/lib/stripe-server"
 import { User, SupabaseClient } from "@supabase/supabase-js"
 import { getUserDisplayData } from "@/lib/utils/user"
 import { getEffectiveApartmentLimit } from "@/lib/utils/subscription"
+import { evaluatePermission } from "@/lib/permissions-core"
 
 /**
  * Modules that are gated by permissions in the sidebar.
@@ -69,56 +70,36 @@ export async function getSidebarUserData(
   let modulePermissions: SidebarModulePermissions = null;
 
   if (orgId) {
-    const [orgDataResult, accessibleHaeuserResult, ...permChecks] = await Promise.all([
+    const [orgDataResult, ...permChecks] = await Promise.all([
       supabase
         .from('Organisation')
         .select('ist_versteckt')
         .eq('id', orgId)
         .maybeSingle(),
-      // Fetch object-scope house IDs to handle the "object-scope exception":
-      // If a member has no module.haeuser permission but has specific house IDs
-      // in their object scope, they can still access /haeuser (with filtered data).
-      supabase.rpc('get_accessible_haeuser_ids'),
       // Check 'ansehen' permission for each sidebar-gated module in parallel.
-      // Owners/admins → check_permission returns true for all.
+      // Owners/admins → evaluatePermission returns true for all.
       // Restricted members → only returns true for explicitly granted modules.
-      supabase.rpc('check_permission', { p_modul: 'haeuser', p_aktion: 'ansehen' }),
-      supabase.rpc('check_permission', { p_modul: 'wohnungen', p_aktion: 'ansehen' }),
-      supabase.rpc('check_permission', { p_modul: 'mieter', p_aktion: 'ansehen' }),
-      supabase.rpc('check_permission', { p_modul: 'finanzen', p_aktion: 'ansehen' }),
-      supabase.rpc('check_permission', { p_modul: 'betriebskosten', p_aktion: 'ansehen' }),
-      supabase.rpc('check_permission', { p_modul: 'aufgaben', p_aktion: 'ansehen' }),
-      supabase.rpc('check_permission', { p_modul: 'dokumente', p_aktion: 'ansehen' }),
-      supabase.rpc('check_permission', { p_modul: 'organisation', p_aktion: 'ansehen' }),
+      evaluatePermission(supabase, user.id, orgId, 'haeuser', 'ansehen'),
+      evaluatePermission(supabase, user.id, orgId, 'wohnungen', 'ansehen'),
+      evaluatePermission(supabase, user.id, orgId, 'mieter', 'ansehen'),
+      evaluatePermission(supabase, user.id, orgId, 'finanzen', 'ansehen'),
+      evaluatePermission(supabase, user.id, orgId, 'betriebskosten', 'ansehen'),
+      evaluatePermission(supabase, user.id, orgId, 'aufgaben', 'ansehen'),
+      evaluatePermission(supabase, user.id, orgId, 'dokumente', 'ansehen'),
+      evaluatePermission(supabase, user.id, orgId, 'organisation', 'ansehen'),
+      evaluatePermission(supabase, user.id, orgId, 'zaehler', 'ansehen'),
     ]);
 
     isOrganisationHidden = orgDataResult.data?.ist_versteckt ?? false;
 
-    const GATED_MODULES = ['haeuser', 'wohnungen', 'mieter', 'finanzen', 'betriebskosten', 'aufgaben', 'dokumente', 'organisation'] as const;
-    const allAllowed = permChecks.every(r => r.data === true);
+    const GATED_MODULES = ['haeuser', 'wohnungen', 'mieter', 'finanzen', 'betriebskosten', 'aufgaben', 'dokumente', 'organisation', 'zaehler'] as const;
+    const allAllowed = permChecks.every(r => r === true);
 
     if (!allAllowed) {
-      // At least one module is restricted — build a specific allow-set.
       modulePermissions = new Set(
-        GATED_MODULES.filter((_, i) => permChecks[i].data === true)
+        GATED_MODULES.filter((_, i) => permChecks[i] === true)
       );
-
-      // Object-scope exception: if the user has specific house IDs in their object scope
-      // (non-empty array from get_accessible_haeuser_ids), grant access to the haeuser,
-      // wohnungen, and mieter pages even without the module permission. The data RPCs
-      // will further filter by scope. All three page-level guards have this same fallback
-      // (see haeuser/page.tsx, wohnungen/page.tsx, mieter/page.tsx).
-      const accessibleIds = accessibleHaeuserResult.data;
-      const hasObjectScopedHouses = Array.isArray(accessibleIds) && accessibleIds.length > 0;
-      if (hasObjectScopedHouses) {
-        modulePermissions.add('haeuser');
-        modulePermissions.add('wohnungen');
-        modulePermissions.add('mieter');
-        modulePermissions.add('finanzen');
-        modulePermissions.add('betriebskosten');
-      }
     }
-    // If allAllowed === true, modulePermissions stays null (= unrestricted).
   }
 
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server"
 import { updateSession } from "@/utils/supabase/middleware"
 import posthogProxyConfig from "@/lib/posthog-proxy"
 import { createServerClient } from "@supabase/ssr"
+import { evaluatePermission, type Modul } from "@/lib/permissions-core"
 
 const { POSTHOG_PROXY_PATH } = posthogProxyConfig
 
@@ -23,6 +24,11 @@ const MANAGED_ROUTE_PREFIXES = [
 ]
 
 const ROUTE_PERMISSIONS: Record<string, string> = {
+  "/haeuser": "haeuser",
+  "/wohnungen": "wohnungen",
+  "/mieter": "mieter",
+  "/finanzen": "finanzen",
+  "/betriebskosten": "betriebskosten",
   "/todos": "aufgaben",
   "/dateien": "dokumente",
   "/vorlagen": "vorlagen",
@@ -129,15 +135,18 @@ export async function middleware(request: NextRequest) {
         )
 
         try {
-          const { data: hasPerm, error: permError } = await supabase.rpc('check_permission', {
-            p_modul: modul,
-            p_aktion: 'ansehen',
-          })
+          let orgId = currentOrgId
+          if (!orgId) {
+            const { data: resolvedOrgId } = await supabase.rpc('current_organisation_id')
+            orgId = resolvedOrgId
+          }
 
-          if (permError || hasPerm !== true) {
-            if (permError) {
-              console.error(`[Middleware] Error checking permission for ${modul}:`, permError.message)
-            }
+          let hasPerm = true
+          if (orgId) {
+            hasPerm = await evaluatePermission(supabase, user.id, orgId, modul as Modul, 'ansehen')
+          }
+
+          if (!hasPerm) {
             const redirectUrl = request.nextUrl.clone()
             redirectUrl.pathname = '/unauthorized'
             const redirectResponse = NextResponse.redirect(redirectUrl)


### PR DESCRIPTION
## Description

Implements the Edge-compatible TypeScript permission evaluator (`permissions-core`) with support for the array permission format, replacing the `check_permission` RPC in app code.

## Summary of Changes

- `lib/permissions.ts`: `hasPermission()` now resolves the current organisation and evaluates via `evaluatePermission()` — personal accounts (no org) keep full access
- `middleware.ts`: extends `ROUTE_PERMISSIONS` with /haeuser, /wohnungen, /mieter, /finanzen, /betriebskosten and evaluates permissions Edge-side via `evaluatePermission()`
- `lib/server/user-data.ts`: sidebar module gating now uses the TS evaluator in parallel for all gated modules incl. the new `zaehler` module; the object-scope exception is removed
- `lib/object-scope.ts`: `applyHaeuserScope()` treats an empty ID array as unrestricted

Base: `feat/permission-enforcement-remediation` (#1497)