### PR TITLE
feat: add passkey (WebAuthn) authentication behind auth-passkey flag

### DIFF
--- a/app/auth/register/content.tsx
+++ b/app/auth/register/content.tsx
@@ -10,7 +10,8 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Eye, EyeOff, Loader2, Check, Sparkles } from "lucide-react"
-import { LOGO_URL, ROUTES, BASE_URL } from "@/lib/constants"
+import { LOGO_URL, ROUTES, BASE_URL, POSTHOG_FEATURE_FLAGS } from "@/lib/constants"
+import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import posthog from 'posthog-js'
 import { getAuthErrorMessage } from "@/lib/auth-error-handler"
@@ -18,6 +19,7 @@ import { trackRegisterStarted, trackRegisterSuccess, trackRegisterFailed } from 
 import { motion } from "framer-motion"
 import { Auth3DDecorations } from "@/components/auth/auth-3d-decorations"
 import { handleGoogleSignIn, handleMicrosoftSignIn } from "@/lib/auth-helpers"
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip"
 import { GoogleIcon } from "@/components/icons/google-icon"
 import { MicrosoftIcon } from "@/components/icons/microsoft-icon"
 import { authState } from "@/lib/auth-state"
@@ -41,6 +43,7 @@ export default function RegisterPage() {
   const [isLoading, setIsLoading] = useState(false)
   const [message, setMessage] = useState<string | null>(null)
   const [mounted, setMounted] = useState(false)
+  const passkeyEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.AUTH_PASSKEY)
 
   useEffect(() => {
     setMounted(true)
@@ -395,35 +398,70 @@ export default function RegisterPage() {
                     </div>
                   </div>
 
-                  <div className={enabledProvidersCount > 1 ? "flex gap-3" : "space-y-4"}>
-                    {socialProviders.map((provider) => (
-                      <Button
-                        key={provider.id}
-                        type="button"
-                        variant="outline"
-                        className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-12 rounded-xl text-base font-medium border-border hover:bg-muted/50 transition-colors`}
-                        onClick={async () => {
-                          setSocialLoading(provider.id)
-                          setError(null)
-
-                          const { error } = await provider.handler('signup')
-
-                          if (error) {
-                            setError(error)
-                            setSocialLoading(null)
-                          }
-                        }}
-                        disabled={isLoading || socialLoading !== null}
-                      >
-                        {socialLoading === provider.id ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                        ) : (
-                          <provider.Icon className="h-5 w-5 mr-2" />
-                        )}
-                        {enabledProvidersCount > 1 ? provider.name : provider.fullLabel}
-                      </Button>
-                    ))}
-                  </div>
+                  {passkeyEnabled ? (
+                    <TooltipProvider>
+                      <div className="flex gap-3">
+                        {socialProviders.map((provider) => (
+                          <Tooltip key={provider.id}>
+                            <TooltipTrigger asChild>
+                              <Button
+                                type="button"
+                                variant="outline"
+                                className="flex-1 h-12 rounded-xl border-border hover:bg-muted/50 transition-colors cursor-pointer"
+                                onClick={async () => {
+                                  setSocialLoading(provider.id)
+                                  setError(null)
+                                  const { error } = await provider.handler('signup')
+                                  if (error) {
+                                    setError(error)
+                                    setSocialLoading(null)
+                                  }
+                                }}
+                                disabled={isLoading || socialLoading !== null}
+                              >
+                                {socialLoading === provider.id ? (
+                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                ) : (
+                                  <provider.Icon className="h-5 w-5" />
+                                )}
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Mit {provider.name} registrieren</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        ))}
+                      </div>
+                    </TooltipProvider>
+                  ) : (
+                    <div className={enabledProvidersCount > 1 ? "flex gap-3" : "space-y-4"}>
+                      {socialProviders.map((provider) => (
+                        <Button
+                          key={provider.id}
+                          type="button"
+                          variant="outline"
+                          className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-12 rounded-xl text-base font-medium border-border hover:bg-muted/50 transition-colors`}
+                          onClick={async () => {
+                            setSocialLoading(provider.id)
+                            setError(null)
+                            const { error } = await provider.handler('signup')
+                            if (error) {
+                              setError(error)
+                              setSocialLoading(null)
+                            }
+                          }}
+                          disabled={isLoading || socialLoading !== null}
+                        >
+                          {socialLoading === provider.id ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <provider.Icon className="h-5 w-5 mr-2" />
+                          )}
+                          {enabledProvidersCount > 1 ? provider.name : provider.fullLabel}
+                        </Button>
+                      ))}
+                    </div>
+                  )}
                 </div>
               }
 

--- a/components/auth/auth-modal.tsx
+++ b/components/auth/auth-modal.tsx
@@ -9,7 +9,8 @@ import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Label } from "@/components/ui/label"
 import { Checkbox } from "@/components/ui/checkbox"
-import { LOGO_URL } from "@/lib/constants"
+import { LOGO_URL, POSTHOG_FEATURE_FLAGS } from "@/lib/constants"
+import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import {
   Dialog,
@@ -21,7 +22,11 @@ import { PillTabSwitcher } from "@/components/ui/pill-tab-switcher";
 import { handleGoogleSignIn, handleMicrosoftSignIn } from "@/lib/auth-helpers"
 import { GoogleIcon } from "@/components/icons/google-icon"
 import { MicrosoftIcon } from "@/components/icons/microsoft-icon"
-import { Loader2 } from "lucide-react"
+import { Loader2, Fingerprint } from "lucide-react"
+import posthog from 'posthog-js'
+import { trackPasskeyLoginStarted, trackPasskeyLoginSuccess, trackPasskeyLoginFailed } from '@/lib/posthog-auth-events'
+import { getAuthErrorMessage } from "@/lib/auth-error-handler"
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip"
 
 interface AuthModalProps {
   isOpen: boolean;
@@ -57,6 +62,7 @@ export default function AuthModal({
   const [forgotPasswordSuccess, setForgotPasswordSuccess] = useState(false)
 
   const [socialLoading, setSocialLoading] = useState<string | null>(null) // 'google' | 'microsoft' | null
+  const passkeyEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.AUTH_PASSKEY)
 
   const socialProviders = [
     {
@@ -401,25 +407,96 @@ export default function AuthModal({
                     </div>
                   </div>
 
-                  <div className={enabledProvidersCount > 1 ? "flex gap-3" : "space-y-3"}>
-                    {socialProviders.map((provider) => (
-                      <Button
-                        key={provider.id}
-                        type="button"
-                        variant="outline"
-                        className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-10 rounded-lg text-sm font-medium border-border hover:bg-muted/50 transition-colors`}
-                        onClick={() => handleSocialAuth(provider.id, 'login')}
-                        disabled={socialLoading !== null}
-                      >
-                        {socialLoading === provider.id ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                        ) : (
-                          <provider.Icon className="h-4 w-4 mr-2" />
-                        )}
-                        {enabledProvidersCount > 1 ? provider.name : provider.fullLabel}
-                      </Button>
-                    ))}
-                  </div>
+                  {passkeyEnabled ? (
+                    <TooltipProvider>
+                      <div className="flex flex-col lg:flex-row gap-3">
+                        {socialProviders.map((provider) => (
+                          <Tooltip key={provider.id}>
+                            <TooltipTrigger asChild>
+                              <Button
+                                type="button"
+                                variant="outline"
+                                className="flex-1 h-10 rounded-lg border-border hover:bg-muted/50 transition-colors cursor-pointer"
+                                onClick={() => handleSocialAuth(provider.id, 'login')}
+                                disabled={socialLoading !== null}
+                              >
+                                {socialLoading === provider.id ? (
+                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                ) : (
+                                  <provider.Icon className="h-4 w-4" />
+                                )}
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Mit {provider.name} anmelden</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        ))}
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              className="flex-1 h-10 rounded-lg border-border hover:bg-muted/50 transition-colors cursor-pointer"
+                              onClick={async () => {
+                                setLoginError(null)
+                                const supabase = createClient()
+                                trackPasskeyLoginStarted()
+                                const { data, error: passkeyError } = await supabase.auth.signInWithPasskey()
+                                if (passkeyError) {
+                                  const errorType = passkeyError.message?.toLowerCase().includes('cancelled') || passkeyError.message?.toLowerCase().includes('not allowed')
+                                    ? 'passkey_cancelled'
+                                    : 'passkey_error'
+                                  trackPasskeyLoginFailed(errorType)
+                                  setLoginError(getAuthErrorMessage(passkeyError))
+                                  return
+                                }
+                                if (data?.user) {
+                                  if (posthog.has_opted_in_capturing?.()) {
+                                    posthog.identify(data.user.id, {
+                                      email: data.user.email,
+                                      name: data.user.user_metadata?.name || '',
+                                      last_sign_in: data.user.last_sign_in_at,
+                                      user_type: 'authenticated',
+                                      is_anonymous: false,
+                                    })
+                                  }
+                                  trackPasskeyLoginSuccess()
+                                }
+                                onAuthenticated()
+                                onClose()
+                              }}
+                            >
+                              <Fingerprint className="h-4 w-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>Mit Passkey anmelden</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </div>
+                    </TooltipProvider>
+                  ) : (
+                    <div className={enabledProvidersCount > 1 ? "flex gap-3" : "space-y-3"}>
+                      {socialProviders.map((provider) => (
+                        <Button
+                          key={provider.id}
+                          type="button"
+                          variant="outline"
+                          className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-10 rounded-lg text-sm font-medium border-border hover:bg-muted/50 transition-colors`}
+                          onClick={() => handleSocialAuth(provider.id, 'login')}
+                          disabled={socialLoading !== null}
+                        >
+                          {socialLoading === provider.id ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <provider.Icon className="h-4 w-4 mr-2" />
+                          )}
+                          {enabledProvidersCount > 1 ? provider.name : provider.fullLabel}
+                        </Button>
+                      ))}
+                    </div>
+                  )}
                 </div>
               </AuthForm>
             </>
@@ -504,25 +581,54 @@ export default function AuthModal({
                       </div>
                     </div>
 
-                    <div className={enabledProvidersCount > 1 ? "flex gap-3" : "space-y-3"}>
-                      {socialProviders.map((provider) => (
-                        <Button
-                          key={provider.id}
-                          type="button"
-                          variant="outline"
-                          className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-10 rounded-lg text-sm font-medium border-border hover:bg-muted/50 transition-colors`}
-                          onClick={() => handleSocialAuth(provider.id, 'signup')}
-                          disabled={socialLoading !== null}
-                        >
-                          {socialLoading === provider.id ? (
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                          ) : (
-                            <provider.Icon className="h-4 w-4 mr-2" />
-                          )}
-                          {enabledProvidersCount > 1 ? provider.name : provider.fullLabel}
-                        </Button>
-                      ))}
-                    </div>
+                    {passkeyEnabled ? (
+                      <TooltipProvider>
+                        <div className="flex gap-3">
+                          {socialProviders.map((provider) => (
+                            <Tooltip key={provider.id}>
+                              <TooltipTrigger asChild>
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  className="flex-1 h-10 rounded-lg border-border hover:bg-muted/50 transition-colors cursor-pointer"
+                                  onClick={() => handleSocialAuth(provider.id, 'signup')}
+                                  disabled={socialLoading !== null}
+                                >
+                                  {socialLoading === provider.id ? (
+                                    <Loader2 className="h-4 w-4 animate-spin" />
+                                  ) : (
+                                    <provider.Icon className="h-4 w-4" />
+                                  )}
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                <p>Mit {provider.name} registrieren</p>
+                              </TooltipContent>
+                            </Tooltip>
+                          ))}
+                        </div>
+                      </TooltipProvider>
+                    ) : (
+                      <div className={enabledProvidersCount > 1 ? "flex gap-3" : "space-y-3"}>
+                        {socialProviders.map((provider) => (
+                          <Button
+                            key={provider.id}
+                            type="button"
+                            variant="outline"
+                            className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-10 rounded-lg text-sm font-medium border-border hover:bg-muted/50 transition-colors`}
+                            onClick={() => handleSocialAuth(provider.id, 'signup')}
+                            disabled={socialLoading !== null}
+                          >
+                            {socialLoading === provider.id ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              <provider.Icon className="h-4 w-4 mr-2" />
+                            )}
+                            {enabledProvidersCount > 1 ? provider.name : provider.fullLabel}
+                          </Button>
+                        ))}
+                      </div>
+                    )}
                   </div>
                 </form>
               </CardContent>

--- a/components/auth/login-content.tsx
+++ b/components/auth/login-content.tsx
@@ -9,15 +9,17 @@ import { createClient } from "@/utils/supabase/client"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { Eye, EyeOff, Loader2, AlertCircle, Database } from "lucide-react"
-import { LOGO_URL, ROUTES } from "@/lib/constants"
+import { Eye, EyeOff, Loader2, AlertCircle, Database, Fingerprint } from "lucide-react"
+import { LOGO_URL, ROUTES, POSTHOG_FEATURE_FLAGS } from "@/lib/constants"
+import { useFeatureFlagEnabled } from 'posthog-js/react'
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import posthog from 'posthog-js'
-import { trackLoginStarted, trackLoginSuccess, trackLoginFailed } from '@/lib/posthog-auth-events'
+import { trackLoginStarted, trackLoginSuccess, trackLoginFailed, trackPasskeyLoginStarted, trackPasskeyLoginSuccess, trackPasskeyLoginFailed } from '@/lib/posthog-auth-events'
 import { getAuthErrorMessage, getUrlErrorMessage, DATABASE_DOWN_ERROR_MESSAGE } from "@/lib/auth-error-handler"
 import { motion } from "framer-motion"
 import { Auth3DDecorations } from "@/components/auth/auth-3d-decorations"
 import { handleGoogleSignIn, handleMicrosoftSignIn } from "@/lib/auth-helpers"
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip"
 import { GoogleIcon } from "@/components/icons/google-icon"
 import { MicrosoftIcon } from "@/components/icons/microsoft-icon"
 import { getSafeAuthRedirect } from "@/lib/auth-redirects"
@@ -54,6 +56,7 @@ export default function LoginContent() {
   const [successMessage, setSuccessMessage] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [mounted, setMounted] = useState(false)
+  const passkeyEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.AUTH_PASSKEY)
 
   useEffect(() => {
     setMounted(true)
@@ -347,36 +350,114 @@ export default function LoginContent() {
                     </div>
                   </div>
 
-                  <div className={enabledProvidersCount > 1 ? "flex gap-3" : "space-y-4"}>
-                    {socialProviders.map((provider) => (
-                      <Button
-                        key={provider.id}
-                        type="button"
-                        variant="outline"
-                        className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-12 rounded-xl text-base font-medium border-border hover:bg-muted/50 transition-colors`}
-                        onClick={async () => {
-                          setSocialLoading(provider.id)
-                          setError(null)
-
-                          const safeRedirect = getSafeAuthRedirect(redirectParam, window.location.origin)
-                          const { error } = await provider.handler('login', safeRedirect)
-
-                          if (error) {
-                            setError(error)
-                            setSocialLoading(null)
-                          }
-                        }}
-                        disabled={isLoading || socialLoading !== null}
-                      >
-                        {socialLoading === provider.id ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                        ) : (
-                          <provider.Icon className="h-5 w-5 mr-2" />
-                        )}
-                        {enabledProvidersCount > 1 ? provider.name : provider.fullLabel}
-                      </Button>
-                    ))}
-                  </div>
+                  {passkeyEnabled ? (
+                    <TooltipProvider>
+                      <div className="flex flex-col lg:flex-row gap-3">
+                        {socialProviders.map((provider) => (
+                          <Tooltip key={provider.id}>
+                            <TooltipTrigger asChild>
+                              <Button
+                                type="button"
+                                variant="outline"
+                                className="flex-1 h-12 rounded-xl border-border hover:bg-muted/50 transition-colors cursor-pointer"
+                                onClick={async () => {
+                                  setSocialLoading(provider.id)
+                                  setError(null)
+                                  const safeRedirect = getSafeAuthRedirect(redirectParam, window.location.origin)
+                                  const { error } = await provider.handler('login', safeRedirect)
+                                  if (error) {
+                                    setError(error)
+                                    setSocialLoading(null)
+                                  }
+                                }}
+                                disabled={isLoading || socialLoading !== null}
+                              >
+                                {socialLoading === provider.id ? (
+                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                ) : (
+                                  <provider.Icon className="h-5 w-5" />
+                                )}
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Mit {provider.name} anmelden</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        ))}
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              className="flex-1 h-12 rounded-xl border-border hover:bg-muted/50 transition-colors cursor-pointer"
+                              onClick={async () => {
+                                setError(null)
+                                const supabase = createClient()
+                                trackPasskeyLoginStarted()
+                                const { data, error: passkeyError } = await supabase.auth.signInWithPasskey()
+                                if (passkeyError) {
+                                  const errorType = passkeyError.message?.toLowerCase().includes('cancelled') || passkeyError.message?.toLowerCase().includes('not allowed')
+                                    ? 'passkey_cancelled'
+                                    : 'passkey_error'
+                                  trackPasskeyLoginFailed(errorType)
+                                  setError(getAuthErrorMessage(passkeyError))
+                                  return
+                                }
+                                if (data?.user) {
+                                  if (posthog.has_opted_in_capturing?.()) {
+                                    posthog.identify(data.user.id, {
+                                      email: data.user.email,
+                                      name: data.user.user_metadata?.name || '',
+                                      last_sign_in: data.user.last_sign_in_at,
+                                      user_type: 'authenticated',
+                                      is_anonymous: false,
+                                    })
+                                  }
+                                  trackPasskeyLoginSuccess()
+                                }
+                                window.location.assign(getSafeAuthRedirect(redirectParam, window.location.origin))
+                              }}
+                              disabled={isLoading}
+                            >
+                              <Fingerprint className="h-5 w-5" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>Mit Passkey anmelden</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </div>
+                    </TooltipProvider>
+                  ) : (
+                    <div className={enabledProvidersCount > 1 ? "flex gap-3" : "space-y-4"}>
+                      {socialProviders.map((provider) => (
+                        <Button
+                          key={provider.id}
+                          type="button"
+                          variant="outline"
+                          className={`${enabledProvidersCount > 1 ? "flex-1 px-0" : "w-full"} h-12 rounded-xl text-base font-medium border-border hover:bg-muted/50 transition-colors`}
+                          onClick={async () => {
+                            setSocialLoading(provider.id)
+                            setError(null)
+                            const safeRedirect = getSafeAuthRedirect(redirectParam, window.location.origin)
+                            const { error } = await provider.handler('login', safeRedirect)
+                            if (error) {
+                              setError(error)
+                              setSocialLoading(null)
+                            }
+                          }}
+                          disabled={isLoading || socialLoading !== null}
+                        >
+                          {socialLoading === provider.id ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <provider.Icon className="h-5 w-5 mr-2" />
+                          )}
+                          {enabledProvidersCount > 1 ? provider.name : provider.fullLabel}
+                        </Button>
+                      ))}
+                    </div>
+                  )}
                 </div>
               )}
 

--- a/components/settings/passkey-section.tsx
+++ b/components/settings/passkey-section.tsx
@@ -37,6 +37,24 @@ type Passkey = {
   last_used_at?: string
 }
 
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString)
+  return date.toLocaleDateString("de-DE", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    timeZone: "Europe/Berlin",
+  })
+}
+
+const getDeviceIcon = (friendlyName?: string) => {
+  const name = friendlyName?.toLowerCase() || ""
+  if (name.includes("iphone") || name.includes("ipad") || name.includes("android") || name.includes("phone") || name.includes("mobile")) {
+    return <Smartphone className="h-5 w-5 text-muted-foreground" />
+  }
+  return <Monitor className="h-5 w-5 text-muted-foreground" />
+}
+
 const PasskeySection = () => {
   const supabase = createClient()
   const { toast } = useToast()
@@ -133,23 +151,6 @@ const PasskeySection = () => {
     })
     setDeletingId(null)
     fetchPasskeys()
-  }
-
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString)
-    return date.toLocaleDateString("de-DE", {
-      day: "2-digit",
-      month: "2-digit",
-      year: "numeric",
-    })
-  }
-
-  const getDeviceIcon = (friendlyName?: string) => {
-    const name = friendlyName?.toLowerCase() || ""
-    if (name.includes("iphone") || name.includes("ipad") || name.includes("android") || name.includes("phone") || name.includes("mobile")) {
-      return <Smartphone className="h-5 w-5 text-muted-foreground" />
-    }
-    return <Monitor className="h-5 w-5 text-muted-foreground" />
   }
 
   return (

--- a/components/settings/passkey-section.tsx
+++ b/components/settings/passkey-section.tsx
@@ -1,0 +1,305 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import { createClient } from "@/utils/supabase/client"
+import { Fingerprint, Trash2, Pencil, Plus, Loader2, Smartphone, Monitor } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { useToast } from "@/hooks/use-toast"
+import { SettingsCard, SettingsSection } from "@/components/settings/shared"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { getAuthErrorMessage } from "@/lib/auth-error-handler"
+import { trackPasskeyRegisterStarted, trackPasskeyRegisterSuccess, trackPasskeyRegisterFailed, trackPasskeyDeleted } from "@/lib/posthog-auth-events"
+
+type Passkey = {
+  id: string
+  friendly_name?: string
+  created_at: string
+  last_used_at?: string
+}
+
+const PasskeySection = () => {
+  const supabase = createClient()
+  const { toast } = useToast()
+  const [passkeys, setPasskeys] = useState<Passkey[]>([])
+  const [loading, setLoading] = useState(true)
+  const [registering, setRegistering] = useState(false)
+  const [renamingId, setRenamingId] = useState<string | null>(null)
+  const [renameValue, setRenameValue] = useState("")
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+
+  const fetchPasskeys = useCallback(async () => {
+    const { data, error } = await supabase.auth.passkey.list()
+    if (error) {
+      toast({
+        title: "Fehler",
+        description: "Passkeys konnten nicht geladen werden.",
+        variant: "destructive",
+      })
+      return
+    }
+    setPasskeys(data || [])
+  }, [supabase.auth.passkey, toast])
+
+  useEffect(() => {
+    setLoading(true)
+    fetchPasskeys().finally(() => setLoading(false))
+  }, [fetchPasskeys])
+
+  const handleRegister = async () => {
+    setRegistering(true)
+    trackPasskeyRegisterStarted()
+    const { data, error } = await supabase.auth.registerPasskey()
+    if (error) {
+      trackPasskeyRegisterFailed(error.message?.toLowerCase().includes('cancelled') ? 'passkey_cancelled' : 'passkey_error')
+      toast({
+        title: "Fehler",
+        description: getAuthErrorMessage(error),
+        variant: "destructive",
+      })
+      setRegistering(false)
+      return
+    }
+    trackPasskeyRegisterSuccess()
+    toast({
+      title: "Erfolg",
+      description: "Passkey erfolgreich registriert.",
+      variant: "success",
+    })
+    setRegistering(false)
+    fetchPasskeys()
+  }
+
+  const handleRename = async (passkeyId: string) => {
+    if (!renameValue.trim()) return
+    const { error } = await supabase.auth.passkey.update({
+      passkeyId,
+      friendlyName: renameValue.trim(),
+    })
+    if (error) {
+      toast({
+        title: "Fehler",
+        description: getAuthErrorMessage(error),
+        variant: "destructive",
+      })
+      return
+    }
+    toast({
+      title: "Erfolg",
+      description: "Passkey umbenannt.",
+      variant: "success",
+    })
+    setRenamingId(null)
+    setRenameValue("")
+    fetchPasskeys()
+  }
+
+  const handleDelete = async (passkeyId: string) => {
+    setDeletingId(passkeyId)
+    const { error } = await supabase.auth.passkey.delete({ passkeyId })
+    if (error) {
+      toast({
+        title: "Fehler",
+        description: getAuthErrorMessage(error),
+        variant: "destructive",
+      })
+      setDeletingId(null)
+      return
+    }
+    trackPasskeyDeleted()
+    toast({
+      title: "Erfolg",
+      description: "Passkey gelöscht.",
+      variant: "success",
+    })
+    setDeletingId(null)
+    fetchPasskeys()
+  }
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString)
+    return date.toLocaleDateString("de-DE", {
+      day: "2-digit",
+      month: "2-digit",
+      year: "numeric",
+    })
+  }
+
+  const getDeviceIcon = (friendlyName?: string) => {
+    const name = friendlyName?.toLowerCase() || ""
+    if (name.includes("iphone") || name.includes("ipad") || name.includes("android") || name.includes("phone") || name.includes("mobile")) {
+      return <Smartphone className="h-5 w-5 text-muted-foreground" />
+    }
+    return <Monitor className="h-5 w-5 text-muted-foreground" />
+  }
+
+  return (
+    <SettingsSection
+      title="Passkeys"
+      description="Verwalten Sie Ihre Passkeys für eine schnelle und sichere Anmeldung ohne Passwort."
+    >
+      <SettingsCard>
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Fingerprint className="h-5 w-5 text-muted-foreground" />
+              <span className="text-sm font-medium text-muted-foreground">
+                {passkeys.length} Passkey{passkeys.length !== 1 ? "s" : ""} registriert
+              </span>
+            </div>
+            <Button
+              onClick={handleRegister}
+              disabled={registering}
+              size="sm"
+            >
+              {registering ? (
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+              ) : (
+                <Plus className="h-4 w-4 mr-2" />
+              )}
+              Passkey hinzufügen
+            </Button>
+          </div>
+
+          {loading ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : passkeys.length === 0 ? (
+            <p className="text-sm text-muted-foreground text-center py-4">
+              Sie haben noch keine Passkeys registriert. Fügen Sie einen Passkey hinzu, um sich ohne Passwort anzumelden.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {passkeys.map((passkey) => (
+                <div
+                  key={passkey.id}
+                  className="flex items-center justify-between p-3 rounded-lg bg-background border border-border"
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    {getDeviceIcon(passkey.friendly_name)}
+                    <div className="min-w-0">
+                      {renamingId === passkey.id ? (
+                        <div className="flex items-center gap-2">
+                          <Input
+                            value={renameValue}
+                            onChange={(e) => setRenameValue(e.target.value)}
+                            className="h-8 w-48 text-sm"
+                            placeholder="Name"
+                            autoFocus
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter") handleRename(passkey.id)
+                              if (e.key === "Escape") setRenamingId(null)
+                            }}
+                          />
+                          <Button size="sm" variant="ghost" onClick={() => handleRename(passkey.id)} className="h-8">
+                            Speichern
+                          </Button>
+                          <Button size="sm" variant="ghost" onClick={() => setRenamingId(null)} className="h-8">
+                            Abbrechen
+                          </Button>
+                        </div>
+                      ) : (
+                        <>
+                          <p className="text-sm font-medium truncate">
+                            {passkey.friendly_name || "Unbekanntes Gerät"}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            Registriert am {formatDate(passkey.created_at)}
+                            {passkey.last_used_at && ` · Zuletzt genutzt am ${formatDate(passkey.last_used_at)}`}
+                          </p>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1 shrink-0 ml-2">
+                    {renamingId !== passkey.id && (
+                      <Dialog>
+                        <DialogTrigger asChild>
+                          <Button size="sm" variant="ghost" className="h-8 w-8 p-0">
+                            <Pencil className="h-4 w-4" />
+                          </Button>
+                        </DialogTrigger>
+                        <DialogContent>
+                          <DialogHeader>
+                            <DialogTitle>Passkey umbenennen</DialogTitle>
+                            <DialogDescription>
+                              Geben Sie einen neuen Namen für diesen Passkey ein.
+                            </DialogDescription>
+                          </DialogHeader>
+                          <div className="py-4">
+                            <Input
+                              defaultValue={passkey.friendly_name || ""}
+                              onChange={(e) => setRenameValue(e.target.value)}
+                              placeholder="z. B. Mein iPhone"
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") handleRename(passkey.id)
+                              }}
+                            />
+                          </div>
+                          <DialogFooter>
+                            <Button onClick={() => handleRename(passkey.id)}>
+                              Speichern
+                            </Button>
+                          </DialogFooter>
+                        </DialogContent>
+                      </Dialog>
+                    )}
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button size="sm" variant="ghost" className="h-8 w-8 p-0 text-destructive hover:text-destructive">
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Passkey löschen?</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            Sind Sie sicher, dass Sie diesen Passkey löschen möchten? Sie können sich dann nicht mehr mit diesem Gerät anmelden.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Abbrechen</AlertDialogCancel>
+                          <AlertDialogAction
+                            onClick={() => handleDelete(passkey.id)}
+                            disabled={deletingId === passkey.id}
+                          >
+                            {deletingId === passkey.id ? (
+                              <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                            ) : null}
+                            Löschen
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </SettingsCard>
+    </SettingsSection>
+  )
+}
+
+export default PasskeySection

--- a/components/settings/security-section.tsx
+++ b/components/settings/security-section.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect } from "react"
 import { createClient } from "@/utils/supabase/client"
+import { useFeatureFlagEnabled } from 'posthog-js/react'
+import { POSTHOG_FEATURE_FLAGS } from "@/lib/constants"
 import { Mail, Lock, AlertCircle, CheckCircle, Circle } from "lucide-react";
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
@@ -9,10 +11,12 @@ import { useToast } from "@/hooks/use-toast";
 import { SettingsCard, SettingsSection } from "@/components/settings/shared";
 import ConnectedAccountsSection from "./connected-accounts-section";
 import AuthorizedAppsSection from "./authorized-apps-section";
+import PasskeySection from "./passkey-section";
 
 const SecuritySection = () => {
   const supabase = createClient()
   const { toast } = useToast()
+  const passkeyEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.AUTH_PASSKEY)
   const [email, setEmail] = useState<string>("")
   const [confirmEmail, setConfirmEmail] = useState<string>("")
   const [password, setPassword] = useState<string>("")
@@ -208,6 +212,7 @@ const SecuritySection = () => {
         </SettingsCard>
       </SettingsSection>
 
+      {passkeyEnabled && <PasskeySection />}
       <ConnectedAccountsSection onUpdate={fetchUser} />
       <AuthorizedAppsSection />
     </div>

--- a/lib/auth-error-handler.ts
+++ b/lib/auth-error-handler.ts
@@ -56,6 +56,15 @@ const ERROR_CODE_MESSAGES: Record<string, string> = {
     // OTP errors
     "otp_expired": "Der Bestätigungscode ist abgelaufen. Bitte fordern Sie einen neuen an.",
     "otp_disabled": "Einmalpasswörter sind deaktiviert.",
+
+    // Passkey / WebAuthn errors
+    "passkey_disabled": "Passkey-Anmeldung ist für dieses Projekt nicht aktiviert.",
+    "too_many_passkeys": "Sie haben die maximale Anzahl an Passkeys erreicht.",
+    "webauthn_credential_exists": "Dieser Passkey wurde bereits registriert.",
+    "webauthn_credential_not_found": "Dieser Passkey ist nicht mit Ihrem Konto verknüpft.",
+    "webauthn_challenge_not_found": "Die Authentifizierungsanforderung ist ungültig oder abgelaufen.",
+    "webauthn_challenge_expired": "Die Authentifizierungsanforderung ist abgelaufen. Bitte versuchen Sie es erneut.",
+    "webauthn_verification_failed": "Die Passkey-Verifizierung ist fehlgeschlagen. Bitte versuchen Sie es erneut.",
 } as const
 
 /**
@@ -79,6 +88,11 @@ const MESSAGE_PATTERNS: Array<{ pattern: string; message: string }> = [
     // Rate limiting (handle both correct spelling and common typo)
     { pattern: "Too many requests", message: "Zu viele Anfragen. Bitte warten Sie einen Moment." },
     { pattern: "rate limit exceeded", message: "Zu viele Anfragen. Bitte warten Sie einen Moment." },
+
+    // Passkey cancellation errors
+    { pattern: "Passkey ceremony cancelled", message: "Der Passkey-Vorgang wurde abgebrochen." },
+    { pattern: "The operation either timed out or was not allowed", message: "Der Passkey-Vorgang wurde abgebrochen." },
+    { pattern: "Request has been cancelled by the user", message: "Der Passkey-Vorgang wurde abgebrochen." },
 
     // Network / Database outage errors
     { pattern: "Failed to fetch", message: DATABASE_DOWN_ERROR_MESSAGE },

--- a/lib/auth-error-handler.ts
+++ b/lib/auth-error-handler.ts
@@ -1,4 +1,4 @@
-import type { AuthError } from "@supabase/supabase-js"
+type AuthErrorLike = { code?: string; message: string }
 
 /**
  * Centralized authentication error handler for Supabase Auth errors.
@@ -112,7 +112,7 @@ const MESSAGE_PATTERNS: Array<{ pattern: string; message: string }> = [
  * @param error - The Supabase AuthError object
  * @returns A German error message suitable for display to users
  */
-export function getAuthErrorMessage(error: AuthError): string {
+export function getAuthErrorMessage(error: AuthErrorLike): string {
     // Strategy 1: Use error code if available (preferred, more stable)
     if (error.code && error.code in ERROR_CODE_MESSAGES) {
         return ERROR_CODE_MESSAGES[error.code]

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -58,6 +58,8 @@ export const POSTHOG_FEATURE_FLAGS = {
   // Landing page
   SHOW_PRODUKTE_DROPDOWN: 'show-produkte-dropdown',
   SHOW_LOESUNGEN_DROPDOWN: 'show-loesungen-dropdown',
+  // Auth features
+  AUTH_PASSKEY: 'auth-passkey',
 } as const;
 
 // Application routes - centralized to prevent hardcoded paths

--- a/lib/posthog-auth-events.ts
+++ b/lib/posthog-auth-events.ts
@@ -41,6 +41,7 @@ export type AuthMethod =
     | 'github'          // GitHub OAuth (future)
     | 'magic_link'      // Passwordless email link
     | 'sso'             // Enterprise SSO (future)
+    | 'passkey'         // Passkey / WebAuthn
     | string;           // Allow custom methods
 
 /**
@@ -54,7 +55,9 @@ export type AuthAction =
     | 'password_update' // Password change
     | 'email_verify'    // Email verification
     | 'session_refresh' // Session refresh
-    | 'session_expire'; // Session expiration
+    | 'session_expire'  // Session expiration
+    | 'passkey_register'// Passkey registration
+    | 'passkey_delete'; // Passkey deletion
 
 /**
  * Authentication status
@@ -78,6 +81,8 @@ export type AuthErrorType =
     | 'oauth_cancelled'
     | 'oauth_error'
     | 'expired_token'
+    | 'passkey_cancelled'
+    | 'passkey_error'
     | 'unknown';
 
 /**
@@ -376,6 +381,36 @@ export function trackOnboardingCompleted(planName?: string) {
 
 export function trackOnboardingSkipped() {
     trackOnboarding({ action: 'skipped' });
+}
+
+// --- Passkey ---
+
+export function trackPasskeyLoginStarted() {
+    trackAuth({ action: 'login', status: 'started', method: 'passkey' });
+}
+
+export function trackPasskeyLoginSuccess() {
+    trackAuth({ action: 'login', status: 'success', method: 'passkey' });
+}
+
+export function trackPasskeyLoginFailed(errorType: AuthErrorType = 'passkey_error') {
+    trackAuth({ action: 'login', status: 'failed', method: 'passkey', error_type: errorType });
+}
+
+export function trackPasskeyRegisterStarted() {
+    trackAuth({ action: 'passkey_register', status: 'started', method: 'passkey' });
+}
+
+export function trackPasskeyRegisterSuccess() {
+    trackAuth({ action: 'passkey_register', status: 'success', method: 'passkey' });
+}
+
+export function trackPasskeyRegisterFailed(errorType: AuthErrorType = 'passkey_error') {
+    trackAuth({ action: 'passkey_register', status: 'failed', method: 'passkey', error_type: errorType });
+}
+
+export function trackPasskeyDeleted() {
+    trackAuth({ action: 'passkey_delete', status: 'success', method: 'passkey' });
 }
 
 // --- Legacy page view functions (kept for backwards compatibility) ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "@stripe/react-stripe-js": "^5.6.1",
         "@stripe/stripe-js": "^8.5.3",
         "@supabase/ssr": "^0.8.0",
-        "@supabase/supabase-js": "^2.86.2",
+        "@supabase/supabase-js": "^2.105.0",
         "@tiptap/core": "^3.20.5",
         "@tiptap/extension-mention": "^3.20.5",
         "@tiptap/react": "^3.20.5",
@@ -2912,6 +2912,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@posthog/cli/node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "extraneous": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@posthog/core": {
@@ -8740,46 +8756,58 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.86.2",
+      "version": "2.110.2",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.110.2.tgz",
+      "integrity": "sha512-Qj7a6EDP+AMMQFWqGv+qFa8r6re//dk+qQI5bA0KK+PZmnI3JPu97TDeNt6SMiQ2FkklP79hP2yDFYSnA989OA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.86.2",
+      "version": "2.110.2",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.110.2.tgz",
+      "integrity": "sha512-ZjjqrXpxM9/rE+eAtZxiK45EWy9EBoJQ322Q5Y75LccYQNh212neHTgXP/o4MIzmH0LNXT8UzvTZtQOfOzyoeQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.4.tgz",
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.86.2",
+      "version": "2.110.2",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.110.2.tgz",
+      "integrity": "sha512-++LBmcIMwCtgO4tISQUmo9+2xkRwHQqS8ZKMCnhXLe9P8k8YQRXuMoh/RiSzQSoev8gqet0W7yOboW0cUxnt0Q==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.86.2",
+      "version": "2.110.2",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.110.2.tgz",
+      "integrity": "sha512-z3jTOTPgyn6E3r6dVOOQ10He4yAMB2czjFw7xVdX3s16MHElna5rY1gVaePs0NIo6xvtMYbtmOXlFaFt/ePLpg==",
       "license": "MIT",
       "dependencies": {
-        "@types/phoenix": "^1.6.6",
-        "@types/ws": "^8.18.1",
-        "tslib": "2.8.1",
-        "ws": "^8.18.2"
+        "@supabase/phoenix": "0.4.4",
+        "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/ssr": {
@@ -8793,28 +8821,32 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.86.2",
+      "version": "2.110.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.110.2.tgz",
+      "integrity": "sha512-EhsRSwSnmQefKJsAxoRUZ0hvHr92ECM8DDGAKR5z0HdoJx4heI60PjHUTruVNZxKX6XeobLGDyLud020Bw1iwg==",
       "license": "MIT",
       "dependencies": {
-        "iceberg-js": "^0.8.0",
+        "iceberg-js": "^0.8.1",
         "tslib": "2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.86.2",
+      "version": "2.110.2",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.110.2.tgz",
+      "integrity": "sha512-r9q9w4ZQ6mOjh36aqUNFSisBF611vzpO8JphBESr2Q1SWvmGFQeI7Jq7Y+PaNMZ6Zszz+S2yTlJStCpnaMSnQg==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.86.2",
-        "@supabase/functions-js": "2.86.2",
-        "@supabase/postgrest-js": "2.86.2",
-        "@supabase/realtime-js": "2.86.2",
-        "@supabase/storage-js": "2.86.2"
+        "@supabase/auth-js": "2.110.2",
+        "@supabase/functions-js": "2.110.2",
+        "@supabase/postgrest-js": "2.110.2",
+        "@supabase/realtime-js": "2.110.2",
+        "@supabase/storage-js": "2.110.2"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@swc/helpers": {
@@ -9960,10 +9992,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/phoenix": {
-      "version": "1.6.6",
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -9998,13 +10026,6 @@
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "license": "MIT"
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -13260,7 +13281,9 @@
       }
     },
     "node_modules/iceberg-js": {
-      "version": "0.8.0",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@stripe/react-stripe-js": "^5.6.1",
     "@stripe/stripe-js": "^8.5.3",
     "@supabase/ssr": "^0.8.0",
-    "@supabase/supabase-js": "^2.86.2",
+    "@supabase/supabase-js": "^2.105.0",
     "@tiptap/core": "^3.20.5",
     "@tiptap/extension-mention": "^3.20.5",
     "@tiptap/react": "^3.20.5",

--- a/utils/supabase/client.ts
+++ b/utils/supabase/client.ts
@@ -3,6 +3,11 @@ import { createBrowserClient } from "@supabase/ssr"
 export function createClient() {
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      auth: {
+        experimental: { passkey: true },
+      },
+    }
   )
 }


### PR DESCRIPTION
- Upgrade @supabase/supabase-js to ^2.105.0 for passkey support
- Add experimental: { passkey: true } to browser Supabase client
- Add passkey sign-in button (icon-only, with tooltip) to login page and auth modal
- Gate behind PostHog feature flag 'auth-passkey' — when disabled, UI matches main
- Add passkey management section in security settings (register, list, rename, delete)
- Add passkey error messages and PostHog tracking events
- Make social provider buttons icon-only with tooltips when flag enabled