### PR TITLE
feat: implement audit log UI in organization settings with lazy loadi…

### DIFF
--- a/app/(dashboard)/organisation/client-wrapper.tsx
+++ b/app/(dashboard)/organisation/client-wrapper.tsx
@@ -43,6 +43,7 @@ import {
 
 import { MitgliedPermissionDetail } from "@/components/organisation/mitglied-permission-detail";
 import { OrganisationPoliciesTab } from "@/components/organisation/organisation-policies-tab";
+import { OrganisationAuditLogTab } from "@/components/organisation/organisation-audit-log-tab";
 
 
 interface Member {
@@ -82,7 +83,7 @@ interface OrganisationClientViewProps {
 }
 
 type UiState = {
-  currentTab: "overview" | "members" | "policies";
+  currentTab: "overview" | "members" | "policies" | "audit_log";
   searchQuery: string;
   roleFilter: string;
   statusFilter: string;
@@ -99,7 +100,7 @@ type UiState = {
 };
 
 type UiAction =
-  | { type: 'SET_TAB'; payload: "overview" | "members" | "policies" }
+  | { type: 'SET_TAB'; payload: "overview" | "members" | "policies" | "audit_log" }
   | { type: 'SET_SEARCH_QUERY'; payload: string }
   | { type: 'SET_ROLE_FILTER'; payload: string }
   | { type: 'SET_STATUS_FILTER'; payload: string }
@@ -148,23 +149,18 @@ function uiReducer(state: UiState, action: UiAction): UiState {
   }
 }
 
-// Extracted sub-components for maintainability
-const ORG_TABS = [
-  { value: "overview" as const, label: "Übersicht", icon: Network },
-  { value: "members" as const, label: "Mitarbeiter", icon: Users },
-  { value: "policies" as const, label: "Richtlinien", icon: Shield },
-];
-
 function OrganisationTabToggle({
   currentTab,
-  onTabChange
+  onTabChange,
+  tabs
 }: {
-  currentTab: "overview" | "members" | "policies";
-  onTabChange: (tab: "overview" | "members" | "policies") => void;
+  currentTab: "overview" | "members" | "policies" | "audit_log";
+  onTabChange: (tab: "overview" | "members" | "policies" | "audit_log") => void;
+  tabs: any[];
 }) {
   return (
     <AnimatedPillToggle
-      tabs={ORG_TABS}
+      tabs={tabs}
       activeTab={currentTab}
       onTabChange={onTabChange}
       layoutId="active-org-tab-pill"
@@ -870,6 +866,26 @@ export default function OrganisationClientView({
 
   const hasVerwaltenPermission = canManage || isUserOwner;
 
+  const isOwnerOrAdmin = useMemo(() => {
+    return members.some(
+      m => m.user_id === currentUser?.id && 
+           m.status === 'aktiv' && 
+           (m.rolle === 'owner' || m.rolle === 'admin')
+    );
+  }, [members, currentUser]);
+
+  const orgTabs = useMemo(() => {
+    const list: { value: "overview" | "members" | "policies" | "audit_log"; label: string; icon: any }[] = [
+      { value: "overview", label: "Übersicht", icon: Network },
+      { value: "members", label: "Mitarbeiter", icon: Users },
+      { value: "policies", label: "Richtlinien", icon: Shield },
+    ];
+    if (isOwnerOrAdmin) {
+      list.push({ value: "audit_log" as const, label: "Audit-Log", icon: Clock });
+    }
+    return list;
+  }, [isOwnerOrAdmin]);
+
   const {
     handleInvite,
     handleRevoke,
@@ -940,6 +956,7 @@ export default function OrganisationClientView({
       <OrganisationTabToggle
         currentTab={uiState.currentTab}
         onTabChange={(tab) => dispatch({ type: 'SET_TAB', payload: tab })}
+        tabs={orgTabs}
       />
 
       {uiState.currentTab === "overview" && <OrganisationOverviewTab stats={stats} />}
@@ -979,6 +996,11 @@ export default function OrganisationClientView({
           hasVerwaltenPermission={hasVerwaltenPermission}
         />
       )}
+
+      {uiState.currentTab === "audit_log" && isOwnerOrAdmin && (
+        <OrganisationAuditLogTab />
+      )}
+
 
       <OrganisationConfirmDialog
         pendingConfirm={uiState.pendingConfirm}

--- a/app/organisation-actions.ts
+++ b/app/organisation-actions.ts
@@ -553,14 +553,22 @@ export const getAuditLogsAction = withLogging(
   'getAuditLogs',
   async (
     limit: number,
-    offset: number
+    offset: number,
+    tableName?: string,
+    actionType?: string
   ): Promise<{ success: boolean; data?: any[]; error?: { message: string } }> => {
     try {
       const { user, supabase } = await ensureAuth();
+
+      if (!(await hasPermission('organisation', 'verwalten'))) {
+        return { success: false, error: { message: "Keine Berechtigung zum Anzeigen der Audit-Logs." } };
+      }
       
       const { data, error } = await supabase.rpc('get_organisation_audit_log', {
         p_limit: limit,
-        p_offset: offset
+        p_offset: offset,
+        p_table_name: tableName || null,
+        p_action: actionType || null
       });
 
       if (error) {
@@ -585,6 +593,10 @@ export const getAuditLogDetailsAction = withLogging(
   ): Promise<{ success: boolean; data?: any; error?: { message: string } }> => {
     try {
       const { user, supabase } = await ensureAuth();
+
+      if (!(await hasPermission('organisation', 'verwalten'))) {
+        return { success: false, error: { message: "Keine Berechtigung zum Anzeigen der Audit-Log-Details." } };
+      }
       
       const { data, error } = await supabase.rpc('get_audit_log_details', {
         p_audit_log_id: auditLogId

--- a/app/organisation-actions.ts
+++ b/app/organisation-actions.ts
@@ -546,4 +546,61 @@ export const switchOrganisationAction = withLogging(
   }
 );
 
+/**
+ * Fetches audit logs for the current organization (paginated, brief view).
+ */
+export const getAuditLogsAction = withLogging(
+  'getAuditLogs',
+  async (
+    limit: number,
+    offset: number
+  ): Promise<{ success: boolean; data?: any[]; error?: { message: string } }> => {
+    try {
+      const { user, supabase } = await ensureAuth();
+      
+      const { data, error } = await supabase.rpc('get_organisation_audit_log', {
+        p_limit: limit,
+        p_offset: offset
+      });
+
+      if (error) {
+        return { success: false, error: { message: error.message } };
+      }
+
+      return { success: true, data: data || [] };
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Fehler beim Laden der Audit-Logs";
+      return { success: false, error: { message: msg } };
+    }
+  }
+);
+
+/**
+ * Fetches detail view for a specific audit log record.
+ */
+export const getAuditLogDetailsAction = withLogging(
+  'getAuditLogDetails',
+  async (
+    auditLogId: string
+  ): Promise<{ success: boolean; data?: any; error?: { message: string } }> => {
+    try {
+      const { user, supabase } = await ensureAuth();
+      
+      const { data, error } = await supabase.rpc('get_audit_log_details', {
+        p_audit_log_id: auditLogId
+      });
+
+      if (error) {
+        return { success: false, error: { message: error.message } };
+      }
+
+      return { success: true, data: data?.[0] || null };
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Fehler beim Laden des Audit-Log-Details";
+      return { success: false, error: { message: msg } };
+    }
+  }
+);
+
+
 

--- a/app/organisation-actions.ts
+++ b/app/organisation-actions.ts
@@ -567,8 +567,8 @@ export const getAuditLogsAction = withLogging(
       const { data, error } = await supabase.rpc('get_organisation_audit_log', {
         p_limit: limit,
         p_offset: offset,
-        p_table_name: tableName || null,
-        p_action: actionType || null
+        p_tabellenname: tableName || null,
+        p_aktion: actionType || null
       });
 
       if (error) {

--- a/components/organisation/organisation-audit-log-tab.tsx
+++ b/components/organisation/organisation-audit-log-tab.tsx
@@ -1,0 +1,526 @@
+"use client";
+
+import { useState, useEffect, useTransition } from "react";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { getAuditLogsAction, getAuditLogDetailsAction } from "@/app/organisation-actions";
+import { 
+  Clock, 
+  Database, 
+  User, 
+  Eye, 
+  RefreshCw, 
+  FileJson, 
+  ListFilter,
+  ChevronLeft,
+  ChevronRight,
+  Info
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface AuditLogSummary {
+  id: string;
+  organisation_id: string;
+  table_name: string;
+  record_id: string;
+  action: 'INSERT' | 'UPDATE' | 'DELETE' | 'SOFT_DELETE' | 'RESTORE';
+  changed_by: string | null;
+  changed_by_name: string;
+  changed_by_email: string | null;
+  changed_at: string;
+}
+
+interface AuditLogDetail extends AuditLogSummary {
+  old_data: any;
+  new_data: any;
+}
+
+// Map database table names to human-readable names
+const TABLE_NAME_MAP: Record<string, string> = {
+  Haeuser: "Häuser",
+  Wohnungen: "Wohnungen",
+  Mieter: "Mieter",
+  Finanzen: "Finanzen",
+  Dokumente_Metadaten: "Dokumente",
+  Aufgaben: "Aufgaben",
+  Nebenkosten: "Nebenkosten",
+  Zaehler: "Zähler",
+  Zaehler_Ablesungen: "Ablesungen",
+  Rechnungen: "Rechnungen",
+  Vorlagen: "Vorlagen",
+};
+
+export function OrganisationAuditLogTab() {
+  const [logs, setLogs] = useState<AuditLogSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  
+  // Pagination State
+  const [page, setPage] = useState(1);
+  const limit = 15;
+  const [hasMore, setHasMore] = useState(true);
+
+  // Filter States
+  const [filterTable, setFilterTable] = useState<string>("all");
+  const [filterAction, setFilterAction] = useState<string>("all");
+
+  // Details Sheet State
+  const [detailedLog, setDetailedLog] = useState<AuditLogDetail | null>(null);
+  const [isDetailsLoading, setIsDetailsLoading] = useState(false);
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+
+  const [, startTransition] = useTransition();
+
+  // Load log summary list
+  const fetchLogs = (currentPage: number) => {
+    setIsLoading(true);
+    setError(null);
+    const offset = (currentPage - 1) * limit;
+
+    startTransition(async () => {
+      const res = await getAuditLogsAction(limit + 1, offset); // Request limit + 1 to check if there is a next page
+      if (res.success && res.data) {
+        const hasNext = res.data.length > limit;
+        const pageData = hasNext ? res.data.slice(0, limit) : res.data;
+        
+        setLogs(pageData as AuditLogSummary[]);
+        setHasMore(hasNext);
+      } else {
+        setError(res.error?.message || "Fehler beim Laden des Audit-Logs.");
+      }
+      setIsLoading(false);
+    });
+  };
+
+  useEffect(() => {
+    fetchLogs(page);
+  }, [page]);
+
+  // Load detailed log on selection
+  const handleSelectLog = (logId: string) => {
+    setIsDetailsLoading(true);
+    setIsSheetOpen(true);
+    setDetailedLog(null);
+
+    startTransition(async () => {
+      const res = await getAuditLogDetailsAction(logId);
+      if (res.success && res.data) {
+        setDetailedLog(res.data as AuditLogDetail);
+      } else {
+        setError(res.error?.message || "Fehler beim Laden der Details.");
+        setIsSheetOpen(false);
+      }
+      setIsDetailsLoading(false);
+    });
+  };
+
+  // Filter logic (Client-side filtering for immediate feedback, database pagination for loading chunks)
+  const filteredLogs = logs.filter(log => {
+    const matchesTable = filterTable === "all" || log.table_name === filterTable;
+    const matchesAction = filterAction === "all" || log.action === filterAction;
+    return matchesTable && matchesAction;
+  });
+
+  const getActionBadgeColor = (action: AuditLogSummary['action']) => {
+    switch (action) {
+      case 'INSERT':
+        return 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20';
+      case 'UPDATE':
+        return 'bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20';
+      case 'SOFT_DELETE':
+        return 'bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20';
+      case 'RESTORE':
+        return 'bg-teal-500/10 text-teal-600 dark:text-teal-400 border-teal-500/20';
+      case 'DELETE':
+        return 'bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/20';
+      default:
+        return 'bg-zinc-500/10 text-zinc-600 dark:text-zinc-400 border-zinc-500/20';
+    }
+  };
+
+  const formatValue = (val: any): string => {
+    if (val === null || val === undefined) return 'NULL';
+    if (typeof val === 'object') return JSON.stringify(val);
+    if (typeof val === 'boolean') return val ? 'Ja' : 'Nein';
+    return String(val);
+  };
+
+  const renderDiff = (action: string, oldData: any, newData: any) => {
+    const oldObj = oldData || {};
+    const newObj = newData || {};
+
+    if (action === 'INSERT') {
+      return (
+        <div className="space-y-1.5 border rounded-lg p-3 bg-muted/20">
+          {Object.entries(newObj).map(([key, val]) => (
+            <div key={key} className="grid grid-cols-3 py-1.5 border-b border-border/40 last:border-0 text-sm">
+              <span className="font-medium text-muted-foreground col-span-1">{key}</span>
+              <span className="text-foreground col-span-2 break-all font-mono text-xs">{formatValue(val)}</span>
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    if (action === 'DELETE' || action === 'SOFT_DELETE') {
+      return (
+        <div className="space-y-1.5 border rounded-lg p-3 bg-muted/20">
+          {Object.entries(oldObj).map(([key, val]) => (
+            <div key={key} className="grid grid-cols-3 py-1.5 border-b border-border/40 last:border-0 text-sm">
+              <span className="font-medium text-muted-foreground col-span-1">{key}</span>
+              <span className="text-foreground col-span-2 line-through opacity-70 break-all font-mono text-xs">{formatValue(val)}</span>
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    // UPDATE or RESTORE diffing
+    const allKeys = Array.from(new Set([...Object.keys(oldObj), ...Object.keys(newObj)]));
+    // Filter out common irrelevant keys or ignore unchanged ones
+    const changedKeys = allKeys.filter(k => {
+      // Exclude generated fields from showing as changed if they only differ by minor format/precision
+      const oldVal = oldObj[k];
+      const newVal = newObj[k];
+      return JSON.stringify(oldVal) !== JSON.stringify(newVal);
+    });
+
+    if (changedKeys.length === 0) {
+      return (
+        <div className="flex items-center gap-2 p-4 rounded-lg bg-zinc-50 border border-zinc-100 dark:bg-zinc-950/20 dark:border-zinc-900/40 text-sm text-muted-foreground">
+          <Info className="size-4 shrink-0 text-zinc-500" />
+          <span>Keine geänderten Felder vorhanden (z.B. nur interne Metadaten oder unberührte Relationen).</span>
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-3">
+        {changedKeys.map(key => (
+          <div key={key} className="border rounded-lg p-3 bg-muted/10 space-y-2">
+            <div className="font-semibold text-xs text-muted-foreground uppercase tracking-wider">{key}</div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs font-mono">
+              <div className="p-2 rounded bg-rose-500/10 border border-rose-500/20 text-rose-700 dark:text-rose-400">
+                <div className="text-[10px] text-rose-500/80 mb-1 font-sans uppercase font-bold">Vorher:</div>
+                <span className="line-through break-all">{formatValue(oldObj[key])}</span>
+              </div>
+              <div className="p-2 rounded bg-emerald-500/10 border border-emerald-500/20 text-emerald-700 dark:text-emerald-400">
+                <div className="text-[10px] text-emerald-500/80 mb-1 font-sans uppercase font-bold">Nachher:</div>
+                <span className="break-all">{formatValue(newObj[key])}</span>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <Card className="shadow-sm border-border/50">
+      <CardHeader>
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+          <div>
+            <CardTitle className="text-xl flex items-center gap-2">
+              <Clock className="size-5 text-indigo-500" />
+              Audit-Log
+            </CardTitle>
+            <CardDescription>
+              Vollständiges Protokoll aller Änderungen an Häusern, Wohnungen, Mietern, Finanzen und mehr.
+            </CardDescription>
+          </div>
+          
+          <Button 
+            variant="outline" 
+            size="sm" 
+            className="w-full md:w-auto flex items-center gap-1.5"
+            onClick={() => fetchLogs(page)}
+            disabled={isLoading}
+          >
+            <RefreshCw className={cn("size-3.5", isLoading && "animate-spin")} />
+            Aktualisieren
+          </Button>
+        </div>
+
+        {/* Filters */}
+        <div className="flex flex-col sm:flex-row gap-3 pt-4 border-t border-border/40 mt-2">
+          <div className="flex-1 max-w-[240px]">
+            <label className="text-xs font-medium text-muted-foreground mb-1 block">Tabelle filtern</label>
+            <Select value={filterTable} onValueChange={setFilterTable}>
+              <SelectTrigger>
+                <SelectValue placeholder="Alle Tabellen" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Alle Tabellen</SelectItem>
+                {Object.entries(TABLE_NAME_MAP).map(([dbName, label]) => (
+                  <SelectItem key={dbName} value={dbName}>{label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex-1 max-w-[200px]">
+            <label className="text-xs font-medium text-muted-foreground mb-1 block">Aktion filtern</label>
+            <Select value={filterAction} onValueChange={setFilterAction}>
+              <SelectTrigger>
+                <SelectValue placeholder="Alle Aktionen" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Alle Aktionen</SelectItem>
+                <SelectItem value="INSERT">Erstellen (INSERT)</SelectItem>
+                <SelectItem value="UPDATE">Bearbeiten (UPDATE)</SelectItem>
+                <SelectItem value="SOFT_DELETE">In Papierkorb (SOFT_DELETE)</SelectItem>
+                <SelectItem value="RESTORE">Wiederherstellen (RESTORE)</SelectItem>
+                <SelectItem value="DELETE">Endgültig löschen (DELETE)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </CardHeader>
+      
+      <CardContent>
+        {error && (
+          <div className="p-4 rounded-lg bg-rose-500/10 border border-rose-500/20 text-rose-600 dark:text-rose-400 text-sm mb-4">
+            {error}
+          </div>
+        )}
+
+        <div className="rounded-md border border-border/40">
+          <Table>
+            <TableHeader>
+              <TableRow className="hover:bg-transparent">
+                <TableHead className="w-[180px]">Zeitpunkt</TableHead>
+                <TableHead className="w-[150px]">Tabelle</TableHead>
+                <TableHead className="w-[140px]">Aktion</TableHead>
+                <TableHead>Geändert von</TableHead>
+                <TableHead className="text-right w-[100px]">Details</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                // Skeleton Loader
+                Array.from({ length: 5 }).map((_, i) => (
+                  <TableRow key={i}>
+                    <TableCell><div className="h-4 w-28 bg-muted animate-pulse rounded" /></TableCell>
+                    <TableCell><div className="h-4 w-20 bg-muted animate-pulse rounded" /></TableCell>
+                    <TableCell><div className="h-6 w-24 bg-muted animate-pulse rounded" /></TableCell>
+                    <TableCell><div className="h-4 w-40 bg-muted animate-pulse rounded" /></TableCell>
+                    <TableCell className="text-right"><div className="h-8 w-8 bg-muted animate-pulse rounded ml-auto" /></TableCell>
+                  </TableRow>
+                ))
+              ) : filteredLogs.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="h-32 text-center text-muted-foreground">
+                    Keine Einträge im Audit-Log gefunden.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                filteredLogs.map(log => (
+                  <TableRow 
+                    key={log.id} 
+                    className="group hover:bg-muted/50 cursor-pointer transition-colors"
+                    onClick={() => handleSelectLog(log.id)}
+                  >
+                    <TableCell className="font-medium whitespace-nowrap">
+                      {new Date(log.changed_at).toLocaleString("de-DE", {
+                        day: "2-digit",
+                        month: "2-digit",
+                        year: "numeric",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                        second: "2-digit"
+                      })}
+                    </TableCell>
+                    <TableCell>
+                      <span className="flex items-center gap-1.5">
+                        <Database className="size-3.5 text-zinc-400 shrink-0" />
+                        {TABLE_NAME_MAP[log.table_name] || log.table_name}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className={cn("px-2 py-0.5 font-semibold text-xs border uppercase rounded-full shadow-none", getActionBadgeColor(log.action))}>
+                        {log.action === 'SOFT_DELETE' ? 'Papierkorb' : log.action}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-col">
+                        <span className="font-semibold text-sm flex items-center gap-1.5">
+                          <User className="size-3.5 text-zinc-400 shrink-0" />
+                          {log.changed_by_name}
+                        </span>
+                        {log.changed_by_email && (
+                          <span className="text-xs text-muted-foreground pl-5">{log.changed_by_email}</span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button variant="ghost" size="icon" className="opacity-0 group-hover:opacity-100 transition-opacity">
+                        <Eye className="size-4 text-muted-foreground" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+
+        {/* Pagination controls */}
+        {!isLoading && logs.length > 0 && (
+          <div className="flex items-center justify-between pt-4">
+            <div className="text-xs text-muted-foreground">
+              Seite {page}
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                className="flex items-center gap-1"
+                disabled={page === 1 || isLoading}
+                onClick={() => setPage(p => Math.max(1, p - 1))}
+              >
+                <ChevronLeft className="size-4" />
+                Vorherige
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="flex items-center gap-1"
+                disabled={!hasMore || isLoading}
+                onClick={() => setPage(p => p + 1)}
+              >
+                Nächste
+                <ChevronRight className="size-4" />
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+
+      {/* Audit Log Entry Details Side Sheet */}
+      <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
+        <SheetContent className="sm:max-w-[640px] w-full flex flex-col h-full bg-background border-l border-border">
+          <SheetHeader className="pb-4 border-b border-border/40">
+            <SheetTitle className="text-xl flex items-center gap-2">
+              <Clock className="size-5 text-indigo-500" />
+              Änderungsdetails
+            </SheetTitle>
+            <SheetDescription>
+              Genaue Details zur ausgeführten Datenbankaktion.
+            </SheetDescription>
+          </SheetHeader>
+
+          {isDetailsLoading ? (
+            <div className="flex-1 flex flex-col items-center justify-center gap-3">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500" />
+              <span className="text-sm text-muted-foreground">Details werden geladen...</span>
+            </div>
+          ) : detailedLog ? (
+            <ScrollArea className="flex-1 pr-1">
+              <div className="space-y-6 py-6">
+                {/* Meta details */}
+                <div className="grid grid-cols-2 gap-4 border rounded-lg p-4 bg-muted/10 text-sm">
+                  <div>
+                    <span className="text-xs font-semibold text-muted-foreground block uppercase">Tabelle</span>
+                    <span className="font-semibold text-foreground">{TABLE_NAME_MAP[detailedLog.table_name] || detailedLog.table_name}</span>
+                  </div>
+                  <div>
+                    <span className="text-xs font-semibold text-muted-foreground block uppercase">Aktion</span>
+                    <Badge variant="outline" className={cn("px-2 py-0.5 mt-0.5 border uppercase font-bold", getActionBadgeColor(detailedLog.action))}>
+                      {detailedLog.action}
+                    </Badge>
+                  </div>
+                  <div>
+                    <span className="text-xs font-semibold text-muted-foreground block uppercase">Zeitpunkt</span>
+                    <span className="text-foreground">
+                      {new Date(detailedLog.changed_at).toLocaleString("de-DE", {
+                        day: "2-digit",
+                        month: "2-digit",
+                        year: "numeric",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                        second: "2-digit"
+                      })}
+                    </span>
+                  </div>
+                  <div>
+                    <span className="text-xs font-semibold text-muted-foreground block uppercase">Ausgeführt von</span>
+                    <span className="text-foreground font-medium block">{detailedLog.changed_by_name}</span>
+                    {detailedLog.changed_by_email && (
+                      <span className="text-xs text-muted-foreground">{detailedLog.changed_by_email}</span>
+                    )}
+                  </div>
+                  <div className="col-span-2 pt-2 border-t border-border/40">
+                    <span className="text-xs font-semibold text-muted-foreground block uppercase">Datensatz-ID (UUID)</span>
+                    <span className="font-mono text-xs break-all text-foreground">{detailedLog.record_id}</span>
+                  </div>
+                </div>
+
+                {/* Data Diff & Raw JSON Tabs */}
+                <Tabs defaultValue="diff" className="w-full">
+                  <TabsList className="w-full grid grid-cols-2 border border-border/40 bg-muted/30">
+                    <TabsTrigger value="diff" className="flex items-center gap-1.5">
+                      <ListFilter className="size-4" />
+                      Änderungsvergleich
+                    </TabsTrigger>
+                    <TabsTrigger value="raw" className="flex items-center gap-1.5">
+                      <FileJson className="size-4" />
+                      Rohdaten (JSON)
+                    </TabsTrigger>
+                  </TabsList>
+
+                  <TabsContent value="diff" className="pt-4">
+                    <h3 className="font-semibold text-sm mb-3 text-foreground">Feldänderungen:</h3>
+                    {renderDiff(detailedLog.action, detailedLog.old_data, detailedLog.new_data)}
+                  </TabsContent>
+
+                  <TabsContent value="raw" className="pt-4">
+                    <div className="space-y-4">
+                      {detailedLog.old_data && (
+                        <div className="space-y-1.5">
+                          <h4 className="text-xs font-semibold text-rose-500 uppercase">Alter Zustand (old_data)</h4>
+                          <pre className="p-3 bg-zinc-950 text-zinc-200 dark:bg-zinc-900 rounded-lg text-xs overflow-auto max-h-[220px] font-mono leading-relaxed">
+                            {JSON.stringify(detailedLog.old_data, null, 2)}
+                          </pre>
+                        </div>
+                      )}
+                      {detailedLog.new_data && (
+                        <div className="space-y-1.5">
+                          <h4 className="text-xs font-semibold text-emerald-500 uppercase">Neuer Zustand (new_data)</h4>
+                          <pre className="p-3 bg-zinc-950 text-zinc-200 dark:bg-zinc-900 rounded-lg text-xs overflow-auto max-h-[220px] font-mono leading-relaxed">
+                            {JSON.stringify(detailedLog.new_data, null, 2)}
+                          </pre>
+                        </div>
+                      )}
+                    </div>
+                  </TabsContent>
+                </Tabs>
+              </div>
+            </ScrollArea>
+          ) : (
+            <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground">
+              Keine Details geladen.
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
+    </Card>
+  );
+}

--- a/components/organisation/organisation-audit-log-tab.tsx
+++ b/components/organisation/organisation-audit-log-tab.tsx
@@ -66,6 +66,12 @@ const TABLE_NAME_MAP: Record<string, string> = {
   Zaehler_Ablesungen: "Ablesungen",
   Rechnungen: "Rechnungen",
   Vorlagen: "Vorlagen",
+  Organisation: "Organisation",
+  Organisation_Mitglieder: "Mitarbeiter",
+  Organisation_Policies: "Richtlinien",
+  Organisation_Mitglieder_Policies: "Mitarbeiter-Richtlinien",
+  Organisation_Mitglieder_Overrides: "Mitarbeiter-Abweichungen",
+  Organisation_Einladungen: "Einladungen",
 };
 
 // Pure helper function to format individual values

--- a/components/organisation/organisation-audit-log-tab.tsx
+++ b/components/organisation/organisation-audit-log-tab.tsx
@@ -39,18 +39,18 @@ import { cn } from "@/lib/utils";
 interface AuditLogSummary {
   id: string;
   organisation_id: string;
-  table_name: string;
-  record_id: string;
-  action: 'INSERT' | 'UPDATE' | 'DELETE' | 'SOFT_DELETE' | 'RESTORE';
-  changed_by: string | null;
-  changed_by_name: string;
-  changed_by_email: string | null;
-  changed_at: string;
+  tabellenname: string;
+  datensatz_id: string;
+  aktion: 'INSERT' | 'UPDATE' | 'DELETE' | 'SOFT_DELETE' | 'RESTORE';
+  geaendert_von: string | null;
+  geaendert_von_name: string;
+  geaendert_von_email: string | null;
+  geaendert_am: string;
 }
 
 interface AuditLogDetail extends AuditLogSummary {
-  old_data: any;
-  new_data: any;
+  alte_daten: any;
+  neue_daten: any;
 }
 
 // Map database table names to human-readable names
@@ -77,7 +77,7 @@ function formatValue(val: any): string {
 }
 
 // Pure helper function to get color classes based on audit action
-function getActionBadgeColor(action: AuditLogSummary['action']) {
+function getActionBadgeColor(action: AuditLogSummary['aktion']) {
   switch (action) {
     case 'INSERT':
       return 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20';
@@ -96,16 +96,16 @@ function getActionBadgeColor(action: AuditLogSummary['action']) {
 
 // Sub-component for showing visual diffs between old and new state
 interface AuditLogDiffProps {
-  action: string;
-  oldData: any;
-  newData: any;
+  aktion: string;
+  alteDaten: any;
+  neueDaten: any;
 }
 
-function AuditLogDiff({ action, oldData, newData }: AuditLogDiffProps) {
-  const oldObj = oldData || {};
-  const newObj = newData || {};
+function AuditLogDiff({ aktion, alteDaten, neueDaten }: AuditLogDiffProps) {
+  const oldObj = alteDaten || {};
+  const newObj = neueDaten || {};
 
-  if (action === 'INSERT') {
+  if (aktion === 'INSERT') {
     return (
       <div className="space-y-1.5 border rounded-lg p-3 bg-muted/20">
         {Object.entries(newObj).map(([key, val]) => (
@@ -118,7 +118,7 @@ function AuditLogDiff({ action, oldData, newData }: AuditLogDiffProps) {
     );
   }
 
-  if (action === 'DELETE' || action === 'SOFT_DELETE') {
+  if (aktion === 'DELETE' || aktion === 'SOFT_DELETE') {
     return (
       <div className="space-y-1.5 border rounded-lg p-3 bg-muted/20">
         {Object.entries(oldObj).map(([key, val]) => (
@@ -356,7 +356,7 @@ export function OrganisationAuditLogTab() {
                     onClick={() => handleSelectLog(log.id)}
                   >
                     <TableCell className="font-medium whitespace-nowrap" suppressHydrationWarning>
-                      {new Date(log.changed_at).toLocaleString("de-DE", {
+                      {new Date(log.geaendert_am).toLocaleString("de-DE", {
                         day: "2-digit",
                         month: "2-digit",
                         year: "numeric",
@@ -368,22 +368,22 @@ export function OrganisationAuditLogTab() {
                     <TableCell>
                       <span className="flex items-center gap-1.5">
                         <Database className="size-3.5 text-zinc-400 shrink-0" />
-                        {TABLE_NAME_MAP[log.table_name] || log.table_name}
+                        {TABLE_NAME_MAP[log.tabellenname] || log.tabellenname}
                       </span>
                     </TableCell>
                     <TableCell>
-                      <Badge variant="outline" className={cn("px-2 py-0.5 font-semibold text-xs border uppercase rounded-full shadow-none", getActionBadgeColor(log.action))}>
-                        {log.action === 'SOFT_DELETE' ? 'Papierkorb' : log.action}
+                      <Badge variant="outline" className={cn("px-2 py-0.5 font-semibold text-xs border uppercase rounded-full shadow-none", getActionBadgeColor(log.aktion))}>
+                        {log.aktion === 'SOFT_DELETE' ? 'Papierkorb' : log.aktion}
                       </Badge>
                     </TableCell>
                     <TableCell>
                       <div className="flex flex-col">
                         <span className="font-semibold text-sm flex items-center gap-1.5">
                           <User className="size-3.5 text-zinc-400 shrink-0" />
-                          {log.changed_by_name}
+                          {log.geaendert_von_name}
                         </span>
-                        {log.changed_by_email && (
-                          <span className="text-xs text-muted-foreground pl-5">{log.changed_by_email}</span>
+                        {log.geaendert_von_email && (
+                          <span className="text-xs text-muted-foreground pl-5">{log.geaendert_von_email}</span>
                         )}
                       </div>
                     </TableCell>
@@ -456,18 +456,18 @@ export function OrganisationAuditLogTab() {
                 <div className="grid grid-cols-2 gap-4 border rounded-lg p-4 bg-muted/10 text-sm">
                   <div>
                     <span className="text-xs font-semibold text-muted-foreground block uppercase">Tabelle</span>
-                    <span className="font-semibold text-foreground">{TABLE_NAME_MAP[detailedLog.table_name] || detailedLog.table_name}</span>
+                    <span className="font-semibold text-foreground">{TABLE_NAME_MAP[detailedLog.tabellenname] || detailedLog.tabellenname}</span>
                   </div>
                   <div>
                     <span className="text-xs font-semibold text-muted-foreground block uppercase">Aktion</span>
-                    <Badge variant="outline" className={cn("px-2 py-0.5 mt-0.5 border uppercase font-bold", getActionBadgeColor(detailedLog.action))}>
-                      {detailedLog.action}
+                    <Badge variant="outline" className={cn("px-2 py-0.5 mt-0.5 border uppercase font-bold", getActionBadgeColor(detailedLog.aktion))}>
+                      {detailedLog.aktion}
                     </Badge>
                   </div>
                   <div>
                     <span className="text-xs font-semibold text-muted-foreground block uppercase">Zeitpunkt</span>
                     <span className="text-foreground" suppressHydrationWarning>
-                      {new Date(detailedLog.changed_at).toLocaleString("de-DE", {
+                      {new Date(detailedLog.geaendert_am).toLocaleString("de-DE", {
                         day: "2-digit",
                         month: "2-digit",
                         year: "numeric",
@@ -479,14 +479,14 @@ export function OrganisationAuditLogTab() {
                   </div>
                   <div>
                     <span className="text-xs font-semibold text-muted-foreground block uppercase">Ausgeführt von</span>
-                    <span className="text-foreground font-medium block">{detailedLog.changed_by_name}</span>
-                    {detailedLog.changed_by_email && (
-                      <span className="text-xs text-muted-foreground">{detailedLog.changed_by_email}</span>
+                    <span className="text-foreground font-medium block">{detailedLog.geaendert_von_name}</span>
+                    {detailedLog.geaendert_von_email && (
+                      <span className="text-xs text-muted-foreground">{detailedLog.geaendert_von_email}</span>
                     )}
                   </div>
                   <div className="col-span-2 pt-2 border-t border-border/40">
                     <span className="text-xs font-semibold text-muted-foreground block uppercase">Datensatz-ID (UUID)</span>
-                    <span className="font-mono text-xs break-all text-foreground">{detailedLog.record_id}</span>
+                    <span className="font-mono text-xs break-all text-foreground">{detailedLog.datensatz_id}</span>
                   </div>
                 </div>
 
@@ -506,27 +506,27 @@ export function OrganisationAuditLogTab() {
                   <TabsContent value="diff" className="pt-4">
                     <h3 className="font-semibold text-sm mb-3 text-foreground">Feldänderungen:</h3>
                     <AuditLogDiff 
-                      action={detailedLog.action} 
-                      oldData={detailedLog.old_data} 
-                      newData={detailedLog.new_data} 
+                      aktion={detailedLog.aktion} 
+                      alteDaten={detailedLog.alte_daten} 
+                      neueDaten={detailedLog.neue_daten} 
                     />
                   </TabsContent>
 
                   <TabsContent value="raw" className="pt-4">
                     <div className="space-y-4">
-                      {detailedLog.old_data && (
+                      {detailedLog.alte_daten && (
                         <div className="space-y-1.5">
-                          <h4 className="text-xs font-semibold text-rose-500 uppercase">Alter Zustand (old_data)</h4>
+                          <h4 className="text-xs font-semibold text-rose-500 uppercase">Alter Zustand (alte_daten)</h4>
                           <pre className="p-3 bg-zinc-950 text-zinc-200 dark:bg-zinc-900 rounded-lg text-xs overflow-auto max-h-[220px] font-mono leading-relaxed">
-                            {JSON.stringify(detailedLog.old_data, null, 2)}
+                            {JSON.stringify(detailedLog.alte_daten, null, 2)}
                           </pre>
                         </div>
                       )}
-                      {detailedLog.new_data && (
+                      {detailedLog.neue_daten && (
                         <div className="space-y-1.5">
-                          <h4 className="text-xs font-semibold text-emerald-500 uppercase">Neuer Zustand (new_data)</h4>
+                          <h4 className="text-xs font-semibold text-emerald-500 uppercase">Neuer Zustand (neue_daten)</h4>
                           <pre className="p-3 bg-zinc-950 text-zinc-200 dark:bg-zinc-900 rounded-lg text-xs overflow-auto max-h-[220px] font-mono leading-relaxed">
-                            {JSON.stringify(detailedLog.new_data, null, 2)}
+                            {JSON.stringify(detailedLog.neue_daten, null, 2)}
                           </pre>
                         </div>
                       )}

--- a/components/organisation/organisation-audit-log-tab.tsx
+++ b/components/organisation/organisation-audit-log-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useTransition } from "react";
+import { useState, useEffect, useTransition, useId } from "react";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -68,9 +68,109 @@ const TABLE_NAME_MAP: Record<string, string> = {
   Vorlagen: "Vorlagen",
 };
 
+// Pure helper function to format individual values
+function formatValue(val: any): string {
+  if (val === null || val === undefined) return 'NULL';
+  if (typeof val === 'object') return JSON.stringify(val);
+  if (typeof val === 'boolean') return val ? 'Ja' : 'Nein';
+  return String(val);
+}
+
+// Pure helper function to get color classes based on audit action
+function getActionBadgeColor(action: AuditLogSummary['action']) {
+  switch (action) {
+    case 'INSERT':
+      return 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20';
+    case 'UPDATE':
+      return 'bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20';
+    case 'SOFT_DELETE':
+      return 'bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20';
+    case 'RESTORE':
+      return 'bg-teal-500/10 text-teal-600 dark:text-teal-400 border-teal-500/20';
+    case 'DELETE':
+      return 'bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/20';
+    default:
+      return 'bg-zinc-500/10 text-zinc-600 dark:text-zinc-400 border-zinc-500/20';
+  }
+}
+
+// Sub-component for showing visual diffs between old and new state
+interface AuditLogDiffProps {
+  action: string;
+  oldData: any;
+  newData: any;
+}
+
+function AuditLogDiff({ action, oldData, newData }: AuditLogDiffProps) {
+  const oldObj = oldData || {};
+  const newObj = newData || {};
+
+  if (action === 'INSERT') {
+    return (
+      <div className="space-y-1.5 border rounded-lg p-3 bg-muted/20">
+        {Object.entries(newObj).map(([key, val]) => (
+          <div key={key} className="grid grid-cols-3 py-1.5 border-b border-border/40 last:border-0 text-sm">
+            <span className="font-medium text-muted-foreground col-span-1">{key}</span>
+            <span className="text-foreground col-span-2 break-all font-mono text-xs">{formatValue(val)}</span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (action === 'DELETE' || action === 'SOFT_DELETE') {
+    return (
+      <div className="space-y-1.5 border rounded-lg p-3 bg-muted/20">
+        {Object.entries(oldObj).map(([key, val]) => (
+          <div key={key} className="grid grid-cols-3 py-1.5 border-b border-border/40 last:border-0 text-sm">
+            <span className="font-medium text-muted-foreground col-span-1">{key}</span>
+            <span className="text-foreground col-span-2 line-through opacity-70 break-all font-mono text-xs">{formatValue(val)}</span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  // UPDATE or RESTORE diffing
+  const allKeys = Array.from(new Set([...Object.keys(oldObj), ...Object.keys(newObj)]));
+  const changedKeys = allKeys.filter(k => {
+    const oldVal = oldObj[k];
+    const newVal = newObj[k];
+    return JSON.stringify(oldVal) !== JSON.stringify(newVal);
+  });
+
+  if (changedKeys.length === 0) {
+    return (
+      <div className="flex items-center gap-2 p-4 rounded-lg bg-zinc-50 border border-zinc-100 dark:bg-zinc-950/20 dark:border-zinc-900/40 text-sm text-muted-foreground">
+        <Info className="size-4 shrink-0 text-zinc-500" />
+        <span>Keine geänderten Felder vorhanden (z.B. nur interne Metadaten oder unberührte Relationen).</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {changedKeys.map(key => (
+        <div key={key} className="border rounded-lg p-3 bg-muted/10 space-y-2">
+          <div className="font-semibold text-xs text-muted-foreground uppercase tracking-wider">{key}</div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs font-mono">
+            <div className="p-2 rounded bg-rose-500/10 border border-rose-500/20 text-rose-700 dark:text-rose-400">
+              <div className="text-[10px] text-rose-500/80 mb-1 font-sans uppercase font-bold">Vorher:</div>
+              <span className="line-through break-all">{formatValue(oldObj[key])}</span>
+            </div>
+            <div className="p-2 rounded bg-emerald-500/10 border border-emerald-500/20 text-emerald-700 dark:text-emerald-400">
+              <div className="text-[10px] text-emerald-500/80 mb-1 font-sans uppercase font-bold">Nachher:</div>
+              <span className="break-all">{formatValue(newObj[key])}</span>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export function OrganisationAuditLogTab() {
   const [logs, setLogs] = useState<AuditLogSummary[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   
   // Pagination State
@@ -87,16 +187,30 @@ export function OrganisationAuditLogTab() {
   const [isDetailsLoading, setIsDetailsLoading] = useState(false);
   const [isSheetOpen, setIsSheetOpen] = useState(false);
 
-  const [, startTransition] = useTransition();
+  // loading state derived from useTransition
+  const [isPending, startTransition] = useTransition();
 
-  // Load log summary list
-  const fetchLogs = (currentPage: number) => {
-    setIsLoading(true);
+  // Generate unique IDs for accessibility labels
+  const tableFilterSelectId = useId();
+  const actionFilterSelectId = useId();
+
+  // Reset page to 1 when filters change to avoid getting stuck on empty pages
+  useEffect(() => {
+    setPage(1);
+  }, [filterTable, filterAction]);
+
+  // Load log summary list from database using page and filter selections
+  const fetchLogs = (currentPage: number, table: string, action: string) => {
     setError(null);
     const offset = (currentPage - 1) * limit;
 
     startTransition(async () => {
-      const res = await getAuditLogsAction(limit + 1, offset); // Request limit + 1 to check if there is a next page
+      const res = await getAuditLogsAction(
+        limit + 1, 
+        offset, 
+        table === "all" ? undefined : table, 
+        action === "all" ? undefined : action
+      );
       if (res.success && res.data) {
         const hasNext = res.data.length > limit;
         const pageData = hasNext ? res.data.slice(0, limit) : res.data;
@@ -106,13 +220,12 @@ export function OrganisationAuditLogTab() {
       } else {
         setError(res.error?.message || "Fehler beim Laden des Audit-Logs.");
       }
-      setIsLoading(false);
     });
   };
 
   useEffect(() => {
-    fetchLogs(page);
-  }, [page]);
+    fetchLogs(page, filterTable, filterAction);
+  }, [page, filterTable, filterAction]);
 
   // Load detailed log on selection
   const handleSelectLog = (logId: string) => {
@@ -120,6 +233,7 @@ export function OrganisationAuditLogTab() {
     setIsSheetOpen(true);
     setDetailedLog(null);
 
+    // Call details action (separate transition for independent detail loading state)
     startTransition(async () => {
       const res = await getAuditLogDetailsAction(logId);
       if (res.success && res.data) {
@@ -130,107 +244,6 @@ export function OrganisationAuditLogTab() {
       }
       setIsDetailsLoading(false);
     });
-  };
-
-  // Filter logic (Client-side filtering for immediate feedback, database pagination for loading chunks)
-  const filteredLogs = logs.filter(log => {
-    const matchesTable = filterTable === "all" || log.table_name === filterTable;
-    const matchesAction = filterAction === "all" || log.action === filterAction;
-    return matchesTable && matchesAction;
-  });
-
-  const getActionBadgeColor = (action: AuditLogSummary['action']) => {
-    switch (action) {
-      case 'INSERT':
-        return 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20';
-      case 'UPDATE':
-        return 'bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20';
-      case 'SOFT_DELETE':
-        return 'bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20';
-      case 'RESTORE':
-        return 'bg-teal-500/10 text-teal-600 dark:text-teal-400 border-teal-500/20';
-      case 'DELETE':
-        return 'bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/20';
-      default:
-        return 'bg-zinc-500/10 text-zinc-600 dark:text-zinc-400 border-zinc-500/20';
-    }
-  };
-
-  const formatValue = (val: any): string => {
-    if (val === null || val === undefined) return 'NULL';
-    if (typeof val === 'object') return JSON.stringify(val);
-    if (typeof val === 'boolean') return val ? 'Ja' : 'Nein';
-    return String(val);
-  };
-
-  const renderDiff = (action: string, oldData: any, newData: any) => {
-    const oldObj = oldData || {};
-    const newObj = newData || {};
-
-    if (action === 'INSERT') {
-      return (
-        <div className="space-y-1.5 border rounded-lg p-3 bg-muted/20">
-          {Object.entries(newObj).map(([key, val]) => (
-            <div key={key} className="grid grid-cols-3 py-1.5 border-b border-border/40 last:border-0 text-sm">
-              <span className="font-medium text-muted-foreground col-span-1">{key}</span>
-              <span className="text-foreground col-span-2 break-all font-mono text-xs">{formatValue(val)}</span>
-            </div>
-          ))}
-        </div>
-      );
-    }
-
-    if (action === 'DELETE' || action === 'SOFT_DELETE') {
-      return (
-        <div className="space-y-1.5 border rounded-lg p-3 bg-muted/20">
-          {Object.entries(oldObj).map(([key, val]) => (
-            <div key={key} className="grid grid-cols-3 py-1.5 border-b border-border/40 last:border-0 text-sm">
-              <span className="font-medium text-muted-foreground col-span-1">{key}</span>
-              <span className="text-foreground col-span-2 line-through opacity-70 break-all font-mono text-xs">{formatValue(val)}</span>
-            </div>
-          ))}
-        </div>
-      );
-    }
-
-    // UPDATE or RESTORE diffing
-    const allKeys = Array.from(new Set([...Object.keys(oldObj), ...Object.keys(newObj)]));
-    // Filter out common irrelevant keys or ignore unchanged ones
-    const changedKeys = allKeys.filter(k => {
-      // Exclude generated fields from showing as changed if they only differ by minor format/precision
-      const oldVal = oldObj[k];
-      const newVal = newObj[k];
-      return JSON.stringify(oldVal) !== JSON.stringify(newVal);
-    });
-
-    if (changedKeys.length === 0) {
-      return (
-        <div className="flex items-center gap-2 p-4 rounded-lg bg-zinc-50 border border-zinc-100 dark:bg-zinc-950/20 dark:border-zinc-900/40 text-sm text-muted-foreground">
-          <Info className="size-4 shrink-0 text-zinc-500" />
-          <span>Keine geänderten Felder vorhanden (z.B. nur interne Metadaten oder unberührte Relationen).</span>
-        </div>
-      );
-    }
-
-    return (
-      <div className="space-y-3">
-        {changedKeys.map(key => (
-          <div key={key} className="border rounded-lg p-3 bg-muted/10 space-y-2">
-            <div className="font-semibold text-xs text-muted-foreground uppercase tracking-wider">{key}</div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-xs font-mono">
-              <div className="p-2 rounded bg-rose-500/10 border border-rose-500/20 text-rose-700 dark:text-rose-400">
-                <div className="text-[10px] text-rose-500/80 mb-1 font-sans uppercase font-bold">Vorher:</div>
-                <span className="line-through break-all">{formatValue(oldObj[key])}</span>
-              </div>
-              <div className="p-2 rounded bg-emerald-500/10 border border-emerald-500/20 text-emerald-700 dark:text-emerald-400">
-                <div className="text-[10px] text-emerald-500/80 mb-1 font-sans uppercase font-bold">Nachher:</div>
-                <span className="break-all">{formatValue(newObj[key])}</span>
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
-    );
   };
 
   return (
@@ -251,10 +264,10 @@ export function OrganisationAuditLogTab() {
             variant="outline" 
             size="sm" 
             className="w-full md:w-auto flex items-center gap-1.5"
-            onClick={() => fetchLogs(page)}
-            disabled={isLoading}
+            onClick={() => fetchLogs(page, filterTable, filterAction)}
+            disabled={isPending}
           >
-            <RefreshCw className={cn("size-3.5", isLoading && "animate-spin")} />
+            <RefreshCw className={cn("size-3.5", isPending && "animate-spin")} />
             Aktualisieren
           </Button>
         </div>
@@ -262,9 +275,11 @@ export function OrganisationAuditLogTab() {
         {/* Filters */}
         <div className="flex flex-col sm:flex-row gap-3 pt-4 border-t border-border/40 mt-2">
           <div className="flex-1 max-w-[240px]">
-            <label className="text-xs font-medium text-muted-foreground mb-1 block">Tabelle filtern</label>
+            <label htmlFor={tableFilterSelectId} className="text-xs font-medium text-muted-foreground mb-1 block">
+              Tabelle filtern
+            </label>
             <Select value={filterTable} onValueChange={setFilterTable}>
-              <SelectTrigger>
+              <SelectTrigger id={tableFilterSelectId}>
                 <SelectValue placeholder="Alle Tabellen" />
               </SelectTrigger>
               <SelectContent>
@@ -277,9 +292,11 @@ export function OrganisationAuditLogTab() {
           </div>
 
           <div className="flex-1 max-w-[200px]">
-            <label className="text-xs font-medium text-muted-foreground mb-1 block">Aktion filtern</label>
+            <label htmlFor={actionFilterSelectId} className="text-xs font-medium text-muted-foreground mb-1 block">
+              Aktion filtern
+            </label>
             <Select value={filterAction} onValueChange={setFilterAction}>
-              <SelectTrigger>
+              <SelectTrigger id={actionFilterSelectId}>
                 <SelectValue placeholder="Alle Aktionen" />
               </SelectTrigger>
               <SelectContent>
@@ -314,8 +331,8 @@ export function OrganisationAuditLogTab() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {isLoading ? (
-                // Skeleton Loader
+              {isPending && logs.length === 0 ? (
+                // Skeleton Loader during initial page load
                 Array.from({ length: 5 }).map((_, i) => (
                   <TableRow key={i}>
                     <TableCell><div className="h-4 w-28 bg-muted animate-pulse rounded" /></TableCell>
@@ -325,20 +342,20 @@ export function OrganisationAuditLogTab() {
                     <TableCell className="text-right"><div className="h-8 w-8 bg-muted animate-pulse rounded ml-auto" /></TableCell>
                   </TableRow>
                 ))
-              ) : filteredLogs.length === 0 ? (
+              ) : logs.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={5} className="h-32 text-center text-muted-foreground">
                     Keine Einträge im Audit-Log gefunden.
                   </TableCell>
                 </TableRow>
               ) : (
-                filteredLogs.map(log => (
+                logs.map(log => (
                   <TableRow 
                     key={log.id} 
                     className="group hover:bg-muted/50 cursor-pointer transition-colors"
                     onClick={() => handleSelectLog(log.id)}
                   >
-                    <TableCell className="font-medium whitespace-nowrap">
+                    <TableCell className="font-medium whitespace-nowrap" suppressHydrationWarning>
                       {new Date(log.changed_at).toLocaleString("de-DE", {
                         day: "2-digit",
                         month: "2-digit",
@@ -383,7 +400,7 @@ export function OrganisationAuditLogTab() {
         </div>
 
         {/* Pagination controls */}
-        {!isLoading && logs.length > 0 && (
+        {!isPending && logs.length > 0 && (
           <div className="flex items-center justify-between pt-4">
             <div className="text-xs text-muted-foreground">
               Seite {page}
@@ -393,7 +410,7 @@ export function OrganisationAuditLogTab() {
                 variant="outline"
                 size="sm"
                 className="flex items-center gap-1"
-                disabled={page === 1 || isLoading}
+                disabled={page === 1 || isPending}
                 onClick={() => setPage(p => Math.max(1, p - 1))}
               >
                 <ChevronLeft className="size-4" />
@@ -403,7 +420,7 @@ export function OrganisationAuditLogTab() {
                 variant="outline"
                 size="sm"
                 className="flex items-center gap-1"
-                disabled={!hasMore || isLoading}
+                disabled={!hasMore || isPending}
                 onClick={() => setPage(p => p + 1)}
               >
                 Nächste
@@ -449,7 +466,7 @@ export function OrganisationAuditLogTab() {
                   </div>
                   <div>
                     <span className="text-xs font-semibold text-muted-foreground block uppercase">Zeitpunkt</span>
-                    <span className="text-foreground">
+                    <span className="text-foreground" suppressHydrationWarning>
                       {new Date(detailedLog.changed_at).toLocaleString("de-DE", {
                         day: "2-digit",
                         month: "2-digit",
@@ -488,7 +505,11 @@ export function OrganisationAuditLogTab() {
 
                   <TabsContent value="diff" className="pt-4">
                     <h3 className="font-semibold text-sm mb-3 text-foreground">Feldänderungen:</h3>
-                    {renderDiff(detailedLog.action, detailedLog.old_data, detailedLog.new_data)}
+                    <AuditLogDiff 
+                      action={detailedLog.action} 
+                      oldData={detailedLog.old_data} 
+                      newData={detailedLog.new_data} 
+                    />
                   </TabsContent>
 
                   <TabsContent value="raw" className="pt-4">

--- a/components/tenants/tenant-edit-modal.tsx
+++ b/components/tenants/tenant-edit-modal.tsx
@@ -797,7 +797,12 @@ export function TenantEditModal({ serverAction }: TenantEditModalProps) {
       })
 
       if (tenantInitialData?.nebenkosten) {
-        setNebenkostenEntries(getSortedNebenkostenEntries(tenantInitialData.nebenkosten))
+        const mappedNebenkosten = tenantInitialData.nebenkosten.map((entry: any) => ({
+          ...entry,
+          amount: entry.amount !== null && entry.amount !== undefined ? String(entry.amount) : "",
+          date: entry.date || ""
+        }))
+        setNebenkostenEntries(getSortedNebenkostenEntries(mappedNebenkosten))
       } else {
         setNebenkostenEntries([{ id: generateId(), amount: "", date: "" }])
       }
@@ -820,12 +825,15 @@ export function TenantEditModal({ serverAction }: TenantEditModalProps) {
 
   const validateNebenkostenEntry = (entry: NebenkostenEntry): { amount?: string; date?: string } => {
     const errors: { amount?: string; date?: string } = {}
-    const amountValue = entry.amount.trim() === "" ? NaN : parseFloat(entry.amount)
-    if (entry.amount.trim() !== "") {
+    const amountStr = entry.amount !== null && entry.amount !== undefined ? String(entry.amount) : ""
+    const dateStr = entry.date !== null && entry.date !== undefined ? String(entry.date) : ""
+    
+    const amountValue = amountStr.trim() === "" ? NaN : parseFloat(amountStr)
+    if (amountStr.trim() !== "") {
       if (isNaN(amountValue)) errors.amount = "Ungültiger Betrag."
       else if (amountValue <= 0) errors.amount = "Betrag muss positiv sein."
     }
-    if (entry.amount.trim() !== "" && entry.date.trim() === "") {
+    if (amountStr.trim() !== "" && dateStr.trim() === "") {
       errors.date = "Datum ist erforderlich, wenn ein Betrag vorhanden ist."
     }
     return errors
@@ -959,7 +967,10 @@ export function TenantEditModal({ serverAction }: TenantEditModalProps) {
 
     if (!isApplicant) {
       for (const entry of nebenkostenEntries) {
-        if (entry.amount.trim() === "" && entry.date.trim() === "") {
+        const amountStr = entry.amount !== null && entry.amount !== undefined ? String(entry.amount) : ""
+        const dateStr = entry.date !== null && entry.date !== undefined ? String(entry.date) : ""
+
+        if (amountStr.trim() === "" && dateStr.trim() === "") {
           if (nebenkostenValidationErrors[entry.id]) {
             setNebenkostenValidationErrors(prev => {
               const newErrors = { ...prev }; delete newErrors[entry.id]; return newErrors
@@ -986,7 +997,10 @@ export function TenantEditModal({ serverAction }: TenantEditModalProps) {
       const currentFormData = new FormData(e.currentTarget as HTMLFormElement)
 
       if (!isApplicant) {
-        const finalNebenkostenEntries = nebenkostenEntries.filter(entry => entry.amount.trim() !== "")
+        const finalNebenkostenEntries = nebenkostenEntries.filter(entry => {
+          const amountStr = entry.amount !== null && entry.amount !== undefined ? String(entry.amount) : ""
+          return amountStr.trim() !== ""
+        })
         currentFormData.set('nebenkosten', JSON.stringify(finalNebenkostenEntries))
       } else {
         currentFormData.set('nebenkosten', JSON.stringify([]))


### PR DESCRIPTION
## Description

Implements an audit log UI in the organization settings with a paginated list, filters and a lazily loaded diff sheet.

## Summary of Changes

- New `OrganisationAuditLogTab` component (~550 lines): paginated audit log list (15/page), table + action filters, detail Sheet with visual diff view (old vs new values) and raw JSON tabs
- `organisation-actions.ts`: new `getAuditLogsAction` (RPC `get_organisation_audit_log`) and `getAuditLogDetailsAction` (RPC `get_audit_log_details`), both gated behind the organisation 'verwalten' permission
- Organisation page: new "Audit-Log" tab visible for owners/admins
- `tenant-edit-modal.tsx`: null-safe nebenkosten entry handling