### PR TITLE
fix(mieter): prevent page unresponsiveness by opening modals asynchro…

### DIFF
--- a/app/(dashboard)/mieter/client-wrapper.tsx
+++ b/app/(dashboard)/mieter/client-wrapper.tsx
@@ -877,7 +877,7 @@ export default function MieterClientView({
                           </ButtonWithTooltip>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end" className="w-64">
-                          <DropdownMenuItem onClick={handleAddTenant} className="flex flex-col items-start gap-1 p-3 cursor-pointer">
+                          <DropdownMenuItem onSelect={() => setTimeout(handleAddTenant, 100)} className="flex flex-col items-start gap-1 p-3 cursor-pointer">
                             <div className="flex items-center font-medium">
                               <UserPlus className="mr-2 size-4" />
                               Manuell hinzufügen
@@ -886,7 +886,7 @@ export default function MieterClientView({
                               Erstellen Sie einen neuen Mieter oder Bewerber per Hand.
                             </span>
                           </DropdownMenuItem>
-                          <DropdownMenuItem onClick={() => setShowImportModal(true)} className="flex flex-col items-start gap-1 p-3 cursor-pointer">
+                          <DropdownMenuItem onSelect={() => setTimeout(() => setShowImportModal(true), 100)} className="flex flex-col items-start gap-1 p-3 cursor-pointer">
                             <div className="flex items-center font-medium">
                               <Mail className="mr-2 size-4" />
                               Aus E-Mails importieren

--- a/app/(dashboard)/mieter/client-wrapper.tsx
+++ b/app/(dashboard)/mieter/client-wrapper.tsx
@@ -877,7 +877,7 @@ export default function MieterClientView({
                           </ButtonWithTooltip>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end" className="w-64">
-                          <DropdownMenuItem onSelect={() => setTimeout(handleAddTenant, 100)} className="flex flex-col items-start gap-1 p-3 cursor-pointer">
+                          <DropdownMenuItem onSelect={() => setTimeout(handleAddTenant, 0)} className="flex flex-col items-start gap-1 p-3 cursor-pointer">
                             <div className="flex items-center font-medium">
                               <UserPlus className="mr-2 size-4" />
                               Manuell hinzufügen
@@ -886,7 +886,7 @@ export default function MieterClientView({
                               Erstellen Sie einen neuen Mieter oder Bewerber per Hand.
                             </span>
                           </DropdownMenuItem>
-                          <DropdownMenuItem onSelect={() => setTimeout(() => setShowImportModal(true), 100)} className="flex flex-col items-start gap-1 p-3 cursor-pointer">
+                          <DropdownMenuItem onSelect={() => setTimeout(() => setShowImportModal(true), 0)} className="flex flex-col items-start gap-1 p-3 cursor-pointer">
                             <div className="flex items-center font-medium">
                               <Mail className="mr-2 size-4" />
                               Aus E-Mails importieren


### PR DESCRIPTION
## Description

Prevents the Mieter page from becoming unresponsive by opening modals asynchronously from the dropdown menu.

## Summary of Changes

- `mieter/client-wrapper.tsx`: switch dropdown items from `onClick` to `onSelect` and defer modal opening (`handleAddTenant`, import modal) into the next event-loop tick via `setTimeout(..., 0)`, so the dropdown can close cleanly before the modal mounts