### PR TITLE
Feat/ai service migration

### DIFF
--- a/app/api/agents/[id]/run/route.ts
+++ b/app/api/agents/[id]/run/route.ts
@@ -1,20 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
-import { validateTrigger } from '@/lib/agents/trigger';
-import { checkAgentAccess, resolveMitgliedId } from '@/lib/agents/permissions';
-import { type SupabaseClient } from '@supabase/supabase-js';
-import { JobsClient } from '@google-cloud/run';
-
-async function failRun(supabase: SupabaseClient, runId: string, message: string) {
-  try {
-    await supabase
-      .from('KI_Runs')
-      .update({ status: 'fehler', beendet_am: new Date().toISOString(), fehler_meldung: message })
-      .eq('id', runId);
-  } catch {
-    // Best-effort cleanup
-  }
-}
+import { proxyToAiService } from '@/lib/ai-service-proxy';
 
 export async function POST(
   req: NextRequest,
@@ -29,85 +15,27 @@ export async function POST(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    // 1. Get agent details
-    const { data: agent, error: agentError } = await supabase.rpc('get_ki_agent_details', { p_agent_id: id });
-    if (agentError || !agent) {
-      return NextResponse.json({ error: 'Agent not found' }, { status: 404 });
+    const { data: rpcOrgId } = await supabase.rpc('current_organisation_id');
+    let orgId = rpcOrgId;
+
+    if (!orgId) {
+      const { data: membership } = await supabase
+        .from('Organisation_Mitglieder')
+        .select('organisation_id')
+        .eq('user_id', user.id)
+        .eq('status', 'aktiv')
+        .limit(1)
+        .maybeSingle();
+      orgId = membership?.organisation_id || null;
     }
 
-    if (agent.status !== 'aktiv') {
-      return NextResponse.json({ error: 'Agent is not active' }, { status: 400 });
+    if (!orgId) {
+      return NextResponse.json({ error: 'No active organization found' }, { status: 400 });
     }
 
-    // 2. Validate trigger configuration
-    const isValid = validateTrigger(agent.trigger, req);
-    if (!isValid) {
-      return NextResponse.json({ error: 'Trigger validation failed' }, { status: 403 });
-    }
-
-    // 3. Check caller has agent-level access (view or manage required to run)
-    const callerMitgliedId = await resolveMitgliedId(supabase, user.id, agent.organisation_id);
-    if (!callerMitgliedId) {
-      return NextResponse.json({ error: 'Caller is not a member of this organisation' }, { status: 403 });
-    }
-
-    const hasAccess = await checkAgentAccess(supabase, id, callerMitgliedId, ['view', 'manage']);
-    if (!hasAccess) {
-      return NextResponse.json({ error: 'Insufficient permissions to run this agent' }, { status: 403 });
-    }
-
-    // 4. Create KI_Runs record in database
-    const { data: runData, error: runError } = await supabase
-      .from('KI_Runs')
-      .insert({
-        organisation_id: agent.organisation_id,
-        agent_id: id,
-        auth_mode: 'agent',
-        status: 'in_warteschlange',
-        ausfuehrungs_typ: 'cloud_run_job',
-        gestartet_am: new Date().toISOString(),
-      })
-      .select('id')
-      .single();
-
-    if (runError || !runData) {
-      return NextResponse.json({ error: 'Failed to create run record' }, { status: 500 });
-    }
-
-    const runId = runData.id;
-
-    // 5. Trigger Cloud Run Job if configured
-    const jobName = process.env.CLOUD_RUN_JOB_NAME || 'mietevo-agent-runner';
-    const project = process.env.GOOGLE_CLOUD_PROJECT;
-    const location = process.env.GOOGLE_CLOUD_LOCATION || 'europe-west1';
-
-    if (project) {
-      try {
-        const runClient = new JobsClient();
-        const parent = `projects/${project}/locations/${location}/jobs/${jobName}`;
-        await runClient.runJob({
-          name: parent,
-          overrides: {
-            containerOverrides: [
-              {
-                env: [
-                  { name: 'AGENT_ID', value: id },
-                  { name: 'RUN_ID', value: runId },
-                ],
-              },
-            ],
-          },
-        });
-      } catch (gcpError: any) {
-        console.error('[Cloud Run Job Trigger] Failed to dispatch Cloud Run Job:', gcpError?.message);
-        await failRun(supabase, runId, `Cloud Run dispatch failed: ${gcpError?.message || 'Unknown error'}`);
-        return NextResponse.json({ error: 'Failed to dispatch agent job' }, { status: 502 });
-      }
-    }
-
-    return NextResponse.json({ runId, status: 'in_warteschlange' }, { status: 202 });
+    return proxyToAiService(`/api/agents/${id}/run`, req, user.id, orgId);
   } catch (err: any) {
-    console.error('[Agent Run] Internal error:', err);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/agents/[id]/run/route.ts
+++ b/app/api/agents/[id]/run/route.ts
@@ -35,7 +35,7 @@ export async function POST(
 
     return proxyToAiService(`/api/agents/${id}/run`, req, user.id, orgId);
   } catch (err: any) {
-    const message = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: message }, { status: 500 });
+    console.error('[POST /api/agents/[id]/run] Internal error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/app/api/agents/[id]/run/route.ts
+++ b/app/api/agents/[id]/run/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/utils/supabase/server';
+import { resolveUserAndOrg } from '@/lib/auth-utils';
 import { proxyToAiService } from '@/lib/ai-service-proxy';
 
 export async function POST(
@@ -8,32 +8,10 @@ export async function POST(
 ) {
   try {
     const { id } = await params;
-    const supabase = await createClient();
+    const { user, orgId, userJwt, errorResponse } = await resolveUserAndOrg(req);
+    if (errorResponse) return errorResponse;
 
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const { data: rpcOrgId } = await supabase.rpc('current_organisation_id');
-    let orgId = rpcOrgId;
-
-    if (!orgId) {
-      const { data: membership } = await supabase
-        .from('Organisation_Mitglieder')
-        .select('organisation_id')
-        .eq('user_id', user.id)
-        .eq('status', 'aktiv')
-        .limit(1)
-        .maybeSingle();
-      orgId = membership?.organisation_id || null;
-    }
-
-    if (!orgId) {
-      return NextResponse.json({ error: 'No active organization found' }, { status: 400 });
-    }
-
-    return proxyToAiService(`/api/agents/${id}/run`, req, user.id, orgId);
+    return proxyToAiService(`/api/agents/${id}/run`, req, user.id, orgId, userJwt);
   } catch (err: any) {
     console.error('[POST /api/agents/[id]/run] Internal error:', err);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/app/api/agents/runs/[id]/route.ts
+++ b/app/api/agents/runs/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
+import { proxyToAiService } from '@/lib/ai-service-proxy';
 
 export async function GET(
   req: NextRequest,
@@ -9,20 +10,31 @@ export async function GET(
     const { id } = await params;
     const supabase = await createClient();
     const { data: { user }, error: authError } = await supabase.auth.getUser();
-
     if (authError || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { data, error } = await supabase.rpc('get_ki_agent_run_details', { p_run_id: id });
-    if (error) {
-      console.error('[GET /api/agents/runs/[id]] RPC error:', error);
-      return NextResponse.json({ error: 'Run not found' }, { status: 404 });
+    const { data: rpcOrgId } = await supabase.rpc('current_organisation_id');
+    let orgId = rpcOrgId;
+
+    if (!orgId) {
+      const { data: membership } = await supabase
+        .from('Organisation_Mitglieder')
+        .select('organisation_id')
+        .eq('user_id', user.id)
+        .eq('status', 'aktiv')
+        .limit(1)
+        .maybeSingle();
+      orgId = membership?.organisation_id || null;
     }
 
-    return NextResponse.json(data);
+    if (!orgId) {
+      return NextResponse.json({ error: 'No active organization found' }, { status: 400 });
+    }
+
+    return proxyToAiService(`/api/agents/runs/${id}`, req, user.id, orgId);
   } catch (err: any) {
-    console.error('[GET /api/agents/runs/[id]] Internal error:', err);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/agents/runs/[id]/route.ts
+++ b/app/api/agents/runs/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/utils/supabase/server';
+import { resolveUserAndOrg } from '@/lib/auth-utils';
 import { proxyToAiService } from '@/lib/ai-service-proxy';
 
 export async function GET(
@@ -8,31 +8,10 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    const supabase = await createClient();
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+    const { user, orgId, userJwt, errorResponse } = await resolveUserAndOrg(req);
+    if (errorResponse) return errorResponse;
 
-    const { data: rpcOrgId } = await supabase.rpc('current_organisation_id');
-    let orgId = rpcOrgId;
-
-    if (!orgId) {
-      const { data: membership } = await supabase
-        .from('Organisation_Mitglieder')
-        .select('organisation_id')
-        .eq('user_id', user.id)
-        .eq('status', 'aktiv')
-        .limit(1)
-        .maybeSingle();
-      orgId = membership?.organisation_id || null;
-    }
-
-    if (!orgId) {
-      return NextResponse.json({ error: 'No active organization found' }, { status: 400 });
-    }
-
-    return proxyToAiService(`/api/agents/runs/${id}`, req, user.id, orgId);
+    return proxyToAiService(`/api/agents/runs/${id}`, req, user.id, orgId, userJwt);
   } catch (err: any) {
     console.error('[GET /api/agents/runs/[id]] Internal error:', err);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/app/api/agents/runs/[id]/route.ts
+++ b/app/api/agents/runs/[id]/route.ts
@@ -34,7 +34,7 @@ export async function GET(
 
     return proxyToAiService(`/api/agents/runs/${id}`, req, user.id, orgId);
   } catch (err: any) {
-    const message = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: message }, { status: 500 });
+    console.error('[GET /api/agents/runs/[id]] Internal error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/app/api/agents/runs/route.ts
+++ b/app/api/agents/runs/route.ts
@@ -1,34 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/utils/supabase/server';
+import { resolveUserAndOrg } from '@/lib/auth-utils';
 import { proxyToAiService } from '@/lib/ai-service-proxy';
 
 export async function GET(req: NextRequest) {
   try {
-    const supabase = await createClient();
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+    const { user, orgId, userJwt, errorResponse } = await resolveUserAndOrg(req);
+    if (errorResponse) return errorResponse;
 
-    const { data: rpcOrgId } = await supabase.rpc('current_organisation_id');
-    let orgId = rpcOrgId;
-
-    if (!orgId) {
-      const { data: membership } = await supabase
-        .from('Organisation_Mitglieder')
-        .select('organisation_id')
-        .eq('user_id', user.id)
-        .eq('status', 'aktiv')
-        .limit(1)
-        .maybeSingle();
-      orgId = membership?.organisation_id || null;
-    }
-
-    if (!orgId) {
-      return NextResponse.json({ error: 'No active organization found' }, { status: 400 });
-    }
-
-    return proxyToAiService('/api/agents/runs', req, user.id, orgId);
+    return proxyToAiService('/api/agents/runs', req, user.id, orgId, userJwt);
   } catch (err: any) {
     console.error('[GET /api/agents/runs] Internal error:', err);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/app/api/agents/runs/route.ts
+++ b/app/api/agents/runs/route.ts
@@ -1,36 +1,36 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
+import { proxyToAiService } from '@/lib/ai-service-proxy';
 
 export async function GET(req: NextRequest) {
   try {
     const supabase = await createClient();
     const { data: { user }, error: authError } = await supabase.auth.getUser();
-
     if (authError || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { searchParams } = new URL(req.url);
-    const agentId = searchParams.get('agent_id') || searchParams.get('agentId') || null;
-    const status = searchParams.get('status') || null;
-    const limit = parseInt(searchParams.get('limit') || '50', 10);
-    const offset = parseInt(searchParams.get('offset') || '0', 10);
+    const { data: rpcOrgId } = await supabase.rpc('current_organisation_id');
+    let orgId = rpcOrgId;
 
-    const { data, error } = await supabase.rpc('get_ki_agenten_runs', {
-      p_agent_id: agentId,
-      p_status: status,
-      p_limit: limit,
-      p_offset: offset,
-    });
-
-    if (error) {
-      console.error('[GET /api/agents/runs] RPC error:', error);
-      return NextResponse.json({ error: 'Failed to fetch agent runs' }, { status: 500 });
+    if (!orgId) {
+      const { data: membership } = await supabase
+        .from('Organisation_Mitglieder')
+        .select('organisation_id')
+        .eq('user_id', user.id)
+        .eq('status', 'aktiv')
+        .limit(1)
+        .maybeSingle();
+      orgId = membership?.organisation_id || null;
     }
 
-    return NextResponse.json(data || []);
+    if (!orgId) {
+      return NextResponse.json({ error: 'No active organization found' }, { status: 400 });
+    }
+
+    return proxyToAiService('/api/agents/runs', req, user.id, orgId);
   } catch (err: any) {
-    console.error('[GET /api/agents/runs] Internal error:', err);
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/agents/runs/route.ts
+++ b/app/api/agents/runs/route.ts
@@ -30,7 +30,7 @@ export async function GET(req: NextRequest) {
 
     return proxyToAiService('/api/agents/runs', req, user.id, orgId);
   } catch (err: any) {
-    const message = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: message }, { status: 500 });
+    console.error('[GET /api/agents/runs] Internal error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/app/api/chat/engine/route.ts
+++ b/app/api/chat/engine/route.ts
@@ -4,7 +4,7 @@ import { waitUntil } from '@vercel/functions';
 import { createSupabaseUserClient } from '@/lib/sandbox/runner';
 import { runAgent } from '@/lib/agents/mietevo-agent';
 
-function timingSafeCompare(a: string | null, b: string): boolean {
+function timingSafeCompare(a: string | null, b: string | undefined): boolean {
   if (!a || !b) {
     return false;
   }
@@ -271,7 +271,7 @@ export async function POST(req: NextRequest) {
       }
     });
   } catch (err: any) {
-    const message = err instanceof Error ? err.message : (err && typeof err === 'object' ? JSON.stringify(err) : String(err));
-    return NextResponse.json({ error: message }, { status: 500 });
+    console.error('[POST /api/chat/engine] Internal error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/app/api/chat/engine/route.ts
+++ b/app/api/chat/engine/route.ts
@@ -4,11 +4,18 @@ import { waitUntil } from '@vercel/functions';
 import { createSupabaseUserClient } from '@/lib/sandbox/runner';
 import { runAgent } from '@/lib/agents/mietevo-agent';
 
-function timingSafeCompare(a: string, b: string): boolean {
-  if (!a || !b || a.length !== b.length) {
+function timingSafeCompare(a: string | null, b: string): boolean {
+  if (!a || !b) {
     return false;
   }
-  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+
+  if (bufA.byteLength !== bufB.byteLength) {
+    timingSafeEqual(bufB, bufB);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
 }
 
 export async function POST(req: NextRequest) {

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -14,6 +14,10 @@ export async function POST(req: NextRequest) {
     const { data: { session } } = await userSupabase.auth.getSession();
     const userJwt = session?.access_token;
 
+    if (!userJwt) {
+      return NextResponse.json({ error: 'Session token not found' }, { status: 401 });
+    }
+
     let orgId = req.headers.get('X-Org-Id');
     if (!orgId) {
       const { data: rpcOrgId } = await userSupabase.rpc('current_organisation_id');
@@ -37,7 +41,7 @@ export async function POST(req: NextRequest) {
 
     return proxyToAiService('/api/chat', req, user.id, orgId, userJwt);
   } catch (err: any) {
-    const message = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error: message }, { status: 500 });
+    console.error('[POST /api/chat] Internal error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,29 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
+import { proxyToAiService } from '@/lib/ai-service-proxy';
 
 export async function POST(req: NextRequest) {
   try {
-    const body = await req.json();
-    let { message, conversationId, orgId, agentMitgliedId, agentId, model } = body;
-
-    const idempotencyKey = req.headers.get('x-idempotency-key') || req.headers.get('X-Idempotency-Key');
-    
-    // 1. Authenticate user session using secure getUser()
     const userSupabase = await createClient();
     const { data: { user }, error: authError } = await userSupabase.auth.getUser();
-    
+
     if (authError || !user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const { data: { session } } = await userSupabase.auth.getSession();
     const userJwt = session?.access_token;
-    
-    if (!userJwt) {
-      return NextResponse.json({ error: 'Session token not found' }, { status: 401 });
-    }
 
-    // Auto-resolve organization if not passed
+    let orgId = req.headers.get('X-Org-Id');
     if (!orgId) {
       const { data: rpcOrgId } = await userSupabase.rpc('current_organisation_id');
       orgId = rpcOrgId;
@@ -44,50 +35,9 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'No active organization found' }, { status: 400 });
     }
 
-    // 2. Validate tenant access (user must belong to the specified organization)
-    const { data: membership, error: membershipError } = await userSupabase
-      .from('Organisation_Mitglieder')
-      .select('id, rolle')
-      .eq('organisation_id', orgId)
-      .eq('user_id', user.id)
-      .eq('status', 'aktiv')
-      .single();
-
-    if (membershipError || !membership) {
-      return NextResponse.json({ error: 'Forbidden: You are not a member of this organization' }, { status: 403 });
-    }
-
-    // Forward request to internal engine (AI Service)
-    const baseSiteUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
-    const aiServiceUrl = process.env.AI_SERVICE_URL ?? `${baseSiteUrl}/api/chat/engine`;
-    const aiServiceSecret = process.env.AI_SERVICE_AUTH_SECRET!;
-
-    const response = await fetch(aiServiceUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-AI-Service-Auth': aiServiceSecret,
-        'X-User-Id': user.id,
-        'X-Org-Id': orgId,
-        ...(idempotencyKey ? { 'X-Idempotency-Key': idempotencyKey } : {}),
-      },
-      body: JSON.stringify({ message, conversationId, agentMitgliedId, agentId, model, userJwt }),
-    });
-
-    if (!response.ok) {
-      const errText = await response.text();
-      return new NextResponse(errText, { status: response.status });
-    }
-
-    return new Response(response.body, {
-      headers: {
-        'Content-Type': 'text/plain',
-        'Cache-Control': 'no-cache, no-transform',
-        'Connection': 'keep-alive',
-      },
-    });
+    return proxyToAiService('/api/chat', req, user.id, orgId, userJwt);
   } catch (err: any) {
-    const message = err instanceof Error ? err.message : (err && typeof err === 'object' ? JSON.stringify(err) : String(err));
+    const message = err instanceof Error ? err.message : String(err);
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,43 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/utils/supabase/server';
+import { resolveUserAndOrg } from '@/lib/auth-utils';
 import { proxyToAiService } from '@/lib/ai-service-proxy';
 
 export async function POST(req: NextRequest) {
   try {
-    const userSupabase = await createClient();
-    const { data: { user }, error: authError } = await userSupabase.auth.getUser();
-
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const { data: { session } } = await userSupabase.auth.getSession();
-    const userJwt = session?.access_token;
-
-    if (!userJwt) {
-      return NextResponse.json({ error: 'Session token not found' }, { status: 401 });
-    }
-
-    let orgId = req.headers.get('X-Org-Id');
-    if (!orgId) {
-      const { data: rpcOrgId } = await userSupabase.rpc('current_organisation_id');
-      orgId = rpcOrgId;
-    }
-
-    if (!orgId) {
-      const { data: membership } = await userSupabase
-        .from('Organisation_Mitglieder')
-        .select('organisation_id')
-        .eq('user_id', user.id)
-        .eq('status', 'aktiv')
-        .limit(1)
-        .maybeSingle();
-      orgId = membership?.organisation_id || null;
-    }
-
-    if (!orgId) {
-      return NextResponse.json({ error: 'No active organization found' }, { status: 400 });
-    }
+    const { user, orgId, userJwt, errorResponse } = await resolveUserAndOrg(req);
+    if (errorResponse) return errorResponse;
 
     return proxyToAiService('/api/chat', req, user.id, orgId, userJwt);
   } catch (err: any) {

--- a/app/api/conversations/[id]/route.ts
+++ b/app/api/conversations/[id]/route.ts
@@ -1,12 +1,22 @@
+import { type User } from '@supabase/supabase-js';
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
 import { proxyToAiService } from '@/lib/ai-service-proxy';
 
-async function resolveUserAndOrg(): Promise<{ user: any; orgId: string; errorResponse: Response | null }> {
+type ResolveResult = { user: User; orgId: string; errorResponse: null } | { user: null; orgId: ''; errorResponse: Response };
+
+async function resolveUserAndOrg(req?: NextRequest): Promise<ResolveResult> {
   const authClient = await createClient();
   const { data: { user }, error: authError } = await authClient.auth.getUser();
 
   if (authError || !user) {
+    if (req) {
+      console.error('[resolveUserAndOrg] Auth failed:', {
+        authError: authError?.message || authError,
+        hasUser: !!user,
+        cookies: req.cookies.getAll().map(c => c.name),
+      });
+    }
     return { user: null, orgId: '', errorResponse: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
   }
 
@@ -31,46 +41,62 @@ async function resolveUserAndOrg(): Promise<{ user: any; orgId: string; errorRes
   return { user, orgId, errorResponse: null };
 }
 
+async function handleRequest(
+  req: NextRequest,
+  params: Promise<{ id: string }>,
+  pathSuffix: string
+): Promise<Response> {
+  const { id } = await params;
+  const { user, orgId, errorResponse } = await resolveUserAndOrg(req);
+  if (errorResponse) return errorResponse;
+
+  return proxyToAiService(`/api/conversations/${id}${pathSuffix}`, req, user.id, orgId);
+}
+
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<Response> {
-  const { id } = await params;
-  const { user, orgId, errorResponse } = await resolveUserAndOrg();
-  if (errorResponse) return errorResponse;
-
-  return proxyToAiService(`/api/conversations/${id}`, req, user.id, orgId);
+  try {
+    return await handleRequest(req, params, '');
+  } catch (err: any) {
+    console.error('[GET /api/conversations/[id]] Internal error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }
 
 export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<Response> {
-  const { id } = await params;
-  const { user, orgId, errorResponse } = await resolveUserAndOrg();
-  if (errorResponse) return errorResponse;
-
-  return proxyToAiService(`/api/conversations/${id}`, req, user.id, orgId);
+  try {
+    return await handleRequest(req, params, '');
+  } catch (err: any) {
+    console.error('[POST /api/conversations/[id]] Internal error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }
 
 export async function PATCH(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<Response> {
-  const { id } = await params;
-  const { user, orgId, errorResponse } = await resolveUserAndOrg();
-  if (errorResponse) return errorResponse;
-
-  return proxyToAiService(`/api/conversations/${id}`, req, user.id, orgId);
+  try {
+    return await handleRequest(req, params, '');
+  } catch (err: any) {
+    console.error('[PATCH /api/conversations/[id]] Internal error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }
 
 export async function DELETE(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<Response> {
-  const { id } = await params;
-  const { user, orgId, errorResponse } = await resolveUserAndOrg();
-  if (errorResponse) return errorResponse;
-
-  return proxyToAiService(`/api/conversations/${id}`, req, user.id, orgId);
+  try {
+    return await handleRequest(req, params, '');
+  } catch (err: any) {
+    console.error('[DELETE /api/conversations/[id]] Internal error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }

--- a/app/api/conversations/[id]/route.ts
+++ b/app/api/conversations/[id]/route.ts
@@ -8,10 +8,10 @@ async function handleRequest(
   pathSuffix: string
 ): Promise<Response> {
   const { id } = await params;
-  const { user, orgId, errorResponse } = await resolveUserAndOrg(req);
+  const { user, orgId, userJwt, errorResponse } = await resolveUserAndOrg(req);
   if (errorResponse) return errorResponse;
 
-  return proxyToAiService(`/api/conversations/${id}${pathSuffix}`, req, user.id, orgId);
+  return proxyToAiService(`/api/conversations/${id}${pathSuffix}`, req, user.id, orgId, userJwt);
 }
 
 export async function GET(

--- a/app/api/conversations/[id]/route.ts
+++ b/app/api/conversations/[id]/route.ts
@@ -1,467 +1,76 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
-import { createClient as createSupabaseClient } from '@supabase/supabase-js';
-import pako from 'pako';
+import { proxyToAiService } from '@/lib/ai-service-proxy';
 
-function getSupabaseService() {
-  return createSupabaseClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL || 'http://localhost:54321',
-    process.env.SUPABASE_SERVICE_ROLE_KEY || 'dummy-key'
-  );
+async function resolveUserAndOrg(): Promise<{ user: any; orgId: string; errorResponse: Response | null }> {
+  const authClient = await createClient();
+  const { data: { user }, error: authError } = await authClient.auth.getUser();
+
+  if (authError || !user) {
+    return { user: null, orgId: '', errorResponse: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
+  }
+
+  const { data: rpcOrgId } = await authClient.rpc('current_organisation_id');
+  let orgId = rpcOrgId;
+
+  if (!orgId) {
+    const { data: membership } = await authClient
+      .from('Organisation_Mitglieder')
+      .select('organisation_id')
+      .eq('user_id', user.id)
+      .eq('status', 'aktiv')
+      .limit(1)
+      .maybeSingle();
+    orgId = membership?.organisation_id || null;
+  }
+
+  if (!orgId) {
+    return { user: null, orgId: '', errorResponse: NextResponse.json({ error: 'No active organization found' }, { status: 400 }) };
+  }
+
+  return { user, orgId, errorResponse: null };
 }
-
-const STORAGE_BUCKET = 'ki-nachrichten';
 
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const { id } = await params;
-    const supabase = await createClient();
-    const { data: { user }, error: authError } = await supabase.auth.getUser();
-    
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+): Promise<Response> {
+  const { id } = await params;
+  const { user, orgId, errorResponse } = await resolveUserAndOrg();
+  if (errorResponse) return errorResponse;
 
-    // RLS on KI_Konversationen SELECT checks Organisation_Mitglieder membership directly
-    // (no cookie dependency — see 20260714000003_ki_realtime_setup.sql)
-    const { data: conversation, error: convError } = await supabase
-      .from('KI_Konversationen')
-      .select('*')
-      .eq('id', id)
-      .is('geloescht_am', null)
-      .single();
-
-    if (convError || !conversation) {
-      return NextResponse.json({ error: 'Conversation not found or access denied' }, { status: 404 });
-    }
-
-    // Org-scoped client for KI_Nachrichten queries (RLS uses current_organisation_id for I/U/D)
-    const orgSupabase = await createClient(conversation.organisation_id);
-
-    const { data: messages, error: messagesError } = await orgSupabase
-      .from('KI_Nachrichten')
-      .select('*')
-      .eq('konversation_id', id)
-      .is('geloescht_am', null)
-      .order('erstellt_am', { ascending: true });
-
-    if (messagesError) {
-      return NextResponse.json({ error: messagesError.message }, { status: 500 });
-    }
-
-    return NextResponse.json({
-      conversation,
-      messages: messages || []
-    });
-  } catch (err: any) {
-    const message = err instanceof Error ? err.message : (err && typeof err === 'object' ? JSON.stringify(err) : String(err));
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
+  return proxyToAiService(`/api/conversations/${id}`, req, user.id, orgId);
 }
 
 export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const { id } = await params;
-    const authClient = await createClient();
-    const { data: { user }, error: authError } = await authClient.auth.getUser();
-    
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+): Promise<Response> {
+  const { id } = await params;
+  const { user, orgId, errorResponse } = await resolveUserAndOrg();
+  if (errorResponse) return errorResponse;
 
-    // Look up org_id via service role (minimal — only organisation_id, no sensitive data)
-    const supabaseService = getSupabaseService();
-    const { data: convMeta, error: metaError } = await supabaseService
-      .from('KI_Konversationen')
-      .select('organisation_id')
-      .eq('id', id)
-      .is('geloescht_am', null)
-      .single();
-
-    if (metaError || !convMeta) {
-      return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
-    }
-
-    // Verify the authenticated user is an active member of the conversation's org
-    const { data: membership, error: membershipError } = await supabaseService
-      .from('Organisation_Mitglieder')
-      .select('id')
-      .eq('organisation_id', convMeta.organisation_id)
-      .eq('user_id', user.id)
-      .eq('status', 'aktiv')
-      .maybeSingle();
-
-    if (membershipError || !membership) {
-      return NextResponse.json({ error: 'Access denied' }, { status: 403 });
-    }
-
-    // Single org-scoped client for all subsequent operations
-    const userSupabase = await createClient(convMeta.organisation_id);
-    const { data: conversation, error: convError } = await userSupabase
-      .from('KI_Konversationen')
-      .select('*')
-      .eq('id', id)
-      .is('geloescht_am', null)
-      .single();
-
-    if (convError || !conversation) {
-      return NextResponse.json({ error: 'Conversation not found or access denied' }, { status: 404 });
-    }
-
-    // Reactivate if archived in bucket
-    if (conversation.storage_status === 'bucket' && conversation.storage_pfad) {
-      const { data: fileData, error: downloadError } = await userSupabase.storage
-        .from(STORAGE_BUCKET)
-        .download(conversation.storage_pfad);
-
-      if (downloadError || !fileData) {
-        return NextResponse.json({ error: 'Failed to download archived conversation' }, { status: 500 });
-      }
-
-      let archive: any;
-      try {
-        const uint8Array = new Uint8Array(await fileData.arrayBuffer());
-        const decompressed = pako.ungzip(uint8Array, { to: 'string' });
-        archive = JSON.parse(decompressed);
-      } catch (parseErr) {
-        console.error('[conversations] Failed to parse archived messages:', parseErr);
-        return NextResponse.json({ error: 'Failed to parse archived conversation data' }, { status: 500 });
-      }
-
-      // Restore messages via upsert (atomic — no data loss on failure).
-      // Uses service role to bypass RLS (current_organisation_id reads from JWT claim, not Cookie header).
-      if (archive && Array.isArray(archive.nachrichten) && archive.nachrichten.length > 0) {
-        const restoredMessages = archive.nachrichten.map((m: Record<string, unknown>) => ({
-          ...m,
-          konversation_id: id,
-          organisation_id: conversation.organisation_id,
-        }));
-
-        const { error: upsertError } = await supabaseService
-          .from('KI_Nachrichten')
-          .upsert(restoredMessages);
-
-        if (upsertError) {
-          return NextResponse.json({ error: `Failed to restore messages: ${upsertError.message}` }, { status: 500 });
-        }
-      }
-
-      // Update conversation first
-      const { error: updateError } = await userSupabase
-        .from('KI_Konversationen')
-        .update({ storage_status: 'db', storage_pfad: null, status: 'aktiv' })
-        .eq('id', id);
-
-      if (updateError) {
-        return NextResponse.json({ error: updateError.message }, { status: 500 });
-      }
-
-      // Clean up bucket archive last
-      await userSupabase.storage
-        .from(STORAGE_BUCKET)
-        .remove([conversation.storage_pfad]);
-    }
-
-    // Touch letzter_zugriff
-    await userSupabase
-      .from('KI_Konversationen')
-      .update({ letzter_zugriff: new Date().toISOString() })
-      .eq('id', id);
-
-    return NextResponse.json({ success: true });
-  } catch (err: any) {
-    const message = err instanceof Error ? err.message : (err && typeof err === 'object' ? JSON.stringify(err) : String(err));
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
+  return proxyToAiService(`/api/conversations/${id}`, req, user.id, orgId);
 }
 
 export async function PATCH(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const { id } = await params;
-    const authClient = await createClient();
-    const { data: { user }, error: authError } = await authClient.auth.getUser();
-    
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+): Promise<Response> {
+  const { id } = await params;
+  const { user, orgId, errorResponse } = await resolveUserAndOrg();
+  if (errorResponse) return errorResponse;
 
-    // Look up org_id via service role + verify membership
-    const supabaseService = getSupabaseService();
-    const { data: convMeta, error: metaError } = await supabaseService
-      .from('KI_Konversationen')
-      .select('organisation_id')
-      .eq('id', id)
-      .is('geloescht_am', null)
-      .single();
-
-    if (metaError || !convMeta) {
-      return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
-    }
-
-    const { data: membership, error: membershipError } = await supabaseService
-      .from('Organisation_Mitglieder')
-      .select('id')
-      .eq('organisation_id', convMeta.organisation_id)
-      .eq('user_id', user.id)
-      .eq('status', 'aktiv')
-      .maybeSingle();
-
-    if (membershipError || !membership) {
-      return NextResponse.json({ error: 'Access denied' }, { status: 403 });
-    }
-
-    // Single org-scoped client for all operations
-    const userSupabase = await createClient(convMeta.organisation_id);
-    const { data: conversation, error: convError } = await userSupabase
-      .from('KI_Konversationen')
-      .select('*')
-      .eq('id', id)
-      .is('geloescht_am', null)
-      .single();
-
-    if (convError || !conversation) {
-      return NextResponse.json({ error: 'Conversation not found or access denied' }, { status: 404 });
-    }
-
-    const { titel, status } = await req.json();
-    const updateData: Record<string, any> = {};
-
-    if (titel !== undefined) updateData.titel = titel;
-    if (status !== undefined) {
-      updateData.status = status;
-    }
-
-    if (Object.keys(updateData).length === 0) {
-      return NextResponse.json({ error: 'No fields to update' }, { status: 400 });
-    }
-
-    // Unarchive: restore messages from bucket to DB
-    if (status === 'aktiv' && conversation.storage_status === 'bucket' && conversation.storage_pfad) {
-      const { data: fileData, error: downloadError } = await userSupabase.storage
-        .from(STORAGE_BUCKET)
-        .download(conversation.storage_pfad);
-
-      if (downloadError || !fileData) {
-        return NextResponse.json({ error: 'Failed to download archived conversation' }, { status: 500 });
-      }
-
-      let archive: any;
-      try {
-        const uint8Array = new Uint8Array(await fileData.arrayBuffer());
-        const decompressed = pako.ungzip(uint8Array, { to: 'string' });
-        archive = JSON.parse(decompressed);
-      } catch (parseErr) {
-        console.error('[conversations] Failed to parse archived messages:', parseErr);
-        return NextResponse.json({ error: 'Failed to parse archived conversation data' }, { status: 500 });
-      }
-
-      // Restore messages via upsert (atomic — no data loss on failure).
-      // Uses service role to bypass RLS (current_organisation_id reads from JWT claim, not Cookie header).
-      if (archive && Array.isArray(archive.nachrichten) && archive.nachrichten.length > 0) {
-        const restoredMessages = archive.nachrichten.map((m: Record<string, unknown>) => ({
-          ...m,
-          konversation_id: id,
-          organisation_id: conversation.organisation_id,
-        }));
-
-        const { error: upsertError } = await supabaseService
-          .from('KI_Nachrichten')
-          .upsert(restoredMessages);
-
-        if (upsertError) {
-          return NextResponse.json({ error: `Failed to restore messages: ${upsertError.message}` }, { status: 500 });
-        }
-      }
-
-      // Update conversation first
-      updateData.storage_status = 'db';
-      updateData.storage_pfad = null;
-      updateData.status = 'aktiv';
-
-      const { data: updatedConv, error: updateError } = await userSupabase
-        .from('KI_Konversationen')
-        .update(updateData)
-        .eq('id', id)
-        .select()
-        .single();
-
-      if (updateError) {
-        return NextResponse.json({ error: updateError.message }, { status: 500 });
-      }
-
-      // Clean up bucket archive last
-      await userSupabase.storage
-        .from(STORAGE_BUCKET)
-        .remove([conversation.storage_pfad]);
-
-      return NextResponse.json(updatedConv);
-    }
-
-    // Archive: move messages from DB to bucket
-    if (status === 'archiviert') {
-      if (conversation.storage_status === 'bucket') {
-        return NextResponse.json({ error: 'Conversation is already archived' }, { status: 409 });
-      }
-
-      const { data: messages, error: messagesError } = await userSupabase
-        .from('KI_Nachrichten')
-        .select('*')
-        .eq('konversation_id', id)
-        .is('geloescht_am', null)
-        .order('erstellt_am', { ascending: true });
-
-      if (messagesError) {
-        return NextResponse.json({ error: messagesError.message }, { status: 500 });
-      }
-
-      // Build archive payload
-      const totalTokens = messages?.reduce((sum: number, m: any) => sum + (m.token_anzahl || 0), 0) || 0;
-      const archive = {
-        konversation_id: id,
-        nachrichten: messages || [],
-        metadaten: {
-          token_gesamt: totalTokens,
-          agent_id: conversation.agent_id,
-        },
-      };
-
-      // Fetch mitglied_id from the conversation if not available
-      const storagePath = `${conversation.mitglied_id || user.id}/${id}/archiv.json.gz`;
-
-      const jsonString = JSON.stringify(archive);
-      const compressed = pako.gzip(jsonString);
-
-      const { error: uploadError } = await userSupabase.storage
-        .from(STORAGE_BUCKET)
-        .upload(storagePath, compressed, {
-          contentType: 'application/gzip',
-          upsert: true,
-        });
-
-      if (uploadError) {
-        return NextResponse.json({ error: `Failed to upload archive: ${uploadError.message}` }, { status: 500 });
-      }
-
-      // Soft-delete archived messages BEFORE updating conversation (safety net: if bucket file is lost,
-      // messages can be recovered by clearing geloescht_am).
-      // Uses service role to bypass RLS and ensure the safety net is reliable.
-      const archivedIds = messages?.flatMap(m => m.id ? [m.id] : []) || [];
-      if (archivedIds.length > 0) {
-        const { error: deleteError } = await supabaseService
-          .from('KI_Nachrichten')
-          .update({ geloescht_am: new Date().toISOString(), geloescht_von: user.id })
-          .in('id', archivedIds);
-
-        if (deleteError) {
-          return NextResponse.json({ error: `Failed to soft-delete archived messages: ${deleteError.message}` }, { status: 500 });
-        }
-      }
-
-      // Update conversation LAST — if soft-delete fails above, conversation is unchanged and user can retry
-      updateData.storage_pfad = storagePath;
-      updateData.storage_status = 'bucket';
-      updateData.archiviert_am = new Date().toISOString();
-
-      const { data: updatedConv, error: updateError } = await userSupabase
-        .from('KI_Konversationen')
-        .update(updateData)
-        .eq('id', id)
-        .select()
-        .single();
-
-      if (updateError) {
-        return NextResponse.json({ error: updateError.message }, { status: 500 });
-      }
-
-      return NextResponse.json(updatedConv);
-    }
-
-    const { data, error } = await userSupabase
-      .from('KI_Konversationen')
-      .update(updateData)
-      .eq('id', id)
-      .select()
-      .single();
-
-    if (error) {
-      return NextResponse.json({ error: error.message }, { status: 500 });
-    }
-
-    return NextResponse.json(data);
-  } catch (err: any) {
-    const message = err instanceof Error ? err.message : (err && typeof err === 'object' ? JSON.stringify(err) : String(err));
-    console.error('[conversations] PATCH unexpected error:', err);
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
+  return proxyToAiService(`/api/conversations/${id}`, req, user.id, orgId);
 }
 
 export async function DELETE(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const { id } = await params;
-    const authClient = await createClient();
-    const { data: { user }, error: authError } = await authClient.auth.getUser();
-    
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+): Promise<Response> {
+  const { id } = await params;
+  const { user, orgId, errorResponse } = await resolveUserAndOrg();
+  if (errorResponse) return errorResponse;
 
-    // Look up org_id via service role + verify membership
-    const supabaseService = getSupabaseService();
-    const { data: convMeta, error: metaError } = await supabaseService
-      .from('KI_Konversationen')
-      .select('organisation_id')
-      .eq('id', id)
-      .is('geloescht_am', null)
-      .single();
-
-    if (metaError || !convMeta) {
-      return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
-    }
-
-    const { data: membership, error: membershipError } = await supabaseService
-      .from('Organisation_Mitglieder')
-      .select('id')
-      .eq('organisation_id', convMeta.organisation_id)
-      .eq('user_id', user.id)
-      .eq('status', 'aktiv')
-      .maybeSingle();
-
-    if (membershipError || !membership) {
-      return NextResponse.json({ error: 'Access denied' }, { status: 403 });
-    }
-
-    // Single org-scoped client for the update
-    const userSupabase = await createClient(convMeta.organisation_id);
-
-    // Perform soft-delete
-    const { error } = await userSupabase
-      .from('KI_Konversationen')
-      .update({
-        geloescht_am: new Date().toISOString(),
-        geloescht_von: user.id,
-        status: 'geloescht'
-      })
-      .eq('id', id);
-
-    if (error) {
-      return NextResponse.json({ error: error.message }, { status: 500 });
-    }
-
-    return NextResponse.json({ success: true });
-  } catch (err: any) {
-    const message = err instanceof Error ? err.message : (err && typeof err === 'object' ? JSON.stringify(err) : String(err));
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
+  return proxyToAiService(`/api/conversations/${id}`, req, user.id, orgId);
 }

--- a/app/api/conversations/[id]/route.ts
+++ b/app/api/conversations/[id]/route.ts
@@ -1,45 +1,6 @@
-import { type User } from '@supabase/supabase-js';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/utils/supabase/server';
+import { resolveUserAndOrg } from '@/lib/auth-utils';
 import { proxyToAiService } from '@/lib/ai-service-proxy';
-
-type ResolveResult = { user: User; orgId: string; errorResponse: null } | { user: null; orgId: ''; errorResponse: Response };
-
-async function resolveUserAndOrg(req?: NextRequest): Promise<ResolveResult> {
-  const authClient = await createClient();
-  const { data: { user }, error: authError } = await authClient.auth.getUser();
-
-  if (authError || !user) {
-    if (req) {
-      console.error('[resolveUserAndOrg] Auth failed:', {
-        authError: authError?.message || authError,
-        hasUser: !!user,
-        cookies: req.cookies.getAll().map(c => c.name),
-      });
-    }
-    return { user: null, orgId: '', errorResponse: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
-  }
-
-  const { data: rpcOrgId } = await authClient.rpc('current_organisation_id');
-  let orgId = rpcOrgId;
-
-  if (!orgId) {
-    const { data: membership } = await authClient
-      .from('Organisation_Mitglieder')
-      .select('organisation_id')
-      .eq('user_id', user.id)
-      .eq('status', 'aktiv')
-      .limit(1)
-      .maybeSingle();
-    orgId = membership?.organisation_id || null;
-  }
-
-  if (!orgId) {
-    return { user: null, orgId: '', errorResponse: NextResponse.json({ error: 'No active organization found' }, { status: 400 }) };
-  }
-
-  return { user, orgId, errorResponse: null };
-}
 
 async function handleRequest(
   req: NextRequest,

--- a/app/api/conversations/route.ts
+++ b/app/api/conversations/route.ts
@@ -1,8 +1,11 @@
+import { type User } from '@supabase/supabase-js';
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
 import { proxyToAiService } from '@/lib/ai-service-proxy';
 
-async function resolveUserAndOrg(req: NextRequest): Promise<{ user: any; orgId: string; errorResponse: Response | null }> {
+type ResolveResult = { user: User; orgId: string; errorResponse: null } | { user: null; orgId: ''; errorResponse: Response };
+
+async function resolveUserAndOrg(req: NextRequest): Promise<ResolveResult> {
   const authClient = await createClient();
   const { data: { user }, error: authError } = await authClient.auth.getUser();
 
@@ -12,7 +15,7 @@ async function resolveUserAndOrg(req: NextRequest): Promise<{ user: any; orgId: 
       hasUser: !!user,
       cookies: req.cookies.getAll().map(c => c.name),
     });
-    return { user: null, orgId: '', errorResponse: NextResponse.json({ error: 'Unauthorized', detail: authError?.message }, { status: 401 }) };
+    return { user: null, orgId: '', errorResponse: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
   }
 
   const { searchParams } = new URL(req.url);
@@ -41,16 +44,27 @@ async function resolveUserAndOrg(req: NextRequest): Promise<{ user: any; orgId: 
   return { user, orgId, errorResponse: null };
 }
 
-export async function GET(req: NextRequest): Promise<Response> {
+async function handleRequest(req: NextRequest): Promise<Response> {
   const { user, orgId, errorResponse } = await resolveUserAndOrg(req);
   if (errorResponse) return errorResponse;
 
   return proxyToAiService('/api/conversations', req, user.id, orgId);
 }
 
-export async function POST(req: NextRequest): Promise<Response> {
-  const { user, orgId, errorResponse } = await resolveUserAndOrg(req);
-  if (errorResponse) return errorResponse;
+export async function GET(req: NextRequest): Promise<Response> {
+  try {
+    return await handleRequest(req);
+  } catch (err: any) {
+    console.error('[GET /api/conversations] Internal error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
 
-  return proxyToAiService('/api/conversations', req, user.id, orgId);
+export async function POST(req: NextRequest): Promise<Response> {
+  try {
+    return await handleRequest(req);
+  } catch (err: any) {
+    console.error('[POST /api/conversations] Internal error:', err);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
 }

--- a/app/api/conversations/route.ts
+++ b/app/api/conversations/route.ts
@@ -7,7 +7,12 @@ async function resolveUserAndOrg(req: NextRequest): Promise<{ user: any; orgId: 
   const { data: { user }, error: authError } = await authClient.auth.getUser();
 
   if (authError || !user) {
-    return { user: null, orgId: '', errorResponse: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
+    console.error('[resolveUserAndOrg] Auth failed:', {
+      authError: authError?.message || authError,
+      hasUser: !!user,
+      cookies: req.cookies.getAll().map(c => c.name),
+    });
+    return { user: null, orgId: '', errorResponse: NextResponse.json({ error: 'Unauthorized', detail: authError?.message }, { status: 401 }) };
   }
 
   const { searchParams } = new URL(req.url);

--- a/app/api/conversations/route.ts
+++ b/app/api/conversations/route.ts
@@ -3,10 +3,10 @@ import { resolveUserAndOrg } from '@/lib/auth-utils';
 import { proxyToAiService } from '@/lib/ai-service-proxy';
 
 async function handleRequest(req: NextRequest): Promise<Response> {
-  const { user, orgId, errorResponse } = await resolveUserAndOrg(req);
+  const { user, orgId, userJwt, errorResponse } = await resolveUserAndOrg(req);
   if (errorResponse) return errorResponse;
 
-  return proxyToAiService('/api/conversations', req, user.id, orgId);
+  return proxyToAiService('/api/conversations', req, user.id, orgId, userJwt);
 }
 
 export async function GET(req: NextRequest): Promise<Response> {

--- a/app/api/conversations/route.ts
+++ b/app/api/conversations/route.ts
@@ -1,48 +1,6 @@
-import { type User } from '@supabase/supabase-js';
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/utils/supabase/server';
+import { resolveUserAndOrg } from '@/lib/auth-utils';
 import { proxyToAiService } from '@/lib/ai-service-proxy';
-
-type ResolveResult = { user: User; orgId: string; errorResponse: null } | { user: null; orgId: ''; errorResponse: Response };
-
-async function resolveUserAndOrg(req: NextRequest): Promise<ResolveResult> {
-  const authClient = await createClient();
-  const { data: { user }, error: authError } = await authClient.auth.getUser();
-
-  if (authError || !user) {
-    console.error('[resolveUserAndOrg] Auth failed:', {
-      authError: authError?.message || authError,
-      hasUser: !!user,
-      cookies: req.cookies.getAll().map(c => c.name),
-    });
-    return { user: null, orgId: '', errorResponse: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
-  }
-
-  const { searchParams } = new URL(req.url);
-  let orgId = searchParams.get('orgId');
-
-  if (!orgId) {
-    const { data: rpcOrgId } = await authClient.rpc('current_organisation_id');
-    orgId = rpcOrgId;
-  }
-
-  if (!orgId) {
-    const { data: membership } = await authClient
-      .from('Organisation_Mitglieder')
-      .select('organisation_id')
-      .eq('user_id', user.id)
-      .eq('status', 'aktiv')
-      .limit(1)
-      .maybeSingle();
-    orgId = membership?.organisation_id || null;
-  }
-
-  if (!orgId) {
-    return { user: null, orgId: '', errorResponse: NextResponse.json({ error: 'No active organization found' }, { status: 400 }) };
-  }
-
-  return { user, orgId, errorResponse: null };
-}
 
 async function handleRequest(req: NextRequest): Promise<Response> {
   const { user, orgId, errorResponse } = await resolveUserAndOrg(req);

--- a/app/api/conversations/route.ts
+++ b/app/api/conversations/route.ts
@@ -1,136 +1,51 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
+import { proxyToAiService } from '@/lib/ai-service-proxy';
 
-export async function GET(req: NextRequest) {
-  try {
-    const authClient = await createClient();
-    const { data: { user }, error: authError } = await authClient.auth.getUser();
-    
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+async function resolveUserAndOrg(req: NextRequest): Promise<{ user: any; orgId: string; errorResponse: Response | null }> {
+  const authClient = await createClient();
+  const { data: { user }, error: authError } = await authClient.auth.getUser();
 
-    const { searchParams } = new URL(req.url);
-    let orgId = searchParams.get('orgId');
-
-    // Auto-resolve organization if not passed
-    if (!orgId) {
-      const { data: rpcOrgId } = await authClient.rpc('current_organisation_id');
-      orgId = rpcOrgId;
-    }
-
-    if (!orgId) {
-      const { data: membership } = await authClient
-        .from('Organisation_Mitglieder')
-        .select('organisation_id')
-        .eq('user_id', user.id)
-        .eq('status', 'aktiv')
-        .limit(1)
-        .maybeSingle();
-      orgId = membership?.organisation_id || null;
-    }
-
-    if (!orgId) {
-      return NextResponse.json({ error: 'No active organization found' }, { status: 400 });
-    }
-
-    // Instantiate userSupabase with the active organization ID
-    const userSupabase = await createClient(orgId);
-
-    // Load non-deleted conversations sorted by status (aktiv first) then by last access
-    const { data, error } = await userSupabase
-      .from('KI_Konversationen')
-      .select('id, titel, letzter_zugriff, status, storage_status')
-      .eq('organisation_id', orgId)
-      .in('status', ['aktiv', 'archiviert'])
-      .is('geloescht_am', null)
-      .order('status', { ascending: true })
-      .order('letzter_zugriff', { ascending: false });
-
-    if (error) {
-      return NextResponse.json({ error: error.message }, { status: 500 });
-    }
-
-    return NextResponse.json(data);
-  } catch (err: any) {
-    const message = err instanceof Error ? err.message : (err && typeof err === 'object' ? JSON.stringify(err) : String(err));
-    return NextResponse.json({ error: message }, { status: 500 });
+  if (authError || !user) {
+    return { user: null, orgId: '', errorResponse: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
   }
+
+  const { searchParams } = new URL(req.url);
+  let orgId = searchParams.get('orgId');
+
+  if (!orgId) {
+    const { data: rpcOrgId } = await authClient.rpc('current_organisation_id');
+    orgId = rpcOrgId;
+  }
+
+  if (!orgId) {
+    const { data: membership } = await authClient
+      .from('Organisation_Mitglieder')
+      .select('organisation_id')
+      .eq('user_id', user.id)
+      .eq('status', 'aktiv')
+      .limit(1)
+      .maybeSingle();
+    orgId = membership?.organisation_id || null;
+  }
+
+  if (!orgId) {
+    return { user: null, orgId: '', errorResponse: NextResponse.json({ error: 'No active organization found' }, { status: 400 }) };
+  }
+
+  return { user, orgId, errorResponse: null };
 }
 
-export async function POST(req: NextRequest) {
-  try {
-    const authClient = await createClient();
-    const { data: { user }, error: authError } = await authClient.auth.getUser();
-    
-    if (authError || !user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
+export async function GET(req: NextRequest): Promise<Response> {
+  const { user, orgId, errorResponse } = await resolveUserAndOrg(req);
+  if (errorResponse) return errorResponse;
 
-    const body = await req.json().catch(() => ({}));
-    let { orgId, titel } = body;
+  return proxyToAiService('/api/conversations', req, user.id, orgId);
+}
 
-    // Auto-resolve organization if not passed
-    if (!orgId) {
-      const { data: rpcOrgId } = await authClient.rpc('current_organisation_id');
-      orgId = rpcOrgId;
-    }
+export async function POST(req: NextRequest): Promise<Response> {
+  const { user, orgId, errorResponse } = await resolveUserAndOrg(req);
+  if (errorResponse) return errorResponse;
 
-    if (!orgId) {
-      const { data: membership } = await authClient
-        .from('Organisation_Mitglieder')
-        .select('organisation_id')
-        .eq('user_id', user.id)
-        .eq('status', 'aktiv')
-        .limit(1)
-        .maybeSingle();
-      orgId = membership?.organisation_id || null;
-    }
-
-    if (!orgId) {
-      return NextResponse.json({ error: 'No active organization found' }, { status: 400 });
-    }
-
-    // Instantiate userSupabase with the active organization ID
-    const userSupabase = await createClient(orgId);
-
-    // Resolve user's membership ID
-    const { data: member, error: memberError } = await userSupabase
-      .from('Organisation_Mitglieder')
-      .select('id')
-      .eq('user_id', user.id)
-      .eq('organisation_id', orgId)
-      .eq('status', 'aktiv')
-      .single();
-
-    if (memberError || !member) {
-      return NextResponse.json({ error: 'Forbidden: You are not a member of this organization' }, { status: 403 });
-    }
-
-    // Create new conversation
-    const { data, error } = await userSupabase
-      .from('KI_Konversationen')
-      .insert({
-        organisation_id: orgId,
-        mitglied_id: member.id,
-        agent_id: null,
-        titel: titel || 'Neue Konversation',
-        status: 'aktiv',
-        storage_status: 'db',
-        erstellt_von: user.id
-      })
-      .select('id')
-      .single();
-
-    if (error) {
-      console.error('[conversations POST database error]:', error);
-      return NextResponse.json({ error: error.message || 'Database error', details: error }, { status: 500 });
-    }
-
-    return NextResponse.json(data);
-  } catch (err: any) {
-    console.error('[conversations POST exception]:', err);
-    const message = err instanceof Error ? err.message : (err && typeof err === 'object' ? JSON.stringify(err) : String(err));
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
+  return proxyToAiService('/api/conversations', req, user.id, orgId);
 }

--- a/app/api/cron/cleanup-runs/route.ts
+++ b/app/api/cron/cleanup-runs/route.ts
@@ -1,10 +1,23 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { proxyToAiService } from '@/lib/ai-service-proxy';
 
+function isCronAuthorized(req: NextRequest): boolean {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) return true;
+  const authHeader = req.headers.get('authorization');
+  return authHeader === `Bearer ${cronSecret}`;
+}
+
 export async function GET(req: NextRequest) {
+  if (!isCronAuthorized(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
   return proxyToAiService('/api/cron/cleanup-runs', req, 'system', 'system');
 }
 
 export async function POST(req: NextRequest) {
+  if (!isCronAuthorized(req)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
   return proxyToAiService('/api/cron/cleanup-runs', req, 'system', 'system');
 }

--- a/app/api/cron/cleanup-runs/route.ts
+++ b/app/api/cron/cleanup-runs/route.ts
@@ -1,89 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { createSupabaseServiceClient } from '@/lib/sandbox/runner';
+import { NextRequest } from 'next/server';
+import { proxyToAiService } from '@/lib/ai-service-proxy';
 
 export async function GET(req: NextRequest) {
-  return handleCleanup(req);
+  return proxyToAiService('/api/cron/cleanup-runs', req, 'system', 'system');
 }
 
 export async function POST(req: NextRequest) {
-  return handleCleanup(req);
-}
-
-async function handleCleanup(req: NextRequest) {
-  try {
-    const authHeader = req.headers.get('Authorization');
-    const cronSecret = process.env.CRON_SECRET;
-    if (!cronSecret) {
-      return NextResponse.json({ error: 'CRON_SECRET environment variable is not set' }, { status: 500 });
-    }
-
-    if (authHeader !== `Bearer ${cronSecret}`) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    const supabase = createSupabaseServiceClient();
-    const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
-
-    // 1. Fetch runs that are stuck in 'laufend' status for more than 10 minutes
-    const { data: timedOutRuns, error: fetchError } = await supabase
-      .from('KI_Runs')
-      .select('id, nachricht_id')
-      .eq('status', 'laufend')
-      .lt('gestartet_am', tenMinutesAgo);
-
-    if (fetchError) {
-      return NextResponse.json({ error: `Fetch error: ${fetchError.message}` }, { status: 500 });
-    }
-
-    if (!timedOutRuns || timedOutRuns.length === 0) {
-      return NextResponse.json({ message: 'No timed out runs found.' });
-    }
-
-    const runIds: string[] = [];
-    const messageIds: string[] = [];
-
-    for (const r of timedOutRuns) {
-      runIds.push(r.id);
-      if (r.nachricht_id) {
-        messageIds.push(r.nachricht_id);
-      }
-    }
-
-    // 2. Mark runs as 'zeitueberschreitung'
-    const { error: updateRunsError } = await supabase
-      .from('KI_Runs')
-      .update({
-        status: 'zeitueberschreitung',
-        beendet_am: new Date().toISOString(),
-        fehler_meldung: 'Run timed out (exceeded 10 minutes limit)',
-      })
-      .in('id', runIds);
-
-    if (updateRunsError) {
-      return NextResponse.json({ error: `Update runs error: ${updateRunsError.message}` }, { status: 500 });
-    }
-
-    // 3. Mark the corresponding generated messages as 'fehler'
-    if (messageIds.length > 0) {
-      const { error: updateMessagesError } = await supabase
-        .from('KI_Nachrichten')
-        .update({
-          status: 'fehler',
-          fehler_meldung: 'Run timed out (exceeded 10 minutes limit)',
-        })
-        .in('id', messageIds);
-
-      if (updateMessagesError) {
-        return NextResponse.json({ error: `Update messages error: ${updateMessagesError.message}` }, { status: 500 });
-      }
-    }
-
-    return NextResponse.json({
-      message: 'Successfully cleaned up timed out runs.',
-      cleaned_runs_count: runIds.length,
-      cleaned_messages_count: messageIds.length,
-    });
-  } catch (err: any) {
-    return NextResponse.json({ error: err.message }, { status: 500 });
-  }
+  return proxyToAiService('/api/cron/cleanup-runs', req, 'system', 'system');
 }

--- a/app/api/cron/cleanup-runs/route.ts
+++ b/app/api/cron/cleanup-runs/route.ts
@@ -3,7 +3,7 @@ import { proxyToAiService } from '@/lib/ai-service-proxy';
 
 function isCronAuthorized(req: NextRequest): boolean {
   const cronSecret = process.env.CRON_SECRET;
-  if (!cronSecret) return true;
+  if (!cronSecret) return false;
   const authHeader = req.headers.get('authorization');
   return authHeader === `Bearer ${cronSecret}`;
 }

--- a/components/ai-chat/ai-chat-sidebar.tsx
+++ b/components/ai-chat/ai-chat-sidebar.tsx
@@ -452,6 +452,32 @@ export function AIChatSidebar() {
         }
       }
 
+      // Process any remaining content left in buffer when stream ends
+      if (buffer.trim()) {
+        let cleanLine = buffer.trim();
+        if (cleanLine.startsWith("data: ")) {
+          cleanLine = cleanLine.slice(6).trim();
+        }
+        if (cleanLine && cleanLine !== "[DONE]") {
+          try {
+            const data = JSON.parse(cleanLine);
+            if (data.type === "content" || data.type === "token") {
+              const textContent = data.content ?? data.text ?? "";
+              setMessages(prev => prev.map(m => 
+                m.id === aiMessageId ? { ...m, content: m.content + textContent } : m
+              ));
+            } else if (data.type === "final_reply" || data.type === "done") {
+              finalReply = data.reply || data.text || "";
+              traceId = data.traceId || "";
+              toolResults = data.toolCalls || toolResults;
+              receivedDone = true;
+            }
+          } catch (e) {
+            console.error("Error parsing trailing stream line:", e, cleanLine);
+          }
+        }
+      }
+
       // If stream ended early without final reply payload, fall back to realtime tracking
       if (!receivedDone && currentConvId) {
         console.log('[AIChatSidebar] Stream disconnected early. Activating Realtime fallback...');

--- a/components/ai-chat/ai-chat-sidebar.tsx
+++ b/components/ai-chat/ai-chat-sidebar.tsx
@@ -394,6 +394,51 @@ export function AIChatSidebar() {
       let toolResults: ToolCallRecord[] = [];
       let receivedDone = false;
 
+      function processStreamLine(raw: string) {
+        let clean = raw.trim();
+        if (clean.startsWith("data: ")) {
+          clean = clean.slice(6).trim();
+        }
+        if (!clean || clean === "[DONE]") return;
+
+        let data: any;
+        try {
+          data = JSON.parse(clean);
+        } catch (e) {
+          return;
+        }
+
+        if (data.type === "step_start") {
+          if (currentStepId) {
+            updateStep(currentStepId, { status: "done" });
+            currentStepId = null;
+          }
+          currentStepId = addStep(data.stepType, data.label, "loading", data.detail);
+        } else if (data.type === "step_done") {
+          if (currentStepId) {
+            updateStep(currentStepId, { status: "done" });
+            currentStepId = null;
+          }
+        } else if (data.type === "tool_result") {
+          toolResults.push(data.toolCall);
+          if (currentStepId) {
+            updateStep(currentStepId, { toolResult: data.toolCall });
+          }
+        } else if (data.type === "content" || data.type === "token") {
+          const textContent = data.content ?? data.text ?? "";
+          setMessages(prev => prev.map(m =>
+            m.id === aiMessageId ? { ...m, content: m.content + textContent } : m
+          ));
+        } else if (data.type === "final_reply" || data.type === "done") {
+          finalReply = data.reply || data.text || "";
+          traceId = data.traceId || "";
+          toolResults = data.toolCalls || toolResults;
+          receivedDone = true;
+        } else if (data.type === "error") {
+          throw new Error(data.message);
+        }
+      }
+
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
@@ -403,78 +448,20 @@ export function AIChatSidebar() {
         buffer = lines.pop() ?? "";
 
         for (const line of lines) {
-          let cleanLine = line.trim();
-          if (cleanLine.startsWith("data: ")) {
-            cleanLine = cleanLine.slice(6).trim();
-          }
-          if (!cleanLine || cleanLine === "[DONE]") continue;
-
           try {
-            const data = JSON.parse(cleanLine);
-            
-            if (data.type === "step_start") {
-              if (currentStepId) {
-                updateStep(currentStepId, { status: "done" });
-                currentStepId = null;
-              }
-              currentStepId = addStep(data.stepType, data.label, "loading", data.detail);
-            } 
-            else if (data.type === "step_done") {
-              if (currentStepId) {
-                updateStep(currentStepId, { status: "done" });
-                currentStepId = null;
-              }
-            } 
-            else if (data.type === "tool_result") {
-              toolResults.push(data.toolCall);
-              if (currentStepId) {
-                updateStep(currentStepId, { toolResult: data.toolCall });
-              }
-            } 
-            else if (data.type === "content" || data.type === "token") {
-              const textContent = data.content ?? data.text ?? "";
-              setMessages(prev => prev.map(m => 
-                m.id === aiMessageId ? { ...m, content: m.content + textContent } : m
-              ));
-            }
-            else if (data.type === "final_reply" || data.type === "done") {
-              finalReply = data.reply || data.text || "";
-              traceId = data.traceId || "";
-              toolResults = data.toolCalls || toolResults;
-              receivedDone = true;
-            }
-            else if (data.type === "error") {
-              throw new Error(data.message);
-            }
+            processStreamLine(line);
           } catch (e) {
-            console.error("Error parsing stream line:", e, cleanLine);
+            console.error("Error parsing stream line:", e, line);
           }
         }
       }
 
       // Process any remaining content left in buffer when stream ends
       if (buffer.trim()) {
-        let cleanLine = buffer.trim();
-        if (cleanLine.startsWith("data: ")) {
-          cleanLine = cleanLine.slice(6).trim();
-        }
-        if (cleanLine && cleanLine !== "[DONE]") {
-          try {
-            const data = JSON.parse(cleanLine);
-            if (data.type === "content" || data.type === "token") {
-              const textContent = data.content ?? data.text ?? "";
-              setMessages(prev => prev.map(m => 
-                m.id === aiMessageId ? { ...m, content: m.content + textContent } : m
-              ));
-            } else if (data.type === "final_reply" || data.type === "done") {
-              finalReply = data.reply || data.text || "";
-              traceId = data.traceId || "";
-              toolResults = data.toolCalls || toolResults;
-              receivedDone = true;
-            }
-          } catch (e) {
-            console.error("Error parsing trailing stream line:", e, cleanLine);
-          }
+        try {
+          processStreamLine(buffer);
+        } catch (e) {
+          console.error("Error parsing trailing stream line:", e, buffer);
         }
       }
 

--- a/components/ai-chat/ai-chat-sidebar.tsx
+++ b/components/ai-chat/ai-chat-sidebar.tsx
@@ -52,10 +52,13 @@ export function AIChatSidebar() {
   useEffect(() => { messagesRef.current = messages; }, [messages]);
 
   const isMountedRef = useRef(true);
+  const abortControllerRef = useRef<AbortController | null>(null);
   useEffect(() => {
-    isMountedRef.current = true;
     return () => {
       isMountedRef.current = false;
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
     };
   }, []);
 
@@ -366,9 +369,16 @@ export function AIChatSidebar() {
     });
 
     try {
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
       const clientNachrichtId = uuidv4();
       const res = await fetch("/api/chat", {
         method: "POST",
+        signal: controller.signal,
         headers: { 
           "Content-Type": "application/json",
           "X-Idempotency-Key": clientNachrichtId

--- a/components/ai-chat/ai-chat-sidebar.tsx
+++ b/components/ai-chat/ai-chat-sidebar.tsx
@@ -50,6 +50,15 @@ export function AIChatSidebar() {
   const [messages, setMessages] = useState<Message[]>([]);
   const messagesRef = useRef(messages);
   useEffect(() => { messagesRef.current = messages; }, [messages]);
+
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
   const [inputValue, setInputValue] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [attachment, setAttachment] = useState<{ name: string; type: string; data: string; } | null>(null);
@@ -426,9 +435,11 @@ export function AIChatSidebar() {
           }
         } else if (data.type === "content" || data.type === "token") {
           const textContent = data.content ?? data.text ?? "";
-          setMessages(prev => prev.map(m =>
-            m.id === aiMessageId ? { ...m, content: m.content + textContent } : m
-          ));
+          if (isMountedRef.current) {
+            setMessages(prev => prev.map(m =>
+              m.id === aiMessageId ? { ...m, content: m.content + textContent } : m
+            ));
+          }
         } else if (data.type === "final_reply" || data.type === "done") {
           finalReply = data.reply || data.text || "";
           traceId = data.traceId || "";
@@ -440,6 +451,7 @@ export function AIChatSidebar() {
       }
 
       while (true) {
+        if (!isMountedRef.current) break;
         const { done, value } = await reader.read();
         if (done) break;
 

--- a/components/ai-chat/ai-chat-sidebar.tsx
+++ b/components/ai-chat/ai-chat-sidebar.tsx
@@ -403,9 +403,14 @@ export function AIChatSidebar() {
         buffer = lines.pop() ?? "";
 
         for (const line of lines) {
-          if (!line.trim()) continue;
+          let cleanLine = line.trim();
+          if (cleanLine.startsWith("data: ")) {
+            cleanLine = cleanLine.slice(6).trim();
+          }
+          if (!cleanLine || cleanLine === "[DONE]") continue;
+
           try {
-            const data = JSON.parse(line);
+            const data = JSON.parse(cleanLine);
             
             if (data.type === "step_start") {
               if (currentStepId) {
@@ -426,14 +431,15 @@ export function AIChatSidebar() {
                 updateStep(currentStepId, { toolResult: data.toolCall });
               }
             } 
-            else if (data.type === "content") {
+            else if (data.type === "content" || data.type === "token") {
+              const textContent = data.content ?? data.text ?? "";
               setMessages(prev => prev.map(m => 
-                m.id === aiMessageId ? { ...m, content: m.content + data.content } : m
+                m.id === aiMessageId ? { ...m, content: m.content + textContent } : m
               ));
             }
-            else if (data.type === "final_reply") {
-              finalReply = data.reply;
-              traceId = data.traceId;
+            else if (data.type === "final_reply" || data.type === "done") {
+              finalReply = data.reply || data.text || "";
+              traceId = data.traceId || "";
               toolResults = data.toolCalls || toolResults;
               receivedDone = true;
             }
@@ -441,7 +447,7 @@ export function AIChatSidebar() {
               throw new Error(data.message);
             }
           } catch (e) {
-            console.error("Error parsing stream line:", e, line);
+            console.error("Error parsing stream line:", e, cleanLine);
           }
         }
       }

--- a/lib/ai-service-proxy.ts
+++ b/lib/ai-service-proxy.ts
@@ -6,7 +6,9 @@ function getAiServiceUrl(): string {
   return process.env.AI_SERVICE_URL || 'https://ai.mietevo.de';
 }
 
-const AI_SERVICE_SECRET = process.env.AI_SERVICE_AUTH_SECRET;
+function getAiServiceSecret(): string | undefined {
+  return process.env.AI_SERVICE_AUTH_SECRET;
+}
 
 export async function proxyToAiService(
   path: string,
@@ -20,8 +22,9 @@ export async function proxyToAiService(
   console.log(`[AI Proxy] Proxying ${request.method} ${path} to ${baseUrl}${path} (user: ${userId}, org: ${orgId})`);
   const headers = new Headers(request.headers);
 
-  if (AI_SERVICE_SECRET) {
-    headers.set('X-AI-Service-Auth', AI_SERVICE_SECRET);
+  const secret = getAiServiceSecret();
+  if (secret) {
+    headers.set('X-AI-Service-Auth', secret);
   }
   headers.set('X-User-Id', userId);
   headers.set('X-Org-Id', orgId);
@@ -51,9 +54,15 @@ export async function proxyToAiService(
   try {
     const response = await fetch(targetUrl, fetchOptions);
 
+    const filteredHeaders = new Headers(response.headers);
+    filteredHeaders.delete('transfer-encoding');
+    filteredHeaders.delete('connection');
+    filteredHeaders.delete('content-encoding');
+    filteredHeaders.delete('content-length');
+
     return new Response(response.body, {
       status: response.status,
-      headers: response.headers,
+      headers: filteredHeaders,
     });
   } catch (err: any) {
     console.error(`[AI Proxy] Failed to proxy request to ${targetUrl}:`, err);

--- a/lib/ai-service-proxy.ts
+++ b/lib/ai-service-proxy.ts
@@ -31,6 +31,11 @@ export async function proxyToAiService(
   if (userJwt) {
     headers.set('X-User-Jwt', userJwt);
   }
+
+  const existingTraceId = headers.get('x-trace-id') || headers.get('x-posthog-trace-id') || headers.get('x-request-id');
+  const traceId = existingTraceId || crypto.randomUUID();
+  headers.set('X-Trace-Id', traceId);
+
   // Remove original auth headers (JWT/Cookie)
   headers.delete('authorization');
   headers.delete('cookie');
@@ -59,6 +64,7 @@ export async function proxyToAiService(
     filteredHeaders.delete('connection');
     filteredHeaders.delete('content-encoding');
     filteredHeaders.delete('content-length');
+    filteredHeaders.set('X-Trace-Id', traceId);
 
     return new Response(response.body, {
       status: response.status,

--- a/lib/ai-service-proxy.ts
+++ b/lib/ai-service-proxy.ts
@@ -73,7 +73,7 @@ export async function proxyToAiService(
   } catch (err: any) {
     console.error(`[AI Proxy] Failed to proxy request to ${targetUrl}:`, err);
     return Response.json(
-      { error: `AI Service proxy failed: ${err?.message || 'Network error'}` },
+      { error: 'AI Service unavailable' },
       { status: 502 }
     );
   }

--- a/lib/ai-service-proxy.ts
+++ b/lib/ai-service-proxy.ts
@@ -17,6 +17,7 @@ export async function proxyToAiService(
   body?: unknown
 ): Promise<Response> {
   const baseUrl = getAiServiceUrl();
+  console.log(`[AI Proxy] Proxying ${request.method} ${path} to ${baseUrl}${path} (user: ${userId}, org: ${orgId})`);
   const headers = new Headers(request.headers);
 
   if (AI_SERVICE_SECRET) {

--- a/lib/ai-service-proxy.ts
+++ b/lib/ai-service-proxy.ts
@@ -1,0 +1,64 @@
+function getAiServiceUrl(): string {
+  const isDev = process.env.DEV === 'true';
+  if (isDev) {
+    return process.env.DEV_AI_SERVICE_URL || process.env.AI_SERVICE_URL || 'http://localhost:8080';
+  }
+  return process.env.AI_SERVICE_URL || 'https://ai.mietevo.de';
+}
+
+const AI_SERVICE_SECRET = process.env.AI_SERVICE_AUTH_SECRET;
+
+export async function proxyToAiService(
+  path: string,
+  request: Request,
+  userId: string,
+  orgId: string,
+  userJwt?: string,
+  body?: unknown
+): Promise<Response> {
+  const baseUrl = getAiServiceUrl();
+  const headers = new Headers(request.headers);
+
+  if (AI_SERVICE_SECRET) {
+    headers.set('X-AI-Service-Auth', AI_SERVICE_SECRET);
+  }
+  headers.set('X-User-Id', userId);
+  headers.set('X-Org-Id', orgId);
+  if (userJwt) {
+    headers.set('X-User-Jwt', userJwt);
+  }
+  // Remove original auth headers (JWT/Cookie)
+  headers.delete('authorization');
+  headers.delete('cookie');
+
+  const fetchOptions: RequestInit = {
+    method: request.method,
+    headers,
+  };
+
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    if (body !== undefined) {
+      fetchOptions.body = JSON.stringify(body);
+      headers.set('Content-Type', 'application/json');
+    } else {
+      fetchOptions.body = await request.text();
+    }
+  }
+
+  const targetUrl = `${baseUrl}${path}`;
+
+  try {
+    const response = await fetch(targetUrl, fetchOptions);
+
+    return new Response(response.body, {
+      status: response.status,
+      headers: response.headers,
+    });
+  } catch (err: any) {
+    console.error(`[AI Proxy] Failed to proxy request to ${targetUrl}:`, err);
+    return Response.json(
+      { error: `AI Service proxy failed: ${err?.message || 'Network error'}` },
+      { status: 502 }
+    );
+  }
+}

--- a/lib/ai-service-proxy.ts
+++ b/lib/ai-service-proxy.ts
@@ -18,7 +18,8 @@ export async function proxyToAiService(
   userId: string,
   orgId: string,
   userJwt?: string,
-  body?: unknown
+  body?: unknown,
+  timeoutMs: number = 120000
 ): Promise<Response> {
   const baseUrl = getAiServiceUrl();
   console.log(`[AI Proxy] Proxying ${request.method} ${path} to ${baseUrl}${path} (user: ${userId}, org: ${orgId})`);
@@ -58,7 +59,7 @@ export async function proxyToAiService(
 
   const targetUrl = `${baseUrl}${path}`;
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 30000);
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
   fetchOptions.signal = controller.signal;
 
   try {

--- a/lib/ai-service-proxy.ts
+++ b/lib/ai-service-proxy.ts
@@ -1,3 +1,5 @@
+import { NextResponse } from 'next/server';
+
 function getAiServiceUrl(): string {
   const isDev = process.env.DEV === 'true';
   if (isDev) {
@@ -72,7 +74,7 @@ export async function proxyToAiService(
     });
   } catch (err: any) {
     console.error(`[AI Proxy] Failed to proxy request to ${targetUrl}:`, err);
-    return Response.json(
+    return NextResponse.json(
       { error: 'AI Service unavailable' },
       { status: 502 }
     );

--- a/lib/ai-service-proxy.ts
+++ b/lib/ai-service-proxy.ts
@@ -57,6 +57,9 @@ export async function proxyToAiService(
   }
 
   const targetUrl = `${baseUrl}${path}`;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30000);
+  fetchOptions.signal = controller.signal;
 
   try {
     const response = await fetch(targetUrl, fetchOptions);
@@ -73,10 +76,19 @@ export async function proxyToAiService(
       headers: filteredHeaders,
     });
   } catch (err: any) {
+    if (err.name === 'AbortError') {
+      console.error(`[AI Proxy] Request timed out for ${targetUrl}`);
+      return NextResponse.json(
+        { error: 'AI Service request timed out' },
+        { status: 504 }
+      );
+    }
     console.error(`[AI Proxy] Failed to proxy request to ${targetUrl}:`, err);
     return NextResponse.json(
       { error: 'AI Service unavailable' },
       { status: 502 }
     );
+  } finally {
+    clearTimeout(timeoutId);
   }
 }

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -1,6 +1,37 @@
-import { type User } from '@supabase/supabase-js';
+import { type User, type SupabaseClient } from '@supabase/supabase-js';
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
+
+export type AuthResult = {
+  user: User;
+  supabase: SupabaseClient;
+};
+
+/**
+ * Ensures the user is authenticated in a server action.
+ * Throws an error if not authenticated.
+ */
+export async function ensureAuth(): Promise<AuthResult> {
+  const supabase = await createClient();
+  const { data: { user }, error } = await supabase.auth.getUser();
+  
+  if (error || !user) {
+    throw new Error("Nicht authentifiziert. Bitte melden Sie sich an.");
+  }
+  
+  return { user, supabase };
+}
+
+/**
+ * Safer version that returns null instead of throwing.
+ */
+export async function getAuth() {
+  try {
+    return await ensureAuth();
+  } catch (error) {
+    return null;
+  }
+}
 
 export type ResolveUserAndOrgResult =
   | { user: User; orgId: string; userJwt?: string; errorResponse: null }

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -1,33 +1,85 @@
-import { createClient } from "@/utils/supabase/server";
-import { type User, type SupabaseClient } from "@supabase/supabase-js";
+import { type User } from '@supabase/supabase-js';
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/utils/supabase/server';
 
-export type AuthResult = {
-  user: User;
-  supabase: SupabaseClient;
-};
+export type ResolveUserAndOrgResult =
+  | { user: User; orgId: string; userJwt?: string; errorResponse: null }
+  | { user: null; orgId: ''; userJwt?: undefined; errorResponse: Response };
 
 /**
- * Ensures the user is authenticated in a server action.
- * Throws an error if not authenticated.
+ * Resolves the authenticated Supabase user and validates their active organization.
+ * Ensures the organization ID is verified against the user's active memberships.
  */
-export async function ensureAuth(): Promise<AuthResult> {
+export async function resolveUserAndOrg(req?: NextRequest): Promise<ResolveUserAndOrgResult> {
   const supabase = await createClient();
-  const { data: { user }, error } = await supabase.auth.getUser();
-  
-  if (error || !user) {
-    throw new Error("Nicht authentifiziert. Bitte melden Sie sich an.");
-  }
-  
-  return { user, supabase };
-}
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
 
-/**
- * Safer version that returns null instead of throwing.
- */
-export async function getAuth() {
-  try {
-    return await ensureAuth();
-  } catch (error) {
-    return null;
+  if (authError || !user) {
+    if (req) {
+      console.error('[resolveUserAndOrg] Auth failed:', {
+        authError: authError?.message || authError,
+        hasUser: !!user,
+      });
+    }
+    return {
+      user: null,
+      orgId: '',
+      errorResponse: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    };
   }
+
+  const { data: { session } } = await supabase.auth.getSession();
+  const userJwt = session?.access_token;
+
+  let requestedOrgId: string | null = null;
+  if (req) {
+    const { searchParams } = new URL(req.url);
+    requestedOrgId = searchParams.get('orgId');
+  }
+
+  let orgId: string | null = null;
+
+  // 1. If explicit orgId requested in query params, verify user membership
+  if (requestedOrgId) {
+    const { data: requestedMembership } = await supabase
+      .from('Organisation_Mitglieder')
+      .select('organisation_id')
+      .eq('user_id', user.id)
+      .eq('organisation_id', requestedOrgId)
+      .eq('status', 'aktiv')
+      .maybeSingle();
+
+    if (requestedMembership) {
+      orgId = requestedMembership.organisation_id;
+    }
+  }
+
+  // 2. Fallback to RPC current_organisation_id
+  if (!orgId) {
+    const { data: rpcOrgId } = await supabase.rpc('current_organisation_id');
+    if (rpcOrgId) orgId = rpcOrgId;
+  }
+
+  // 3. Fallback to first active membership
+  if (!orgId) {
+    const { data: membership } = await supabase
+      .from('Organisation_Mitglieder')
+      .select('organisation_id')
+      .eq('user_id', user.id)
+      .eq('status', 'aktiv')
+      .limit(1)
+      .maybeSingle();
+
+    orgId = membership?.organisation_id || null;
+  }
+
+  if (!orgId) {
+    return {
+      user: null,
+      orgId: '',
+      errorResponse: NextResponse.json({ error: 'No active organization found' }, { status: 400 }),
+    };
+  }
+
+  return { user, orgId, userJwt, errorResponse: null };
 }

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -80,9 +80,14 @@ export async function resolveUserAndOrg(req?: NextRequest): Promise<ResolveUserA
       .eq('status', 'aktiv')
       .maybeSingle();
 
-    if (requestedMembership) {
-      orgId = requestedMembership.organisation_id;
+    if (!requestedMembership) {
+      return {
+        user: null,
+        orgId: '',
+        errorResponse: NextResponse.json({ error: 'Forbidden: Access to requested organization denied' }, { status: 403 }),
+      };
     }
+    orgId = requestedMembership.organisation_id;
   }
 
   // 2. Fallback to RPC current_organisation_id (verified against active user memberships)

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -85,10 +85,22 @@ export async function resolveUserAndOrg(req?: NextRequest): Promise<ResolveUserA
     }
   }
 
-  // 2. Fallback to RPC current_organisation_id
+  // 2. Fallback to RPC current_organisation_id (verified against active user memberships)
   if (!orgId) {
     const { data: rpcOrgId } = await supabase.rpc('current_organisation_id');
-    if (rpcOrgId) orgId = rpcOrgId;
+    if (rpcOrgId) {
+      const { data: rpcMembership } = await supabase
+        .from('Organisation_Mitglieder')
+        .select('organisation_id')
+        .eq('user_id', user.id)
+        .eq('organisation_id', rpcOrgId)
+        .eq('status', 'aktiv')
+        .maybeSingle();
+
+      if (rpcMembership) {
+        orgId = rpcMembership.organisation_id;
+      }
+    }
   }
 
   // 3. Fallback to first active membership

--- a/lib/auth-utils.ts
+++ b/lib/auth-utils.ts
@@ -59,8 +59,17 @@ export async function resolveUserAndOrg(req?: NextRequest): Promise<ResolveUserA
     };
   }
 
-  const { data: { session } } = await supabase.auth.getSession();
-  const userJwt = session?.access_token;
+  let userJwt: string | undefined = undefined;
+  if (req) {
+    const authHeader = req.headers.get('authorization');
+    if (authHeader?.startsWith('Bearer ')) {
+      userJwt = authHeader.substring(7).trim();
+    }
+  }
+  if (!userJwt) {
+    const { data: { session } } = await supabase.auth.getSession();
+    userJwt = session?.access_token;
+  }
 
   let requestedOrgId: string | null = null;
   if (req) {

--- a/lib/supabase-env.ts
+++ b/lib/supabase-env.ts
@@ -1,0 +1,24 @@
+export function getSupabasePublicEnv() {
+  const isDev = process.env.NEXT_PUBLIC_DEV === 'true' || process.env.DEV === 'true';
+
+  const url = isDev
+    ? (process.env.NEXT_PUBLIC_DEV_SUPABASE_URL || process.env.DEV_SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || '')
+    : (process.env.NEXT_PUBLIC_SUPABASE_URL || '');
+
+  const anonKey = isDev
+    ? (process.env.NEXT_PUBLIC_DEV_SUPABASE_ANON_KEY || process.env.DEV_SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '')
+    : (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '');
+
+  return { url, anonKey };
+}
+
+export function getSupabaseServerEnv() {
+  const { url, anonKey } = getSupabasePublicEnv();
+  const isDev = process.env.NEXT_PUBLIC_DEV === 'true' || process.env.DEV === 'true';
+
+  const serviceKey = isDev
+    ? (process.env.DEV_SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY || '')
+    : (process.env.SUPABASE_SERVICE_ROLE_KEY || '');
+
+  return { url, anonKey, serviceKey };
+}

--- a/utils/supabase/client.ts
+++ b/utils/supabase/client.ts
@@ -1,8 +1,7 @@
 import { createBrowserClient } from "@supabase/ssr"
+import { getSupabasePublicEnv } from "@/lib/supabase-env"
 
 export function createClient() {
-  return createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  )
+  const { url, anonKey } = getSupabasePublicEnv()
+  return createBrowserClient(url, anonKey)
 }

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server"
 import type { User } from "@supabase/supabase-js"
-
 import { createServerClient, type CookieOptions } from "@supabase/ssr"
+import { getSupabasePublicEnv } from "@/lib/supabase-env"
 
 export async function updateSession(request: NextRequest, response: NextResponse): Promise<User | null> {
   const currentOrgId = request.cookies.get('current_organisation_id')?.value
@@ -10,16 +10,17 @@ export async function updateSession(request: NextRequest, response: NextResponse
     globalHeaders['Cookie'] = `current_organisation_id=${currentOrgId}`
   }
 
+  const { url, anonKey } = getSupabasePublicEnv()
+
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    url,
+    anonKey,
     {
       global: {
         headers: globalHeaders
       },
       cookies: {
         getAll() {
-
           return request.cookies.getAll()
         },
         setAll(cookiesToSet) {

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from "@supabase/ssr"
 import { cookies } from "next/headers"
+import { getSupabasePublicEnv } from "@/lib/supabase-env"
 
 export async function createClient(orgIdOverride?: string) {
   const cookieStore = await cookies()
@@ -10,7 +11,9 @@ export async function createClient(orgIdOverride?: string) {
     globalHeaders['Cookie'] = `current_organisation_id=${currentOrgId}`
   }
 
-  return createServerClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, {
+  const { url, anonKey } = getSupabasePublicEnv()
+
+  return createServerClient(url, anonKey, {
     global: {
       headers: globalHeaders
     },
@@ -32,4 +35,3 @@ export async function createClient(orgIdOverride?: string) {
     },
   })
 }
-


### PR DESCRIPTION
## Summary

This PR migrates all AI-related API routes from direct Supabase DB calls to a proxy pattern that forwards requests to the `ai.mietevo.de` microservice. It adds a shared `proxyToAiService` utility, a reusable `resolveUserAndOrg` auth helper, environment-aware Supabase configuration (`DEV_*` env vars), and hardens the frontend streaming parser with abort-on-unmount and proper SSE `data:` line parsing.

## Changes

### New modules
- **`lib/ai-service-proxy.ts`** — Universal proxy function for forwarding requests to the AI service. Sets auth headers (`X-AI-Service-Auth`, `X-User-Id`, `X-Org-Id`, `X-User-Jwt`), propagates trace IDs (`X-Trace-Id`), strips original auth/cookie headers, supports configurable timeout (default 120s), and returns sanitized 502 (unavailable) / 504 (timeout) errors.
- **`lib/supabase-env.ts`** — Shared utility for resolving Supabase URL/anonKey/serviceKey with DEV environment overrides (`DEV_SUPABASE_URL`, `DEV_SUPABASE_ANON_KEY`, `DEV_SUPABASE_SERVICE_ROLE_KEY`). Used by all three Supabase client factories.

### Modified modules
- **`lib/auth-utils.ts`** — Added `resolveUserAndOrg(req?)` that authenticates via `supabase.auth.getUser()`, resolves the active org ID through three fallbacks (explicit query param → RPC `current_organisation_id` → first active membership), and extracts the user JWT from the Authorization header or session. Returns a typed discriminated union result. Exports `ensureAuth` and `getAuth` preserved.
- **`app/api/chat/route.ts`** — Replaced inline auth/org resolution + manual fetch with `resolveUserAndOrg` + `proxyToAiService(/api/chat, ...)`.
- **`app/api/conversations/route.ts`** — Replaced inline CRUD and auth logic with `proxyToAiService(/api/conversations, ...)` via shared `handleRequest` helper.
- **`app/api/conversations/[id]/route.ts`** — All five HTTP methods (GET/POST/PATCH/DELETE) now delegate to `proxyToAiService`. Removed ~400 lines of inline DB logic (org verification, bucket archive/restore, soft-delete).
- **`app/api/agents/runs/route.ts`** — Replaced inline RPC call with `proxyToAiService(/api/agents/runs, ...)`.
- **`app/api/cron/cleanup-runs/route.ts`** — Secured with `isCronAuthorized` check (Bearer token) and proxied to `/api/cron/cleanup-runs`. Removed inline DB cleanup logic.
- **`app/api/chat/engine/route.ts`** — Fixed `timingSafeCompare`: handles null/undefined inputs, avoids timing leak on length mismatch by calling `timingSafeEqual(bufB, bufB)`. Sanitized catch error response (no longer leaks error details to client).
- **`components/ai-chat/ai-chat-sidebar.tsx`** — Added `AbortController` with cleanup on unmount; abort previous in-flight requests before starting new ones. Refactored SSE stream parsing into `processStreamLine()` with `data: ` prefix support. Processes trailing buffer content after stream ends.
- **`utils/supabase/client.ts`**, **`utils/supabase/middleware.ts`**, **`utils/supabase/server.ts`** — Use `getSupabasePublicEnv()` instead of directly reading `process.env.NEXT_PUBLIC_SUPABASE_*` for DEV environment support.

## Security
- Internal error messages (DB errors, stack traces) are no longer leaked to clients — replaced with `"Internal server error"`.
- `timingSafeCompare` hardened against timing oracle attacks (null/undefined handling + constant-time length mismatch).
- Cron endpoint protected with `isCronAuthorized` check against `CRON_SECRET`.
- Auth/cookie headers stripped before proxying to downstream service.
- X-Trace-Id propagated for end-to-end request tracing.

## Testing
- pgTAP test plan count updated (21 → 22) to account for the added constraint test assertion.
