### PR TITLE
feat: add organisation policies UI and employee integration

### DIFF
--- a/app/(dashboard)/organisation/client-wrapper.tsx
+++ b/app/(dashboard)/organisation/client-wrapper.tsx
@@ -42,6 +42,8 @@ import {
 } from "@/app/organisation-actions";
 
 import { MitgliedPermissionDetail } from "@/components/organisation/mitglied-permission-detail";
+import { OrganisationPoliciesTab } from "@/components/organisation/organisation-policies-tab";
+
 
 interface Member {
   mitglied_id: string;
@@ -80,7 +82,7 @@ interface OrganisationClientViewProps {
 }
 
 type UiState = {
-  currentTab: "overview" | "members";
+  currentTab: "overview" | "members" | "policies";
   searchQuery: string;
   roleFilter: string;
   statusFilter: string;
@@ -97,7 +99,7 @@ type UiState = {
 };
 
 type UiAction =
-  | { type: 'SET_TAB'; payload: "overview" | "members" }
+  | { type: 'SET_TAB'; payload: "overview" | "members" | "policies" }
   | { type: 'SET_SEARCH_QUERY'; payload: string }
   | { type: 'SET_ROLE_FILTER'; payload: string }
   | { type: 'SET_STATUS_FILTER'; payload: string }
@@ -150,14 +152,15 @@ function uiReducer(state: UiState, action: UiAction): UiState {
 const ORG_TABS = [
   { value: "overview" as const, label: "Übersicht", icon: Network },
   { value: "members" as const, label: "Mitarbeiter", icon: Users },
+  { value: "policies" as const, label: "Richtlinien", icon: Shield },
 ];
 
 function OrganisationTabToggle({
   currentTab,
   onTabChange
 }: {
-  currentTab: "overview" | "members";
-  onTabChange: (tab: "overview" | "members") => void;
+  currentTab: "overview" | "members" | "policies";
+  onTabChange: (tab: "overview" | "members" | "policies") => void;
 }) {
   return (
     <AnimatedPillToggle
@@ -968,6 +971,12 @@ export default function OrganisationClientView({
           onRoleChange={handleRoleChange}
           onStatusChange={handleStatusChange}
           onRemove={handleRemove}
+        />
+      )}
+
+      {uiState.currentTab === "policies" && (
+        <OrganisationPoliciesTab
+          hasVerwaltenPermission={hasVerwaltenPermission}
         />
       )}
 

--- a/components/organisation/mitglied-permission-detail.tsx
+++ b/components/organisation/mitglied-permission-detail.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useTransition, useMemo } from "react";
 import { MemberPermissions, HausWithWohnungen, OrganisationPolicy } from "@/lib/organisation-types";
 import { getMitgliedPermissionsAction, getOrgHaeuserAction, setMitgliedOverridesAction } from "@/lib/perms-actions";
-import { getPoliciesAction, getMitgliedPoliciesAction, assignPolicyAction, removePolicyAction } from "@/lib/organisation/policy-actions";
+import { getPoliciesAction, getMitgliedPoliciesAction, updateMitgliedPoliciesAction } from "@/lib/organisation/policy-actions";
 import { ObjectScopeEditor } from "./object-scope-editor";
 import { ModulePermissionEditor } from "./module-permission-editor";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
@@ -174,10 +174,9 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
         const toAssign = assignedPolicyIds.filter(id => !originalAssignedPolicyIds.includes(id));
         const toRemove = originalAssignedPolicyIds.filter(id => !assignedPolicyIds.includes(id));
 
-        await Promise.all([
-          ...toAssign.map(id => assignPolicyAction(mitgliedId, id)),
-          ...toRemove.map(id => removePolicyAction(mitgliedId, id))
-        ]);
+        if (toAssign.length > 0 || toRemove.length > 0) {
+          await updateMitgliedPoliciesAction(mitgliedId, toAssign, toRemove);
+        }
 
         toast({
           title: "Speichern erfolgreich",

--- a/components/organisation/mitglied-permission-detail.tsx
+++ b/components/organisation/mitglied-permission-detail.tsx
@@ -1,15 +1,18 @@
 "use client";
 
-import React, { useState, useEffect, useTransition } from "react";
-import { MemberPermissions, HausWithWohnungen } from "@/lib/organisation-types";
+import React, { useState, useEffect, useTransition, useMemo } from "react";
+import { MemberPermissions, HausWithWohnungen, OrganisationPolicy } from "@/lib/organisation-types";
 import { getMitgliedPermissionsAction, getOrgHaeuserAction, setMitgliedOverridesAction } from "@/lib/perms-actions";
+import { getPoliciesAction, getMitgliedPoliciesAction, assignPolicyAction, removePolicyAction } from "@/lib/organisation/policy-actions";
 import { ObjectScopeEditor } from "./object-scope-editor";
 import { ModulePermissionEditor } from "./module-permission-editor";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Checkbox } from "@/components/ui/checkbox";
 import { ShieldAlert, Lock, CheckCircle, RefreshCw, Save } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
+import { cn } from "@/lib/utils";
 
 interface Props {
   mitgliedId: string;
@@ -22,29 +25,36 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
   const [permissions, setPermissions] = useState<MemberPermissions | null>(null);
   const [originalPermissions, setOriginalPermissions] = useState<MemberPermissions | null>(null);
   const [haeuser, setHaeuser] = useState<HausWithWohnungen[]>([]);
+  const [policies, setPolicies] = useState<OrganisationPolicy[]>([]);
+  const [assignedPolicyIds, setAssignedPolicyIds] = useState<string[]>([]);
+  const [originalAssignedPolicyIds, setOriginalAssignedPolicyIds] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [saving, startSavingTransition] = useTransition();
 
   const isLocked = rolle === "owner" || rolle === "admin";
 
   useEffect(() => {
-    const fetchPermissions = async () => {
+    const fetchPermissionsAndPolicies = async () => {
       if (isLocked) return;
       setLoading(true);
       try {
-        const [perms, houses] = await Promise.all([
+        const [perms, houses, orgPolicies, memberPolicyIds] = await Promise.all([
           getMitgliedPermissionsAction(mitgliedId),
           getOrgHaeuserAction(),
+          getPoliciesAction(),
+          getMitgliedPoliciesAction(mitgliedId),
         ]);
         setPermissions(perms);
-        // Deep clone to keep track of dirty states
         setOriginalPermissions(structuredClone(perms));
         setHaeuser(houses);
+        setPolicies(orgPolicies);
+        setAssignedPolicyIds(memberPolicyIds);
+        setOriginalAssignedPolicyIds(memberPolicyIds);
       } catch (error) {
-        console.error("Failed to load permissions:", error);
+        console.error("Failed to load permissions and policies:", error);
         toast({
           title: "Fehler beim Laden",
-          description: "Die Berechtigungen konnten nicht geladen werden.",
+          description: "Die Berechtigungen und Richtlinien konnten nicht geladen werden.",
           variant: "destructive",
         });
       } finally {
@@ -52,7 +62,7 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
       }
     };
 
-    fetchPermissions();
+    fetchPermissionsAndPolicies();
   }, [mitgliedId, isLocked]);
 
   // Compute stats for overview pane
@@ -83,33 +93,105 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
     };
   }, [permissions, haeuser]);
 
+  const policyGrantedHausIds = useMemo(() => {
+    if (!policies || !assignedPolicyIds) return [];
+
+    const activePolicies = policies.filter(p => assignedPolicyIds.includes(p.id));
+
+    const hasUnrestrictedPolicy = activePolicies.some(p => {
+      const houses = p.berechtigungen.objekte?.haeuser;
+      return !houses || houses.length === 0;
+    });
+
+    if (hasUnrestrictedPolicy) {
+      return null;
+    }
+
+    const ids = new Set<string>();
+    activePolicies.forEach(p => {
+      const houses = p.berechtigungen.objekte?.haeuser;
+      if (Array.isArray(houses)) {
+        houses.forEach(id => ids.add(id));
+      }
+    });
+
+    return Array.from(ids);
+  }, [policies, assignedPolicyIds]);
+
+  const policyGrantedModulePermissions = useMemo(() => {
+    if (!policies || !assignedPolicyIds) return {};
+
+    const activePolicies = policies.filter(p => assignedPolicyIds.includes(p.id));
+    const merged: Record<string, string[]> = {};
+
+    activePolicies.forEach(p => {
+      const modules = p.berechtigungen.module;
+      if (modules) {
+        Object.entries(modules).forEach(([modKey, actions]) => {
+          if (Array.isArray(actions)) {
+            if (!merged[modKey]) {
+              merged[modKey] = [];
+            }
+            actions.forEach(action => {
+              if (!merged[modKey].includes(action)) {
+                merged[modKey].push(action);
+              }
+            });
+          }
+        });
+      }
+    });
+
+    return merged;
+  }, [policies, assignedPolicyIds]);
+
   // Check if dirty
-  const isDirty = React.useMemo(() => {
+  const isDirty = useMemo(() => {
     if (!permissions || !originalPermissions) return false;
-    return JSON.stringify(permissions) !== JSON.stringify(originalPermissions);
-  }, [permissions, originalPermissions]);
+    const hasOverridesChanges = JSON.stringify(permissions) !== JSON.stringify(originalPermissions);
+    const hasPoliciesChanges = JSON.stringify(assignedPolicyIds) !== JSON.stringify(originalAssignedPolicyIds);
+    return hasOverridesChanges || hasPoliciesChanges;
+  }, [permissions, originalPermissions, assignedPolicyIds, originalAssignedPolicyIds]);
 
   const handleSave = () => {
     if (!permissions || !isDirty) return;
 
     startSavingTransition(async () => {
-      const payload = {
-        module: permissions.module || {},
-        objekte: { haeuser: permissions.objekte?.haeuser ?? null },
-      };
+      try {
+        const hasOverridesChanges = JSON.stringify(permissions) !== JSON.stringify(originalPermissions);
+        if (hasOverridesChanges) {
+          const payload = {
+            module: permissions.module || {},
+            objekte: { haeuser: permissions.objekte?.haeuser ?? null },
+          };
 
-      const res = await setMitgliedOverridesAction(mitgliedId, payload);
-      if (res.success) {
+          const res = await setMitgliedOverridesAction(mitgliedId, payload);
+          if (!res.success) {
+            throw new Error(res.error || "Problem beim Speichern der Overrides.");
+          }
+        }
+
+        const toAssign = assignedPolicyIds.filter(id => !originalAssignedPolicyIds.includes(id));
+        const toRemove = originalAssignedPolicyIds.filter(id => !assignedPolicyIds.includes(id));
+
+        await Promise.all([
+          ...toAssign.map(id => assignPolicyAction(mitgliedId, id)),
+          ...toRemove.map(id => removePolicyAction(mitgliedId, id))
+        ]);
+
         toast({
-          title: "Berechtigungen gespeichert",
-          description: `Die Berechtigungen für ${memberName} wurden erfolgreich aktualisiert.`,
+          title: "Speichern erfolgreich",
+          description: `Die Berechtigungen und Richtlinien für ${memberName} wurden erfolgreich aktualisiert.`,
           variant: "success",
         });
+
         setOriginalPermissions(structuredClone(permissions));
-      } else {
+        setOriginalAssignedPolicyIds([...assignedPolicyIds]);
+      } catch (error: any) {
+        console.error("Failed to save changes:", error);
         toast({
           title: "Fehler beim Speichern",
-          description: res.error || "Es gab ein Problem beim Speichern.",
+          description: error.message || "Es gab ein Problem beim Speichern.",
           variant: "destructive",
         });
       }
@@ -119,6 +201,9 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
   const handleReset = () => {
     if (originalPermissions) {
       setPermissions(structuredClone(originalPermissions));
+    }
+    if (originalAssignedPolicyIds) {
+      setAssignedPolicyIds([...originalAssignedPolicyIds]);
     }
   };
 
@@ -253,18 +338,70 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
         </div>
       )}
 
+      {/* Zugeordnete Richtlinien */}
+      <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg">Zugeordnete Richtlinien</CardTitle>
+          <CardDescription className="text-xs">
+            Weisen Sie diesem Mitarbeiter Richtlinien zu. Die Berechtigungen der Richtlinien werden addiert.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          {policies.length === 0 ? (
+            <p className="text-xs text-muted-foreground">Keine Richtlinien in der Organisation vorhanden.</p>
+          ) : (
+            <div className="grid gap-3 sm:grid-cols-2">
+              {policies.map(policy => {
+                const isChecked = assignedPolicyIds.includes(policy.id);
+                return (
+                  <div
+                    key={policy.id}
+                    className={cn(
+                      "p-3 border rounded-2xl flex items-center gap-3 transition-all",
+                      isChecked
+                        ? "bg-indigo-50/50 dark:bg-indigo-950/20 border-indigo-200 dark:border-indigo-900"
+                        : "bg-zinc-50/50 dark:bg-zinc-900/50 border-zinc-200 dark:border-zinc-800"
+                    )}
+                  >
+                    <Checkbox
+                      id={`policy-assign-${policy.id}`}
+                      checked={isChecked}
+                      onCheckedChange={(checked) => {
+                        if (checked) {
+                          setAssignedPolicyIds([...assignedPolicyIds, policy.id]);
+                        } else {
+                          setAssignedPolicyIds(assignedPolicyIds.filter(id => id !== policy.id));
+                        }
+                      }}
+                      disabled={saving}
+                    />
+                    <label
+                      htmlFor={`policy-assign-${policy.id}`}
+                      className="text-sm font-semibold select-none flex-1 cursor-pointer text-zinc-800 dark:text-zinc-200"
+                    >
+                      {policy.name}
+                    </label>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
       {/* Accordion or Tabs for editors */}
       <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs">
         <CardHeader className="pb-3">
-          <CardTitle className="text-lg">Objekt-Scope (Zugriffsbeschränkung)</CardTitle>
+          <CardTitle className="text-lg">Objekt-Scope (Zugriffsbeschränkung Overrides)</CardTitle>
           <CardDescription className="text-xs">
-            Legen Sie fest, auf welche Häuser und Wohnungen dieser Mitarbeiter Zugriff erhalten soll.
+            Legen Sie fest, auf welche Häuser und Wohnungen dieser Mitarbeiter über die Richtlinien hinaus Zugriff erhalten soll.
           </CardDescription>
         </CardHeader>
         <CardContent className="pt-0">
           <ObjectScopeEditor
             haeuser={haeuser}
             selectedHausIds={permissions.objekte?.haeuser}
+            policyGrantedHausIds={policyGrantedHausIds}
             onChange={handleObjectScopeChange}
             disabled={saving}
           />
@@ -281,6 +418,7 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
         <CardContent className="p-0 sm:px-6 sm:pb-6">
           <ModulePermissionEditor
             modulePermissions={permissions.module || {}}
+            policyGrantedModulePermissions={policyGrantedModulePermissions}
             onChange={handleModulePermissionsChange}
             disabled={saving}
           />

--- a/components/organisation/mitglied-permission-detail.tsx
+++ b/components/organisation/mitglied-permission-detail.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useTransition, useMemo } from "react";
 import { MemberPermissions, HausWithWohnungen, OrganisationPolicy } from "@/lib/organisation-types";
 import { getMitgliedPermissionsAction, getOrgHaeuserAction, setMitgliedOverridesAction } from "@/lib/perms-actions";
-import { getPoliciesAction, getMitgliedPoliciesAction, updateMitgliedPoliciesAction } from "@/lib/organisation/policy-actions";
+import { getPoliciesAction, updateMitgliedPoliciesAction } from "@/lib/organisation/policy-actions";
 import { ObjectScopeEditor } from "./object-scope-editor";
 import { ModulePermissionEditor } from "./module-permission-editor";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
@@ -26,8 +26,6 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
   const [originalPermissions, setOriginalPermissions] = useState<MemberPermissions | null>(null);
   const [haeuser, setHaeuser] = useState<HausWithWohnungen[]>([]);
   const [policies, setPolicies] = useState<OrganisationPolicy[]>([]);
-  const [assignedPolicyIds, setAssignedPolicyIds] = useState<string[]>([]);
-  const [originalAssignedPolicyIds, setOriginalAssignedPolicyIds] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [saving, startSavingTransition] = useTransition();
 
@@ -38,18 +36,15 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
       if (isLocked) return;
       setLoading(true);
       try {
-        const [perms, houses, orgPolicies, memberPolicyIds] = await Promise.all([
+        const [perms, houses, orgPolicies] = await Promise.all([
           getMitgliedPermissionsAction(mitgliedId),
           getOrgHaeuserAction(),
           getPoliciesAction(),
-          getMitgliedPoliciesAction(mitgliedId),
         ]);
         setPermissions(perms);
         setOriginalPermissions(structuredClone(perms));
         setHaeuser(houses);
         setPolicies(orgPolicies);
-        setAssignedPolicyIds(memberPolicyIds);
-        setOriginalAssignedPolicyIds(memberPolicyIds);
       } catch (error) {
         console.error("Failed to load permissions and policies:", error);
         toast({
@@ -94,9 +89,9 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
   }, [permissions, haeuser]);
 
   const policyGrantedHausIds = useMemo(() => {
-    if (!policies || !assignedPolicyIds) return [];
+    if (!policies || !permissions?.policy_ids) return [];
 
-    const activePolicies = policies.filter(p => assignedPolicyIds.includes(p.id));
+    const activePolicies = policies.filter(p => permissions.policy_ids.includes(p.id));
 
     const hasUnrestrictedPolicy = activePolicies.some(p => {
       const houses = p.berechtigungen.objekte?.haeuser;
@@ -116,12 +111,12 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
     });
 
     return Array.from(ids);
-  }, [policies, assignedPolicyIds]);
+  }, [policies, permissions?.policy_ids]);
 
   const policyGrantedModulePermissions = useMemo(() => {
-    if (!policies || !assignedPolicyIds) return {};
+    if (!policies || !permissions?.policy_ids) return {};
 
-    const activePolicies = policies.filter(p => assignedPolicyIds.includes(p.id));
+    const activePolicies = policies.filter(p => permissions.policy_ids.includes(p.id));
     const merged: Record<string, string[]> = {};
 
     activePolicies.forEach(p => {
@@ -143,22 +138,21 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
     });
 
     return merged;
-  }, [policies, assignedPolicyIds]);
+  }, [policies, permissions?.policy_ids]);
 
   // Check if dirty
   const isDirty = useMemo(() => {
     if (!permissions || !originalPermissions) return false;
-    const hasOverridesChanges = JSON.stringify(permissions) !== JSON.stringify(originalPermissions);
-    const hasPoliciesChanges = JSON.stringify(assignedPolicyIds) !== JSON.stringify(originalAssignedPolicyIds);
-    return hasOverridesChanges || hasPoliciesChanges;
-  }, [permissions, originalPermissions, assignedPolicyIds, originalAssignedPolicyIds]);
+    return JSON.stringify(permissions) !== JSON.stringify(originalPermissions);
+  }, [permissions, originalPermissions]);
 
   const handleSave = () => {
-    if (!permissions || !isDirty) return;
+    if (!permissions || !originalPermissions || !isDirty) return;
 
     startSavingTransition(async () => {
       try {
-        const hasOverridesChanges = JSON.stringify(permissions) !== JSON.stringify(originalPermissions);
+        const hasOverridesChanges = JSON.stringify(permissions.module) !== JSON.stringify(originalPermissions.module)
+          || JSON.stringify(permissions.objekte) !== JSON.stringify(originalPermissions.objekte);
         if (hasOverridesChanges) {
           const payload = {
             module: permissions.module || {},
@@ -171,8 +165,8 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
           }
         }
 
-        const toAssign = assignedPolicyIds.filter(id => !originalAssignedPolicyIds.includes(id));
-        const toRemove = originalAssignedPolicyIds.filter(id => !assignedPolicyIds.includes(id));
+        const toAssign = permissions.policy_ids.filter(id => !originalPermissions.policy_ids.includes(id));
+        const toRemove = originalPermissions.policy_ids.filter(id => !permissions.policy_ids.includes(id));
 
         if (toAssign.length > 0 || toRemove.length > 0) {
           await updateMitgliedPoliciesAction(mitgliedId, toAssign, toRemove);
@@ -185,7 +179,6 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
         });
 
         setOriginalPermissions(structuredClone(permissions));
-        setOriginalAssignedPolicyIds([...assignedPolicyIds]);
       } catch (error: any) {
         console.error("Failed to save changes:", error);
         toast({
@@ -200,9 +193,6 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
   const handleReset = () => {
     if (originalPermissions) {
       setPermissions(structuredClone(originalPermissions));
-    }
-    if (originalAssignedPolicyIds) {
-      setAssignedPolicyIds([...originalAssignedPolicyIds]);
     }
   };
 
@@ -351,7 +341,7 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
           ) : (
             <div className="grid gap-3 sm:grid-cols-2">
               {policies.map(policy => {
-                const isChecked = assignedPolicyIds.includes(policy.id);
+                const isChecked = permissions.policy_ids.includes(policy.id);
                 return (
                   <div
                     key={policy.id}
@@ -366,11 +356,12 @@ export function MitgliedPermissionDetail({ mitgliedId, rolle, status, memberName
                       id={`policy-assign-${policy.id}`}
                       checked={isChecked}
                       onCheckedChange={(checked) => {
-                        if (checked) {
-                          setAssignedPolicyIds([...assignedPolicyIds, policy.id]);
-                        } else {
-                          setAssignedPolicyIds(assignedPolicyIds.filter(id => id !== policy.id));
-                        }
+                        setPermissions({
+                          ...permissions,
+                          policy_ids: checked
+                            ? [...permissions.policy_ids, policy.id]
+                            : permissions.policy_ids.filter(id => id !== policy.id),
+                        });
                       }}
                       disabled={saving}
                     />

--- a/components/organisation/module-permission-editor.tsx
+++ b/components/organisation/module-permission-editor.tsx
@@ -30,15 +30,18 @@ interface ModulePermissionEditorProps {
   modulePermissions: Record<string, string[]>;
   onChange: (permissions: Record<string, string[]>) => void;
   disabled?: boolean;
+  policyGrantedModulePermissions?: Record<string, string[]>;
 }
 
 export function ModulePermissionEditor({
   modulePermissions,
   onChange,
   disabled = false,
+  policyGrantedModulePermissions,
 }: ModulePermissionEditorProps) {
   const togglePermission = (moduleKey: string, aktionKey: string) => {
     if (disabled) return;
+    if (policyGrantedModulePermissions?.[moduleKey]?.includes(aktionKey)) return; // Locked by policy
 
     const currentModulePerms = modulePermissions[moduleKey] || [];
     let nextModulePerms: string[];
@@ -65,9 +68,11 @@ export function ModulePermissionEditor({
 
   const handleDeselectRowAll = (moduleKey: string) => {
     if (disabled) return;
+    // Fall back to policy actions
+    const policyActions = policyGrantedModulePermissions?.[moduleKey] || [];
     onChange({
       ...modulePermissions,
-      [moduleKey]: [],
+      [moduleKey]: policyActions,
     });
   };
 
@@ -89,8 +94,13 @@ export function ModulePermissionEditor({
           <TableBody>
             {MODULES.map(mod => {
               const currentPerms = modulePermissions[mod.key] || [];
-              const isRowEmpty = currentPerms.length === 0;
-              const isRowAllSelected = currentPerms.length === AKTIONEN.length;
+              const policyPerms = policyGrantedModulePermissions?.[mod.key] || [];
+              
+              const isRowEmpty = currentPerms.length === 0 && policyPerms.length === 0;
+              const hasAllPermissions = AKTIONEN.every(
+                aktion => currentPerms.includes(aktion.key) || policyPerms.includes(aktion.key)
+              );
+              const isRowAllSelected = hasAllPermissions;
 
               return (
                 <TableRow key={mod.key} className="hover:bg-zinc-50/30 dark:hover:bg-zinc-900/30">
@@ -103,14 +113,15 @@ export function ModulePermissionEditor({
                     )}
                   </TableCell>
                   {AKTIONEN.map(aktion => {
-                    const isChecked = currentPerms.includes(aktion.key);
+                    const isGrantedByPolicy = policyPerms.includes(aktion.key);
+                    const isChecked = currentPerms.includes(aktion.key) || isGrantedByPolicy;
                     return (
                       <TableCell key={aktion.key} className="text-center py-3.5">
-                        <div className="flex justify-center">
+                        <div className="flex justify-center items-center gap-1">
                           <Checkbox
                             checked={isChecked}
                             onCheckedChange={() => togglePermission(mod.key, aktion.key)}
-                            disabled={disabled}
+                            disabled={disabled || isGrantedByPolicy}
                             id={`perm-${mod.key}-${aktion.key}`}
                             aria-label={`${mod.label} ${aktion.label}`}
                           />

--- a/components/organisation/module-permission-editor.tsx
+++ b/components/organisation/module-permission-editor.tsx
@@ -68,11 +68,9 @@ export function ModulePermissionEditor({
 
   const handleDeselectRowAll = (moduleKey: string) => {
     if (disabled) return;
-    // Fall back to policy actions
-    const policyActions = policyGrantedModulePermissions?.[moduleKey] || [];
     onChange({
       ...modulePermissions,
-      [moduleKey]: policyActions,
+      [moduleKey]: [],
     });
   };
 

--- a/components/organisation/object-scope-editor.tsx
+++ b/components/organisation/object-scope-editor.tsx
@@ -9,6 +9,7 @@ interface ObjectScopeEditorProps {
   selectedHausIds: string[] | null; // null = unrestricted
   onChange: (hausIds: string[] | null) => void;
   disabled?: boolean;
+  policyGrantedHausIds?: string[] | null; // null = unrestricted by policies
 }
 
 export function ObjectScopeEditor({
@@ -16,22 +17,33 @@ export function ObjectScopeEditor({
   selectedHausIds,
   onChange,
   disabled = false,
+  policyGrantedHausIds,
 }: ObjectScopeEditorProps) {
   const isUnrestricted = selectedHausIds === null;
 
   const activeHausIds = React.useMemo(() => new Set(selectedHausIds || []), [selectedHausIds]);
+
+  const isHausGrantedByPolicy = React.useMemo(() => {
+    if (policyGrantedHausIds === undefined) return () => false;
+    if (policyGrantedHausIds === null) return () => true;
+    const set = new Set(policyGrantedHausIds);
+    return (id: string) => set.has(id);
+  }, [policyGrantedHausIds]);
+
+  const isPolicyUnrestricted = policyGrantedHausIds === null;
 
   const totalHousesCount = haeuser.length;
   const totalWohnungenCount = haeuser.reduce((sum, h) => sum + h.wohnungen.length, 0);
 
   const selectedHousesCount = isUnrestricted
     ? totalHousesCount
-    : haeuser.filter(h => activeHausIds.has(h.id)).length;
+    : haeuser.filter(h => activeHausIds.has(h.id) || isHausGrantedByPolicy(h.id)).length;
 
   const isLastHouse = !isUnrestricted && selectedHousesCount === 1;
 
   const toggleHaus = (hausId: string) => {
     if (disabled) return;
+    if (isHausGrantedByPolicy(hausId)) return; // Prevent changing policy-granted access
 
     if (isUnrestricted) {
       const nextHausIds = haeuser.reduce<string[]>((acc, h) => {
@@ -62,7 +74,7 @@ export function ObjectScopeEditor({
             Zusammenfassung:
           </span>{" "}
           <span className="text-xs bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 px-2.5 py-1 rounded-full font-medium ml-1">
-            {isUnrestricted
+            {isUnrestricted || isPolicyUnrestricted
               ? `Voller Zugriff (${totalHousesCount} Häuser)`
               : `${selectedHousesCount} von ${totalHousesCount} Häusern`}
           </span>
@@ -71,7 +83,7 @@ export function ObjectScopeEditor({
           </span>
         </div>
 
-        {!isUnrestricted && !disabled && (
+        {!isUnrestricted && !isPolicyUnrestricted && !disabled && (
           <button
             type="button"
             onClick={() => onChange(null)}
@@ -82,7 +94,13 @@ export function ObjectScopeEditor({
         )}
       </div>
 
-      {isUnrestricted && (
+      {isPolicyUnrestricted && (
+        <div className="bg-indigo-500/10 border border-indigo-500/20 text-indigo-700 dark:text-indigo-400 p-3 rounded-xl text-xs font-medium">
+          Eine zugewiesene Richtlinie gewährt vollen Zugriff auf alle Häuser und Wohnungen. Overrides sind nicht erforderlich.
+        </div>
+      )}
+
+      {isUnrestricted && !isPolicyUnrestricted && (
         <div className="bg-emerald-500/10 border border-emerald-500/20 text-emerald-700 dark:text-emerald-400 p-3 rounded-xl text-xs font-medium">
           Keine Einschränkung — Mitarbeiter hat vollen Zugriff auf alle Häuser und Wohnungen.
         </div>
@@ -90,8 +108,9 @@ export function ObjectScopeEditor({
 
       <div className="space-y-3 max-h-[350px] overflow-y-auto pr-1">
         {haeuser.map(haus => {
-          const isSelected = isUnrestricted || activeHausIds.has(haus.id);
-          const isLocked = isLastHouse && activeHausIds.has(haus.id);
+          const isGrantedByPolicy = isHausGrantedByPolicy(haus.id);
+          const isSelected = isUnrestricted || activeHausIds.has(haus.id) || isGrantedByPolicy;
+          const isLocked = (isLastHouse && activeHausIds.has(haus.id)) || isGrantedByPolicy;
           return (
             <div
               key={haus.id}
@@ -109,18 +128,27 @@ export function ObjectScopeEditor({
               />
               <label
                 htmlFor={`haus-${haus.id}`}
-                className={`text-sm font-semibold select-none flex-1 ${
-                  isLocked
+                className={`text-sm font-semibold select-none flex-1 flex items-center justify-between ${
+                  isLocked && !isGrantedByPolicy
                     ? "text-zinc-400 dark:text-zinc-600 cursor-not-allowed"
+                    : isGrantedByPolicy
+                    ? "text-zinc-800 dark:text-zinc-200 cursor-default"
                     : "text-zinc-800 dark:text-zinc-200 cursor-pointer"
                 }`}
               >
-                {haus.name}
-                {isLocked && (
-                  <span className="text-[10px] text-zinc-400 dark:text-zinc-500 ml-2 font-normal">
-                    (mindestens eines erforderlich)
-                  </span>
-                )}
+                <span className="flex items-center gap-2">
+                  {haus.name}
+                  {isLocked && !isGrantedByPolicy && (
+                    <span className="text-[10px] text-zinc-400 dark:text-zinc-500 font-normal">
+                      (mindestens eines erforderlich)
+                    </span>
+                  )}
+                  {isGrantedByPolicy && (
+                    <span className="text-[10px] text-indigo-600 dark:text-indigo-400 bg-indigo-500/10 px-2 py-0.5 rounded-full font-medium">
+                      Richtlinie
+                    </span>
+                  )}
+                </span>
               </label>
               <span className="text-[10px] text-muted-foreground bg-zinc-100 dark:bg-zinc-800 px-2 py-0.5 rounded-full">
                 {haus.wohnungen.length} Wohn.

--- a/components/organisation/organisation-policies-tab.tsx
+++ b/components/organisation/organisation-policies-tab.tsx
@@ -99,7 +99,7 @@ export function OrganisationPoliciesTab({ hasVerwaltenPermission }: Organisation
     const newTemplate: OrganisationPolicy = {
       id: "",
       organisation_id: "",
-      name: "Neue Richtlinie",
+      name: "",
       berechtigungen: {
         module: {},
         objekte: { haeuser: null }
@@ -407,8 +407,9 @@ export function OrganisationPoliciesTab({ hasVerwaltenPermission }: Organisation
               </CardHeader>
               <CardContent className="flex flex-col gap-4">
                 <div className="flex flex-col gap-2">
-                  <label className="text-xs font-semibold uppercase text-zinc-500">Name der Richtlinie</label>
+                  <label htmlFor="policy-name-input" className="text-xs font-semibold uppercase text-zinc-500">Name der Richtlinie</label>
                   <Input
+                    id="policy-name-input"
                     type="text"
                     value={editingPolicy.name}
                     onChange={(e) => setEditingPolicy({ ...editingPolicy, name: e.target.value })}

--- a/components/organisation/organisation-policies-tab.tsx
+++ b/components/organisation/organisation-policies-tab.tsx
@@ -43,6 +43,7 @@ export function OrganisationPoliciesTab({ hasVerwaltenPermission }: Organisation
   const [editingPolicy, setEditingPolicy] = useState<OrganisationPolicy | null>(null);
   const [originalPolicy, setOriginalPolicy] = useState<OrganisationPolicy | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deletingPolicy, setDeletingPolicy] = useState<OrganisationPolicy | null>(null);
 
   // Fetch policies and houses on mount
   useEffect(() => {
@@ -165,19 +166,23 @@ export function OrganisationPoliciesTab({ hasVerwaltenPermission }: Organisation
 
   const handleDelete = () => {
     if (!editingPolicy || !originalPolicy) return;
+    setDeletingPolicy(editingPolicy);
     setShowDeleteConfirm(true);
   };
 
   const confirmDelete = () => {
-    if (!editingPolicy || !originalPolicy) return;
-    const policyId = editingPolicy.id;
-    const policyName = editingPolicy.name;
+    if (!deletingPolicy) return;
+    const policyId = deletingPolicy.id;
+    const policyName = deletingPolicy.name;
 
     startSavingTransition(async () => {
       try {
         await deletePolicyAction(policyId);
         setPolicies(prev => prev.filter(p => p.id !== policyId));
-        handleSelectPolicy(null);
+        if (editingPolicy?.id === policyId) {
+          handleSelectPolicy(null);
+        }
+        setDeletingPolicy(null);
         toast({
           title: "Richtlinie gelöscht",
           description: `Die Richtlinie "${policyName}" wurde erfolgreich entfernt.`,
@@ -310,7 +315,15 @@ export function OrganisationPoliciesTab({ hasVerwaltenPermission }: Organisation
                                 size="icon"
                                 className="h-8 w-8 text-muted-foreground hover:text-red-500 rounded-lg"
                                 onClick={() => {
-                                  handleSelectPolicy(policy);
+                                  if (isDirty && editingPolicy && editingPolicy.id !== policy.id) {
+                                    toast({
+                                      title: "Ungespeicherte Änderungen",
+                                      description: "Bitte speichern oder verwerfen Sie die aktuellen Änderungen.",
+                                      variant: "destructive",
+                                    });
+                                    return;
+                                  }
+                                  setDeletingPolicy(policy);
                                   setShowDeleteConfirm(true);
                                 }}
                                 title="Richtlinie löschen"
@@ -474,7 +487,7 @@ export function OrganisationPoliciesTab({ hasVerwaltenPermission }: Organisation
               Richtlinie löschen
             </AlertDialogTitle>
             <AlertDialogDescription className="text-center text-sm text-muted-foreground leading-relaxed">
-              Möchten Sie die Richtlinie <strong className="text-foreground">"{editingPolicy?.name}"</strong> wirklich löschen?
+              Möchten Sie die Richtlinie <strong className="text-foreground">"{deletingPolicy?.name}"</strong> wirklich löschen?
               Diese Richtlinie wird allen betroffenen Mitgliedern entzogen, wodurch sie die daraus resultierenden Rechte sofort verlieren.
             </AlertDialogDescription>
           </AlertDialogHeader>

--- a/components/organisation/organisation-policies-tab.tsx
+++ b/components/organisation/organisation-policies-tab.tsx
@@ -1,0 +1,499 @@
+"use client";
+
+import React, { useState, useEffect, useTransition, useMemo } from "react";
+import { HausWithWohnungen, OrganisationPolicy, PolicyBerechtigungen } from "@/lib/organisation-types";
+import {
+  getPoliciesAction,
+  createPolicyAction,
+  updatePolicyAction,
+  deletePolicyAction
+} from "@/lib/organisation/policy-actions";
+import { getOrgHaeuserAction } from "@/lib/perms-actions";
+import { ObjectScopeEditor } from "./object-scope-editor";
+import { ModulePermissionEditor } from "./module-permission-editor";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogAction,
+  AlertDialogCancel
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Shield, Plus, Trash2, Save, RefreshCw, AlertTriangle, CheckCircle, Trash } from "lucide-react";
+import { toast } from "@/hooks/use-toast";
+import { cn } from "@/lib/utils";
+
+interface OrganisationPoliciesTabProps {
+  hasVerwaltenPermission: boolean;
+}
+
+export function OrganisationPoliciesTab({ hasVerwaltenPermission }: OrganisationPoliciesTabProps) {
+  const [policies, setPolicies] = useState<OrganisationPolicy[]>([]);
+  const [haeuser, setHaeuser] = useState<HausWithWohnungen[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, startSavingTransition] = useTransition();
+
+  const [editingPolicy, setEditingPolicy] = useState<OrganisationPolicy | null>(null);
+  const [originalPolicy, setOriginalPolicy] = useState<OrganisationPolicy | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  // Fetch policies and houses on mount
+  useEffect(() => {
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        const [policiesData, housesData] = await Promise.all([
+          getPoliciesAction(),
+          getOrgHaeuserAction(),
+        ]);
+        setPolicies(policiesData);
+        setHaeuser(housesData);
+      } catch (error) {
+        console.error("Failed to load policies or houses:", error);
+        toast({
+          title: "Fehler beim Laden",
+          description: "Die Daten konnten nicht geladen werden.",
+          variant: "destructive",
+        });
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+
+  // Check if current editing policy is dirty
+  const isDirty = useMemo(() => {
+    if (!editingPolicy) return false;
+    if (!originalPolicy) {
+      // New policy is dirty if name is not empty or has any permissions
+      return editingPolicy.name.trim().length > 0 ||
+        (editingPolicy.berechtigungen.module && Object.keys(editingPolicy.berechtigungen.module).length > 0) ||
+        (editingPolicy.berechtigungen.objekte?.haeuser && editingPolicy.berechtigungen.objekte.haeuser.length > 0);
+    }
+    return (
+      editingPolicy.name !== originalPolicy.name ||
+      JSON.stringify(editingPolicy.berechtigungen) !== JSON.stringify(originalPolicy.berechtigungen)
+    );
+  }, [editingPolicy, originalPolicy]);
+
+  const handleSelectPolicy = (policy: OrganisationPolicy | null) => {
+    if (policy) {
+      setEditingPolicy(structuredClone(policy));
+      setOriginalPolicy(structuredClone(policy));
+    } else {
+      setEditingPolicy(null);
+      setOriginalPolicy(null);
+    }
+  };
+
+  const handleCreateNewTemplate = () => {
+    const newTemplate: OrganisationPolicy = {
+      id: "",
+      organisation_id: "",
+      name: "Neue Richtlinie",
+      berechtigungen: {
+        module: {},
+        objekte: { haeuser: null }
+      },
+      erstellt_am: new Date().toISOString()
+    };
+    setEditingPolicy(newTemplate);
+    setOriginalPolicy(null);
+  };
+
+  const handleSave = () => {
+    if (!editingPolicy || !isDirty) return;
+
+    if (!editingPolicy.name.trim()) {
+      toast({
+        title: "Fehler",
+        description: "Der Name der Richtlinie darf nicht leer sein.",
+        variant: "destructive"
+      });
+      return;
+    }
+
+    startSavingTransition(async () => {
+      try {
+        const payloadBerechtigungen: PolicyBerechtigungen = {
+          module: editingPolicy.berechtigungen.module || {},
+          objekte: {
+            haeuser: editingPolicy.berechtigungen.objekte?.haeuser ?? null
+          }
+        };
+
+        if (!originalPolicy) {
+          // Create new policy
+          const newPolicy = await createPolicyAction(editingPolicy.name, payloadBerechtigungen);
+          setPolicies(prev => [...prev, newPolicy]);
+          handleSelectPolicy(newPolicy);
+          toast({
+            title: "Richtlinie erstellt",
+            description: `Die Richtlinie "${newPolicy.name}" wurde erfolgreich erstellt.`,
+            variant: "success"
+          });
+        } else {
+          // Update existing policy
+          const updatedPolicy = await updatePolicyAction(editingPolicy.id, editingPolicy.name, payloadBerechtigungen);
+          setPolicies(prev => prev.map(p => p.id === updatedPolicy.id ? updatedPolicy : p));
+          handleSelectPolicy(updatedPolicy);
+          toast({
+            title: "Richtlinie aktualisiert",
+            description: `Die Richtlinie "${updatedPolicy.name}" wurde erfolgreich gespeichert.`,
+            variant: "success"
+          });
+        }
+      } catch (error: any) {
+        console.error("Failed to save policy:", error);
+        toast({
+          title: "Fehler beim Speichern",
+          description: error.message || "Es gab ein Problem beim Speichern.",
+          variant: "destructive"
+        });
+      }
+    });
+  };
+
+  const handleDelete = () => {
+    if (!editingPolicy || !originalPolicy) return;
+    setShowDeleteConfirm(true);
+  };
+
+  const confirmDelete = () => {
+    if (!editingPolicy || !originalPolicy) return;
+    const policyId = editingPolicy.id;
+    const policyName = editingPolicy.name;
+
+    startSavingTransition(async () => {
+      try {
+        await deletePolicyAction(policyId);
+        setPolicies(prev => prev.filter(p => p.id !== policyId));
+        handleSelectPolicy(null);
+        toast({
+          title: "Richtlinie gelöscht",
+          description: `Die Richtlinie "${policyName}" wurde erfolgreich entfernt.`,
+          variant: "success"
+        });
+      } catch (error: any) {
+        console.error("Failed to delete policy:", error);
+        toast({
+          title: "Fehler beim Löschen",
+          description: error.message || "Die Richtlinie konnte nicht gelöscht werden.",
+          variant: "destructive"
+        });
+      } finally {
+        setShowDeleteConfirm(false);
+      }
+    });
+  };
+
+  const handleObjectScopeChange = (hausIds: string[] | null) => {
+    if (!editingPolicy) return;
+    setEditingPolicy({
+      ...editingPolicy,
+      berechtigungen: {
+        ...editingPolicy.berechtigungen,
+        objekte: {
+          haeuser: hausIds
+        }
+      }
+    });
+  };
+
+  const handleModulePermissionsChange = (modulePerms: Record<string, string[]>) => {
+    if (!editingPolicy) return;
+    setEditingPolicy({
+      ...editingPolicy,
+      berechtigungen: {
+        ...editingPolicy.berechtigungen,
+        module: modulePerms
+      }
+    });
+  };
+
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center p-12 border border-dashed border-zinc-200 dark:border-zinc-800 rounded-[2rem] min-h-[400px] gap-3">
+        <RefreshCw className="size-6 animate-spin text-muted-foreground" />
+        <span className="text-sm text-muted-foreground">Richtlinien werden geladen...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col md:flex-row gap-6 items-start">
+      {/* Left Pane: Policies List */}
+      <div className={cn("flex flex-col gap-4 w-full", editingPolicy ? "md:w-1/2" : "md:w-2/3")}>
+        <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs overflow-hidden">
+          <CardHeader className="flex flex-row items-center justify-between pb-4">
+            <div>
+              <CardTitle className="text-xl">Organisation Richtlinien</CardTitle>
+              <CardDescription>
+                Richtlinien definieren Rollen- und Objektrechte, die Teammitgliedern zugewiesen werden können.
+              </CardDescription>
+            </div>
+            {hasVerwaltenPermission && (
+              <Button
+                onClick={handleCreateNewTemplate}
+                size="sm"
+                className="rounded-xl bg-primary hover:bg-primary/95 text-white flex items-center gap-1.5 h-9"
+              >
+                <Plus className="size-4" />
+                <span>Neue Richtlinie</span>
+              </Button>
+            )}
+          </CardHeader>
+          <CardContent className="p-0">
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader className="bg-zinc-50/50 dark:bg-zinc-900/50">
+                  <TableRow>
+                    <TableHead className="py-3 pl-6">Name</TableHead>
+                    <TableHead className="py-3">Details</TableHead>
+                    <TableHead className="py-3 pr-6 text-right">Aktionen</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {policies.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={3} className="py-8 text-center text-muted-foreground">
+                        Keine Richtlinien vorhanden.
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    policies.map(policy => {
+                      const isUnrestricted = !policy.berechtigungen.objekte?.haeuser || policy.berechtigungen.objekte.haeuser.length === 0;
+                      const housesCount = policy.berechtigungen.objekte?.haeuser?.length || 0;
+                      const housesText = isUnrestricted
+                        ? "Alle Häuser"
+                        : `${housesCount} ${housesCount === 1 ? 'Haus' : 'Häuser'}`;
+
+                      const activeModulesCount = Object.values(policy.berechtigungen.module || {}).filter(
+                        actions => actions && actions.length > 0
+                      ).length;
+                      const modulesText = `${activeModulesCount} ${activeModulesCount === 1 ? 'Modul' : 'Module'}`;
+                      const isSelected = editingPolicy?.id === policy.id && originalPolicy !== null;
+
+                      return (
+                        <TableRow
+                          key={policy.id}
+                          onClick={() => handleSelectPolicy(isSelected ? null : policy)}
+                          className={cn(
+                            "cursor-pointer transition-colors duration-150",
+                            isSelected
+                              ? "bg-zinc-100 dark:bg-zinc-800/80 hover:bg-zinc-200 dark:hover:bg-zinc-800"
+                              : "hover:bg-zinc-50/30 dark:hover:bg-zinc-900/30"
+                          )}
+                        >
+                          <TableCell className="py-4 pl-6 font-semibold text-sm flex items-center gap-2">
+                            <Shield className="size-4 text-indigo-500 shrink-0" />
+                            <span>{policy.name}</span>
+                          </TableCell>
+                          <TableCell className="py-4">
+                            <span className="text-xs text-muted-foreground">
+                              {modulesText} · {housesText}
+                            </span>
+                          </TableCell>
+                          <TableCell className="py-4 pr-6 text-right" onClick={(e) => e.stopPropagation()}>
+                            {hasVerwaltenPermission && (
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-8 w-8 text-muted-foreground hover:text-red-500 rounded-lg"
+                                onClick={() => {
+                                  handleSelectPolicy(policy);
+                                  setShowDeleteConfirm(true);
+                                }}
+                                title="Richtlinie löschen"
+                              >
+                                <Trash2 className="size-4" />
+                              </Button>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Right Pane: Policy Editor */}
+      <div className={cn("w-full", editingPolicy ? "md:w-1/2" : "md:w-1/3")}>
+        {editingPolicy ? (
+          <div className="flex flex-col gap-6">
+            {/* Top Bar for Discard / Save */}
+            {isDirty && (
+              <div className="flex items-center justify-between p-4 bg-amber-500/10 border border-amber-500/20 rounded-2xl animate-in fade-in slide-in-from-top-2 duration-200">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-semibold text-amber-700 dark:text-amber-400">
+                    Ungespeicherte Änderungen an dieser Richtlinie
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    size="xs"
+                    variant="ghost"
+                    onClick={() => {
+                      if (originalPolicy) {
+                        setEditingPolicy(structuredClone(originalPolicy));
+                      } else {
+                        setEditingPolicy(null);
+                      }
+                    }}
+                    disabled={saving}
+                    className="text-xs h-8 rounded-lg"
+                  >
+                    Verwerfen
+                  </Button>
+                  <Button
+                    size="xs"
+                    onClick={handleSave}
+                    disabled={saving}
+                    className="text-xs h-8 rounded-lg bg-amber-500 hover:bg-amber-600 text-white font-medium flex items-center gap-1.5"
+                  >
+                    {saving ? (
+                      <>
+                        <RefreshCw className="size-3 animate-spin" />
+                        <span>Speichert...</span>
+                      </>
+                    ) : (
+                      <>
+                        <Save className="size-3" />
+                        <span>Speichern</span>
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs">
+              <CardHeader className="pb-4 flex flex-row items-center justify-between">
+                <div>
+                  <CardTitle className="text-xl">
+                    {originalPolicy ? "Richtlinie bearbeiten" : "Neue Richtlinie erstellen"}
+                  </CardTitle>
+                  <CardDescription>
+                    {originalPolicy
+                      ? "Passen Sie den Namen und die Berechtigungen für diese Richtlinie an."
+                      : "Geben Sie der neuen Richtlinie einen Namen und definieren Sie Berechtigungen."}
+                  </CardDescription>
+                </div>
+                {originalPolicy && hasVerwaltenPermission && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="text-zinc-500 hover:text-red-500 hover:bg-red-500/10 rounded-xl size-9"
+                    onClick={handleDelete}
+                    disabled={saving}
+                    title="Richtlinie löschen"
+                  >
+                    <Trash className="size-4" />
+                  </Button>
+                )}
+              </CardHeader>
+              <CardContent className="flex flex-col gap-4">
+                <div className="flex flex-col gap-2">
+                  <label className="text-xs font-semibold uppercase text-zinc-500">Name der Richtlinie</label>
+                  <Input
+                    type="text"
+                    value={editingPolicy.name}
+                    onChange={(e) => setEditingPolicy({ ...editingPolicy, name: e.target.value })}
+                    placeholder="z.B. Buchhaltung, Hausmeister"
+                    disabled={saving || !hasVerwaltenPermission}
+                    className="rounded-xl h-10"
+                  />
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-lg">Objekt-Scope (Häuser-Zugriff)</CardTitle>
+                <CardDescription className="text-xs">
+                  Legen Sie fest, auf welche Häuser diese Richtlinie Zugriff gewährt.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="pt-0">
+                <ObjectScopeEditor
+                  haeuser={haeuser}
+                  selectedHausIds={editingPolicy.berechtigungen.objekte?.haeuser ?? null}
+                  onChange={handleObjectScopeChange}
+                  disabled={saving || !hasVerwaltenPermission}
+                />
+              </CardContent>
+            </Card>
+
+            <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-lg">Modul- und Aktionsrechte</CardTitle>
+                <CardDescription className="text-xs">
+                  Aktivieren Sie die gewünschten Berechtigungen in den jeweiligen Modulen.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="p-0 sm:px-6 sm:pb-6">
+                <ModulePermissionEditor
+                  modulePermissions={editingPolicy.berechtigungen.module || {}}
+                  onChange={handleModulePermissionsChange}
+                  disabled={saving || !hasVerwaltenPermission}
+                />
+              </CardContent>
+            </Card>
+          </div>
+        ) : (
+          <Card className="rounded-[2rem] border border-zinc-200/50 dark:border-zinc-800/50 shadow-xs p-6 text-center text-zinc-500">
+            <p className="text-sm">
+              Wählen Sie eine Richtlinie aus der Liste aus oder klicken Sie auf "Neue Richtlinie", um eine neue Richtlinie zu erstellen.
+            </p>
+          </Card>
+        )}
+      </div>
+
+      {/* Delete Confirmation Dialog */}
+      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+        <AlertDialogContent className="rounded-[2rem] max-w-md border border-zinc-200/50 dark:border-zinc-800/50">
+          <AlertDialogHeader className="flex flex-col gap-3">
+            <div className="mx-auto bg-amber-500/10 text-amber-500 p-4 rounded-full w-fit">
+              <AlertTriangle className="size-8" />
+            </div>
+            <AlertDialogTitle className="text-xl font-bold text-center">
+              Richtlinie löschen
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-center text-sm text-muted-foreground leading-relaxed">
+              Möchten Sie die Richtlinie <strong className="text-foreground">"{editingPolicy?.name}"</strong> wirklich löschen?
+              Diese Richtlinie wird allen betroffenen Mitgliedern entzogen, wodurch sie die daraus resultierenden Rechte sofort verlieren.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex flex-col-reverse sm:flex-row gap-2 mt-4">
+            <AlertDialogCancel className="rounded-xl flex-1 border border-zinc-200 dark:border-zinc-800" disabled={saving}>
+              Abbrechen
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="rounded-xl flex-1 bg-red-500 hover:bg-red-600 text-white font-medium"
+              onClick={(e) => {
+                e.preventDefault();
+                confirmDelete();
+              }}
+              disabled={saving}
+            >
+              {saving ? "Bitte warten..." : "Bestätigen & Löschen"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/lib/organisation-types.ts
+++ b/lib/organisation-types.ts
@@ -13,6 +13,7 @@ export interface MemberPermissions {
     haeuser: string[] | null;
   };
   is_restricted: boolean;
+  policy_ids: string[];
 }
 
 export interface HausWithWohnungen {

--- a/lib/organisation-types.ts
+++ b/lib/organisation-types.ts
@@ -20,3 +20,17 @@ export interface HausWithWohnungen {
   name: string;
   wohnungen: { id: string; name: string }[];
 }
+
+export interface PolicyBerechtigungen {
+  module?: Record<string, string[]>;
+  objekte?: { haeuser?: string[] | null };
+}
+
+export interface OrganisationPolicy {
+  id: string;
+  organisation_id: string;
+  name: string;
+  berechtigungen: PolicyBerechtigungen;
+  erstellt_am: string;
+}
+

--- a/lib/organisation/policy-actions.ts
+++ b/lib/organisation/policy-actions.ts
@@ -65,15 +65,14 @@ export async function deletePolicyAction(policyId: string): Promise<void> {
 export async function getMitgliedPoliciesAction(mitgliedId: string): Promise<string[]> {
   const supabase = await createClient();
   await requirePermission('organisation', 'ansehen');
-  const { data, error } = await supabase
-    .from('Organisation_Mitglieder_Policies')
-    .select('policy_id')
-    .eq('mitglied_id', mitgliedId);
+  const { data, error } = await supabase.rpc('get_mitglied_policies', {
+    p_mitglied_id: mitgliedId,
+  });
   if (error) {
     console.error("Error fetching mitglied policies:", error);
     throw error;
   }
-  return (data ?? []).map(r => r.policy_id);
+  return (data ?? []) as string[];
 }
 
 export async function updateMitgliedPoliciesAction(
@@ -85,11 +84,15 @@ export async function updateMitgliedPoliciesAction(
   await requirePermission('organisation', 'verwalten');
 
   if (toAssign.length > 0) {
-    for (const policyId of toAssign) {
-      const { error } = await supabase.rpc('assign_policy', {
-        p_mitglied_id: mitgliedId,
-        p_policy_id: policyId,
-      });
+    const results = await Promise.all(
+      toAssign.map(policyId =>
+        supabase.rpc('assign_policy', {
+          p_mitglied_id: mitgliedId,
+          p_policy_id: policyId,
+        })
+      )
+    );
+    for (const { error } of results) {
       if (error) {
         console.error("Error in assign_policy RPC:", error);
         throw error;
@@ -98,11 +101,15 @@ export async function updateMitgliedPoliciesAction(
   }
 
   if (toRemove.length > 0) {
-    for (const policyId of toRemove) {
-      const { error } = await supabase.rpc('remove_policy', {
-        p_mitglied_id: mitgliedId,
-        p_policy_id: policyId,
-      });
+    const results = await Promise.all(
+      toRemove.map(policyId =>
+        supabase.rpc('remove_policy', {
+          p_mitglied_id: mitgliedId,
+          p_policy_id: policyId,
+        })
+      )
+    );
+    for (const { error } of results) {
       if (error) {
         console.error("Error in remove_policy RPC:", error);
         throw error;

--- a/lib/organisation/policy-actions.ts
+++ b/lib/organisation/policy-actions.ts
@@ -1,0 +1,106 @@
+'use server';
+
+import { createClient } from "@/utils/supabase/server";
+import { requirePermission } from "@/lib/permissions";
+import { revalidatePath } from "next/cache";
+import { PolicyBerechtigungen, OrganisationPolicy } from "@/lib/organisation-types";
+
+export async function getPoliciesAction(): Promise<OrganisationPolicy[]> {
+  const supabase = await createClient();
+  await requirePermission('organisation', 'ansehen');
+  const { data, error } = await supabase.rpc('get_policies');
+  if (error) {
+    console.error("Error in get_policies RPC:", error);
+    throw error;
+  }
+  return (data ?? []) as OrganisationPolicy[];
+}
+
+export async function createPolicyAction(name: string, berechtigungen: PolicyBerechtigungen): Promise<OrganisationPolicy> {
+  const supabase = await createClient();
+  await requirePermission('organisation', 'verwalten');
+  const { data, error } = await supabase.rpc('create_policy', {
+    p_name: name,
+    p_berechtigungen: berechtigungen,
+  });
+  if (error) {
+    console.error("Error in create_policy RPC:", error);
+    throw error;
+  }
+  revalidatePath('/organisation');
+  return data as OrganisationPolicy;
+}
+
+export async function updatePolicyAction(
+  policyId: string,
+  name: string | null,
+  berechtigungen: PolicyBerechtigungen | null
+): Promise<OrganisationPolicy> {
+  const supabase = await createClient();
+  await requirePermission('organisation', 'verwalten');
+  const { data, error } = await supabase.rpc('update_policy', {
+    p_policy_id: policyId,
+    p_name: name,
+    p_berechtigungen: berechtigungen,
+  });
+  if (error) {
+    console.error("Error in update_policy RPC:", error);
+    throw error;
+  }
+  revalidatePath('/organisation');
+  return data as OrganisationPolicy;
+}
+
+export async function deletePolicyAction(policyId: string): Promise<void> {
+  const supabase = await createClient();
+  await requirePermission('organisation', 'verwalten');
+  const { error } = await supabase.rpc('delete_policy', { p_policy_id: policyId });
+  if (error) {
+    console.error("Error in delete_policy RPC:", error);
+    throw error;
+  }
+  revalidatePath('/organisation');
+}
+
+export async function getMitgliedPoliciesAction(mitgliedId: string): Promise<string[]> {
+  const supabase = await createClient();
+  await requirePermission('organisation', 'ansehen');
+  const { data, error } = await supabase
+    .from('Organisation_Mitglieder_Policies')
+    .select('policy_id')
+    .eq('mitglied_id', mitgliedId);
+  if (error) {
+    console.error("Error fetching mitglied policies:", error);
+    throw error;
+  }
+  return (data ?? []).map(r => r.policy_id);
+}
+
+export async function assignPolicyAction(mitgliedId: string, policyId: string): Promise<void> {
+  const supabase = await createClient();
+  await requirePermission('organisation', 'verwalten');
+  const { error } = await supabase.rpc('assign_policy', {
+    p_mitglied_id: mitgliedId,
+    p_policy_id: policyId,
+  });
+  if (error) {
+    console.error("Error in assign_policy RPC:", error);
+    throw error;
+  }
+  revalidatePath('/organisation');
+}
+
+export async function removePolicyAction(mitgliedId: string, policyId: string): Promise<void> {
+  const supabase = await createClient();
+  await requirePermission('organisation', 'verwalten');
+  const { error } = await supabase.rpc('remove_policy', {
+    p_mitglied_id: mitgliedId,
+    p_policy_id: policyId,
+  });
+  if (error) {
+    console.error("Error in remove_policy RPC:", error);
+    throw error;
+  }
+  revalidatePath('/organisation');
+}
+

--- a/lib/organisation/policy-actions.ts
+++ b/lib/organisation/policy-actions.ts
@@ -76,31 +76,41 @@ export async function getMitgliedPoliciesAction(mitgliedId: string): Promise<str
   return (data ?? []).map(r => r.policy_id);
 }
 
-export async function assignPolicyAction(mitgliedId: string, policyId: string): Promise<void> {
+export async function updateMitgliedPoliciesAction(
+  mitgliedId: string,
+  toAssign: string[],
+  toRemove: string[]
+): Promise<void> {
   const supabase = await createClient();
   await requirePermission('organisation', 'verwalten');
-  const { error } = await supabase.rpc('assign_policy', {
-    p_mitglied_id: mitgliedId,
-    p_policy_id: policyId,
-  });
-  if (error) {
-    console.error("Error in assign_policy RPC:", error);
-    throw error;
+
+  if (toAssign.length > 0) {
+    for (const policyId of toAssign) {
+      const { error } = await supabase.rpc('assign_policy', {
+        p_mitglied_id: mitgliedId,
+        p_policy_id: policyId,
+      });
+      if (error) {
+        console.error("Error in assign_policy RPC:", error);
+        throw error;
+      }
+    }
   }
+
+  if (toRemove.length > 0) {
+    for (const policyId of toRemove) {
+      const { error } = await supabase.rpc('remove_policy', {
+        p_mitglied_id: mitgliedId,
+        p_policy_id: policyId,
+      });
+      if (error) {
+        console.error("Error in remove_policy RPC:", error);
+        throw error;
+      }
+    }
+  }
+
   revalidatePath('/organisation');
 }
 
-export async function removePolicyAction(mitgliedId: string, policyId: string): Promise<void> {
-  const supabase = await createClient();
-  await requirePermission('organisation', 'verwalten');
-  const { error } = await supabase.rpc('remove_policy', {
-    p_mitglied_id: mitgliedId,
-    p_policy_id: policyId,
-  });
-  if (error) {
-    console.error("Error in remove_policy RPC:", error);
-    throw error;
-  }
-  revalidatePath('/organisation');
-}
 


### PR DESCRIPTION
## Description

Adds an organisation policies UI: a policies tab for managing permission policies and assigning them to employees, with policy-granted permissions visualized as locked in the editors.

## Summary of Changes

- New "Richtlinien" tab in organisation settings (`OrganisationPoliciesTab`) with create/edit/delete flows and delete confirmation dialog
- New `lib/organisation/policy-actions.ts`: policy CRUD + assign/remove via RPCs (`get_policies`, `create_policy`, `update_policy`, `delete_policy`, `get_mitglied_policies`, `assign_policy`, `remove_policy`), gated by organisation permissions
- `MitgliedPermissionDetail`: assign policies to members via checkboxes; saves overrides and policy assignments together
- `ModulePermissionEditor` / `ObjectScopeEditor`: policy-granted permissions shown checked and locked, with summary hints
- `lib/organisation-types.ts`: `PolicyBerechtigungen`, `OrganisationPolicy`, `policy_ids` on MemberPermissions