### PR TITLE
fix: correct settings link destination in landing page navigation

### DIFF
--- a/app/modern/components/navigation.tsx
+++ b/app/modern/components/navigation.tsx
@@ -469,7 +469,7 @@ export default function Navigation({ onLogin }: NavigationProps) {
                           className="px-3 py-2 rounded-xl group hover:bg-primary hover:text-primary-foreground dark:hover:bg-primary/90 cursor-pointer"
                           onClick={() => {
                             // Navigate to settings
-                            window.location.href = ROUTES.SETTINGS;
+                            router.push(ROUTES.SETTINGS);
                           }}
                         >
                           <Settings className="size-4 mr-3 text-muted-foreground group-hover:text-white" />

--- a/app/modern/components/navigation.tsx
+++ b/app/modern/components/navigation.tsx
@@ -468,8 +468,8 @@ export default function Navigation({ onLogin }: NavigationProps) {
                         <DropdownMenuItem
                           className="px-3 py-2 rounded-xl group hover:bg-primary hover:text-primary-foreground dark:hover:bg-primary/90 cursor-pointer"
                           onClick={() => {
-                            // Navigate to dashboard
-                            window.location.href = ROUTES.HOME;
+                            // Navigate to settings
+                            window.location.href = ROUTES.SETTINGS;
                           }}
                         >
                           <Settings className="size-4 mr-3 text-muted-foreground group-hover:text-white" />


### PR DESCRIPTION
In the landing page (`modern` navigation components), the 'Einstellungen' dropdown item under the user menu was incorrectly navigating to `ROUTES.HOME` (Dashboard) instead of the actual settings page (`ROUTES.SETTINGS` or `/einstellungen`). For users with an incomplete profile, navigating to the dashboard was incorrectly triggering the onboarding modal instead of taking them to their settings. 

This commit fixes the `window.location.href` to route directly to `ROUTES.SETTINGS`.

- Fixed `app/modern/components/navigation.tsx` settings dropdown destination.
- Executed linting, strict TS validation, and unit tests to ensure no regressions.

---
*PR created automatically by Jules for task [17612063221735215211](https://jules.google.com/task/17612063221735215211) started by @NtFelix*