### PR TITLE
fix(docker): add retry logic for npm ci to handle transient network e…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM node:22-alpine AS deps
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-# Cache npm registry between builds
+# Cache npm registry between builds (retry up to 3 times on network failure)
 RUN --mount=type=cache,target=/root/.npm \
-    npm ci
+    for i in $(seq 1 3); do npm ci && break || sleep 5; done
 
 # Stage 2: Build the source code
 FROM node:22-alpine AS builder


### PR DESCRIPTION
## Description

Adds retry logic to `npm ci` in the Dockerfile to make builds resilient against transient network errors.

## Summary of Changes

- `Dockerfile`: `npm ci` now retries up to 3 times with a 5s backoff (`for i in $(seq 1 3); do npm ci && break || sleep 5; done`) while keeping the npm cache mount