### PR TITLE
fix: exclude agent/ from Next.js type-checking

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,7 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
+    "agent",
     "node_modules",
     "supabase/functions",
     "workers"


### PR DESCRIPTION
## Description

Excludes the `agent/` directory from Next.js TypeScript type-checking.

## Summary of Changes

- `tsconfig.json`: add `agent` to the `exclude` list so types in the agent directory no longer break `tsc --noEmit` and production builds