### PR TITLE
feat(worker): add PostHog OpenTelemetry tracing for Cloudflare Worker…

### DIFF
--- a/workers/mietevo-backend/src/index.ts
+++ b/workers/mietevo-backend/src/index.ts
@@ -5,6 +5,7 @@ import Papa from 'papaparse';
 import { GoogleGenAI } from '@google/genai';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { WorkerLogger, ExecutionContext, getPostHogApiKey } from './logger';
+import { initTracing, startSpan, endSpan, flushSpans, withSpan, runWithTrace, generateTraceId, SPAN_KINDS, STATUS_CODES } from './tracing';
 import pako from 'pako';
 import { PostHog } from 'posthog-node';
 
@@ -1011,6 +1012,8 @@ export async function processQueue(request: Request, env: Env, ctx: ExecutionCon
         const aiStartTime = Date.now();
 
         if (dateipfad) {
+            // Create a child span for AI analysis (wraps the AI call + PostHog $ai_generation event)
+            const aiChildSpan = startSpan('aiAnalysis', SPAN_KINDS.INTERNAL);
             try {
                 // Download & AI with retry for rate limits
                 logger.info('Starting email download', { msgId, mailId: mail_id, dateipfad });
@@ -1062,6 +1065,7 @@ export async function processQueue(request: Request, env: Env, ctx: ExecutionCon
                     score: aiScore || 0,
                     totalProcessingMs: Date.now() - processingStartTime
                 });
+                endSpan(aiChildSpan, { code: STATUS_CODES.OK });
 
                 // Update DB with Top-Level fields for easier access/sorting
                 logger.info('Updating tenant record in database', { mailId: mail_id, msgId });
@@ -1095,6 +1099,9 @@ export async function processQueue(request: Request, env: Env, ctx: ExecutionCon
                 logger.info('Tenant record updated successfully', { mailId: mail_id, msgId });
 
             } catch (processError: unknown) {
+                if (!aiChildSpan.endTimeUnixNano) {
+                    endSpan(aiChildSpan, { code: STATUS_CODES.ERROR, message: (processError as Error).message });
+                }
                 logger.error('Queue item processing failed', {
                     msgId,
                     mailId: mail_id,
@@ -1352,8 +1359,14 @@ export async function handleFileGeneration(request: Request, env: Env, ctx: Exec
 
 export default {
     async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-        const logger = new WorkerLogger(env, ctx);
+        // Initialize tracing with PostHog env vars
+        initTracing({ POSTHOG_API_KEY: env.POSTHOG_API_KEY, POSTHOG_HOST: env.POSTHOG_HOST });
+
         const requestStartTime = Date.now();
+        const url = new URL(request.url);
+        const method = request.method;
+        const pathname = url.pathname;
+        const userAgent = request.headers.get('User-Agent') || 'none';
 
         const origin = request.headers.get('Origin') || '*';
         const corsHeaders: Record<string, string> = {
@@ -1365,72 +1378,88 @@ export default {
             'Access-Control-Expose-Headers': 'X-PDF-Page-Count, X-PDF-Generation-Time',
         };
 
-        const url = new URL(request.url);
-        logger.info('Worker request received', {
-            method: request.method,
-            pathname: url.pathname,
-            userAgent: request.headers.get('User-Agent') || 'none'
-        });
+        // Run the entire request lifecycle under a single trace context
+        return runWithTrace(generateTraceId(), async () => {
+            const logger = new WorkerLogger(env, ctx);
 
-        // Handle CORS preflight requests
-        if (request.method === "OPTIONS") {
-            logger.info('CORS preflight handled', { pathname: url.pathname });
-            return new Response(null, {
-                headers: corsHeaders
-            });
-        }
+            // Create root span for the entire request
+            const rootSpan = startSpan(`${method} ${pathname}`, SPAN_KINDS.SERVER, [
+                { key: 'http.method', value: { stringValue: method } },
+                { key: 'http.url', value: { stringValue: pathname } },
+                { key: 'http.user_agent', value: { stringValue: userAgent } },
+            ]);
 
-        try {
-            // Route based on URL path first (more robust)
-            let response: Response;
+            logger.info('Worker request received', { method, pathname, userAgent });
 
-            // Handle simple GET/HEAD requests (health checks, root)
-            if (request.method === 'GET' || request.method === 'HEAD') {
-                if (url.pathname === '/' || url.pathname === '/health') {
-                    response = new Response('OK', { status: 200 });
-                } else {
-                    response = new Response('Not Found', { status: 404 });
-                }
-            } else if (url.pathname === '/ai') {
-                response = await handleAIRequest(request, env, ctx);
-            } else if (url.pathname === '/process-queue') {
-                response = await processQueue(request, env, ctx);
-            } else {
-                // Fallback to file generation logic (PDF/ZIP/CSV)
-                response = await handleFileGeneration(request, env, ctx);
+            // Handle CORS preflight requests
+            if (method === "OPTIONS") {
+                logger.info('CORS preflight handled', { pathname });
+                endSpan(rootSpan, { code: STATUS_CODES.OK });
+                logger.flush();
+                ctx.waitUntil(flushSpans());
+                return new Response(null, {
+                    headers: corsHeaders
+                });
             }
 
-            // Append CORS headers to every response
-            const newHeaders = new Headers(response.headers);
-            Object.entries(corsHeaders).forEach(([key, value]) => {
-                newHeaders.set(key, value);
-            });
+            try {
+                // Route based on URL path first (more robust)
+                let response: Response;
 
-            const duration = Date.now() - requestStartTime;
-            logger.info('Worker request completed', {
-                pathname: url.pathname,
-                status: response.status,
-                durationMs: duration
-            });
-            logger.flush();
+                // Handle simple GET/HEAD requests (health checks, root)
+                if (method === 'GET' || method === 'HEAD') {
+                    if (pathname === '/' || pathname === '/health') {
+                        response = new Response('OK', { status: 200 });
+                    } else {
+                        response = new Response('Not Found', { status: 404 });
+                    }
+                } else if (pathname === '/ai') {
+                    response = await withSpan('handleAIRequest', () => handleAIRequest(request, env, ctx), SPAN_KINDS.SERVER);
+                } else if (pathname === '/process-queue') {
+                    response = await withSpan('processQueue', () => processQueue(request, env, ctx), SPAN_KINDS.SERVER);
+                } else {
+                    // Fallback to file generation logic (PDF/ZIP/CSV)
+                    response = await withSpan('handleFileGeneration', () => handleFileGeneration(request, env, ctx), SPAN_KINDS.SERVER);
+                }
 
-            return new Response(response.body, {
-                status: response.status,
-                statusText: response.statusText,
-                headers: newHeaders
-            });
+                // Append CORS headers to every response
+                const newHeaders = new Headers(response.headers);
+                Object.entries(corsHeaders).forEach(([key, value]) => {
+                    newHeaders.set(key, value);
+                });
 
-        } catch (error: unknown) {
-            // Re-use existing logger instance
-            logger.error('Worker request failed with unhandled error', {
-                error: (error as Error).message,
-                pathname: url.pathname,
-                method: request.method,
-                durationMs: Date.now() - requestStartTime
-            });
-            logger.flush();
+                const duration = Date.now() - requestStartTime;
+                const status = response.status;
+                logger.info('Worker request completed', {
+                    pathname, status, durationMs: duration
+                });
 
-            return new Response(`Error: ${(error as Error).message}`, { status: 500, headers: corsHeaders });
-        }
+                endSpan(rootSpan, { code: STATUS_CODES.OK });
+
+                logger.flush();
+                ctx.waitUntil(flushSpans());
+
+                return new Response(response.body, {
+                    status,
+                    statusText: response.statusText,
+                    headers: newHeaders
+                });
+
+            } catch (error: unknown) {
+                const errMsg = (error as Error).message;
+                endSpan(rootSpan, { code: STATUS_CODES.ERROR, message: errMsg });
+
+                logger.error('Worker request failed with unhandled error', {
+                    error: errMsg,
+                    pathname,
+                    method,
+                    durationMs: Date.now() - requestStartTime
+                });
+                logger.flush();
+                ctx.waitUntil(flushSpans());
+
+                return new Response(`Error: ${errMsg}`, { status: 500, headers: corsHeaders });
+            }
+        });
     },
 };

--- a/workers/mietevo-backend/src/logger.ts
+++ b/workers/mietevo-backend/src/logger.ts
@@ -5,6 +5,8 @@
  * and we need to use ctx.waitUntil for async operations.
  */
 
+import { getTraceContext } from './tracing';
+
 export interface Env {
     POSTHOG_API_KEY?: string;
     NEXT_PUBLIC_POSTHOG_KEY?: string;
@@ -60,6 +62,8 @@ interface LogRecord {
     severityNumber: number;
     severityText: string;
     body: { stringValue: string };
+    traceId?: string;
+    spanId?: string;
     attributes: { key: string; value: Record<string, unknown> }[];
 }
 
@@ -67,7 +71,6 @@ export class WorkerLogger {
     private logs: LogRecord[] = [];
     private env: Env;
     private ctx: ExecutionContext;
-
     constructor(env: Env, ctx: ExecutionContext) {
         this.env = env;
         this.ctx = ctx;
@@ -93,14 +96,21 @@ export class WorkerLogger {
 
         const timestamp = new Date().toISOString();
 
+        // Get trace context from the live async context
+        const trace = getTraceContext() ?? undefined;
+
         // Enrich attributes
-        const enrichedAttributes = {
+        const enrichedAttributes: LogAttributes = {
             ...attributes,
             'log.timestamp': timestamp,
             'service.name': SERVICE_NAME,
         };
+        if (trace) {
+            enrichedAttributes['trace.trace_id'] = trace.traceId;
+            enrichedAttributes['trace.span_id'] = trace.spanId;
+        }
 
-        this.logs.push({
+        const record: LogRecord = {
             timeUnixNano: String(Date.now() * 1000000),
             severityNumber: getSeverityNumber(severity),
             severityText: severity.toUpperCase(),
@@ -111,7 +121,12 @@ export class WorkerLogger {
                     key,
                     value: formatAttributeValue(value)
                 }))
-        });
+        };
+        if (trace) {
+            record.traceId = trace.traceId;
+            record.spanId = trace.spanId;
+        }
+        this.logs.push(record);
     }
 
     debug(message: string, attributes?: LogAttributes) { this.log('debug', message, attributes); }

--- a/workers/mietevo-backend/src/tracing.test.ts
+++ b/workers/mietevo-backend/src/tracing.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import {
+  startSpan,
+  endSpan,
+  withSpan,
+  getTraceContext,
+  generateTraceId,
+  runWithTrace,
+  SPAN_KINDS,
+  STATUS_CODES,
+} from './tracing';
+
+describe('tracing', () => {
+  describe('generateTraceId', () => {
+    it('should return a 32-character hex string', () => {
+      const id = generateTraceId();
+      expect(id).toMatch(/^[0-9a-f]{32}$/);
+    });
+
+    it('should generate unique IDs', () => {
+      const ids = new Set(Array.from({ length: 100 }, () => generateTraceId()));
+      expect(ids.size).toBe(100);
+    });
+  });
+
+  describe('startSpan and endSpan', () => {
+    it('should create a span with correct properties', async () => {
+      await runWithTrace(generateTraceId(), async () => {
+        const span = startSpan('test-span', SPAN_KINDS.SERVER);
+        expect(span.name).toBe('test-span');
+        expect(span.kind).toBe(SPAN_KINDS.SERVER);
+        expect(span.traceId).toMatch(/^[0-9a-f]{32}$/);
+        expect(span.spanId).toMatch(/^[0-9a-f]{16}$/);
+        expect(span.parentSpanId).toBeUndefined();
+        expect(span.startTimeUnixNano).toBeTruthy();
+        expect(span.endTimeUnixNano).toBeUndefined();
+        endSpan(span, { code: STATUS_CODES.OK });
+        expect(span.endTimeUnixNano).toBeTruthy();
+        expect(span.status?.code).toBe(STATUS_CODES.OK);
+      });
+    });
+
+    it('should default kind to INTERNAL', async () => {
+      await runWithTrace(generateTraceId(), async () => {
+        const span = startSpan('test-span');
+        expect(span.kind).toBe(SPAN_KINDS.INTERNAL);
+        endSpan(span);
+      });
+    });
+
+    it('should set ERROR status correctly', async () => {
+      await runWithTrace(generateTraceId(), async () => {
+        const span = startSpan('failing-span');
+        endSpan(span, { code: STATUS_CODES.ERROR, message: 'something went wrong' });
+        expect(span.status?.code).toBe(STATUS_CODES.ERROR);
+        expect(span.status?.message).toBe('something went wrong');
+      });
+    });
+  });
+
+  describe('trace context propagation', () => {
+    it('should propagate trace context through nested spans', async () => {
+      await runWithTrace(generateTraceId(), async () => {
+        const rootSpan = startSpan('root', SPAN_KINDS.SERVER);
+
+        const childSpan = startSpan('child', SPAN_KINDS.INTERNAL);
+        expect(childSpan.traceId).toBe(rootSpan.traceId);
+        expect(childSpan.parentSpanId).toBe(rootSpan.spanId);
+
+        const grandchildSpan = startSpan('grandchild', SPAN_KINDS.INTERNAL);
+        expect(grandchildSpan.traceId).toBe(rootSpan.traceId);
+        expect(grandchildSpan.parentSpanId).toBe(childSpan.spanId);
+
+        endSpan(grandchildSpan);
+        endSpan(childSpan);
+        endSpan(rootSpan);
+      });
+    });
+
+    it('should return trace context via getTraceContext', async () => {
+      await runWithTrace(generateTraceId(), async () => {
+        const ctx = getTraceContext();
+        expect(ctx).not.toBeNull();
+        expect(ctx!.traceId).toMatch(/^[0-9a-f]{32}$/);
+        expect(ctx!.spanId).toBe('');
+      });
+    });
+
+    it('should update trace context on startSpan', async () => {
+      await runWithTrace(generateTraceId(), async () => {
+        const span = startSpan('active-span');
+        const ctx = getTraceContext();
+        expect(ctx!.spanId).toBe(span.spanId);
+        endSpan(span);
+      });
+    });
+
+    it('should restore parent span context on endSpan', async () => {
+      await runWithTrace(generateTraceId(), async () => {
+        const rootSpan = startSpan('root');
+        const ctxBeforeChild = getTraceContext();
+        expect(ctxBeforeChild!.spanId).toBe(rootSpan.spanId);
+
+        const childSpan = startSpan('child');
+        const ctxDuringChild = getTraceContext();
+        expect(ctxDuringChild!.spanId).toBe(childSpan.spanId);
+
+        endSpan(childSpan);
+        const ctxAfterChild = getTraceContext();
+        expect(ctxAfterChild!.spanId).toBe(rootSpan.spanId);
+
+        endSpan(rootSpan);
+      });
+    });
+  });
+
+  describe('withSpan', () => {
+    it('should auto-close span on success', async () => {
+      const result = await withSpan('auto-span', async () => {
+        return 42;
+      });
+      expect(result).toBe(42);
+    });
+
+    it('should set ERROR status when function throws', async () => {
+      await runWithTrace(generateTraceId(), async () => {
+        try {
+          const err = new Error('boom');
+          await withSpan('failing', async () => {
+            throw err;
+          });
+        } catch {
+          // Expected
+        }
+      });
+    });
+
+    it('should propagate trace context inside withSpan callback', async () => {
+      await runWithTrace(generateTraceId(), async () => {
+        let childContext: { traceId: string; spanId: string } | null = null;
+
+        await withSpan('parent', async () => {
+          await withSpan('child', async () => {
+            childContext = getTraceContext();
+          });
+        });
+
+        expect(childContext).not.toBeNull();
+      });
+    });
+  });
+
+  describe('runWithTrace', () => {
+    it('should return the callback result', () => {
+      const result = runWithTrace(generateTraceId(), () => 99);
+      expect(result).toBe(99);
+    });
+
+    it('should make getTraceContext available inside callback', async () => {
+      const traceId = generateTraceId();
+      let ctx: { traceId: string; spanId: string } | null = null;
+      await runWithTrace(traceId, async () => {
+        ctx = getTraceContext();
+      });
+      expect(ctx!.traceId).toBe(traceId);
+    });
+  });
+});

--- a/workers/mietevo-backend/src/tracing.ts
+++ b/workers/mietevo-backend/src/tracing.ts
@@ -1,0 +1,227 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+// --- Types ---
+
+interface Span {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  name: string;
+  kind: number;
+  startTimeUnixNano: string;
+  endTimeUnixNano?: string;
+  attributes: { key: string; value: Record<string, unknown> }[];
+  status?: { code: number; message?: string };
+}
+
+interface Store {
+  traceId: string;
+  currentSpanId: string;
+  spans: Span[];
+}
+
+// --- Constants ---
+
+export const SPAN_KINDS = {
+  INTERNAL: 1,
+  SERVER: 2,
+  CLIENT: 3,
+} as const;
+
+export const STATUS_CODES = {
+  OK: 1,
+  ERROR: 2,
+} as const;
+
+// --- Module state ---
+
+const als = new AsyncLocalStorage<Store>();
+let _env: { POSTHOG_API_KEY?: string; NEXT_PUBLIC_POSTHOG_KEY?: string; POSTHOG_HOST?: string } | null = null;
+
+// --- Helpers ---
+
+function generateId(length: number): string {
+  const bytes = new Uint8Array(length / 2);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export function generateTraceId(): string {
+  return generateId(32);
+}
+
+function generateSpanId(): string {
+  return generateId(16);
+}
+
+function getTimestampNano(): string {
+  return String(Date.now() * 1_000_000);
+}
+
+function formatAttributeValue(value: unknown): Record<string, unknown> {
+  if (typeof value === 'string') return { stringValue: value };
+  if (typeof value === 'number') {
+    if (Number.isInteger(value)) return { intValue: String(value) };
+    return { doubleValue: value };
+  }
+  if (typeof value === 'boolean') return { boolValue: value };
+  if (Array.isArray(value)) {
+    return { arrayValue: { values: value.map((v) => formatAttributeValue(v)) } };
+  }
+  return { stringValue: String(value) };
+}
+
+function getPostHogApiKey(): string | undefined {
+  if (!_env) return undefined;
+  const key = _env.POSTHOG_API_KEY;
+  if (key && !key.startsWith('phx_')) return key;
+  return _env.NEXT_PUBLIC_POSTHOG_KEY;
+}
+
+// --- Public API ---
+
+export function initTracing(env: { POSTHOG_API_KEY?: string; NEXT_PUBLIC_POSTHOG_KEY?: string; POSTHOG_HOST?: string }): void {
+  _env = env;
+}
+
+/**
+ * Establish a trace context for the duration of `fn`.
+ * All spans created inside `fn` will share the given `traceId`.
+ */
+export function runWithTrace<T>(traceId: string, fn: () => T): T {
+  return als.run({ traceId, currentSpanId: '', spans: [] }, fn);
+}
+
+export function startSpan(
+  name: string,
+  kind: number = SPAN_KINDS.INTERNAL,
+  attributes: { key: string; value: Record<string, unknown> }[] = [],
+): Span {
+  const store = als.getStore();
+  const traceId = store?.traceId ?? generateTraceId();
+  const spanId = generateSpanId();
+
+  const span: Span = {
+    traceId,
+    spanId,
+    parentSpanId: store?.currentSpanId || undefined,
+    name,
+    kind,
+    startTimeUnixNano: getTimestampNano(),
+    attributes: [...attributes],
+  };
+
+  if (store) {
+    store.currentSpanId = spanId;
+    store.spans.push(span);
+  }
+
+  return span;
+}
+
+export function endSpan(span: Span, status?: { code: number; message?: string }): void {
+  span.endTimeUnixNano = getTimestampNano();
+  if (status) {
+    span.status = status;
+  }
+  const store = als.getStore();
+  if (store) {
+    store.currentSpanId = span.parentSpanId || '';
+  }
+}
+
+export function addSpanAttributes(span: Span, attrs: Record<string, unknown>): void {
+  for (const [key, value] of Object.entries(attrs)) {
+    span.attributes.push({ key, value: formatAttributeValue(value) });
+  }
+}
+
+export async function withSpan<T>(
+  name: string,
+  fn: () => Promise<T>,
+  kind: number = SPAN_KINDS.INTERNAL,
+  attributes: Record<string, unknown> = {},
+): Promise<T> {
+  const attrList = Object.entries(attributes).map(([key, value]) => ({
+    key,
+    value: formatAttributeValue(value),
+  }));
+  const span = startSpan(name, kind, attrList);
+  try {
+    const result = await fn();
+    endSpan(span, { code: STATUS_CODES.OK });
+    return result;
+  } catch (error) {
+    endSpan(span, { code: STATUS_CODES.ERROR, message: (error as Error).message });
+    throw error;
+  }
+}
+
+export function getTraceContext(): { traceId: string; spanId: string } | null {
+  const store = als.getStore();
+  if (!store) return null;
+  return { traceId: store.traceId, spanId: store.currentSpanId };
+}
+
+export async function flushSpans(): Promise<void> {
+  const store = als.getStore();
+  if (!store || store.spans.length === 0) return;
+
+  const completed = store.spans.filter((s) => s.endTimeUnixNano);
+  if (completed.length === 0) return;
+
+  store.spans = store.spans.filter((s) => !s.endTimeUnixNano);
+
+  const apiKey = getPostHogApiKey();
+  if (!apiKey) return;
+
+  const host = _env?.POSTHOG_HOST || 'https://eu.i.posthog.com';
+  const endpoint = `${host.replace(/\/$/, '')}/i/v1/traces`;
+
+  const payload = {
+    resourceSpans: [
+      {
+        resource: {
+          attributes: [
+            { key: 'service.name', value: { stringValue: 'backend' } },
+            { key: 'deployment.environment', value: { stringValue: 'production' } },
+            { key: 'telemetry.sdk.name', value: { stringValue: 'posthog-worker-tracing' } },
+          ],
+        },
+        scopeSpans: [
+          {
+            scope: { name: 'backend', version: '1.0.0' },
+            spans: completed.map((s) => ({
+              traceId: s.traceId,
+              spanId: s.spanId,
+              parentSpanId: s.parentSpanId,
+              name: s.name,
+              kind: s.kind,
+              startTimeUnixNano: s.startTimeUnixNano,
+              endTimeUnixNano: s.endTimeUnixNano!,
+              attributes: s.attributes,
+              ...(s.status ? { status: s.status } : {}),
+            })),
+          },
+        ],
+      },
+    ],
+  };
+
+  try {
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      const errorBody = await res.text().catch(() => 'Could not read body');
+      console.error(`[Tracing] Failed to send traces to PostHog: ${res.status} ${res.statusText}`, errorBody);
+    }
+  } catch (err) {
+    console.error('[Tracing] Failed to send traces to PostHog', err);
+  }
+}


### PR DESCRIPTION
## Description

Adds lightweight, OTel-compatible distributed tracing to the mietevo-backend Cloudflare Worker, mirroring the pattern from the main RMS Next.js app (`lib/posthog-tracing.ts`). Since Workers lack the full Node SDK, this version manually generates trace/span IDs, exports OTLP-format spans to PostHog's `/i/v1/traces` endpoint, and propagates trace context via AsyncLocalStorage so that WorkerLogger log records are correlated with their originating trace.

## Summary of Changes

- `workers/mietevo-backend/src/tracing.ts` — lightweight tracer with startSpan/endSpan/withSpan/runWithTrace, AsyncLocalStorage-based context propagation, span batching and OTLP HTTP export
- `workers/mietevo-backend/src/tracing.test.ts` — 14 tests covering ID generation, span lifecycle, context propagation, and runWithTrace
- `workers/mietevo-backend/src/logger.ts` — WorkerLogger now captures live trace context (traceId/spanId) from the active span on every log call instead of caching stale context at construction time
- `workers/mietevo-backend/src/index.ts` — root SERVER span per request, child spans for handleAIRequest/processQueue/handleFileGeneration, flush spans via ctx.waitUntil; initTracing falls back to NEXT_PUBLIC_POSTHOG_KEY when POSTHOG_API_KEY is a personal phx_ key