### PR TITLE
refactor(agents): use maybeSingle in resolveMitgliedId

### DIFF
--- a/lib/agents/permissions.ts
+++ b/lib/agents/permissions.ts
@@ -14,7 +14,7 @@ export async function resolveMitgliedId(
     .eq('user_id', userId)
     .eq('status', 'aktiv')
     .is('geloescht_am', null)
-    .single();
+    .maybeSingle();
 
   if (!member) return null;
   return member.id;


### PR DESCRIPTION
Replaces `.single()` with `.maybeSingle()` in `resolveMitgliedId` to cleanly return `null` when an active member is not found, avoiding PostgREST PGRST116 error logs.