### PR TITLE
feat(analytics): add PostHog event tracking for core actions

### DIFF
--- a/app/(dashboard)/haeuser/actions.ts
+++ b/app/(dashboard)/haeuser/actions.ts
@@ -2,6 +2,7 @@
 import { ensureAuth } from "@/lib/auth-utils";
 import { revalidatePath } from "next/cache";
 import { logAction } from '@/lib/logging-middleware';
+import { getPostHogServer } from '@/app/posthog-server.mjs';
 
 // Update function signature to accept id as the first parameter
 // Define the expected fields and their types
@@ -108,6 +109,24 @@ export async function handleSubmit(id: string | null, formData: FormData): Promi
         if (scopeError) {
           console.error('Failed to auto-grant scope for new house:', scopeError);
         }
+      }
+
+      try {
+        const posthog = getPostHogServer();
+        await posthog.capture({
+          distinctId: user.id,
+          event: 'house_created',
+          properties: {
+            house_id: newHouse.id,
+            house_name: name,
+            has_location: !!ort,
+            has_size: processedGroesse !== null,
+            source: 'server_action',
+          },
+        });
+        await posthog.flush();
+      } catch (phError) {
+        console.error('[PostHog] Failed to capture house_created:', phError);
       }
     }
     revalidatePath("/haeuser");

--- a/app/(dashboard)/wohnungen/actions.ts
+++ b/app/(dashboard)/wohnungen/actions.ts
@@ -6,8 +6,6 @@ import { revalidatePath } from "next/cache";
 import { fetchUserProfile } from '@/lib/data-fetching'; // Assuming this fetches { id, email, stripe_price_id, stripe_subscription_status, ... }
 import { getPlanDetails } from '@/lib/stripe-server'; // Import getPlanDetails
 import { logAction } from '@/lib/logging-middleware';
-
-
 type WohnungFormData = {
   name: string;
   groesse: string;

--- a/app/(public)/einladung/annehmen/actions.ts
+++ b/app/(public)/einladung/annehmen/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createClient } from "@/utils/supabase/server";
+import { getPostHogServer } from '@/app/posthog-server.mjs';
 
 export type AcceptEinladungResult =
   | { success: true }
@@ -61,6 +62,21 @@ export async function acceptEinladungAction(token: string): Promise<AcceptEinlad
     const msg = rpcError instanceof Error ? rpcError.message : String(rpcError);
     console.error("[acceptEinladungAction] Unexpected RPC error:", msg);
     return { success: false, error: "Ein unerwarteter Fehler ist aufgetreten.", code: "unknown" };
+  }
+
+  try {
+    const posthog = getPostHogServer();
+    await posthog.capture({
+      distinctId: user.id,
+      event: 'invitation_accepted',
+      properties: {
+        user_email: user.email,
+        source: 'server_action',
+      },
+    });
+    await posthog.flush();
+  } catch (phError) {
+    console.error('[PostHog] Failed to capture invitation_accepted:', phError);
   }
 
   return { success: true };

--- a/app/api/dateien/create-file/route.ts
+++ b/app/api/dateien/create-file/route.ts
@@ -129,6 +129,25 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    try {
+      await fetch(`${process.env.NEXT_PUBLIC_POSTHOG_HOST}/capture/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          api_key: process.env.NEXT_PUBLIC_POSTHOG_KEY,
+          event: 'file_created',
+          distinct_id: user.id,
+          properties: {
+            file_name: fileName,
+            file_size_bytes: new Blob([content]).size,
+            source: 'api_route',
+          },
+        }),
+      });
+    } catch (phError) {
+      console.error('[PostHog] Failed to capture file_created:', phError);
+    }
+
     return NextResponse.json({
       success: true,
       filePath: newFilePath,

--- a/app/api/stripe/checkout-session/route.ts
+++ b/app/api/stripe/checkout-session/route.ts
@@ -155,6 +155,26 @@ export async function POST(req: Request) {
       action: 'checkout_session_created'
     });
 
+    try {
+      await fetch(`${process.env.NEXT_PUBLIC_POSTHOG_HOST}/capture/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          api_key: process.env.NEXT_PUBLIC_POSTHOG_KEY,
+          event: 'checkout_initiated',
+          distinct_id: user.id,
+          properties: {
+            price_id: requestedPriceId,
+            session_id: session.id,
+            has_trial: isEligibleForTrial(),
+            source: 'api_route',
+          },
+        }),
+      });
+    } catch (phError) {
+      console.error('[PostHog] Failed to capture checkout_initiated:', phError);
+    }
+
     return NextResponse.json({ sessionId: session.id, url: session.url }, { headers: NO_CACHE_HEADERS });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Internal Server Error';

--- a/app/betriebskosten-actions.ts
+++ b/app/betriebskosten-actions.ts
@@ -113,6 +113,25 @@ export async function createNebenkosten(formData: NebenkostenFormData) {
   revalidatePath("/dashboard/betriebskosten");
   logAction(actionName, 'success', { nebenkosten_id: data?.id, house_id: formData.haeuser_id });
 
+  try {
+    const posthog = getPostHogServer();
+    await posthog.capture({
+      distinctId: user.id,
+      event: 'betriebskosten_created',
+      properties: {
+        nebenkosten_id: data?.id,
+        house_id: formData.haeuser_id,
+        start_date: formData.startdatum,
+        end_date: formData.enddatum,
+        cost_types_count: formData.nebenkostenart?.length ?? 0,
+        source: 'server_action',
+      },
+    });
+    await posthog.flush();
+  } catch (phError) {
+    logger.error('[PostHog] Failed to capture betriebskosten_created:', phError instanceof Error ? phError : new Error(String(phError)));
+  }
+
   // Return optimized data for the UI
   const { data: optimizedData } = await fetchOptimizedNebenkostenById(data.id);
   return { success: true, data: optimizedData || data };
@@ -2557,6 +2576,24 @@ export async function createAbrechnungCalculationAction(
       totalSettlements: summary.totalSettlements,
       averageSettlement: summary.averageSettlement
     });
+
+    try {
+      const posthog = getPostHogServer();
+      await posthog.capture({
+        distinctId: user.id,
+        event: 'abrechnung_created',
+        properties: {
+          nebenkosten_id: nebenkostenId,
+          tenant_count: tenantCalculations.length,
+          total_settlements: summary.totalSettlements,
+          apartment_count: nebenkosten_data.anzahlWohnungen || 0,
+          source: 'server_action',
+        },
+      });
+      await posthog.flush();
+    } catch (phError) {
+      logger.error('[PostHog] Failed to capture abrechnung_created:', phError instanceof Error ? phError : new Error(String(phError)));
+    }
 
     return { success: true, data: result, message: calculationWarning };
 

--- a/app/mieter-actions.ts
+++ b/app/mieter-actions.ts
@@ -176,7 +176,22 @@ export async function deleteTenantAction(tenantId: string): Promise<{ success: b
     // without knowing which apartment was affected.
     revalidatePath('/wohnungen');
     // Also consider revalidating the dashboard if it summarizes tenant counts or related info.
-    // revalidatePath('/'); 
+    // revalidatePath('/');
+
+    try {
+      const posthog = getPostHogServer();
+      await posthog.capture({
+        distinctId: user.id,
+        event: 'tenant_deleted',
+        properties: {
+          tenant_id: tenantId,
+          source: 'server_action',
+        },
+      });
+      await posthog.flush();
+    } catch (phError) {
+      console.error('[PostHog] Failed to capture tenant_deleted:', phError);
+    }
 
     return { success: true };
 


### PR DESCRIPTION
## Description

Adds best-effort PostHog event tracking across key server actions and API routes. Each event is fired with a `source` property and wrapped in try/catch so analytics never block the main flow.

## Summary of Changes

- **Häuser**: `house_created` event after creating a house (`haeuser/actions.ts`)
- **Betriebskosten**: `betriebskosten_created` and `abrechnung_created` events (`betriebskosten-actions.ts`)
- **Mieter**: `tenant_deleted` event when a tenant is removed (`mieter-actions.ts`)
- **Einladungen**: `invitation_accepted` event on invite acceptance (`einladung/annehmen/actions.ts`)
- **Dateien**: `file_created` event in the file-upload route (`api/dateien/create-file/route.ts`)
- **Stripe**: `checkout_initiated` event when a checkout session is created (`api/stripe/checkout-session/route.ts`)
- Minor whitespace cleanup in `wohnungen/actions.ts`