### PR TITLE
Feature/soft delete fixes

### DIFF
--- a/__tests__/api/haeuser/bulk-delete.test.ts
+++ b/__tests__/api/haeuser/bulk-delete.test.ts
@@ -1,0 +1,102 @@
+import { POST } from '@/app/api/haeuser/bulk-delete/route';
+import { createClient } from '@/utils/supabase/server';
+import { requireApiPermission, verifyEntityInScope } from '@/lib/api-permissions';
+
+jest.mock('@/utils/supabase/server', () => ({
+  createClient: jest.fn(),
+}));
+
+jest.mock('@/lib/api-permissions', () => ({
+  requireApiPermission: jest.fn(),
+  verifyEntityInScope: jest.fn(),
+}));
+
+describe('POST /api/haeuser/bulk-delete', () => {
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSupabase = {
+      rpc: jest.fn(),
+    };
+    (createClient as jest.Mock).mockResolvedValue(mockSupabase);
+  });
+
+  it('should return 400 if ids is not an array or empty', async () => {
+    const request = {
+      json: jest.fn().mockResolvedValue({}),
+    } as unknown as Request;
+
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe('Mindestens eine Haus-ID ist erforderlich.');
+  });
+
+  it('should return 403 if permission check fails', async () => {
+    (requireApiPermission as jest.Mock).mockRejectedValue(new Error('Permission denied'));
+
+    const request = {
+      json: jest.fn().mockResolvedValue({ ids: ['id-1'] }),
+    } as unknown as Request;
+
+    const response = await POST(request);
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toBe('Permission denied');
+  });
+
+  it('should return 403 if verifyEntityInScope fails', async () => {
+    (requireApiPermission as jest.Mock).mockResolvedValue(undefined);
+    (verifyEntityInScope as jest.Mock).mockResolvedValue(false);
+
+    const request = {
+      json: jest.fn().mockResolvedValue({ ids: ['id-1'] }),
+    } as unknown as Request;
+
+    const response = await POST(request);
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toBe('Permission denied');
+  });
+
+  it('should call soft_delete_record for each ID and return success', async () => {
+    (requireApiPermission as jest.Mock).mockResolvedValue(undefined);
+    (verifyEntityInScope as jest.Mock).mockResolvedValue(true);
+    mockSupabase.rpc.mockResolvedValue({ error: null });
+
+    const request = {
+      json: jest.fn().mockResolvedValue({ ids: ['id-1', 'id-2'] }),
+    } as unknown as Request;
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.successCount).toBe(2);
+
+    expect(mockSupabase.rpc).toHaveBeenCalledTimes(2);
+    expect(mockSupabase.rpc).toHaveBeenNthCalledWith(1, 'soft_delete_record', {
+      p_table_name: 'Haeuser',
+      p_record_id: 'id-1',
+    });
+    expect(mockSupabase.rpc).toHaveBeenNthCalledWith(2, 'soft_delete_record', {
+      p_table_name: 'Haeuser',
+      p_record_id: 'id-2',
+    });
+  });
+
+  it('should return 500 if supabase RPC fails', async () => {
+    (requireApiPermission as jest.Mock).mockResolvedValue(undefined);
+    (verifyEntityInScope as jest.Mock).mockResolvedValue(true);
+    mockSupabase.rpc.mockResolvedValue({ error: { message: 'Database error' } });
+
+    const request = {
+      json: jest.fn().mockResolvedValue({ ids: ['id-1'] }),
+    } as unknown as Request;
+
+    const response = await POST(request);
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.error).toBe('Database error');
+  });
+});

--- a/__tests__/api/haeuser/bulk-delete.test.ts
+++ b/__tests__/api/haeuser/bulk-delete.test.ts
@@ -1,25 +1,23 @@
 import { POST } from '@/app/api/haeuser/bulk-delete/route';
-import { createClient } from '@/utils/supabase/server';
-import { requireApiPermission, verifyEntityInScope } from '@/lib/api-permissions';
-
-jest.mock('@/utils/supabase/server', () => ({
-  createClient: jest.fn(),
-}));
+import { requireApiPermission } from '@/lib/api-permissions';
+import { getAccessibleHaeuserIds } from '@/lib/object-scope';
+import { softDeleteEntryAction } from '@/lib/papierkorb/utils';
 
 jest.mock('@/lib/api-permissions', () => ({
   requireApiPermission: jest.fn(),
-  verifyEntityInScope: jest.fn(),
+}));
+
+jest.mock('@/lib/object-scope', () => ({
+  getAccessibleHaeuserIds: jest.fn(),
+}));
+
+jest.mock('@/lib/papierkorb/utils', () => ({
+  softDeleteEntryAction: jest.fn(),
 }));
 
 describe('POST /api/haeuser/bulk-delete', () => {
-  let mockSupabase: any;
-
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSupabase = {
-      rpc: jest.fn(),
-    };
-    (createClient as jest.Mock).mockResolvedValue(mockSupabase);
   });
 
   it('should return 400 if ids is not an array or empty', async () => {
@@ -46,12 +44,12 @@ describe('POST /api/haeuser/bulk-delete', () => {
     expect(body.error).toBe('Permission denied');
   });
 
-  it('should return 403 if verifyEntityInScope fails', async () => {
+  it('should return 403 if getAccessibleHaeuserIds denies scope', async () => {
     (requireApiPermission as jest.Mock).mockResolvedValue(undefined);
-    (verifyEntityInScope as jest.Mock).mockResolvedValue(false);
+    (getAccessibleHaeuserIds as jest.Mock).mockResolvedValue(['accessible-id-1']);
 
     const request = {
-      json: jest.fn().mockResolvedValue({ ids: ['id-1'] }),
+      json: jest.fn().mockResolvedValue({ ids: ['inaccessible-id'] }),
     } as unknown as Request;
 
     const response = await POST(request);
@@ -60,10 +58,10 @@ describe('POST /api/haeuser/bulk-delete', () => {
     expect(body.error).toBe('Permission denied');
   });
 
-  it('should call soft_delete_record for each ID and return success', async () => {
+  it('should call softDeleteEntryAction for each ID and return success', async () => {
     (requireApiPermission as jest.Mock).mockResolvedValue(undefined);
-    (verifyEntityInScope as jest.Mock).mockResolvedValue(true);
-    mockSupabase.rpc.mockResolvedValue({ error: null });
+    (getAccessibleHaeuserIds as jest.Mock).mockResolvedValue(null); // unrestricted
+    (softDeleteEntryAction as jest.Mock).mockResolvedValue(undefined);
 
     const request = {
       json: jest.fn().mockResolvedValue({ ids: ['id-1', 'id-2'] }),
@@ -74,21 +72,15 @@ describe('POST /api/haeuser/bulk-delete', () => {
     const body = await response.json();
     expect(body.successCount).toBe(2);
 
-    expect(mockSupabase.rpc).toHaveBeenCalledTimes(2);
-    expect(mockSupabase.rpc).toHaveBeenNthCalledWith(1, 'soft_delete_record', {
-      p_table_name: 'Haeuser',
-      p_record_id: 'id-1',
-    });
-    expect(mockSupabase.rpc).toHaveBeenNthCalledWith(2, 'soft_delete_record', {
-      p_table_name: 'Haeuser',
-      p_record_id: 'id-2',
-    });
+    expect(softDeleteEntryAction).toHaveBeenCalledTimes(2);
+    expect(softDeleteEntryAction).toHaveBeenNthCalledWith(1, 'Haeuser', 'id-1');
+    expect(softDeleteEntryAction).toHaveBeenNthCalledWith(2, 'Haeuser', 'id-2');
   });
 
-  it('should return 500 if supabase RPC fails', async () => {
+  it('should return 500 if softDeleteEntryAction fails', async () => {
     (requireApiPermission as jest.Mock).mockResolvedValue(undefined);
-    (verifyEntityInScope as jest.Mock).mockResolvedValue(true);
-    mockSupabase.rpc.mockResolvedValue({ error: { message: 'Database error' } });
+    (getAccessibleHaeuserIds as jest.Mock).mockResolvedValue(null);
+    (softDeleteEntryAction as jest.Mock).mockRejectedValue(new Error('Database error'));
 
     const request = {
       json: jest.fn().mockResolvedValue({ ids: ['id-1'] }),

--- a/app/api/apartments/bulk-delete/route.ts
+++ b/app/api/apartments/bulk-delete/route.ts
@@ -6,7 +6,7 @@ export const runtime = 'edge';
 
 export async function POST(request: Request) {
   try {
-    const { requireApiPermission, verifyEntityInScope } = await import("@/lib/api-permissions");
+    const { requireApiPermission } = await import("@/lib/api-permissions");
     await requireApiPermission('wohnungen', 'loeschen');
 
     const supabase = await createClient()
@@ -39,25 +39,19 @@ export async function POST(request: Request) {
       }
     }
 
-    let successCount = 0;
-    for (const id of ids) {
-      const { error } = await supabase.rpc('soft_delete_record', {
-        p_table_name: 'Wohnungen',
-        p_record_id: id,
-      });
-
-      if (error) {
-        console.error(`Supabase Bulk Delete Error for Wohnung ${id}:`, error);
-        return NextResponse.json(
-          { error: error.message },
-          { status: 500, headers: NO_CACHE_HEADERS }
-        )
-      }
-      successCount++;
+    try {
+      const { softDeleteEntryAction } = await import("@/lib/papierkorb/utils");
+      await Promise.all(ids.map(id => softDeleteEntryAction("Wohnungen", id)));
+    } catch (error: any) {
+      console.error("Supabase Bulk Delete Error for Wohnungen:", error);
+      return NextResponse.json(
+        { error: error.message },
+        { status: 500, headers: NO_CACHE_HEADERS }
+      )
     }
 
     return NextResponse.json(
-      { successCount },
+      { successCount: ids.length },
       { status: 200, headers: NO_CACHE_HEADERS }
     )
   } catch (e) {

--- a/app/api/apartments/bulk-delete/route.ts
+++ b/app/api/apartments/bulk-delete/route.ts
@@ -39,22 +39,25 @@ export async function POST(request: Request) {
       }
     }
 
-    const { data, error } = await supabase
-      .from('Wohnungen')
-      .delete()
-      .in('id', ids)
-      .select()
+    let successCount = 0;
+    for (const id of ids) {
+      const { error } = await supabase.rpc('soft_delete_record', {
+        p_table_name: 'Wohnungen',
+        p_record_id: id,
+      });
 
-    if (error) {
-      console.error("Supabase Bulk Delete Error:", error)
-      return NextResponse.json(
-        { error: error.message },
-        { status: 500, headers: NO_CACHE_HEADERS }
-      )
+      if (error) {
+        console.error(`Supabase Bulk Delete Error for Wohnung ${id}:`, error);
+        return NextResponse.json(
+          { error: error.message },
+          { status: 500, headers: NO_CACHE_HEADERS }
+        )
+      }
+      successCount++;
     }
 
     return NextResponse.json(
-      { successCount: data?.length || 0 },
+      { successCount },
       { status: 200, headers: NO_CACHE_HEADERS }
     )
   } catch (e) {

--- a/app/api/finanzen/bulk-delete/route.ts
+++ b/app/api/finanzen/bulk-delete/route.ts
@@ -42,22 +42,26 @@ export async function POST(
       }
     }
     
-    // Delete all selected finance records in a single transaction
-    const { data, error } = await supabase
-      .from('Finanzen')
-      .delete()
-      .in('id', ids);
-      
-    if (error) {
-      console.error('Bulk delete error:', error);
-      return NextResponse.json(
-        { error: 'Fehler beim Löschen der Transaktionen' }, 
-        { status: 500, headers: NO_CACHE_HEADERS }
-      );
+    // Delete all selected finance records
+    let successCount = 0;
+    for (const id of ids) {
+      const { error } = await supabase.rpc('soft_delete_record', {
+        p_table_name: 'Finanzen',
+        p_record_id: id,
+      });
+
+      if (error) {
+        console.error(`Supabase Bulk Delete Error for Finanzen ${id}:`, error);
+        return NextResponse.json(
+          { error: error.message },
+          { status: 500, headers: NO_CACHE_HEADERS }
+        );
+      }
+      successCount++;
     }
     
     return NextResponse.json(
-      { success: true, count: ids.length }, 
+      { success: true, count: successCount }, 
       { status: 200, headers: NO_CACHE_HEADERS }
     );
     

--- a/app/api/finanzen/bulk-delete/route.ts
+++ b/app/api/finanzen/bulk-delete/route.ts
@@ -8,7 +8,7 @@ export async function POST(
   request: NextRequest
 ): Promise<NextResponse> {
   try {
-    const { requireApiPermission, verifyWohnungInScope } = await import("@/lib/api-permissions");
+    const { requireApiPermission } = await import("@/lib/api-permissions");
     await requireApiPermission('finanzen', 'loeschen');
 
     const { ids } = await request.json();
@@ -42,26 +42,29 @@ export async function POST(
       }
     }
     
-    // Delete all selected finance records
-    let successCount = 0;
-    for (const id of ids) {
-      const { error } = await supabase.rpc('soft_delete_record', {
-        p_table_name: 'Finanzen',
-        p_record_id: id,
-      });
-
-      if (error) {
-        console.error(`Supabase Bulk Delete Error for Finanzen ${id}:`, error);
-        return NextResponse.json(
-          { error: error.message },
-          { status: 500, headers: NO_CACHE_HEADERS }
-        );
-      }
-      successCount++;
+    // Delete all selected finance records concurrently
+    try {
+      await Promise.all(
+        ids.map(async (id) => {
+          const { error } = await supabase.rpc('soft_delete_record', {
+            p_table_name: 'Finanzen',
+            p_record_id: id,
+          });
+          if (error) {
+            console.error("Supabase Bulk Delete Error for Finanzen:", id, error);
+            throw new Error(error.message);
+          }
+        })
+      );
+    } catch (error: any) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 500, headers: NO_CACHE_HEADERS }
+      );
     }
     
     return NextResponse.json(
-      { success: true, count: successCount }, 
+      { success: true, count: ids.length }, 
       { status: 200, headers: NO_CACHE_HEADERS }
     );
     

--- a/app/api/haeuser/bulk-delete/route.ts
+++ b/app/api/haeuser/bulk-delete/route.ts
@@ -6,10 +6,9 @@ export const runtime = 'edge';
 
 export async function POST(request: Request) {
   try {
-    const { requireApiPermission, verifyEntityInScope } = await import("@/lib/api-permissions");
+    const { requireApiPermission } = await import("@/lib/api-permissions");
     await requireApiPermission('haeuser', 'loeschen');
 
-    const supabase = await createClient()
     const { ids } = await request.json()
 
     if (!ids || !Array.isArray(ids) || ids.length === 0) {
@@ -20,8 +19,11 @@ export async function POST(request: Request) {
     }
 
     // Verify all houses are in user's scope
-    for (const id of ids) {
-      if (!(await verifyEntityInScope(id))) {
+    const { getAccessibleHaeuserIds } = await import("@/lib/object-scope");
+    const accessibleHaeuserIds = await getAccessibleHaeuserIds();
+    if (accessibleHaeuserIds !== null) {
+      const inaccessibleId = ids.find(id => !accessibleHaeuserIds.includes(id));
+      if (inaccessibleId) {
         return NextResponse.json(
           { error: "Permission denied" },
           { status: 403, headers: NO_CACHE_HEADERS }
@@ -29,25 +31,19 @@ export async function POST(request: Request) {
       }
     }
 
-    let successCount = 0;
-    for (const id of ids) {
-      const { error } = await supabase.rpc('soft_delete_record', {
-        p_table_name: 'Haeuser',
-        p_record_id: id,
-      });
-
-      if (error) {
-        console.error(`Supabase Bulk Delete Error for house ${id}:`, error);
-        return NextResponse.json(
-          { error: error.message },
-          { status: 500, headers: NO_CACHE_HEADERS }
-        )
-      }
-      successCount++;
+    try {
+      const { softDeleteEntryAction } = await import("@/lib/papierkorb/utils");
+      await Promise.all(ids.map(id => softDeleteEntryAction("Haeuser", id)));
+    } catch (error: any) {
+      console.error("Supabase Bulk Delete Error for Haeuser:", error);
+      return NextResponse.json(
+        { error: error.message },
+        { status: 500, headers: NO_CACHE_HEADERS }
+      )
     }
 
     return NextResponse.json(
-      { successCount },
+      { successCount: ids.length },
       { status: 200, headers: NO_CACHE_HEADERS }
     )
   } catch (e) {
@@ -59,4 +55,5 @@ export async function POST(request: Request) {
     )
   }
 }
+
 

--- a/app/api/haeuser/bulk-delete/route.ts
+++ b/app/api/haeuser/bulk-delete/route.ts
@@ -6,6 +6,9 @@ export const runtime = 'edge';
 
 export async function POST(request: Request) {
   try {
+    const { requireApiPermission, verifyEntityInScope } = await import("@/lib/api-permissions");
+    await requireApiPermission('haeuser', 'loeschen');
+
     const supabase = await createClient()
     const { ids } = await request.json()
 
@@ -16,29 +19,44 @@ export async function POST(request: Request) {
       )
     }
 
-    const { data, error } = await supabase
-      .from('Haeuser')
-      .delete()
-      .in('id', ids)
-      .select()
+    // Verify all houses are in user's scope
+    for (const id of ids) {
+      if (!(await verifyEntityInScope(id))) {
+        return NextResponse.json(
+          { error: "Permission denied" },
+          { status: 403, headers: NO_CACHE_HEADERS }
+        )
+      }
+    }
 
-    if (error) {
-      console.error("Supabase Bulk Delete Error:", error)
-      return NextResponse.json(
-        { error: error.message },
-        { status: 500, headers: NO_CACHE_HEADERS }
-      )
+    let successCount = 0;
+    for (const id of ids) {
+      const { error } = await supabase.rpc('soft_delete_record', {
+        p_table_name: 'Haeuser',
+        p_record_id: id,
+      });
+
+      if (error) {
+        console.error(`Supabase Bulk Delete Error for house ${id}:`, error);
+        return NextResponse.json(
+          { error: error.message },
+          { status: 500, headers: NO_CACHE_HEADERS }
+        )
+      }
+      successCount++;
     }
 
     return NextResponse.json(
-      { successCount: data?.length || 0 },
+      { successCount },
       { status: 200, headers: NO_CACHE_HEADERS }
     )
   } catch (e) {
     console.error("POST /api/haeuser/bulk-delete error:", e)
+    const status = (e as Error).message === 'Permission denied' ? 403 : 500
     return NextResponse.json(
-      { error: "Serverfehler beim Löschen der Häuser." },
-      { status: 500, headers: NO_CACHE_HEADERS }
+      { error: (e as Error).message || "Serverfehler beim Löschen der Häuser." },
+      { status, headers: NO_CACHE_HEADERS }
     )
   }
 }
+

--- a/app/api/mieter/bulk-delete/route.ts
+++ b/app/api/mieter/bulk-delete/route.ts
@@ -39,22 +39,25 @@ export async function POST(request: Request) {
       }
     }
 
-    const { data, error } = await supabase
-      .from('Mieter')
-      .delete()
-      .in('id', ids)
-      .select()
+    let successCount = 0;
+    for (const id of ids) {
+      const { error } = await supabase.rpc('soft_delete_record', {
+        p_table_name: 'Mieter',
+        p_record_id: id,
+      });
 
-    if (error) {
-      console.error("Supabase Bulk Delete Error:", error)
-      return NextResponse.json(
-        { error: error.message },
-        { status: 500, headers: NO_CACHE_HEADERS }
-      )
+      if (error) {
+        console.error(`Supabase Bulk Delete Error for Mieter ${id}:`, error);
+        return NextResponse.json(
+          { error: error.message },
+          { status: 500, headers: NO_CACHE_HEADERS }
+        )
+      }
+      successCount++;
     }
 
     return NextResponse.json(
-      { successCount: data?.length || 0 },
+      { successCount },
       { status: 200, headers: NO_CACHE_HEADERS }
     )
   } catch (e) {

--- a/app/api/mieter/bulk-delete/route.ts
+++ b/app/api/mieter/bulk-delete/route.ts
@@ -6,7 +6,7 @@ export const runtime = 'edge';
 
 export async function POST(request: Request) {
   try {
-    const { requireApiPermission, verifyWohnungInScope } = await import("@/lib/api-permissions");
+    const { requireApiPermission } = await import("@/lib/api-permissions");
     await requireApiPermission('mieter', 'loeschen');
 
     const supabase = await createClient()
@@ -39,25 +39,28 @@ export async function POST(request: Request) {
       }
     }
 
-    let successCount = 0;
-    for (const id of ids) {
-      const { error } = await supabase.rpc('soft_delete_record', {
-        p_table_name: 'Mieter',
-        p_record_id: id,
-      });
-
-      if (error) {
-        console.error(`Supabase Bulk Delete Error for Mieter ${id}:`, error);
-        return NextResponse.json(
-          { error: error.message },
-          { status: 500, headers: NO_CACHE_HEADERS }
-        )
-      }
-      successCount++;
+    try {
+      await Promise.all(
+        ids.map(async (id) => {
+          const { error } = await supabase.rpc('soft_delete_record', {
+            p_table_name: 'Mieter',
+            p_record_id: id,
+          });
+          if (error) {
+            console.error("Supabase Bulk Delete Error for Mieter:", id, error);
+            throw new Error(error.message);
+          }
+        })
+      );
+    } catch (error: any) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 500, headers: NO_CACHE_HEADERS }
+      )
     }
 
     return NextResponse.json(
-      { successCount },
+      { successCount: ids.length },
       { status: 200, headers: NO_CACHE_HEADERS }
     )
   } catch (e) {

--- a/app/betriebskosten-actions.ts
+++ b/app/betriebskosten-actions.ts
@@ -267,19 +267,15 @@ export async function bulkDeleteNebenkosten(ids: string[]) {
 
   try {
     const { softDeleteEntryAction } = await import("@/lib/papierkorb/utils");
-    let successCount = 0;
-    for (const id of ids) {
-      await softDeleteEntryAction("Nebenkosten", id);
-      successCount++;
-    }
+    await Promise.all(ids.map(id => softDeleteEntryAction("Nebenkosten", id)));
 
     // Invalidate cache and refresh data
     revalidatePath("/dashboard/betriebskosten");
 
     return {
       success: true,
-      count: successCount,
-      message: `${successCount} Betriebskostenabrechnung${successCount !== 1 ? 'en' : ''} erfolgreich gelöscht`
+      count: ids.length,
+      message: `${ids.length} Betriebskostenabrechnung${ids.length !== 1 ? 'en' : ''} erfolgreich gelöscht`
     };
   } catch (error) {
     console.error("Error bulk deleting Nebenkosten:", error);
@@ -419,9 +415,7 @@ export async function deleteRechnungenByNebenkostenId(nebenkostenId: string): Pr
   if (rechnungen && rechnungen.length > 0) {
     try {
       const { softDeleteEntryAction } = await import("@/lib/papierkorb/utils");
-      for (const r of rechnungen) {
-        await softDeleteEntryAction("Rechnungen", r.id);
-      }
+      await Promise.all(rechnungen.map(r => softDeleteEntryAction("Rechnungen", r.id)));
     } catch (err: any) {
       console.error('Error soft deleting Rechnungen for nebenkosten_id %s:', nebenkostenId, err);
       return { success: false, message: err.message };

--- a/app/betriebskosten-actions.ts
+++ b/app/betriebskosten-actions.ts
@@ -213,12 +213,10 @@ export async function deleteNebenkosten(id: string) {
     }
   }
 
-  const { error } = await supabase
-    .from("Nebenkosten")
-    .delete()
-    .eq("id", id);
-
-  if (error) {
+  try {
+    const { softDeleteEntryAction } = await import("@/lib/papierkorb/utils");
+    await softDeleteEntryAction("Nebenkosten", id);
+  } catch (error: any) {
     logAction(actionName, 'error', { nebenkosten_id: id, error_message: error.message });
     return { success: false, message: error.message };
   }
@@ -268,21 +266,20 @@ export async function bulkDeleteNebenkosten(ids: string[]) {
 
 
   try {
-    // Use in_ operator to delete multiple records in a single query
-    const { count, error } = await supabase
-      .from("Nebenkosten")
-      .delete()
-      .in("id", ids);
-
-    if (error) throw error;
+    const { softDeleteEntryAction } = await import("@/lib/papierkorb/utils");
+    let successCount = 0;
+    for (const id of ids) {
+      await softDeleteEntryAction("Nebenkosten", id);
+      successCount++;
+    }
 
     // Invalidate cache and refresh data
     revalidatePath("/dashboard/betriebskosten");
 
     return {
       success: true,
-      count: count || 0,
-      message: `${count} Betriebskostenabrechnung${count !== 1 ? 'en' : ''} erfolgreich gelöscht`
+      count: successCount,
+      message: `${successCount} Betriebskostenabrechnung${successCount !== 1 ? 'en' : ''} erfolgreich gelöscht`
     };
   } catch (error) {
     console.error("Error bulk deleting Nebenkosten:", error);
@@ -408,14 +405,27 @@ export async function deleteRechnungenByNebenkostenId(nebenkostenId: string): Pr
     }
   }
 
-  const { error } = await supabase
+  // Fetch Rechnungen for this Nebenkosten ID
+  const { data: rechnungen, error: fetchError } = await supabase
     .from("Rechnungen")
-    .delete()
+    .select("id")
     .eq("nebenkosten_id", nebenkostenId);
 
-  if (error) {
-    console.error('Error deleting Rechnungen for nebenkosten_id %s:', nebenkostenId, error);
-    return { success: false, message: error.message };
+  if (fetchError) {
+    console.error('Error fetching Rechnungen for deletion:', fetchError);
+    return { success: false, message: fetchError.message };
+  }
+
+  if (rechnungen && rechnungen.length > 0) {
+    try {
+      const { softDeleteEntryAction } = await import("@/lib/papierkorb/utils");
+      for (const r of rechnungen) {
+        await softDeleteEntryAction("Rechnungen", r.id);
+      }
+    } catch (err: any) {
+      console.error('Error soft deleting Rechnungen for nebenkosten_id %s:', nebenkostenId, err);
+      return { success: false, message: err.message };
+    }
   }
 
   console.log(`[Server Action] Successfully deleted Rechnungen for nebenkosten_id ${nebenkostenId}`);

--- a/app/meter-actions.ts
+++ b/app/meter-actions.ts
@@ -528,15 +528,8 @@ export async function deleteZaehler(id: string) {
       return { success: false, message: "Zähler nicht gefunden." };
     }
 
-    const { error } = await supabase
-      .from("Zaehler")
-      .delete()
-      .eq("id", id);
-
-    if (error) {
-      console.error("Error deleting meter:", error);
-      return { success: false, message: error.message };
-    }
+    const { softDeleteEntryAction } = await import("@/lib/papierkorb/utils");
+    await softDeleteEntryAction("Zaehler", id);
 
     revalidatePath("/betriebskosten");
     return { success: true };
@@ -742,15 +735,8 @@ export async function deleteAblesung(id: string) {
 
   try {
 
-    const { error } = await supabase
-      .from("Zaehler_Ablesungen")
-      .delete()
-      .eq("id", id);
-
-    if (error) {
-      console.error("Error deleting reading:", error);
-      return { success: false, message: error.message };
-    }
+    const { softDeleteEntryAction } = await import("@/lib/papierkorb/utils");
+    await softDeleteEntryAction("Zaehler_Ablesungen", id);
 
     revalidatePath("/betriebskosten");
     return { success: true };

--- a/app/mieter-actions.ts
+++ b/app/mieter-actions.ts
@@ -552,9 +552,7 @@ export async function deleteAllApplicantsAction(): Promise<{ success: boolean; e
 
     if (applicants && applicants.length > 0) {
       const { softDeleteEntryAction } = await import("@/lib/papierkorb/utils");
-      for (const applicant of applicants) {
-        await softDeleteEntryAction("Mieter", applicant.id);
-      }
+      await Promise.all(applicants.map(applicant => softDeleteEntryAction("Mieter", applicant.id)));
     }
 
     revalidatePath('/mieter');

--- a/app/mieter-actions.ts
+++ b/app/mieter-actions.ts
@@ -538,16 +538,23 @@ export async function deleteAllApplicantsAction(): Promise<{ success: boolean; e
     }
     
     const wohnungIds = await getAccessibleWohnungIds();
-    let query = supabase.from('Mieter').delete().eq('status', 'bewerber');
+    let fetchQuery = supabase.from('Mieter').select('id').eq('status', 'bewerber');
     if (wohnungIds !== null) {
-      query = query.in('wohnung_id', wohnungIds);
+      fetchQuery = fetchQuery.in('wohnung_id', wohnungIds);
     }
 
-    const { error } = await query;
+    const { data: applicants, error: fetchError } = await fetchQuery;
 
-    if (error) {
-      console.error('Error deleting all applicants:', error);
-      return { success: false, error: { message: error.message } };
+    if (fetchError) {
+      console.error('Error fetching applicants for deletion:', fetchError);
+      return { success: false, error: { message: fetchError.message } };
+    }
+
+    if (applicants && applicants.length > 0) {
+      const { softDeleteEntryAction } = await import("@/lib/papierkorb/utils");
+      for (const applicant of applicants) {
+        await softDeleteEntryAction("Mieter", applicant.id);
+      }
     }
 
     revalidatePath('/mieter');


### PR DESCRIPTION
## Description

Converts the remaining hard deletes to soft deletes so records land in the Papierkorb (trash) instead of being permanently removed, and adds permission + object-scope checks to the houses bulk-delete route.

## Summary of Changes

- Bulk-delete API routes (wohnungen, finanzen, haeuser, mieter): replace `.delete()` with `softDeleteEntryAction` / `soft_delete_record` RPC
- `api/haeuser/bulk-delete`: add `requireApiPermission('haeuser', 'loeschen')` and object-scope verification (403 for inaccessible IDs)
- `betriebskosten-actions.ts`: deleteNebenkosten, bulkDeleteNebenkosten and deleteRechnungenByNebenkostenId now soft delete
- `meter-actions.ts`: deleteZaehler and deleteAblesung soft delete
- `mieter-actions.ts`: deleteAllApplicantsAction soft deletes applicants
- New test suite `__tests__/api/haeuser/bulk-delete.test.ts` (validation, permission, scope, success and error cases)