### PR TITLE
fix(betriebskosten): simplify benchmark text

### DIFF
--- a/app/(dashboard)/betriebskosten/client-wrapper.tsx
+++ b/app/(dashboard)/betriebskosten/client-wrapper.tsx
@@ -1533,7 +1533,7 @@ export default function BetriebskostenClientView({
 
                       <p className="text-[10px] text-zinc-500 dark:text-zinc-400 leading-relaxed font-medium mt-auto px-1 italic">
                         {isOptimal 
-                          ? "✓ Ihre Kosten liegen unter dem Bundesdurchschnitt. Die Abrechnung entspricht dem Gebot der Wirtschaftlichkeit."
+                          ? "✓ Ihre Kosten liegen unter dem Bundesdurchschnitt."
                           : "⚠ Ihre Kosten übersteigen den Marktdurchschnitt. Prüfen Sie Optimierungspotenziale bei Versicherungen oder Dienstleistern."
                         }
                       </p>


### PR DESCRIPTION
## Description

Simplifies the benchmark info text on the Betriebskosten page.

## Summary of Changes

- `betriebskosten/client-wrapper.tsx`: shortens the "optimal" benchmark hint to "✓ Ihre Kosten liegen unter dem Bundesdurchschnitt." (removes the sentence about the Gebot der Wirtschaftlichkeit)