### PR TITLE
fix(agents): enforce active member status and harden webhook secret generation

### DIFF
--- a/components/agent-builder/steps/Step4Trigger.tsx
+++ b/components/agent-builder/steps/Step4Trigger.tsx
@@ -28,7 +28,7 @@ export function Step4Trigger({ trigger, onChange }: Step4Props) {
     if (type === 'cron') {
       defaultConfig = { cron_expression: '0 8 * * *', timezone: 'Europe/Berlin' };
     } else if (type === 'webhook') {
-      defaultConfig = { secret: typeof crypto !== 'undefined' ? crypto.randomUUID() : 'whsec_default' };
+      defaultConfig = { secret: crypto.randomUUID() };
     } else if (type === 'db_event') {
       defaultConfig = { table: 'Mieter', event: 'INSERT' };
     }

--- a/lib/agents/permissions.ts
+++ b/lib/agents/permissions.ts
@@ -12,6 +12,7 @@ export async function resolveMitgliedId(
     .select('id, rolle')
     .eq('organisation_id', orgId)
     .eq('user_id', userId)
+    .eq('status', 'aktiv')
     .is('geloescht_am', null)
     .single();
 


### PR DESCRIPTION
## Overview
This PR hardens agent permissions and trigger initialization.

## Key Changes

### 1. Active Membership Enforcement
- Adds `.eq('status', 'aktiv')` filter to `resolveMitgliedId(...)` in [lib/agents/permissions.ts](file:///Users/felixplant/Downloads/Felix/GitHub-Repo/mietevo-repos/RMS/lib/agents/permissions.ts).
- Ensures inactive or suspended organization members cannot resolve valid member IDs or execute agent workflows.

### 2. Hardened Webhook Secret Generation
- Removes hardcoded default fallback string `'whsec_default'`, using `crypto.randomUUID()` directly in [components/agent-builder/steps/Step4Trigger.tsx](file:///Users/felixplant/Downloads/Felix/GitHub-Repo/mietevo-repos/RMS/components/agent-builder/steps/Step4Trigger.tsx).

Note: Earlier route logic changes were superseded by the `mietevo-ai` proxy migration (#1591) and have been removed.