### PR TITLE
chore: update Playwright Docker image to v1.61.0-noble

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -917,7 +917,7 @@ jobs:
     name: E2E Smoke Check
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      image: mcr.microsoft.com/playwright:v1.61.0-noble
     env:
       HOME: /root
     needs: [check-runs, build-app, lint, type-check]
@@ -968,7 +968,7 @@ jobs:
     name: E2E Tests (${{ matrix.browser }})
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      image: mcr.microsoft.com/playwright:v1.61.0-noble
     env:
       HOME: /root
     needs: [check-runs, build-app, lint, type-check, e2e-smoke]
@@ -1892,7 +1892,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      image: mcr.microsoft.com/playwright:v1.61.0-noble
     env:
       HOME: /root
     needs: [lint, type-check, check-runs, build-app, e2e-smoke]


### PR DESCRIPTION
The CI Docker image was pinned to v1.59.1-noble but Playwright was bumped to 1.61.0, causing all smoke tests to fail because the browser executable was missing.

Fixes the version mismatch by aligning the Docker image tag with the installed Playwright version.