### PR TITLE
Fix product tour skip not saving in setup wizard

### DIFF
--- a/components/onboarding/setup-wizard.test.tsx
+++ b/components/onboarding/setup-wizard.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SetupWizard } from './setup-wizard';
+
+// Mock hooks
+jest.mock('posthog-js/react', () => ({
+    usePostHog: () => ({
+        capture: jest.fn(),
+    }),
+}));
+
+jest.mock('@/hooks/use-toast', () => ({
+    useToast: () => ({
+        toast: jest.fn(),
+    }),
+}));
+
+// Mock ResizeObserver
+global.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+};
+
+describe('SetupWizard', () => {
+    let mockFetch: jest.Mock;
+
+    beforeEach(() => {
+        mockFetch = jest.fn();
+        global.fetch = mockFetch;
+
+        // Setup initial API response for check
+        mockFetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                setupCompleted: false,
+                stripeCustomerId: null,
+                firstName: '',
+                lastName: '',
+                billingAddress: null,
+            }),
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('calls /api/user/onboarding when skipping the product tour', async () => {
+        const onCompleteMock = jest.fn();
+
+        render(<SetupWizard isOpen={true} onComplete={onCompleteMock} />);
+
+        // Wait for loading to finish and "Jetzt starten" button to appear
+        const startButton = await screen.findByRole('button', { name: /Jetzt starten/i });
+        fireEvent.click(startButton);
+
+        // Wait for the 'name' step and fill inputs
+        const nameInput = await screen.findByLabelText(/Vorname/i);
+        fireEvent.change(nameInput, { target: { value: 'John' } });
+        const lastNameInput = await screen.findByLabelText(/Nachname/i);
+        fireEvent.change(lastNameInput, { target: { value: 'Doe' } });
+
+        // Re-mock fetch for saving setup
+        mockFetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({ success: true, skipped: false }),
+        });
+
+        const saveNameButton = await screen.findByRole('button', { name: /Einrichtung abschließen/i });
+        fireEvent.click(saveNameButton);
+
+        // Wait for the 'tour_prompt' step which says "Selbst entdecken"
+        const skipTourButton = await screen.findByRole('button', { name: /Selbst entdecken/i });
+        expect(skipTourButton).toBeInTheDocument();
+
+        // Re-mock fetch for saving onboarding status
+        mockFetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({ success: true }),
+        });
+
+        // Click skip tour
+        fireEvent.click(skipTourButton);
+
+        // Verify the API was called to mark onboarding as completed
+        expect(mockFetch).toHaveBeenCalledWith('/api/user/onboarding', { method: 'POST' });
+
+        // Verify that it transitions to finalizing and calls onComplete
+        const finalizingText = await screen.findByText(/Wir bereiten Ihr Dashboard vor/i);
+        expect(finalizingText).toBeInTheDocument();
+
+        // Wait for the timeout
+        await waitFor(() => {
+            expect(onCompleteMock).toHaveBeenCalled();
+        }, { timeout: 3000 });
+    });
+});

--- a/components/onboarding/setup-wizard.test.tsx
+++ b/components/onboarding/setup-wizard.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { SetupWizard } from './setup-wizard';
 
 // Mock hooks
@@ -26,6 +26,7 @@ describe('SetupWizard', () => {
     let mockFetch: jest.Mock;
 
     beforeEach(() => {
+        jest.useFakeTimers();
         mockFetch = jest.fn();
         global.fetch = mockFetch;
 
@@ -43,6 +44,7 @@ describe('SetupWizard', () => {
     });
 
     afterEach(() => {
+        jest.useRealTimers();
         jest.clearAllMocks();
     });
 
@@ -51,9 +53,18 @@ describe('SetupWizard', () => {
 
         render(<SetupWizard isOpen={true} onComplete={onCompleteMock} />);
 
+        // Advance timers if there are any immediate microtasks/useEffect timers
+        act(() => {
+            jest.advanceTimersByTime(100);
+        });
+
         // Wait for loading to finish and "Jetzt starten" button to appear
         const startButton = await screen.findByRole('button', { name: /Jetzt starten/i });
         fireEvent.click(startButton);
+
+        act(() => {
+            jest.advanceTimersByTime(100);
+        });
 
         // Wait for the 'name' step and fill inputs
         const nameInput = await screen.findByLabelText(/Vorname/i);
@@ -69,6 +80,10 @@ describe('SetupWizard', () => {
 
         const saveNameButton = await screen.findByRole('button', { name: /Einrichtung abschließen/i });
         fireEvent.click(saveNameButton);
+
+        act(() => {
+            jest.advanceTimersByTime(100);
+        });
 
         // Wait for the 'tour_prompt' step which says "Selbst entdecken"
         const skipTourButton = await screen.findByRole('button', { name: /Selbst entdecken/i });
@@ -86,13 +101,15 @@ describe('SetupWizard', () => {
         // Verify the API was called to mark onboarding as completed
         expect(mockFetch).toHaveBeenCalledWith('/api/user/onboarding', { method: 'POST' });
 
-        // Verify that it transitions to finalizing and calls onComplete
+        // Verify that it transitions to finalizing
         const finalizingText = await screen.findByText(/Wir bereiten Ihr Dashboard vor/i);
         expect(finalizingText).toBeInTheDocument();
 
-        // Wait for the timeout
-        await waitFor(() => {
-            expect(onCompleteMock).toHaveBeenCalled();
-        }, { timeout: 3000 });
+        // Fast-forward the completeTimeout (2000ms)
+        act(() => {
+            jest.advanceTimersByTime(2000);
+        });
+
+        expect(onCompleteMock).toHaveBeenCalled();
     });
 });

--- a/components/onboarding/setup-wizard.tsx
+++ b/components/onboarding/setup-wizard.tsx
@@ -239,7 +239,11 @@ export function SetupWizard({ isOpen, onComplete }: SetupWizardProps) {
         });
 
         // Mark the onboarding tour as completed so it doesn't automatically start next time
-        fetch('/api/user/onboarding', { method: 'POST' }).catch(console.error);
+        fetch('/api/user/onboarding', { method: 'POST' })
+            .then(res => {
+                if (!res.ok) throw new Error('Failed to update onboarding status: ' + res.status);
+            })
+            .catch(console.error);
 
         setStep('finalizing');
         completeTimeoutRef.current = setTimeout(() => {

--- a/components/onboarding/setup-wizard.tsx
+++ b/components/onboarding/setup-wizard.tsx
@@ -237,6 +237,10 @@ export function SetupWizard({ isOpen, onComplete }: SetupWizardProps) {
             total_steps: 13,
             source: 'setup_wizard',
         });
+
+        // Mark the onboarding tour as completed so it doesn't automatically start next time
+        fetch('/api/user/onboarding', { method: 'POST' }).catch(console.error);
+
         setStep('finalizing');
         completeTimeoutRef.current = setTimeout(() => {
             onCompleteRef.current();


### PR DESCRIPTION
Fixes a bug where choosing to skip the product tour in the setup wizard did not persist the decision to the database. Added a corresponding test in `components/onboarding/setup-wizard.test.tsx` and modified the `handleSkipTour` callback in `components/onboarding/setup-wizard.tsx` to explicitly invoke the `fetch('/api/user/onboarding', { method: 'POST' })` endpoint.

---
*PR created automatically by Jules for task [11771392988138313047](https://jules.google.com/task/11771392988138313047) started by @NtFelix*