### PR TITLE
Feat/sidebar header redesign

### DIFF
--- a/components/common/user-settings.tsx
+++ b/components/common/user-settings.tsx
@@ -29,7 +29,7 @@ const triggerVariants = {
   collapsed: {
     width: "40px",
     height: "40px",
-    borderRadius: "24px", // rounded-2xl
+    borderRadius: "9999px", // rounded-full
     paddingLeft: "0px",
     paddingRight: "0px",
     paddingTop: "0px",

--- a/components/common/user-settings.tsx
+++ b/components/common/user-settings.tsx
@@ -309,52 +309,6 @@ export function UserSettings({
           </CustomDropdownItem>
         )}
         <CustomDropdownSeparator />
-        <CustomDropdownLabel className="text-xs text-gray-500 font-semibold uppercase tracking-wider px-3 py-1">
-          Organisationen:
-        </CustomDropdownLabel>
-        <CustomDropdownItem
-          onClick={() => handleSwitchOrg(null)}
-          disabled={isSwitchingOrg}
-          className="flex items-center cursor-pointer"
-        >
-          {currentOrgId === null ? (
-            <Check className="mr-2 size-4 text-emerald-500 shrink-0" />
-          ) : (
-            <div className="mr-2 size-4 shrink-0" />
-          )}
-          <span className={cn(currentOrgId === null && "font-medium text-emerald-600 dark:text-emerald-400")}>
-            Privat
-          </span>
-        </CustomDropdownItem>
-        {organisations.map((org) => {
-          const isActive = currentOrgId === org.organisation_id;
-          const roleLabel =
-            org.rolle === 'owner' ? 'Owner' :
-            org.rolle === 'admin' ? 'Admin' :
-            'Mitarbeiter';
-
-          return (
-            <CustomDropdownItem
-              key={org.organisation_id}
-              onClick={() => handleSwitchOrg(org.organisation_id)}
-              disabled={isSwitchingOrg}
-              className="flex items-center cursor-pointer"
-            >
-              {isActive ? (
-                <Check className="mr-2 size-4 text-emerald-500 shrink-0" />
-              ) : (
-                <div className="mr-2 size-4 shrink-0" />
-              )}
-              <span className={cn(
-                "truncate",
-                isActive && "font-medium text-emerald-600 dark:text-emerald-400"
-              )}>
-                {org.name} <span className="text-xs text-gray-400 font-normal">({roleLabel})</span>
-              </span>
-            </CustomDropdownItem>
-          )
-        })}
-        <CustomDropdownSeparator />
         <CustomDropdownItem
           onClick={handleLogout}
           disabled={isLoadingLogout}

--- a/components/common/user-settings.tsx
+++ b/components/common/user-settings.tsx
@@ -29,7 +29,7 @@ const triggerVariants = {
   collapsed: {
     width: "40px",
     height: "40px",
-    borderRadius: "9999px", // rounded-full
+    borderRadius: "24px", // rounded-2xl
     paddingLeft: "0px",
     paddingRight: "0px",
     paddingTop: "0px",
@@ -211,7 +211,7 @@ export function UserSettings({
             transition={{ duration: 0.2, ease: "easeInOut" }}
             className={cn(
               "flex items-center cursor-pointer transition-colors duration-200 select-none outline-none hover:bg-hover-bg data-[state=open]:bg-hover-bg rounded-xl",
-              collapsed ? "justify-center p-1" : "pl-1 pr-2 p-1"
+              collapsed ? "justify-center p-0" : "pl-1 pr-2 p-1 w-full justify-start"
             )}
             aria-label="User menu"
           >

--- a/components/common/user-settings.tsx
+++ b/components/common/user-settings.tsx
@@ -1,15 +1,14 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import { LogOut, Settings, FileText, Check, Trash2 } from "lucide-react"
+import { LogOut, Settings, FileText, Trash2 } from "lucide-react"
 import { createClient } from "@/utils/supabase/client"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { useRouter } from "next/navigation"
 import { cn } from "@/lib/utils"
 import { m } from "framer-motion"
 import { trackLogout } from "@/lib/posthog-auth-events"
-import { getMyOrganisationsAction, switchOrganisationAction } from "@/app/organisation-actions"
-import { useToast } from "@/hooks/use-toast"
+import { getMyOrganisationsAction } from "@/app/organisation-actions"
 
 const layoutTransition = {
   duration: 0
@@ -60,7 +59,6 @@ export function UserSettings({
   collapsed?: boolean;
   initialData: SidebarUserData;
 }) {
-  const { toast } = useToast()
   const router = useRouter()
   const [isLoadingLogout, setIsLoadingLogout] = useState(false)
   const supabase = createClient()

--- a/components/common/user-settings.tsx
+++ b/components/common/user-settings.tsx
@@ -208,12 +208,10 @@ export function UserSettings({
           <m.div
             variants={triggerVariants}
             animate={collapsed ? "collapsed" : "expanded"}
-            whileHover={{ scale: 1.02 }}
-            whileTap={{ scale: 0.98 }}
             transition={{ duration: 0.2, ease: "easeInOut" }}
             className={cn(
-              "flex items-center cursor-pointer transition-all duration-200 select-none outline-none border border-zinc-200/20 dark:border-zinc-800/30 hover:border-zinc-200/50 dark:hover:border-zinc-800/50 hover:shadow-md bg-zinc-100/50 dark:bg-zinc-900/50 hover:bg-white dark:hover:bg-zinc-900/90 rounded-2xl",
-              collapsed ? "justify-center p-1.5" : "px-3 py-2.5"
+              "flex items-center cursor-pointer transition-colors duration-200 select-none outline-none hover:bg-hover-bg data-[state=open]:bg-hover-bg rounded-xl",
+              collapsed ? "justify-center p-1" : "pl-1 pr-2 p-1"
             )}
             aria-label="User menu"
           >

--- a/components/common/user-settings.tsx
+++ b/components/common/user-settings.tsx
@@ -89,7 +89,7 @@ export function UserSettings({
     ? true 
     : activeOrg 
     ? (activeOrg.rolle === 'owner' || activeOrg.rolle === 'admin') 
-    : initialData.hasOrganisationPermission;
+    : (organisations.length > 0 ? false : initialData.hasOrganisationPermission);
 
   const {
     count: apartmentCount,

--- a/components/common/user-settings.tsx
+++ b/components/common/user-settings.tsx
@@ -84,8 +84,12 @@ export function UserSettings({
     isLoading: isLoadingUser
   } = useUserProfile(initialData)
 
-  const activeOrg = organisations.find(o => o.organisation_id === currentOrgId);
-  const isOrgAdminOrOwner = currentOrgId === null || (activeOrg && (activeOrg.rolle === 'owner' || activeOrg.rolle === 'admin'));
+  const activeOrg = currentOrgId ? organisations.find(o => o.organisation_id === currentOrgId) : null;
+  const isOrgAdminOrOwner = currentOrgId === null 
+    ? true 
+    : activeOrg 
+    ? (activeOrg.rolle === 'owner' || activeOrg.rolle === 'admin') 
+    : initialData.hasOrganisationPermission;
 
   const {
     count: apartmentCount,

--- a/components/common/user-settings.tsx
+++ b/components/common/user-settings.tsx
@@ -198,62 +198,38 @@ export function UserSettings({
                 </AvatarFallback>
               </Avatar>
             </m.div>
-            <m.div
-              initial={false}
-              variants={{
-                expanded: {
-                  opacity: 1,
-                  width: "auto",
-                  marginLeft: "12px",
-                  display: "flex",
-                  transition: {
-                    type: "spring",
-                    stiffness: 400,
-                    damping: 38,
-                    mass: 0.8
-                  }
-                },
-                collapsed: {
-                  opacity: 0,
-                  width: 0,
-                  marginLeft: "0px",
-                  transition: {
-                    type: "spring",
-                    stiffness: 400,
-                    damping: 38,
-                    mass: 0.8
-                  },
-                  transitionEnd: { display: "none" }
-                }
-              }}
-              animate={collapsed ? "collapsed" : "expanded"}
-              className="flex flex-col flex-1 text-left min-w-0 overflow-hidden shrink-0"
-            >
-              <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
-                {isLoadingUser ? "Lade..." : userName}
-              </span>
-              {!isLoadingUser && !isLoadingApartmentData && apartmentLimit !== null && apartmentLimit !== Infinity && (
-                <div className="flex flex-col gap-1 mt-1 w-full">
-                  <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
-                    <span className="truncate">{apartmentCount} / {apartmentLimit} Wohnungen</span>
-                  </div>
-                  <Progress
-                    value={progressPercentage}
-                    className="h-1.5 bg-gray-200 dark:bg-gray-700 [&>div]:bg-accent"
-                  />
-                </div>
-              )}
-              {!isLoadingUser && !isLoadingApartmentData && (apartmentLimit === null || apartmentLimit === Infinity) && (
-                <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
-                  Unbegrenzte Wohnungen
+            {!collapsed && (
+              <m.div
+                initial={false}
+                animate="expanded"
+                className="flex flex-col flex-1 text-left min-w-0 overflow-hidden shrink-0 ml-3"
+              >
+                <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                  {isLoadingUser ? "Lade..." : userName}
                 </span>
-              )}
-              {(isLoadingUser || isLoadingApartmentData) && (
-                <div className="h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full mt-1.5 w-full">
-                  <div className="h-full bg-gray-300 dark:bg-gray-600 rounded-full animate-pulse w-1/2"></div>
-                </div>
-              )}
-            </m.div>
+                {!isLoadingUser && !isLoadingApartmentData && apartmentLimit !== null && apartmentLimit !== Infinity && (
+                  <div className="flex flex-col gap-1 mt-1 w-full">
+                    <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+                      <span className="truncate">{apartmentCount} / {apartmentLimit} Wohnungen</span>
+                    </div>
+                    <Progress
+                      value={progressPercentage}
+                      className="h-1.5 bg-gray-200 dark:bg-gray-700 [&>div]:bg-accent"
+                    />
+                  </div>
+                )}
+                {!isLoadingUser && !isLoadingApartmentData && (apartmentLimit === null || apartmentLimit === Infinity) && (
+                  <span className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                    Unbegrenzte Wohnungen
+                  </span>
+                )}
+                {(isLoadingUser || isLoadingApartmentData) && (
+                  <div className="h-1.5 bg-gray-200 dark:bg-gray-700 rounded-full mt-1.5 w-full">
+                    <div className="h-full bg-gray-300 dark:bg-gray-600 rounded-full animate-pulse w-1/2"></div>
+                  </div>
+                )}
+              </m.div>
+            )}
           </m.div>
         }
       >

--- a/components/common/user-settings.tsx
+++ b/components/common/user-settings.tsx
@@ -76,7 +76,6 @@ export function UserSettings({
 
   const [organisations, setOrganisations] = useState<OrganisationItem[]>([])
   const [currentOrgId, setCurrentOrgId] = useState<string | null>(null)
-  const [isSwitchingOrg, setIsSwitchingOrg] = useState(false)
 
   useEffect(() => {
     const loadOrganisations = async () => {
@@ -110,33 +109,6 @@ export function UserSettings({
 
     loadOrganisations()
   }, [])
-
-  const handleSwitchOrg = async (orgId: string | null) => {
-    if (orgId === currentOrgId) return;
-    setIsSwitchingOrg(true);
-    try {
-      const res = await switchOrganisationAction(orgId);
-      if (res.success) {
-        window.location.reload();
-      } else {
-        console.error("Failed to switch organisation:", res.error?.message);
-        toast({
-          variant: "destructive",
-          title: "Fehler beim Wechseln",
-          description: res.error?.message || "Die Organisation konnte nicht gewechselt werden.",
-        });
-      }
-    } catch (e) {
-      console.error("Exception switching organisation:", e);
-      toast({
-        variant: "destructive",
-        title: "Fehler",
-        description: "Ein unerwarteter Fehler ist aufgetreten.",
-      });
-    } finally {
-      setIsSwitchingOrg(false);
-    }
-  };
 
 
   // Use custom hooks for data fetching

--- a/components/common/user-settings.tsx
+++ b/components/common/user-settings.tsx
@@ -12,10 +12,7 @@ import { getMyOrganisationsAction, switchOrganisationAction } from "@/app/organi
 import { useToast } from "@/hooks/use-toast"
 
 const layoutTransition = {
-  type: "spring",
-  stiffness: 400,
-  damping: 38,
-  mass: 0.8
+  duration: 0
 } as const;
 
 const triggerVariants = {
@@ -27,12 +24,7 @@ const triggerVariants = {
     paddingRight: "12px",
     paddingTop: "10px",
     paddingBottom: "10px",
-    transition: {
-      type: "spring",
-      stiffness: 400,
-      damping: 38,
-      mass: 0.8
-    }
+    transition: { duration: 0 }
   },
   collapsed: {
     width: "40px",
@@ -42,12 +34,7 @@ const triggerVariants = {
     paddingRight: "0px",
     paddingTop: "0px",
     paddingBottom: "0px",
-    transition: {
-      type: "spring",
-      stiffness: 400,
-      damping: 38,
-      mass: 0.8
-    }
+    transition: { duration: 0 }
   }
 } as const;
 
@@ -224,7 +211,10 @@ export function UserSettings({
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
             transition={{ duration: 0.2, ease: "easeInOut" }}
-            className="flex items-center cursor-pointer transition-all duration-200 select-none outline-none border border-zinc-200/20 dark:border-zinc-800/30 hover:border-zinc-200/50 dark:hover:border-zinc-800/50 hover:shadow-md bg-zinc-100/50 dark:bg-zinc-900/50 hover:bg-white dark:hover:bg-zinc-900/90 rounded-2xl"
+            className={cn(
+              "flex items-center cursor-pointer transition-all duration-200 select-none outline-none border border-zinc-200/20 dark:border-zinc-800/30 hover:border-zinc-200/50 dark:hover:border-zinc-800/50 hover:shadow-md bg-zinc-100/50 dark:bg-zinc-900/50 hover:bg-white dark:hover:bg-zinc-900/90 rounded-2xl",
+              collapsed ? "justify-center p-1.5" : "px-3 py-2.5"
+            )}
             aria-label="User menu"
           >
             <m.div 

--- a/components/common/user-settings.tsx
+++ b/components/common/user-settings.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { LogOut, Settings, FileText, Trash2 } from "lucide-react"
 import { createClient } from "@/utils/supabase/client"
 import { useFeatureFlagEnabled } from "posthog-js/react"
@@ -8,7 +8,6 @@ import { useRouter } from "next/navigation"
 import { cn } from "@/lib/utils"
 import { m } from "framer-motion"
 import { trackLogout } from "@/lib/posthog-auth-events"
-import { getMyOrganisationsAction } from "@/app/organisation-actions"
 
 const layoutTransition = {
   duration: 0
@@ -52,61 +51,29 @@ import {
   CustomDropdownSeparator,
 } from "@/components/ui/custom-dropdown"
 
+export interface OrganisationItem {
+  organisation_id: string;
+  owner_id: string;
+  rolle: 'owner' | 'admin' | 'mitarbeiter';
+  name: string;
+}
+
 export function UserSettings({ 
   collapsed,
-  initialData 
+  initialData,
+  organisations = [],
+  currentOrgId = null
 }: { 
   collapsed?: boolean;
   initialData: SidebarUserData;
+  organisations?: OrganisationItem[];
+  currentOrgId?: string | null;
 }) {
   const router = useRouter()
   const [isLoadingLogout, setIsLoadingLogout] = useState(false)
   const supabase = createClient()
   const { openTemplatesModal, openTrashBinModal } = useModalStore()
   const templateModalEnabled = useFeatureFlagEnabled('template-modal-enabled')
-
-  interface OrganisationItem {
-    organisation_id: string;
-    owner_id: string;
-    rolle: 'owner' | 'admin' | 'mitarbeiter';
-    name: string;
-  }
-
-  const [organisations, setOrganisations] = useState<OrganisationItem[]>([])
-  const [currentOrgId, setCurrentOrgId] = useState<string | null>(null)
-
-  useEffect(() => {
-    const loadOrganisations = async () => {
-      try {
-        const res = await getMyOrganisationsAction()
-        if (res.success && res.data) {
-          setOrganisations(res.data)
-          setCurrentOrgId(res.currentOrgId ?? null)
-          sessionStorage.setItem("cached_organisations:v1", JSON.stringify({
-            orgs: res.data,
-            currentOrgId: res.currentOrgId
-          }))
-        }
-      } catch (e) {
-        console.error("Failed to load organisations:", e)
-      }
-    }
-
-    const cached = sessionStorage.getItem("cached_organisations:v1")
-    if (cached) {
-      try {
-        const parsed = JSON.parse(cached)
-        setOrganisations(parsed.orgs)
-        if (parsed.currentOrgId !== undefined) {
-          setCurrentOrgId(parsed.currentOrgId ?? null)
-        }
-      } catch {
-        sessionStorage.removeItem("cached_organisations:v1")
-      }
-    }
-
-    loadOrganisations()
-  }, [])
 
 
   // Use custom hooks for data fetching

--- a/components/dashboard/dashboard-layout.tsx
+++ b/components/dashboard/dashboard-layout.tsx
@@ -9,6 +9,7 @@ import type { SidebarUserData } from "@/lib/server/user-data"
 import { useSidebarStore } from "@/hooks/use-sidebar-store"
 import { TaskDndProvider } from "@/components/tasks/task-dnd-provider"
 import { useAIChatStore } from "@/hooks/use-ai-chat-store"
+import { useMediaQuery } from "@/hooks/use-media-query"
 
 export function DashboardLayout({
   children,
@@ -19,7 +20,7 @@ export function DashboardLayout({
 }) {
   const [mounted, setMounted] = useState(false)
   const [isMobile, setIsMobile] = useState(false)
-  const [isTabletCollapsed, setIsTabletCollapsed] = useState(false)
+  const isTabletCollapsed = useMediaQuery('(max-width: 1023px)')
   const { preference } = useSidebarStore()
   const { isOpen, displayMode } = useAIChatStore()
   const isPushMode = mounted && isOpen && displayMode === 'push' && !isMobile
@@ -31,20 +32,10 @@ export function DashboardLayout({
 
     // Check initial screen size with proper breakpoint detection
     const checkScreenSize = () => {
-      const newIsMobile = window.innerWidth < 768
-      const newIsTablet = window.innerWidth <= 1023
-      setIsMobile(newIsMobile)
-      setIsTabletCollapsed(newIsTablet)
-      return newIsMobile
+      setIsMobile(window.innerWidth < 768)
     }
 
     checkScreenSize()
-
-    const mediaQuery = window.matchMedia('(max-width: 1023px)')
-    const handleMediaChange = (e: MediaQueryListEvent) => {
-      setIsTabletCollapsed(e.matches)
-    }
-    mediaQuery.addEventListener('change', handleMediaChange)
 
     let resizeTimeout: NodeJS.Timeout
     const handleResize = () => {
@@ -58,7 +49,6 @@ export function DashboardLayout({
 
     return () => {
       window.removeEventListener('resize', handleResize)
-      mediaQuery.removeEventListener('change', handleMediaChange)
       clearTimeout(resizeTimeout)
     }
   }, [])

--- a/components/dashboard/dashboard-layout.tsx
+++ b/components/dashboard/dashboard-layout.tsx
@@ -128,10 +128,10 @@ export function DashboardLayout({
           // Enhanced responsive padding with CSS-only fallbacks
           "main-content-responsive",
           "responsive-transition",
-          // Responsive padding matching sidebar p-3 (12px)
-          "p-3 md:p-3",
+          // Responsive padding: 0px on left, 12px on top, bottom, right
+          "py-3 pr-3 pl-0",
           // JavaScript-enhanced responsive padding
-          isMobile ? "pb-20 pt-3" : "p-3",
+          isMobile ? "pb-20 pt-3 px-3" : "py-3 pr-3 pl-0",
           // Push mode: shift content by adding right margin matching sidebar width
           isPushMode && "md:mr-[450px]"
         )}>

--- a/components/dashboard/dashboard-layout.tsx
+++ b/components/dashboard/dashboard-layout.tsx
@@ -117,7 +117,7 @@ export function DashboardLayout({
         <div
           className="desktop-sidebar-responsive hydration-safe-desktop prevent-layout-shift overflow-hidden h-screen sticky top-0"
           style={{
-            width: isCollapsed ? "4.25rem" : "16rem"
+            width: isCollapsed ? "4.5rem" : "16rem"
           }}
         >
           <DashboardSidebar sidebarData={sidebarData} />

--- a/components/dashboard/dashboard-layout.tsx
+++ b/components/dashboard/dashboard-layout.tsx
@@ -19,9 +19,7 @@ export function DashboardLayout({
 }) {
   const [mounted, setMounted] = useState(false)
   const [isMobile, setIsMobile] = useState(false)
-  const [isTabletCollapsed, setIsTabletCollapsed] = useState(() =>
-    typeof window !== "undefined" ? window.matchMedia('(max-width: 1023px)').matches : false
-  )
+  const [isTabletCollapsed, setIsTabletCollapsed] = useState(false)
   const { preference } = useSidebarStore()
   const { isOpen, displayMode } = useAIChatStore()
   const isPushMode = mounted && isOpen && displayMode === 'push' && !isMobile

--- a/components/dashboard/dashboard-layout.tsx
+++ b/components/dashboard/dashboard-layout.tsx
@@ -48,7 +48,6 @@ export function DashboardLayout({
 
     let resizeTimeout: NodeJS.Timeout
     const handleResize = () => {
-      setIsTabletCollapsed(window.innerWidth <= 1023)
       clearTimeout(resizeTimeout)
       resizeTimeout = setTimeout(() => {
         setIsMobile(window.innerWidth < 768)

--- a/components/dashboard/dashboard-layout.tsx
+++ b/components/dashboard/dashboard-layout.tsx
@@ -126,7 +126,7 @@ export function DashboardLayout({
         </div>
 
         <main className={cn(
-          "flex flex-1 flex-col min-h-0 overflow-hidden border-2 border-fuchsia-500",
+          "flex flex-1 flex-col min-h-0 overflow-hidden",
           // Enhanced responsive padding with CSS-only fallbacks
           "main-content-responsive",
           "responsive-transition",
@@ -138,7 +138,7 @@ export function DashboardLayout({
           isPushMode && "md:mr-[450px]"
         )}>
           <div className={cn(
-            "flex-1 border-2 border-green-500 shadow-xs bg-white dark:bg-[#181818] relative overflow-y-auto overflow-x-hidden",
+            "flex-1 border shadow-xs bg-white dark:bg-[#181818] relative overflow-y-auto overflow-x-hidden",
             "rounded-[2rem] md:rounded-[2.5rem]",
             "responsive-transition",
             "prevent-layout-shift",

--- a/components/dashboard/dashboard-layout.tsx
+++ b/components/dashboard/dashboard-layout.tsx
@@ -111,7 +111,7 @@ export function DashboardLayout({
       <div className="flex min-h-screen bg-background w-full max-w-full">
         {/* Desktop sidebar */}
         <div
-          className="desktop-sidebar-responsive hydration-safe-desktop prevent-layout-shift transition-all duration-300 ease-in-out overflow-hidden h-screen sticky top-0"
+          className="desktop-sidebar-responsive hydration-safe-desktop prevent-layout-shift overflow-hidden h-screen sticky top-0"
           style={{
             width: preference === 'expanded' ? "16rem" : "5rem"
           }}
@@ -119,40 +119,30 @@ export function DashboardLayout({
           <DashboardSidebar sidebarData={sidebarData} />
         </div>
 
-        <div className="flex flex-1 flex-col overflow-hidden">
-
         <main className={cn(
-          "flex flex-1 flex-col min-h-0",
+          "flex flex-1 flex-col min-h-0 overflow-hidden border-2 border-fuchsia-500",
           // Enhanced responsive padding with CSS-only fallbacks
           "main-content-responsive",
           "responsive-transition",
-          // Responsive padding: no top padding on mobile since header is hidden
-          "p-6 md:p-6",
-          "pt-6 md:pt-6",
+          // Responsive padding matching sidebar p-3 (12px)
+          "p-3 md:p-3",
           // JavaScript-enhanced responsive padding
-          isMobile ? "pb-20 pt-6" : "pb-6 pt-6",
+          isMobile ? "pb-20 pt-3" : "p-3",
           // Push mode: shift content by adding right margin matching sidebar width
           isPushMode && "md:mr-[450px]"
         )}>
           <div className={cn(
-            "flex-1 overflow-y-auto overflow-x-hidden",
-            "mb-4 md:mb-0",
-            "responsive-transition"
+            "flex-1 border-2 border-green-500 shadow-xs bg-white dark:bg-[#181818] relative overflow-y-auto overflow-x-hidden",
+            "rounded-[2rem] md:rounded-[2.5rem]",
+            "responsive-transition",
+            "prevent-layout-shift",
+            "mobile-smooth-scroll",
+            "mb-0",
+            isMobile && "pb-20"
           )}>
-            <div className={cn(
-              "flex-1 border shadow-xs bg-white dark:bg-[#181818] relative overflow-hidden",
-              "rounded-[2rem] md:rounded-[2.5rem]",
-              "responsive-transition",
-              "prevent-layout-shift",
-              "mobile-smooth-scroll",
-              "mb-0",
-              isMobile && "pb-20"
-            )}>
-              {children}
-            </div>
+            {children}
           </div>
         </main>
-      </div>
 
         {mounted && isMobile && <MobileBottomNavigation sidebarData={sidebarData} />}
       </div>

--- a/components/dashboard/dashboard-layout.tsx
+++ b/components/dashboard/dashboard-layout.tsx
@@ -19,9 +19,13 @@ export function DashboardLayout({
 }) {
   const [mounted, setMounted] = useState(false)
   const [isMobile, setIsMobile] = useState(false)
+  const [isTabletCollapsed, setIsTabletCollapsed] = useState(() =>
+    typeof window !== "undefined" ? window.matchMedia('(max-width: 1023px)').matches : false
+  )
   const { preference } = useSidebarStore()
   const { isOpen, displayMode } = useAIChatStore()
   const isPushMode = mounted && isOpen && displayMode === 'push' && !isMobile
+  const isCollapsed = isTabletCollapsed || preference === 'collapsed'
 
   // Prevent hydration errors and handle responsive behavior
   useEffect(() => {
@@ -30,7 +34,9 @@ export function DashboardLayout({
     // Check initial screen size with proper breakpoint detection
     const checkScreenSize = () => {
       const newIsMobile = window.innerWidth < 768
+      const newIsTablet = window.innerWidth <= 1023
       setIsMobile(newIsMobile)
+      setIsTabletCollapsed(newIsTablet)
       return newIsMobile
     }
 
@@ -113,7 +119,7 @@ export function DashboardLayout({
         <div
           className="desktop-sidebar-responsive hydration-safe-desktop prevent-layout-shift overflow-hidden h-screen sticky top-0"
           style={{
-            width: preference === 'expanded' ? "16rem" : "5rem"
+            width: isCollapsed ? "4.25rem" : "16rem"
           }}
         >
           <DashboardSidebar sidebarData={sidebarData} />

--- a/components/dashboard/dashboard-layout.tsx
+++ b/components/dashboard/dashboard-layout.tsx
@@ -38,22 +38,28 @@ export function DashboardLayout({
       return newIsMobile
     }
 
-    // Set initial state
     checkScreenSize()
 
-    // Add resize listener for responsive behavior with debouncing
+    const mediaQuery = window.matchMedia('(max-width: 1023px)')
+    const handleMediaChange = (e: MediaQueryListEvent) => {
+      setIsTabletCollapsed(e.matches)
+    }
+    mediaQuery.addEventListener('change', handleMediaChange)
+
     let resizeTimeout: NodeJS.Timeout
     const handleResize = () => {
+      setIsTabletCollapsed(window.innerWidth <= 1023)
       clearTimeout(resizeTimeout)
       resizeTimeout = setTimeout(() => {
-        checkScreenSize()
-      }, 150) // Debounce resize events to prevent excessive re-renders
+        setIsMobile(window.innerWidth < 768)
+      }, 150)
     }
 
     window.addEventListener('resize', handleResize, { passive: true })
 
     return () => {
       window.removeEventListener('resize', handleResize)
+      mediaQuery.removeEventListener('change', handleMediaChange)
       clearTimeout(resizeTimeout)
     }
   }, [])

--- a/components/dashboard/dashboard-layout.tsx
+++ b/components/dashboard/dashboard-layout.tsx
@@ -10,6 +10,7 @@ import { useSidebarStore } from "@/hooks/use-sidebar-store"
 import { TaskDndProvider } from "@/components/tasks/task-dnd-provider"
 import { useAIChatStore } from "@/hooks/use-ai-chat-store"
 import { useMediaQuery } from "@/hooks/use-media-query"
+import { TABLET_BREAKPOINT } from "@/lib/constants"
 
 export function DashboardLayout({
   children,
@@ -20,7 +21,7 @@ export function DashboardLayout({
 }) {
   const [mounted, setMounted] = useState(false)
   const [isMobile, setIsMobile] = useState(false)
-  const isTabletCollapsed = useMediaQuery('(max-width: 1023px)')
+  const isTabletCollapsed = useMediaQuery(TABLET_BREAKPOINT)
   const { preference } = useSidebarStore()
   const { isOpen, displayMode } = useAIChatStore()
   const isPushMode = mounted && isOpen && displayMode === 'push' && !isMobile

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -350,6 +350,42 @@ function SidebarContent({
     }, []);
   }, [featureFlags, sidebarData.isOrganisationHidden, sidebarData.modulePermissions]);
 
+  const [organisations, setOrganisations] = useState<OrganisationItem[]>([])
+  const [currentOrgId, setCurrentOrgId] = useState<string | null>(null)
+
+  useEffect(() => {
+    const loadOrganisations = async () => {
+      try {
+        const res = await getMyOrganisationsAction()
+        if (res.success && res.data) {
+          setOrganisations(res.data)
+          setCurrentOrgId(res.currentOrgId ?? null)
+          sessionStorage.setItem("cached_organisations:v1", JSON.stringify({
+            orgs: res.data,
+            currentOrgId: res.currentOrgId
+          }))
+        }
+      } catch (e) {
+        console.error("Failed to load organisations:", e)
+      }
+    }
+
+    const cached = sessionStorage.getItem("cached_organisations:v1")
+    if (cached) {
+      try {
+        const parsed = JSON.parse(cached)
+        setOrganisations(parsed.orgs)
+        if (parsed.currentOrgId !== undefined) {
+          setCurrentOrgId(parsed.currentOrgId ?? null)
+        }
+      } catch {
+        sessionStorage.removeItem("cached_organisations:v1")
+      }
+    }
+
+    loadOrganisations()
+  }, [])
+
   return (
     <TooltipProvider delayDuration={100} skipDelayDuration={300}>
       <div className="h-full w-full flex flex-col relative m-0 p-2.5 overflow-visible">
@@ -357,6 +393,9 @@ function SidebarContent({
         <SidebarHeader
           isCollapsed={isCollapsed}
           isMobile={isMobile}
+          organisations={organisations}
+          currentOrgId={currentOrgId}
+          setCurrentOrgId={setCurrentOrgId}
         />
 
         <div className={cn(
@@ -394,7 +433,12 @@ function SidebarContent({
           "pt-2.5 pb-2.5 flex flex-col gap-2 border-t border-border shrink-0 overflow-visible",
           isCollapsed && !isMobile ? "items-center justify-center px-0" : "px-1.5"
         )}>
-          <UserSettings collapsed={isCollapsed && !isMobile} initialData={sidebarData} />
+          <UserSettings 
+            collapsed={isCollapsed && !isMobile} 
+            initialData={sidebarData}
+            organisations={organisations}
+            currentOrgId={currentOrgId}
+          />
         </div>
       </div>
     </TooltipProvider>
@@ -412,47 +456,18 @@ interface OrganisationItem {
 function SidebarHeader({
   isCollapsed,
   isMobile,
+  organisations,
+  currentOrgId,
+  setCurrentOrgId
 }: {
   isCollapsed: boolean
   isMobile: boolean
+  organisations: OrganisationItem[]
+  currentOrgId: string | null
+  setCurrentOrgId: (id: string | null) => void
 }) {
   const { toast } = useToast()
-  const [organisations, setOrganisations] = useState<OrganisationItem[]>([])
-  const [currentOrgId, setCurrentOrgId] = useState<string | null>(null)
   const [isSwitchingOrg, setIsSwitchingOrg] = useState(false)
-
-  useEffect(() => {
-    const loadOrganisations = async () => {
-      try {
-        const res = await getMyOrganisationsAction()
-        if (res.success && res.data) {
-          setOrganisations(res.data)
-          setCurrentOrgId(res.currentOrgId ?? null)
-          sessionStorage.setItem("cached_organisations:v1", JSON.stringify({
-            orgs: res.data,
-            currentOrgId: res.currentOrgId
-          }))
-        }
-      } catch (e) {
-        console.error("Failed to load organisations:", e)
-      }
-    }
-
-    const cached = sessionStorage.getItem("cached_organisations:v1")
-    if (cached) {
-      try {
-        const parsed = JSON.parse(cached)
-        setOrganisations(parsed.orgs)
-        if (parsed.currentOrgId !== undefined) {
-          setCurrentOrgId(parsed.currentOrgId ?? null)
-        }
-      } catch {
-        sessionStorage.removeItem("cached_organisations:v1")
-      }
-    }
-
-    loadOrganisations()
-  }, [])
 
   const handleSwitchOrg = async (orgId: string | null) => {
     if (orgId === currentOrgId) return;
@@ -460,6 +475,9 @@ function SidebarHeader({
     try {
       const res = await switchOrganisationAction(orgId);
       if (res.success) {
+        // Clear cached organisations to prevent stale cache flash on reload
+        sessionStorage.removeItem("cached_organisations:v1");
+        setCurrentOrgId(orgId);
         window.location.reload();
       } else {
         console.error("Failed to switch organisation:", res.error?.message);
@@ -483,7 +501,11 @@ function SidebarHeader({
 
   const activeOrg = organisations.find(o => o.organisation_id === currentOrgId);
   const activeName = currentOrgId === null ? "Mietevo" : (activeOrg?.name || "Mietevo");
-  const activeSubtitle = currentOrgId === null ? "Immobilienverwaltung" : (activeOrg?.rolle === 'owner' ? 'Eigentümer' : activeOrg?.rolle === 'admin' ? 'Admin' : 'Mitarbeiter');
+  const activeSubtitle = currentOrgId === null 
+    ? "Immobilienverwaltung" 
+    : activeOrg 
+    ? (activeOrg.rolle === 'owner' ? 'Eigentümer' : activeOrg.rolle === 'admin' ? 'Admin' : 'Mitarbeiter')
+    : "Organisation";
 
   const triggerPill = (
     <m.div 

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -362,8 +362,14 @@ function SidebarContent({
           setIsOpen={setIsOpen}
         />
 
-        <div className="flex-1 overflow-y-auto min-h-0 p-1.5 custom-scrollbar">
-          <nav className="grid gap-1.5 w-full">
+        <div className={cn(
+          "flex-1 overflow-y-auto min-h-0 custom-scrollbar",
+          isCollapsed && !isMobile ? "flex flex-col items-center px-0 py-1.5" : "p-1.5"
+        )}>
+          <nav className={cn(
+            "grid gap-1.5 w-full",
+            isCollapsed && !isMobile ? "justify-items-center" : ""
+          )}>
             {visibleNavItems.map((item) => (
               <SidebarNavLink
                 key={item.href}
@@ -387,7 +393,10 @@ function SidebarContent({
         />
         
         {/* User profile / settings */}
-        <div className="pt-2.5 pb-2.5 px-1.5 flex flex-col gap-2 border-t border-border shrink-0 overflow-visible">
+        <div className={cn(
+          "pt-2.5 pb-2.5 flex flex-col gap-2 border-t border-border shrink-0 overflow-visible",
+          isCollapsed && !isMobile ? "items-center justify-center px-0" : "px-1.5"
+        )}>
           <UserSettings collapsed={isCollapsed && !isMobile} initialData={sidebarData} />
         </div>
       </div>
@@ -539,8 +548,8 @@ function SidebarHeader({
 
   return (
     <div className={cn(
-      "flex items-center justify-between gap-2 w-full mb-2.5 pt-0 pb-1.5 px-1.5 shrink-0",
-      isCollapsed && !isMobile ? "justify-center" : ""
+      "flex items-center justify-between gap-2 w-full mb-2.5 pt-0 pb-1.5 shrink-0",
+      isCollapsed && !isMobile ? "justify-center px-0" : "px-1.5"
     )}>
       {/* Organisation Switcher Dropdown */}
       <CustomDropdown
@@ -682,7 +691,7 @@ function SidebarNavLink({
       }}
       className={cn(
         "group flex items-center h-10 text-sm font-medium transition-colors duration-200 relative cursor-pointer active:scale-98 hover:z-10 rounded-xl isolate",
-        isCollapsed && !isMobile ? "w-10 h-10 justify-center px-0 mx-auto" : "w-full px-3 justify-start",
+        isCollapsed && !isMobile ? "w-10 h-10 justify-center items-center px-0 mx-auto" : "w-full px-3 justify-start",
         !isActive && "hover:bg-accent/10 dark:hover:bg-accent/15",
         getActiveStateClasses(item.href),
       )}
@@ -702,10 +711,10 @@ function SidebarNavLink({
       ) : (
         <item.icon className={cn(getIconClassName(item.href), "shrink-0")} />
       )}
-      {!isMobile && (
+      {!isMobile && !isCollapsed && (
         <m.span
           variants={textVariants}
-          animate={isCollapsed && !isMobile ? "collapsed" : "expanded"}
+          animate="expanded"
           className="whitespace-nowrap truncate flex-1 overflow-hidden"
         >
           {item.title}

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -179,8 +179,8 @@ const linkVariants: Variants = {
     transition: { duration: 0 }
   },
   collapsed: {
-    width: "40px",
-    borderRadius: "9999px", // rounded-full
+    width: "100%",
+    borderRadius: "20px", // rounded-xl
     transition: { duration: 0 }
   }
 };
@@ -195,7 +195,7 @@ const logoVariants: Variants = {
   collapsed: {
     width: "40px",
     height: "40px",
-    borderRadius: "9999px", // rounded-full
+    borderRadius: "20px", // rounded-xl
     transition: { duration: 0 }
   }
 };
@@ -363,10 +363,7 @@ function SidebarContent({
           setIsOpen={setIsOpen}
         />
 
-        <div className={cn(
-          "flex-1 overflow-y-auto min-h-0 p-1.5 custom-scrollbar",
-          isCollapsed && !isMobile ? "flex flex-col items-center" : ""
-        )}>
+        <div className="flex-1 overflow-y-auto min-h-0 p-1.5 custom-scrollbar">
           <nav className="grid gap-1.5 w-full">
             {visibleNavItems.map((item) => (
               <SidebarNavLink
@@ -391,10 +388,7 @@ function SidebarContent({
         />
         
         {/* User profile / settings */}
-        <div className={cn(
-          "pt-2.5 pb-2.5 flex flex-col gap-2 border-t border-border shrink-0 overflow-visible",
-          isCollapsed && !isMobile ? "items-center justify-center" : ""
-        )}>
+        <div className="pt-2.5 pb-2.5 flex flex-col gap-2 border-t border-border shrink-0 overflow-visible">
           <UserSettings collapsed={isCollapsed && !isMobile} initialData={sidebarData} />
         </div>
       </div>
@@ -493,8 +487,8 @@ function SidebarHeader({
       variants={logoVariants}
       animate={isCollapsed && !isMobile ? "collapsed" : "expanded"}
       className={cn(
-        "flex items-center gap-2.5 p-1 rounded-xl hover:bg-hover-bg data-[state=open]:bg-hover-bg transition-colors duration-200 group/logo select-none min-h-[40px] cursor-pointer outline-none w-full",
-        isCollapsed && !isMobile ? "justify-center p-1 w-10 h-10 mx-auto" : "pl-1 pr-2"
+        "flex items-center gap-2.5 rounded-xl hover:bg-hover-bg data-[state=open]:bg-hover-bg transition-colors duration-200 group/logo select-none min-h-[40px] cursor-pointer outline-none",
+        isCollapsed && !isMobile ? "justify-center p-1" : "w-full pl-1 pr-2 p-1 justify-start"
       )}
       title={isCollapsed && !isMobile ? "Organisationen wechseln" : undefined}
     >
@@ -688,8 +682,7 @@ function SidebarNavLink({
         }
       }}
       className={cn(
-        "group flex items-center h-10 text-sm font-medium transition-colors duration-200 relative cursor-pointer active:scale-98 hover:z-10 rounded-xl isolate",
-        isCollapsed && !isMobile ? "px-0 justify-center mx-auto" : "px-3 justify-start w-full",
+        "group flex items-center h-10 text-sm font-medium transition-colors duration-200 relative cursor-pointer active:scale-98 hover:z-10 rounded-xl isolate px-3 justify-start w-full",
         !isActive && "hover:bg-accent/10 dark:hover:bg-accent/15",
         getActiveStateClasses(item.href),
       )}
@@ -769,7 +762,7 @@ function SidebarActions({
       transition={layoutTransition}
       className={cn(
         "flex gap-3 w-full pb-4 shrink-0 transition-colors duration-200",
-        isCollapsed ? "flex-col items-center justify-center" : "flex-row justify-start"
+        isCollapsed ? "flex-col items-start justify-start px-1" : "flex-row justify-start"
       )}
     >
       {/* Support Popover */}

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -6,7 +6,7 @@ import Image from "next/image"
 import { usePathname } from "next/navigation"
 import { 
   BarChart3, Building2, Home, Users, Wallet, FileSpreadsheet, CheckSquare, 
-  Menu, X, Folder, Mail, Search, PanelLeft, MessageCircle, Bell, Network, Bot, ChevronDown
+  Menu, X, Folder, Mail, Search, PanelLeft, MessageCircle, Bell, Network, Bot, ChevronDown, Check
 } from "lucide-react"
 import { LazyMotion, domAnimation, m, Variants } from "framer-motion"
 import { LOGO_URL, ROUTES } from "@/lib/constants"
@@ -22,6 +22,14 @@ import { useOnboardingStore } from "@/hooks/use-onboarding-store"
 import { SidebarUserData } from "@/lib/server/user-data"
 import { useSidebarStore } from "@/hooks/use-sidebar-store"
 import { POSTHOG_FEATURE_FLAGS } from "@/lib/constants"
+import { getMyOrganisationsAction, switchOrganisationAction } from "@/app/organisation-actions"
+import { useToast } from "@/hooks/use-toast"
+import {
+  CustomDropdown,
+  CustomDropdownItem,
+  CustomDropdownLabel,
+  CustomDropdownSeparator,
+} from "@/components/ui/custom-dropdown"
 
 type SidebarNavItemType = {
   title: string;
@@ -395,6 +403,13 @@ function SidebarContent({
   )
 }
 
+interface OrganisationItem {
+  organisation_id: string;
+  owner_id: string;
+  rolle: 'owner' | 'admin' | 'mitarbeiter';
+  name: string;
+}
+
 // Brand Logo & Collapse Toggle Subcomponent
 function SidebarHeader({
   isCollapsed,
@@ -407,123 +422,236 @@ function SidebarHeader({
   toggleCollapse?: () => void
   setIsOpen: (open: boolean) => void
 }) {
+  const { toast } = useToast() || {}
+  const [organisations, setOrganisations] = useState<OrganisationItem[]>([])
+  const [currentOrgId, setCurrentOrgId] = useState<string | null>(null)
+  const [isSwitchingOrg, setIsSwitchingOrg] = useState(false)
+
+  useEffect(() => {
+    const loadOrganisations = async () => {
+      try {
+        const res = await getMyOrganisationsAction()
+        if (res.success && res.data) {
+          setOrganisations(res.data)
+          setCurrentOrgId(res.currentOrgId ?? null)
+          sessionStorage.setItem("cached_organisations:v1", JSON.stringify({
+            orgs: res.data,
+            currentOrgId: res.currentOrgId
+          }))
+        }
+      } catch (e) {
+        console.error("Failed to load organisations:", e)
+      }
+    }
+
+    const cached = sessionStorage.getItem("cached_organisations:v1")
+    if (cached) {
+      try {
+        const parsed = JSON.parse(cached)
+        setOrganisations(parsed.orgs)
+        if (parsed.currentOrgId !== undefined) {
+          setCurrentOrgId(parsed.currentOrgId ?? null)
+        }
+      } catch {
+        sessionStorage.removeItem("cached_organisations:v1")
+      }
+    }
+
+    loadOrganisations()
+  }, [])
+
+  const handleSwitchOrg = async (orgId: string | null) => {
+    if (orgId === currentOrgId) return;
+    setIsSwitchingOrg(true);
+    try {
+      const res = await switchOrganisationAction(orgId);
+      if (res.success) {
+        window.location.reload();
+      } else {
+        console.error("Failed to switch organisation:", res.error?.message);
+        toast({
+          variant: "destructive",
+          title: "Fehler beim Wechseln",
+          description: res.error?.message || "Die Organisation konnte nicht gewechselt werden.",
+        });
+      }
+    } catch (e) {
+      console.error("Exception switching organisation:", e);
+      toast({
+        variant: "destructive",
+        title: "Fehler",
+        description: "Ein unerwarteter Fehler ist aufgetreten.",
+      });
+    } finally {
+      setIsSwitchingOrg(false);
+    }
+  };
+
+  const activeOrg = organisations.find(o => o.organisation_id === currentOrgId);
+  const activeName = currentOrgId === null ? "Mietevo" : (activeOrg?.name || "Mietevo");
+  const activeSubtitle = currentOrgId === null ? "Immobilienverwaltung" : `${activeOrg?.rolle === 'owner' ? 'Owner' : activeOrg?.rolle === 'admin' ? 'Admin' : 'Mitarbeiter'}`;
+
+  const triggerPill = (
+    <m.div 
+      variants={logoVariants}
+      animate={isCollapsed && !isMobile ? "collapsed" : "expanded"}
+      className={cn(
+        "flex items-center justify-between gap-2 p-1 rounded-xl hover:bg-zinc-100 dark:hover:bg-zinc-800/60 transition-colors duration-150 group/logo select-none border-2 border-pink-500 min-h-[40px] cursor-pointer outline-none",
+        isCollapsed && !isMobile ? "justify-center p-1 w-10 h-10 mx-auto" : "w-full pl-1 pr-0.5"
+      )}
+    >
+      {/* Workspace Click Target */}
+      <div
+        className={cn(
+          "flex items-center gap-2.5 min-w-0 flex-1 overflow-hidden",
+          isCollapsed && !isMobile ? "justify-center p-0" : ""
+        )}
+        title={isCollapsed && !isMobile ? "Organisationen wechseln" : undefined}
+      >
+        <m.div 
+          layout={false}
+          className="relative size-8 min-w-8 min-h-8 rounded-lg overflow-hidden shadow-2xs shrink-0 flex items-center justify-center"
+        >
+          {/* Logo Image */}
+          <div className={cn(
+            "absolute inset-0 transition-opacity duration-200",
+            isCollapsed && !isMobile ? "group-hover/logo:opacity-0" : ""
+          )}>
+            <Image
+              src={LOGO_URL}
+              alt="Mietevo Logo"
+              fill
+              className="object-cover rounded-lg"
+              sizes="32px"
+              unoptimized
+            />
+          </div>
+          {/* Hover Collapse Icon (only when collapsed) */}
+          {isCollapsed && !isMobile && (
+            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover/logo:opacity-100 transition-opacity duration-200 pointer-events-none">
+              <ChevronDown className="size-4 text-zinc-900 dark:text-zinc-50" />
+            </div>
+          )}
+        </m.div>
+
+        {!isMobile && !isCollapsed && (
+          <div className="flex flex-col flex-1 min-w-0 text-left overflow-hidden">
+            <div className="flex items-center gap-1">
+              <span className="text-sm font-bold text-zinc-900 dark:text-zinc-100 truncate leading-tight">
+                {activeName}
+              </span>
+              <ChevronDown className="size-3.5 text-zinc-400 shrink-0" />
+            </div>
+            <span className="text-[11px] font-medium text-zinc-500 dark:text-zinc-400 truncate leading-tight">
+              {activeSubtitle}
+            </span>
+          </div>
+        )}
+        {isMobile && (
+          <div className="flex flex-col flex-1 min-w-0 text-left">
+            <div className="flex items-center gap-1">
+              <span className="text-sm font-bold text-zinc-900 dark:text-zinc-100 truncate leading-tight">
+                {activeName}
+              </span>
+              <ChevronDown className="size-3.5 text-zinc-400 shrink-0" />
+            </div>
+            <span className="text-[11px] font-medium text-zinc-500 dark:text-zinc-400 truncate leading-tight">
+              {activeSubtitle}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Collapse Button inside the container (Purple Border) */}
+      {!isMobile && (
+        <m.button
+          variants={{
+            expanded: {
+              opacity: 1,
+              scale: 1,
+              display: "flex",
+              transition: { duration: 0 }
+            },
+            collapsed: {
+              opacity: 0,
+              scale: 0.8,
+              transition: { duration: 0 },
+              transitionEnd: { display: "none" }
+            }
+          }}
+          animate={isCollapsed ? "collapsed" : "expanded"}
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            toggleCollapse?.();
+          }}
+          type="button"
+          className="size-8 min-w-[32px] mr-0 rounded-lg border border-zinc-200/80 dark:border-zinc-800/80 bg-white dark:bg-zinc-900 shadow-2xs hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100 flex items-center justify-center transition-colors shrink-0 cursor-pointer border-2 border-purple-500"
+          title="Menü einklappen"
+        >
+          <PanelLeft className="size-4" />
+        </m.button>
+      )}
+    </m.div>
+  );
+
   return (
     <div className={cn(
       "flex items-center justify-between gap-2 w-full mb-2.5 pt-0 pb-1.5 px-1.5 shrink-0 border-2 border-blue-500",
       isCollapsed && !isMobile ? "justify-center" : ""
     )}>
-      {/* Workspace / Brand Pill Container (Pink Border) */}
-      <m.div 
-        variants={logoVariants}
-        animate={isCollapsed && !isMobile ? "collapsed" : "expanded"}
-        className={cn(
-          "flex items-center justify-between gap-2 p-1 rounded-xl hover:bg-zinc-100 dark:hover:bg-zinc-800/60 transition-colors duration-150 group/logo select-none border-2 border-pink-500 min-h-[40px]",
-          isCollapsed && !isMobile ? "justify-center p-1 w-10 h-10 mx-auto" : "w-full pl-1 pr-0.5"
-        )}
+      <CustomDropdown
+        align="start"
+        className="w-60"
+        trigger={triggerPill}
       >
-        {/* Brand Link (Logo + Name + Subtitle) */}
-        <Link
-          href="/"
-          onClick={(e) => {
-            if (isCollapsed && !isMobile) {
-              e.preventDefault();
-              toggleCollapse?.();
-            }
-          }}
-          className={cn(
-            "flex items-center gap-2.5 min-w-0 cursor-pointer overflow-hidden",
-            isCollapsed && !isMobile ? "justify-center p-0" : "flex-1"
-          )}
-          title={isCollapsed && !isMobile ? "Menü ausklappen" : undefined}
+        <CustomDropdownLabel className="text-xs text-gray-500 font-semibold uppercase tracking-wider px-3 py-1">
+          Organisationen:
+        </CustomDropdownLabel>
+        <CustomDropdownSeparator />
+        <CustomDropdownItem
+          onClick={() => handleSwitchOrg(null)}
+          disabled={isSwitchingOrg}
+          className="flex items-center cursor-pointer"
         >
-          <m.div 
-            layout={false}
-            className="relative size-8 min-w-8 min-h-8 rounded-lg overflow-hidden shadow-2xs shrink-0 flex items-center justify-center"
-          >
-            {/* Logo Image */}
-            <div className={cn(
-              "absolute inset-0 transition-opacity duration-200",
-              isCollapsed && !isMobile ? "group-hover/logo:opacity-0" : ""
-            )}>
-              <Image
-                src={LOGO_URL}
-                alt="Mietevo Logo"
-                fill
-                className="object-cover rounded-lg"
-                sizes="32px"
-                unoptimized
-              />
-            </div>
-            {/* Hover Collapse Icon (only when collapsed) */}
-            {isCollapsed && !isMobile && (
-              <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover/logo:opacity-100 transition-opacity duration-200 pointer-events-none">
-                <PanelLeft className="size-4 text-zinc-900 dark:text-zinc-50" />
-              </div>
-            )}
-          </m.div>
-
-          {!isMobile && !isCollapsed && (
-            <div className="flex flex-col flex-1 min-w-0 text-left overflow-hidden">
-              <div className="flex items-center gap-1">
-                <span className="text-sm font-bold text-zinc-900 dark:text-zinc-100 truncate leading-tight">
-                  Mietevo
-                </span>
-                <ChevronDown className="size-3.5 text-zinc-400 shrink-0" />
-              </div>
-              <span className="text-[11px] font-medium text-zinc-500 dark:text-zinc-400 truncate leading-tight">
-                Immobilienverwaltung
-              </span>
-            </div>
+          {currentOrgId === null ? (
+            <Check className="mr-2 size-4 text-emerald-500 shrink-0" />
+          ) : (
+            <div className="mr-2 size-4 shrink-0" />
           )}
-          {isMobile && (
-            <div className="flex flex-col flex-1 min-w-0 text-left">
-              <span className="text-sm font-bold text-zinc-900 dark:text-zinc-100 truncate">
-                Mietevo
-              </span>
-              <span className="text-[11px] font-medium text-zinc-500 dark:text-zinc-400 truncate">
-                Immobilienverwaltung
-              </span>
-            </div>
-          )}
-        </Link>
+          <span className={cn(currentOrgId === null && "font-medium text-emerald-600 dark:text-emerald-400")}>
+            Privat
+          </span>
+        </CustomDropdownItem>
+        {organisations.map((org) => {
+          const isActive = currentOrgId === org.organisation_id;
+          const roleLabel =
+            org.rolle === 'owner' ? 'Owner' :
+            org.rolle === 'admin' ? 'Admin' :
+            'Mitarbeiter';
 
-        {/* Collapse Button inside the container (Purple Border) */}
-        {!isMobile && (
-          <m.button
-            variants={{
-              expanded: {
-                opacity: 1,
-                scale: 1,
-                display: "flex",
-                transition: {
-                  duration: 0.2,
-                  ease: [0.2, 0.8, 0.2, 1]
-                }
-              },
-              collapsed: {
-                opacity: 0,
-                scale: 0.8,
-                transition: {
-                  duration: 0.15,
-                  ease: [0.2, 0.8, 0.2, 1]
-                },
-                transitionEnd: { display: "none" }
-              }
-            }}
-            animate={isCollapsed ? "collapsed" : "expanded"}
-            onClick={(e) => {
-              e.stopPropagation();
-              e.preventDefault();
-              toggleCollapse?.();
-            }}
-            type="button"
-            className="size-8 min-w-[32px] mr-0 rounded-lg border border-zinc-200/80 dark:border-zinc-800/80 bg-white dark:bg-zinc-900 shadow-2xs hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100 flex items-center justify-center transition-colors shrink-0 cursor-pointer border-2 border-purple-500"
-            title="Menü einklappen"
-          >
-            <PanelLeft className="size-4" />
-          </m.button>
-        )}
-      </m.div>
+          return (
+            <CustomDropdownItem
+              key={org.organisation_id}
+              onClick={() => handleSwitchOrg(org.organisation_id)}
+              disabled={isSwitchingOrg}
+              className="flex items-center cursor-pointer"
+            >
+              {isActive ? (
+                <Check className="mr-2 size-4 text-emerald-500 shrink-0" />
+              ) : (
+                <div className="mr-2 size-4 shrink-0" />
+              )}
+              <span className={cn(
+                "truncate",
+                isActive && "font-medium text-emerald-600 dark:text-emerald-400"
+              )}>
+                {org.name} <span className="text-xs text-gray-400 font-normal">({roleLabel})</span>
+              </span>
+            </CustomDropdownItem>
+          )
+        })}
+      </CustomDropdown>
     </div>
   )
 }

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -355,7 +355,7 @@ function SidebarContent({
 
   return (
     <TooltipProvider delayDuration={100} skipDelayDuration={300}>
-      <div className="h-full w-full flex flex-col relative m-0 p-2.5 overflow-visible border-2 border-red-500">
+      <div className="h-full w-full flex flex-col relative m-0 p-2.5 overflow-visible">
         {/* Header / Brand Logo */}
         <SidebarHeader
           isCollapsed={isCollapsed}
@@ -364,7 +364,7 @@ function SidebarContent({
         />
 
         <div className={cn(
-          "flex-1 overflow-y-auto min-h-0 p-1.5 custom-scrollbar border-2 border-cyan-500",
+          "flex-1 overflow-y-auto min-h-0 p-1.5 custom-scrollbar",
           isCollapsed && !isMobile ? "flex flex-col items-center" : ""
         )}>
           <nav className="grid gap-1.5 w-full">
@@ -392,7 +392,7 @@ function SidebarContent({
         
         {/* User profile / settings */}
         <div className={cn(
-          "pt-2.5 pb-2.5 flex flex-col gap-2 border-t border-border shrink-0 overflow-visible border-2 border-orange-500 p-0.5",
+          "pt-2.5 pb-2.5 flex flex-col gap-2 border-t border-border shrink-0 overflow-visible",
           isCollapsed && !isMobile ? "items-center justify-center" : ""
         )}>
           <UserSettings collapsed={isCollapsed && !isMobile} initialData={sidebarData} />
@@ -493,7 +493,7 @@ function SidebarHeader({
       variants={logoVariants}
       animate={isCollapsed && !isMobile ? "collapsed" : "expanded"}
       className={cn(
-        "flex items-center gap-2.5 p-1 rounded-xl hover:bg-zinc-100 dark:hover:bg-zinc-800/60 transition-colors duration-150 group/logo select-none border-2 border-pink-500 min-h-[40px] cursor-pointer outline-none w-full",
+        "flex items-center gap-2.5 p-1 rounded-xl hover:bg-hover-bg data-[state=open]:bg-hover-bg transition-colors duration-200 group/logo select-none min-h-[40px] cursor-pointer outline-none w-full",
         isCollapsed && !isMobile ? "justify-center p-1 w-10 h-10 mx-auto" : "pl-1 pr-2"
       )}
       title={isCollapsed && !isMobile ? "Organisationen wechseln" : undefined}
@@ -546,10 +546,10 @@ function SidebarHeader({
 
   return (
     <div className={cn(
-      "flex items-center justify-between gap-2 w-full mb-2.5 pt-0 pb-1.5 px-1.5 shrink-0 border-2 border-blue-500",
+      "flex items-center justify-between gap-2 w-full mb-2.5 pt-0 pb-1.5 px-1.5 shrink-0",
       isCollapsed && !isMobile ? "justify-center" : ""
     )}>
-      {/* Organisation Switcher Dropdown (Pink Border) */}
+      {/* Organisation Switcher Dropdown */}
       <CustomDropdown
         align="start"
         className="w-60"

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -221,23 +221,8 @@ export function DashboardSidebar({ sidebarData }: { sidebarData: SidebarUserData
   const [currentOrgId, setCurrentOrgId] = useState<string | null>(null)
 
   useEffect(() => {
+    let ignore = false
     const cacheKey = sidebarData.user?.id ? `cached_organisations:${sidebarData.user.id}` : "cached_organisations:v1"
-
-    const loadOrganisations = async () => {
-      try {
-        const res = await getMyOrganisationsAction()
-        if (res.success && res.data) {
-          setOrganisations(res.data)
-          setCurrentOrgId(res.currentOrgId ?? null)
-          sessionStorage.setItem(cacheKey, JSON.stringify({
-            orgs: res.data,
-            currentOrgId: res.currentOrgId
-          }))
-        }
-      } catch (e) {
-        console.error("Failed to load organisations:", e)
-      }
-    }
 
     const cached = sessionStorage.getItem(cacheKey)
     if (cached) {
@@ -252,7 +237,26 @@ export function DashboardSidebar({ sidebarData }: { sidebarData: SidebarUserData
       }
     }
 
-    loadOrganisations()
+    getMyOrganisationsAction()
+      .then((res) => {
+        if (!ignore && res.success && res.data) {
+          setOrganisations(res.data)
+          setCurrentOrgId(res.currentOrgId ?? null)
+          sessionStorage.setItem(cacheKey, JSON.stringify({
+            orgs: res.data,
+            currentOrgId: res.currentOrgId
+          }))
+        }
+      })
+      .catch((e) => {
+        if (!ignore) {
+          console.error("Failed to load organisations:", e)
+        }
+      })
+
+    return () => {
+      ignore = true
+    }
   }, [sidebarData.user?.id])
 
   return (

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect, useMemo } from "react"
 import Link from "next/link"
 import Image from "next/image"
-import { usePathname } from "next/navigation"
 import { 
   BarChart3, Building2, Home, Users, Wallet, FileSpreadsheet, CheckSquare, 
   Menu, X, Folder, Mail, Search, MessageCircle, Bell, Network, Bot, ChevronDown, Check
@@ -12,7 +11,7 @@ import { LazyMotion, domAnimation, m, Variants } from "framer-motion"
 import { LOGO_URL, ROUTES } from "@/lib/constants"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
-import { UserSettings } from "@/components/common/user-settings"
+import { UserSettings, type OrganisationItem } from "@/components/common/user-settings"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover"
 import { useSidebarActiveState } from "@/hooks/use-active-state-manager"
@@ -21,6 +20,7 @@ import { useFeatureFlagEnabled } from "posthog-js/react"
 import { useOnboardingStore } from "@/hooks/use-onboarding-store"
 import { SidebarUserData } from "@/lib/server/user-data"
 import { useSidebarStore } from "@/hooks/use-sidebar-store"
+import { useMediaQuery } from "@/hooks/use-media-query"
 import { POSTHOG_FEATURE_FLAGS } from "@/lib/constants"
 import { getMyOrganisationsAction, switchOrganisationAction } from "@/app/organisation-actions"
 import { useToast } from "@/hooks/use-toast"
@@ -201,10 +201,9 @@ const logoVariants: Variants = {
 };
 
 export function DashboardSidebar({ sidebarData }: { sidebarData: SidebarUserData }) {
-  const pathname = usePathname()
   const [isOpen, setIsOpen] = useState(false)
-  const { preference, setPreference } = useSidebarStore()
-  const [isResponsiveCollapsed, setIsResponsiveCollapsed] = useState(false)
+  const { preference } = useSidebarStore()
+  const isResponsiveCollapsed = useMediaQuery('(max-width: 1023px)')
   
   const isCollapsed = isResponsiveCollapsed || preference === 'collapsed'
   const { isRouteActive, getActiveStateClasses } = useSidebarActiveState()
@@ -218,137 +217,6 @@ export function DashboardSidebar({ sidebarData }: { sidebarData: SidebarUserData
     ['/mails', !!mailsEnabled],
     ['/agenten', !!agentBuilderEnabled],
   ]), [documentsEnabled, mailsEnabled, agentBuilderEnabled]);
-
-  useEffect(() => {
-    const mediaQuery = window.matchMedia('(max-width: 1023px)');
-    setIsResponsiveCollapsed(mediaQuery.matches);
-    const handleMediaChange = (e: MediaQueryListEvent) => {
-      setIsResponsiveCollapsed(e.matches);
-    };
-    mediaQuery.addEventListener('change', handleMediaChange);
-    return () => mediaQuery.removeEventListener('change', handleMediaChange);
-  }, [])
-
-  const toggleCollapse = () => {
-    if (preference === 'expanded') {
-      setPreference('collapsed');
-    } else if (preference === 'collapsed') {
-      setPreference('expanded');
-    } else {
-      setPreference(isCollapsed ? 'expanded' : 'collapsed');
-    }
-  }
-
-  return (
-    <LazyMotion features={domAnimation}>
-      {/* Mobile Menu Button */}
-      <Button
-        variant="outline"
-        size="icon"
-        className="fixed left-4 top-4 z-40 md:hidden"
-        onClick={() => setIsOpen(!isOpen)}
-      >
-        {isOpen ? <X className="size-4" /> : <Menu className="size-4" />}
-        <span className="sr-only">Toggle menu</span>
-      </Button>
-
-      {/* Backdrop */}
-      <div
-        className={cn(
-          "fixed inset-0 z-30 bg-background/80 backdrop-blur-xs transition-all duration-100 md:hidden",
-          isOpen ? "opacity-100" : "pointer-events-none opacity-0",
-        )}
-        onClick={() => setIsOpen(false)}
-      />
-
-      {/* Desktop Sidebar */}
-      <aside className="hidden md:flex flex-col z-30 h-screen sticky top-0 py-0 w-full overflow-visible">
-        <div className="hidden md:flex flex-col h-full w-full overflow-visible">
-          <SidebarContent
-            isCollapsed={isCollapsed}
-            pathname={pathname}
-            setOpen={setOpen}
-            featureFlags={featureFlags}
-            isRouteActive={isRouteActive}
-            getActiveStateClasses={getActiveStateClasses}
-            isMobile={false}
-            setIsOpen={setIsOpen}
-            toggleCollapse={toggleCollapse}
-            sidebarData={sidebarData}
-          />
-        </div>
-      </aside>
-
-      {/* Mobile Drawer */}
-      <aside
-        className={cn(
-          "fixed inset-y-0 left-0 z-49 flex flex-col bg-background border-r transition-transform duration-300 ease-in-out w-72 md:hidden",
-          isOpen ? "translate-x-0" : "-translate-x-full"
-        )}
-      >
-        <SidebarContent
-          isCollapsed={false}
-          pathname={pathname}
-          setOpen={setOpen}
-          featureFlags={featureFlags}
-          isRouteActive={isRouteActive}
-          getActiveStateClasses={getActiveStateClasses}
-          isMobile={true}
-          setIsOpen={setIsOpen}
-          sidebarData={sidebarData}
-        />
-      </aside>
-    </LazyMotion>
-  )
-}
-
-interface SidebarContentProps {
-  isCollapsed: boolean
-  pathname: string
-  setOpen: (open: boolean) => void
-  featureFlags: Map<string, boolean>
-  isRouteActive: (href: string) => boolean
-  getActiveStateClasses: (href: string) => string
-  isMobile: boolean
-  setIsOpen: (open: boolean) => void
-  toggleCollapse?: () => void
-  sidebarData: SidebarUserData
-}
-
-function SidebarContent({
-  isCollapsed,
-  setOpen,
-  featureFlags,
-  isRouteActive,
-  getActiveStateClasses,
-  isMobile,
-  setIsOpen,
-  sidebarData
-}: SidebarContentProps) {
-  const supportButtonEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.SUPPORT_BUTTON)
-  const notificationCenterFeatureEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.NOTIFICATION_CENTER)
-
-  // Combined loop iteration (flatMap/filter optimized into a single pass using reduce)
-  const visibleNavItems = useMemo(() => {
-    return sidebarNavGroups.reduce<SidebarNavItemType[]>((acc, group) => {
-      for (const item of group.items) {
-        if (featureFlags.has(item.href) && !featureFlags.get(item.href)) {
-          continue;
-        }
-        if (item.href === '/organisation' && sidebarData.isOrganisationHidden) {
-          continue;
-        }
-        const requiredModule = SIDEBAR_MODULE_MAP[item.href];
-        if (requiredModule && sidebarData.modulePermissions !== null) {
-          if (!sidebarData.modulePermissions.has(requiredModule)) {
-            continue;
-          }
-        }
-        acc.push(item);
-      }
-      return acc;
-    }, []);
-  }, [featureFlags, sidebarData.isOrganisationHidden, sidebarData.modulePermissions]);
 
   const [organisations, setOrganisations] = useState<OrganisationItem[]>([])
   const [currentOrgId, setCurrentOrgId] = useState<string | null>(null)
@@ -389,6 +257,124 @@ function SidebarContent({
   }, [sidebarData.user?.id])
 
   return (
+    <LazyMotion features={domAnimation}>
+      {/* Mobile Menu Button */}
+      <Button
+        variant="outline"
+        size="icon"
+        className="fixed left-4 top-4 z-40 md:hidden"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        {isOpen ? <X className="size-4" /> : <Menu className="size-4" />}
+        <span className="sr-only">Toggle menu</span>
+      </Button>
+
+      {/* Backdrop */}
+      <div
+        className={cn(
+          "fixed inset-0 z-30 bg-background/80 backdrop-blur-xs transition-all duration-100 md:hidden",
+          isOpen ? "opacity-100" : "pointer-events-none opacity-0",
+        )}
+        onClick={() => setIsOpen(false)}
+      />
+
+      {/* Desktop Sidebar */}
+      <aside className="hidden md:flex flex-col z-30 h-screen sticky top-0 py-0 w-full overflow-visible">
+        <div className="hidden md:flex flex-col h-full w-full overflow-visible">
+          <SidebarContent
+            isCollapsed={isCollapsed}
+            setOpen={setOpen}
+            featureFlags={featureFlags}
+            isRouteActive={isRouteActive}
+            getActiveStateClasses={getActiveStateClasses}
+            isMobile={false}
+            setIsOpen={setIsOpen}
+            sidebarData={sidebarData}
+            organisations={organisations}
+            currentOrgId={currentOrgId}
+            setCurrentOrgId={setCurrentOrgId}
+          />
+        </div>
+      </aside>
+
+      {/* Mobile Drawer */}
+      <aside
+        className={cn(
+          "fixed inset-y-0 left-0 z-49 flex flex-col bg-background border-r transition-transform duration-300 ease-in-out w-72 md:hidden",
+          isOpen ? "translate-x-0" : "-translate-x-full"
+        )}
+      >
+        <SidebarContent
+          isCollapsed={false}
+          setOpen={setOpen}
+          featureFlags={featureFlags}
+          isRouteActive={isRouteActive}
+          getActiveStateClasses={getActiveStateClasses}
+          isMobile={true}
+          setIsOpen={setIsOpen}
+          sidebarData={sidebarData}
+          organisations={organisations}
+          currentOrgId={currentOrgId}
+          setCurrentOrgId={setCurrentOrgId}
+        />
+      </aside>
+    </LazyMotion>
+  )
+}
+
+interface SidebarContentProps {
+  isCollapsed: boolean
+  setOpen: (open: boolean) => void
+  featureFlags: Map<string, boolean>
+  isRouteActive: (href: string) => boolean
+  getActiveStateClasses: (href: string) => string
+  isMobile: boolean
+  setIsOpen: (open: boolean) => void
+  sidebarData: SidebarUserData
+  organisations: OrganisationItem[]
+  currentOrgId: string | null
+  setCurrentOrgId: (id: string | null) => void
+}
+
+function SidebarContent({
+  isCollapsed,
+  setOpen,
+  featureFlags,
+  isRouteActive,
+  getActiveStateClasses,
+  isMobile,
+  setIsOpen,
+  sidebarData,
+  organisations,
+  currentOrgId,
+  setCurrentOrgId
+}: SidebarContentProps) {
+  const supportButtonEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.SUPPORT_BUTTON)
+  const notificationCenterFeatureEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.NOTIFICATION_CENTER)
+
+  // Combined loop iteration (flatMap/filter optimized into a single pass using reduce)
+  const visibleNavItems = useMemo(() => {
+    return sidebarNavGroups.reduce<SidebarNavItemType[]>((acc, group) => {
+      for (const item of group.items) {
+        if (featureFlags.has(item.href) && !featureFlags.get(item.href)) {
+          continue;
+        }
+        if (item.href === '/organisation' && sidebarData.isOrganisationHidden) {
+          continue;
+        }
+        const requiredModule = SIDEBAR_MODULE_MAP[item.href];
+        if (requiredModule && sidebarData.modulePermissions !== null) {
+          if (!sidebarData.modulePermissions.has(requiredModule)) {
+            continue;
+          }
+        }
+        acc.push(item);
+      }
+      return acc;
+    }, []);
+  }, [featureFlags, sidebarData.isOrganisationHidden, sidebarData.modulePermissions]);
+
+  return (
     <TooltipProvider delayDuration={100} skipDelayDuration={300}>
       <div className="h-full w-full flex flex-col relative m-0 p-2.5 overflow-visible">
         {/* Header / Brand Logo */}
@@ -398,6 +384,7 @@ function SidebarContent({
           organisations={organisations}
           currentOrgId={currentOrgId}
           setCurrentOrgId={setCurrentOrgId}
+          userId={sidebarData.user?.id}
         />
 
         <div className={cn(
@@ -447,13 +434,6 @@ function SidebarContent({
   )
 }
 
-interface OrganisationItem {
-  organisation_id: string;
-  owner_id: string;
-  rolle: 'owner' | 'admin' | 'mitarbeiter';
-  name: string;
-}
-
 function getRoleLabel(role?: string): string {
   if (role === 'owner') return 'Eigentümer';
   if (role === 'admin') return 'Admin';
@@ -466,13 +446,15 @@ function SidebarHeader({
   isMobile,
   organisations,
   currentOrgId,
-  setCurrentOrgId
+  setCurrentOrgId,
+  userId
 }: {
   isCollapsed: boolean
   isMobile: boolean
   organisations: OrganisationItem[]
   currentOrgId: string | null
   setCurrentOrgId: (id: string | null) => void
+  userId?: string
 }) {
   const { toast } = useToast()
   const [isSwitchingOrg, setIsSwitchingOrg] = useState(false)
@@ -483,9 +465,9 @@ function SidebarHeader({
     try {
       const res = await switchOrganisationAction(orgId);
       if (res.success) {
-        // Clear cached organisations to prevent stale cache flash on reload
-        sessionStorage.removeItem("cached_organisations:v1");
-        setCurrentOrgId(orgId);
+        // Clear cached organisations under the proper user-specific key to prevent stale cache flash on reload
+        const cacheKey = userId ? `cached_organisations:${userId}` : "cached_organisations:v1";
+        sessionStorage.removeItem(cacheKey);
         window.location.reload();
       } else {
         console.error("Failed to switch organisation:", res.error?.message);

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -354,13 +354,15 @@ function SidebarContent({
   const [currentOrgId, setCurrentOrgId] = useState<string | null>(null)
 
   useEffect(() => {
+    const cacheKey = sidebarData.user?.id ? `cached_organisations:${sidebarData.user.id}` : "cached_organisations:v1"
+
     const loadOrganisations = async () => {
       try {
         const res = await getMyOrganisationsAction()
         if (res.success && res.data) {
           setOrganisations(res.data)
           setCurrentOrgId(res.currentOrgId ?? null)
-          sessionStorage.setItem("cached_organisations:v1", JSON.stringify({
+          sessionStorage.setItem(cacheKey, JSON.stringify({
             orgs: res.data,
             currentOrgId: res.currentOrgId
           }))
@@ -370,7 +372,7 @@ function SidebarContent({
       }
     }
 
-    const cached = sessionStorage.getItem("cached_organisations:v1")
+    const cached = sessionStorage.getItem(cacheKey)
     if (cached) {
       try {
         const parsed = JSON.parse(cached)
@@ -379,12 +381,12 @@ function SidebarContent({
           setCurrentOrgId(parsed.currentOrgId ?? null)
         }
       } catch {
-        sessionStorage.removeItem("cached_organisations:v1")
+        sessionStorage.removeItem(cacheKey)
       }
     }
 
     loadOrganisations()
-  }, [])
+  }, [sidebarData.user?.id])
 
   return (
     <TooltipProvider delayDuration={100} skipDelayDuration={300}>
@@ -452,6 +454,12 @@ interface OrganisationItem {
   name: string;
 }
 
+function getRoleLabel(role?: string): string {
+  if (role === 'owner') return 'Eigentümer';
+  if (role === 'admin') return 'Admin';
+  return 'Mitarbeiter';
+}
+
 // Brand Logo & Header Subcomponent
 function SidebarHeader({
   isCollapsed,
@@ -504,7 +512,7 @@ function SidebarHeader({
   const activeSubtitle = currentOrgId === null 
     ? "Immobilienverwaltung" 
     : activeOrg 
-    ? (activeOrg.rolle === 'owner' ? 'Eigentümer' : activeOrg.rolle === 'admin' ? 'Admin' : 'Mitarbeiter')
+    ? getRoleLabel(activeOrg.rolle)
     : "Organisation";
 
   const triggerPill = (
@@ -604,10 +612,7 @@ function SidebarHeader({
         </CustomDropdownItem>
         {organisations.map((org) => {
           const isActive = currentOrgId === org.organisation_id;
-          const roleLabel =
-            org.rolle === 'owner' ? 'Eigentümer' :
-            org.rolle === 'admin' ? 'Admin' :
-            'Mitarbeiter';
+          const roleLabel = getRoleLabel(org.rolle);
 
           return (
             <CustomDropdownItem

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -6,7 +6,7 @@ import Image from "next/image"
 import { usePathname } from "next/navigation"
 import { 
   BarChart3, Building2, Home, Users, Wallet, FileSpreadsheet, CheckSquare, 
-  Menu, X, Folder, Mail, Search, PanelLeft, MessageCircle, Bell, Network, Bot, ChevronDown, Check
+  Menu, X, Folder, Mail, Search, MessageCircle, Bell, Network, Bot, ChevronDown, Check
 } from "lucide-react"
 import { LazyMotion, domAnimation, m, Variants } from "framer-motion"
 import { LOGO_URL, ROUTES } from "@/lib/constants"
@@ -317,14 +317,12 @@ interface SidebarContentProps {
 
 function SidebarContent({
   isCollapsed,
-  pathname,
   setOpen,
   featureFlags,
   isRouteActive,
   getActiveStateClasses,
   isMobile,
   setIsOpen,
-  toggleCollapse,
   sidebarData
 }: SidebarContentProps) {
   const supportButtonEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.SUPPORT_BUTTON)
@@ -359,7 +357,6 @@ function SidebarContent({
         <SidebarHeader
           isCollapsed={isCollapsed}
           isMobile={isMobile}
-          setIsOpen={setIsOpen}
         />
 
         <div className={cn(
@@ -415,13 +412,11 @@ interface OrganisationItem {
 function SidebarHeader({
   isCollapsed,
   isMobile,
-  setIsOpen
 }: {
   isCollapsed: boolean
   isMobile: boolean
-  setIsOpen: (open: boolean) => void
 }) {
-  const { toast } = useToast() || {}
+  const { toast } = useToast()
   const [organisations, setOrganisations] = useState<OrganisationItem[]>([])
   const [currentOrgId, setCurrentOrgId] = useState<string | null>(null)
   const [isSwitchingOrg, setIsSwitchingOrg] = useState(false)

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -619,9 +619,17 @@ function SidebarHeader({
           ) : (
             <div className="mr-2 size-4 shrink-0" />
           )}
-          <span className={cn(currentOrgId === null && "font-medium text-emerald-600 dark:text-emerald-400")}>
-            Privat
-          </span>
+          <div className="flex flex-col text-left min-w-0">
+            <span className={cn(
+              "truncate font-semibold text-sm leading-snug",
+              currentOrgId === null && "text-emerald-600 dark:text-emerald-400"
+            )}>
+              Privat
+            </span>
+            <span className="text-xs text-zinc-500 dark:text-zinc-400 leading-tight">
+              Persönlicher Bereich
+            </span>
+          </div>
         </CustomDropdownItem>
         {organisations.map((org) => {
           const isActive = currentOrgId === org.organisation_id;
@@ -642,12 +650,17 @@ function SidebarHeader({
               ) : (
                 <div className="mr-2 size-4 shrink-0" />
               )}
-              <span className={cn(
-                "truncate",
-                isActive && "font-medium text-emerald-600 dark:text-emerald-400"
-              )}>
-                {org.name} <span className="text-xs text-gray-400 font-normal">({roleLabel})</span>
-              </span>
+              <div className="flex flex-col text-left min-w-0">
+                <span className={cn(
+                  "truncate font-semibold text-sm leading-snug",
+                  isActive && "text-emerald-600 dark:text-emerald-400"
+                )}>
+                  {org.name}
+                </span>
+                <span className="text-xs text-zinc-500 dark:text-zinc-400 leading-tight">
+                  {roleLabel}
+                </span>
+              </div>
             </CustomDropdownItem>
           )
         })}

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -8,7 +8,7 @@ import {
   Menu, X, Folder, Mail, Search, MessageCircle, Bell, Network, Bot, ChevronDown, Check
 } from "lucide-react"
 import { LazyMotion, domAnimation, m, Variants } from "framer-motion"
-import { LOGO_URL, ROUTES } from "@/lib/constants"
+import { LOGO_URL, ROUTES, POSTHOG_FEATURE_FLAGS, TABLET_BREAKPOINT } from "@/lib/constants"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { UserSettings, type OrganisationItem } from "@/components/common/user-settings"
@@ -21,7 +21,6 @@ import { useOnboardingStore } from "@/hooks/use-onboarding-store"
 import { SidebarUserData } from "@/lib/server/user-data"
 import { useSidebarStore } from "@/hooks/use-sidebar-store"
 import { useMediaQuery } from "@/hooks/use-media-query"
-import { POSTHOG_FEATURE_FLAGS } from "@/lib/constants"
 import { getMyOrganisationsAction, switchOrganisationAction } from "@/app/organisation-actions"
 import { useToast } from "@/hooks/use-toast"
 import {
@@ -203,7 +202,7 @@ const logoVariants: Variants = {
 export function DashboardSidebar({ sidebarData }: { sidebarData: SidebarUserData }) {
   const [isOpen, setIsOpen] = useState(false)
   const { preference } = useSidebarStore()
-  const isResponsiveCollapsed = useMediaQuery('(max-width: 1023px)')
+  const isResponsiveCollapsed = useMediaQuery(TABLET_BREAKPOINT)
   
   const isCollapsed = isResponsiveCollapsed || preference === 'collapsed'
   const { isRouteActive, getActiveStateClasses } = useSidebarActiveState()
@@ -292,7 +291,6 @@ export function DashboardSidebar({ sidebarData }: { sidebarData: SidebarUserData
             sidebarData={sidebarData}
             organisations={organisations}
             currentOrgId={currentOrgId}
-            setCurrentOrgId={setCurrentOrgId}
           />
         </div>
       </aside>
@@ -315,7 +313,6 @@ export function DashboardSidebar({ sidebarData }: { sidebarData: SidebarUserData
           sidebarData={sidebarData}
           organisations={organisations}
           currentOrgId={currentOrgId}
-          setCurrentOrgId={setCurrentOrgId}
         />
       </aside>
     </LazyMotion>
@@ -333,7 +330,6 @@ interface SidebarContentProps {
   sidebarData: SidebarUserData
   organisations: OrganisationItem[]
   currentOrgId: string | null
-  setCurrentOrgId: (id: string | null) => void
 }
 
 function SidebarContent({
@@ -346,8 +342,7 @@ function SidebarContent({
   setIsOpen,
   sidebarData,
   organisations,
-  currentOrgId,
-  setCurrentOrgId
+  currentOrgId
 }: SidebarContentProps) {
   const supportButtonEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.SUPPORT_BUTTON)
   const notificationCenterFeatureEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.NOTIFICATION_CENTER)
@@ -383,7 +378,6 @@ function SidebarContent({
           isMobile={isMobile}
           organisations={organisations}
           currentOrgId={currentOrgId}
-          setCurrentOrgId={setCurrentOrgId}
           userId={sidebarData.user?.id}
         />
 
@@ -446,14 +440,12 @@ function SidebarHeader({
   isMobile,
   organisations,
   currentOrgId,
-  setCurrentOrgId,
   userId
 }: {
   isCollapsed: boolean
   isMobile: boolean
   organisations: OrganisationItem[]
   currentOrgId: string | null
-  setCurrentOrgId: (id: string | null) => void
   userId?: string
 }) {
   const { toast } = useToast()
@@ -474,7 +466,7 @@ function SidebarHeader({
         toast({
           variant: "destructive",
           title: "Fehler beim Wechseln",
-          description: res.error?.message || "Die Organisation konnte nicht gewechselt werden.",
+          description: "Die Organisation konnte nicht gewechselt werden. Bitte versuche es später erneut.",
         });
       }
     } catch (e) {

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -179,8 +179,8 @@ const linkVariants: Variants = {
     transition: { duration: 0 }
   },
   collapsed: {
-    width: "100%",
-    borderRadius: "20px", // rounded-xl
+    width: "40px",
+    borderRadius: "9999px", // rounded-full
     transition: { duration: 0 }
   }
 };
@@ -195,7 +195,7 @@ const logoVariants: Variants = {
   collapsed: {
     width: "40px",
     height: "40px",
-    borderRadius: "20px", // rounded-xl
+    borderRadius: "9999px", // rounded-full
     transition: { duration: 0 }
   }
 };
@@ -387,7 +387,7 @@ function SidebarContent({
         />
         
         {/* User profile / settings */}
-        <div className="pt-2.5 pb-2.5 flex flex-col gap-2 border-t border-border shrink-0 overflow-visible">
+        <div className="pt-2.5 pb-2.5 px-1.5 flex flex-col gap-2 border-t border-border shrink-0 overflow-visible">
           <UserSettings collapsed={isCollapsed && !isMobile} initialData={sidebarData} />
         </div>
       </div>
@@ -487,7 +487,7 @@ function SidebarHeader({
       animate={isCollapsed && !isMobile ? "collapsed" : "expanded"}
       className={cn(
         "flex items-center gap-2.5 rounded-xl hover:bg-hover-bg data-[state=open]:bg-hover-bg transition-colors duration-200 group/logo select-none min-h-[40px] cursor-pointer outline-none",
-        isCollapsed && !isMobile ? "justify-center p-1" : "w-full pl-1 pr-2 p-1 justify-start"
+        isCollapsed && !isMobile ? "justify-center p-1 w-10 h-10" : "w-full pl-1 pr-2 p-1 justify-start"
       )}
       title={isCollapsed && !isMobile ? "Organisationen wechseln" : undefined}
     >
@@ -681,7 +681,8 @@ function SidebarNavLink({
         }
       }}
       className={cn(
-        "group flex items-center h-10 text-sm font-medium transition-colors duration-200 relative cursor-pointer active:scale-98 hover:z-10 rounded-xl isolate px-3 justify-start w-full",
+        "group flex items-center h-10 text-sm font-medium transition-colors duration-200 relative cursor-pointer active:scale-98 hover:z-10 rounded-xl isolate",
+        isCollapsed && !isMobile ? "w-10 h-10 justify-center px-0 mx-auto" : "w-full px-3 justify-start",
         !isActive && "hover:bg-accent/10 dark:hover:bg-accent/15",
         getActiveStateClasses(item.href),
       )}

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -409,7 +409,7 @@ function SidebarHeader({
 }) {
   return (
     <div className={cn(
-      "flex items-center justify-between gap-2 w-full mb-2.5 p-1.5 shrink-0 border-2 border-blue-500",
+      "flex items-center justify-between gap-2 w-full mb-2.5 pt-0 pb-1.5 px-1.5 shrink-0 border-2 border-blue-500",
       isCollapsed && !isMobile ? "justify-center" : ""
     )}>
       {/* Workspace / Brand Pill Container (Pink Border) */}

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -494,6 +494,8 @@ function SidebarHeader({
     <m.div 
       variants={logoVariants}
       animate={isCollapsed && !isMobile ? "collapsed" : "expanded"}
+      aria-label="Organisation menu"
+      data-org-switcher-trigger
       className={cn(
         "flex items-center gap-2.5 rounded-xl hover:bg-hover-bg data-[state=open]:bg-hover-bg transition-colors duration-200 group/logo select-none min-h-[40px] cursor-pointer outline-none",
         isCollapsed && !isMobile ? "justify-center p-1 w-10 h-10" : "w-full pl-1 pr-2 p-1 justify-start"

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -354,21 +354,20 @@ function SidebarContent({
   }, [featureFlags, sidebarData.isOrganisationHidden, sidebarData.modulePermissions]);
 
   return (
-    <div className="h-full w-full flex flex-col relative m-0 p-2.5 overflow-visible border-2 border-red-500">
-      {/* Header / Brand Logo */}
-      <SidebarHeader
-        isCollapsed={isCollapsed}
-        isMobile={isMobile}
-        toggleCollapse={toggleCollapse}
-        setIsOpen={setIsOpen}
-      />
+    <TooltipProvider delayDuration={100} skipDelayDuration={300}>
+      <div className="h-full w-full flex flex-col relative m-0 p-2.5 overflow-visible border-2 border-red-500">
+        {/* Header / Brand Logo */}
+        <SidebarHeader
+          isCollapsed={isCollapsed}
+          isMobile={isMobile}
+          setIsOpen={setIsOpen}
+        />
 
-      <div className={cn(
-        "flex-1 overflow-y-auto min-h-0 p-1.5 custom-scrollbar border-2 border-cyan-500",
-        isCollapsed && !isMobile ? "flex flex-col items-center" : ""
-      )}>
-        <nav className="grid gap-1.5 w-full">
-          <TooltipProvider delayDuration={100} skipDelayDuration={300}>
+        <div className={cn(
+          "flex-1 overflow-y-auto min-h-0 p-1.5 custom-scrollbar border-2 border-cyan-500",
+          isCollapsed && !isMobile ? "flex flex-col items-center" : ""
+        )}>
+          <nav className="grid gap-1.5 w-full">
             {visibleNavItems.map((item) => (
               <SidebarNavLink
                 key={item.href}
@@ -381,25 +380,25 @@ function SidebarContent({
                 getActiveStateClasses={getActiveStateClasses}
               />
             ))}
-          </TooltipProvider>
-        </nav>
-      </div>
+          </nav>
+        </div>
 
-      {/* Popover Actions */}
-      <SidebarActions
-        isCollapsed={isCollapsed}
-        supportButtonEnabled={!!supportButtonEnabled}
-        notificationCenterFeatureEnabled={!!notificationCenterFeatureEnabled}
-      />
-      
-      {/* User profile / settings */}
-      <div className={cn(
-        "pt-2.5 pb-2.5 flex flex-col gap-2 border-t border-border shrink-0 overflow-visible border-2 border-orange-500 p-0.5",
-        isCollapsed && !isMobile ? "items-center justify-center" : ""
-      )}>
-        <UserSettings collapsed={isCollapsed && !isMobile} initialData={sidebarData} />
+        {/* Popover Actions */}
+        <SidebarActions
+          isCollapsed={isCollapsed}
+          supportButtonEnabled={!!supportButtonEnabled}
+          notificationCenterFeatureEnabled={!!notificationCenterFeatureEnabled}
+        />
+        
+        {/* User profile / settings */}
+        <div className={cn(
+          "pt-2.5 pb-2.5 flex flex-col gap-2 border-t border-border shrink-0 overflow-visible border-2 border-orange-500 p-0.5",
+          isCollapsed && !isMobile ? "items-center justify-center" : ""
+        )}>
+          <UserSettings collapsed={isCollapsed && !isMobile} initialData={sidebarData} />
+        </div>
       </div>
-    </div>
+    </TooltipProvider>
   )
 }
 
@@ -410,16 +409,14 @@ interface OrganisationItem {
   name: string;
 }
 
-// Brand Logo & Collapse Toggle Subcomponent
+// Brand Logo & Header Subcomponent
 function SidebarHeader({
   isCollapsed,
   isMobile,
-  toggleCollapse,
   setIsOpen
 }: {
   isCollapsed: boolean
   isMobile: boolean
-  toggleCollapse?: () => void
   setIsOpen: (open: boolean) => void
 }) {
   const { toast } = useToast() || {}
@@ -489,108 +486,60 @@ function SidebarHeader({
 
   const activeOrg = organisations.find(o => o.organisation_id === currentOrgId);
   const activeName = currentOrgId === null ? "Mietevo" : (activeOrg?.name || "Mietevo");
-  const activeSubtitle = currentOrgId === null ? "Immobilienverwaltung" : `${activeOrg?.rolle === 'owner' ? 'Owner' : activeOrg?.rolle === 'admin' ? 'Admin' : 'Mitarbeiter'}`;
+  const activeSubtitle = currentOrgId === null ? "Immobilienverwaltung" : (activeOrg?.rolle === 'owner' ? 'Eigentümer' : activeOrg?.rolle === 'admin' ? 'Admin' : 'Mitarbeiter');
 
   const triggerPill = (
     <m.div 
       variants={logoVariants}
       animate={isCollapsed && !isMobile ? "collapsed" : "expanded"}
       className={cn(
-        "flex items-center justify-between gap-2 p-1 rounded-xl hover:bg-zinc-100 dark:hover:bg-zinc-800/60 transition-colors duration-150 group/logo select-none border-2 border-pink-500 min-h-[40px] cursor-pointer outline-none",
-        isCollapsed && !isMobile ? "justify-center p-1 w-10 h-10 mx-auto" : "w-full pl-1 pr-0.5"
+        "flex items-center gap-2.5 p-1 rounded-xl hover:bg-zinc-100 dark:hover:bg-zinc-800/60 transition-colors duration-150 group/logo select-none border-2 border-pink-500 min-h-[40px] cursor-pointer outline-none w-full",
+        isCollapsed && !isMobile ? "justify-center p-1 w-10 h-10 mx-auto" : "pl-1 pr-2"
       )}
+      title={isCollapsed && !isMobile ? "Organisationen wechseln" : undefined}
     >
-      {/* Workspace Click Target */}
-      <div
-        className={cn(
-          "flex items-center gap-2.5 min-w-0 flex-1 overflow-hidden",
-          isCollapsed && !isMobile ? "justify-center p-0" : ""
-        )}
-        title={isCollapsed && !isMobile ? "Organisationen wechseln" : undefined}
+      <m.div 
+        layout={false}
+        className="relative size-8 min-w-8 min-h-8 rounded-lg overflow-hidden shadow-2xs shrink-0 flex items-center justify-center"
       >
-        <m.div 
-          layout={false}
-          className="relative size-8 min-w-8 min-h-8 rounded-lg overflow-hidden shadow-2xs shrink-0 flex items-center justify-center"
-        >
-          {/* Logo Image */}
-          <div className={cn(
-            "absolute inset-0 transition-opacity duration-200",
-            isCollapsed && !isMobile ? "group-hover/logo:opacity-0" : ""
-          )}>
-            <Image
-              src={LOGO_URL}
-              alt="Mietevo Logo"
-              fill
-              className="object-cover rounded-lg"
-              sizes="32px"
-              unoptimized
-            />
-          </div>
-          {/* Hover Collapse Icon (only when collapsed) */}
-          {isCollapsed && !isMobile && (
-            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover/logo:opacity-100 transition-opacity duration-200 pointer-events-none">
-              <ChevronDown className="size-4 text-zinc-900 dark:text-zinc-50" />
-            </div>
-          )}
-        </m.div>
+        {/* Logo Image */}
+        <div className="absolute inset-0 transition-opacity duration-200">
+          <Image
+            src={LOGO_URL}
+            alt="Mietevo Logo"
+            fill
+            className="object-cover rounded-lg"
+            sizes="32px"
+            unoptimized
+          />
+        </div>
+      </m.div>
 
-        {!isMobile && !isCollapsed && (
-          <div className="flex flex-col flex-1 min-w-0 text-left overflow-hidden">
-            <div className="flex items-center gap-1">
-              <span className="text-sm font-bold text-zinc-900 dark:text-zinc-100 truncate leading-tight">
-                {activeName}
-              </span>
-              <ChevronDown className="size-3.5 text-zinc-400 shrink-0" />
-            </div>
-            <span className="text-[11px] font-medium text-zinc-500 dark:text-zinc-400 truncate leading-tight">
-              {activeSubtitle}
+      {!isMobile && !isCollapsed && (
+        <div className="flex flex-col flex-1 min-w-0 text-left overflow-hidden">
+          <div className="flex items-center gap-1">
+            <span className="text-sm font-bold text-zinc-900 dark:text-zinc-100 truncate leading-tight">
+              {activeName}
             </span>
+            <ChevronDown className="size-3.5 text-zinc-400 shrink-0" />
           </div>
-        )}
-        {isMobile && (
-          <div className="flex flex-col flex-1 min-w-0 text-left">
-            <div className="flex items-center gap-1">
-              <span className="text-sm font-bold text-zinc-900 dark:text-zinc-100 truncate leading-tight">
-                {activeName}
-              </span>
-              <ChevronDown className="size-3.5 text-zinc-400 shrink-0" />
-            </div>
-            <span className="text-[11px] font-medium text-zinc-500 dark:text-zinc-400 truncate leading-tight">
-              {activeSubtitle}
+          <span className="text-[11px] font-medium text-zinc-500 dark:text-zinc-400 truncate leading-tight">
+            {activeSubtitle}
+          </span>
+        </div>
+      )}
+      {isMobile && (
+        <div className="flex flex-col flex-1 min-w-0 text-left">
+          <div className="flex items-center gap-1">
+            <span className="text-sm font-bold text-zinc-900 dark:text-zinc-100 truncate leading-tight">
+              {activeName}
             </span>
+            <ChevronDown className="size-3.5 text-zinc-400 shrink-0" />
           </div>
-        )}
-      </div>
-
-      {/* Collapse Button inside the container (Purple Border) */}
-      {!isMobile && (
-        <m.button
-          variants={{
-            expanded: {
-              opacity: 1,
-              scale: 1,
-              display: "flex",
-              transition: { duration: 0 }
-            },
-            collapsed: {
-              opacity: 0,
-              scale: 0.8,
-              transition: { duration: 0 },
-              transitionEnd: { display: "none" }
-            }
-          }}
-          animate={isCollapsed ? "collapsed" : "expanded"}
-          onClick={(e) => {
-            e.stopPropagation();
-            e.preventDefault();
-            toggleCollapse?.();
-          }}
-          type="button"
-          className="size-8 min-w-[32px] mr-0 rounded-lg border border-zinc-200/80 dark:border-zinc-800/80 bg-white dark:bg-zinc-900 shadow-2xs hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100 flex items-center justify-center transition-colors shrink-0 cursor-pointer border-2 border-purple-500"
-          title="Menü einklappen"
-        >
-          <PanelLeft className="size-4" />
-        </m.button>
+          <span className="text-[11px] font-medium text-zinc-500 dark:text-zinc-400 truncate leading-tight">
+            {activeSubtitle}
+          </span>
+        </div>
       )}
     </m.div>
   );
@@ -600,6 +549,7 @@ function SidebarHeader({
       "flex items-center justify-between gap-2 w-full mb-2.5 pt-0 pb-1.5 px-1.5 shrink-0 border-2 border-blue-500",
       isCollapsed && !isMobile ? "justify-center" : ""
     )}>
+      {/* Organisation Switcher Dropdown (Pink Border) */}
       <CustomDropdown
         align="start"
         className="w-60"
@@ -615,14 +565,14 @@ function SidebarHeader({
           className="flex items-center cursor-pointer"
         >
           {currentOrgId === null ? (
-            <Check className="mr-2 size-4 text-emerald-500 shrink-0" />
+            <Check className="mr-2 size-4 text-primary shrink-0" />
           ) : (
             <div className="mr-2 size-4 shrink-0" />
           )}
           <div className="flex flex-col text-left min-w-0">
             <span className={cn(
               "truncate font-semibold text-sm leading-snug",
-              currentOrgId === null && "text-emerald-600 dark:text-emerald-400"
+              currentOrgId === null && "text-primary font-bold"
             )}>
               Privat
             </span>
@@ -634,7 +584,7 @@ function SidebarHeader({
         {organisations.map((org) => {
           const isActive = currentOrgId === org.organisation_id;
           const roleLabel =
-            org.rolle === 'owner' ? 'Owner' :
+            org.rolle === 'owner' ? 'Eigentümer' :
             org.rolle === 'admin' ? 'Admin' :
             'Mitarbeiter';
 
@@ -646,14 +596,14 @@ function SidebarHeader({
               className="flex items-center cursor-pointer"
             >
               {isActive ? (
-                <Check className="mr-2 size-4 text-emerald-500 shrink-0" />
+                <Check className="mr-2 size-4 text-primary shrink-0" />
               ) : (
                 <div className="mr-2 size-4 shrink-0" />
               )}
               <div className="flex flex-col text-left min-w-0">
                 <span className={cn(
                   "truncate font-semibold text-sm leading-snug",
-                  isActive && "text-emerald-600 dark:text-emerald-400"
+                  isActive && "text-primary font-bold"
                 )}>
                   {org.name}
                 </span>

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -204,9 +204,7 @@ export function DashboardSidebar({ sidebarData }: { sidebarData: SidebarUserData
   const pathname = usePathname()
   const [isOpen, setIsOpen] = useState(false)
   const { preference, setPreference } = useSidebarStore()
-  const [isResponsiveCollapsed, setIsResponsiveCollapsed] = useState(() => 
-    typeof window !== "undefined" ? window.matchMedia('(max-width: 1023px)').matches : false
-  )
+  const [isResponsiveCollapsed, setIsResponsiveCollapsed] = useState(false)
   
   const isCollapsed = isResponsiveCollapsed || preference === 'collapsed'
   const { isRouteActive, getActiveStateClasses } = useSidebarActiveState()
@@ -223,6 +221,7 @@ export function DashboardSidebar({ sidebarData }: { sidebarData: SidebarUserData
 
   useEffect(() => {
     const mediaQuery = window.matchMedia('(max-width: 1023px)');
+    setIsResponsiveCollapsed(mediaQuery.matches);
     const handleMediaChange = (e: MediaQueryListEvent) => {
       setIsResponsiveCollapsed(e.matches);
     };

--- a/components/dashboard/dashboard-sidebar.tsx
+++ b/components/dashboard/dashboard-sidebar.tsx
@@ -6,7 +6,7 @@ import Image from "next/image"
 import { usePathname } from "next/navigation"
 import { 
   BarChart3, Building2, Home, Users, Wallet, FileSpreadsheet, CheckSquare, 
-  Menu, X, Folder, Mail, Search, PanelLeft, MessageCircle, Bell, Network, Bot
+  Menu, X, Folder, Mail, Search, PanelLeft, MessageCircle, Bell, Network, Bot, ChevronDown
 } from "lucide-react"
 import { LazyMotion, domAnimation, m, Variants } from "framer-motion"
 import { LOGO_URL, ROUTES } from "@/lib/constants"
@@ -130,10 +130,7 @@ const SIDEBAR_MODULE_MAP: Record<string, string> = {
 };
 
 const layoutTransition = {
-  type: "spring",
-  stiffness: 400,
-  damping: 38,
-  mass: 0.8
+  duration: 0
 } as const;
 
 const MotionLink = m(Link);
@@ -145,43 +142,25 @@ const textVariants: Variants = {
     width: "auto",
     marginLeft: "12px",
     display: "block",
-    transition: {
-      type: "spring",
-      stiffness: 400,
-      damping: 38,
-      mass: 0.8
-    }
+    transition: { duration: 0 }
   },
   collapsed: {
     opacity: 0,
     width: 0,
     marginLeft: "0px",
-    transition: {
-      type: "spring",
-      stiffness: 400,
-      damping: 38,
-      mass: 0.8
-    },
-    transitionEnd: {
-      display: "none"
-    }
+    transition: { duration: 0 },
+    transitionEnd: { display: "none" }
   }
 };
 
 const iconVariants: Variants = {
   expanded: {
     scale: 1,
-    transition: {
-      duration: 0.2,
-      ease: [0.2, 0.8, 0.2, 1]
-    }
+    transition: { duration: 0 }
   },
   collapsed: {
     scale: 1.1,
-    transition: {
-      duration: 0.2,
-      ease: [0.2, 0.8, 0.2, 1]
-    }
+    transition: { duration: 0 }
   }
 };
 
@@ -189,45 +168,27 @@ const linkVariants: Variants = {
   expanded: {
     width: "100%",
     borderRadius: "20px", // rounded-xl
-    transition: {
-      type: "spring",
-      stiffness: 400,
-      damping: 38,
-      mass: 0.8
-    }
+    transition: { duration: 0 }
   },
   collapsed: {
     width: "40px",
     borderRadius: "9999px", // rounded-full
-    transition: {
-      type: "spring",
-      stiffness: 400,
-      damping: 38,
-      mass: 0.8
-    }
+    transition: { duration: 0 }
   }
 };
 
 const logoVariants: Variants = {
   expanded: {
     width: "100%",
+    height: "40px",
     borderRadius: "20px", // rounded-xl
-    transition: {
-      type: "spring",
-      stiffness: 400,
-      damping: 38,
-      mass: 0.8
-    }
+    transition: { duration: 0 }
   },
   collapsed: {
     width: "40px",
+    height: "40px",
     borderRadius: "9999px", // rounded-full
-    transition: {
-      type: "spring",
-      stiffness: 400,
-      damping: 38,
-      mass: 0.8
-    }
+    transition: { duration: 0 }
   }
 };
 
@@ -294,7 +255,7 @@ export function DashboardSidebar({ sidebarData }: { sidebarData: SidebarUserData
       />
 
       {/* Desktop Sidebar */}
-      <aside className="hidden md:flex flex-col z-30 h-screen sticky top-0 py-4 w-full overflow-visible">
+      <aside className="hidden md:flex flex-col z-30 h-screen sticky top-0 py-0 w-full overflow-visible">
         <div className="hidden md:flex flex-col h-full w-full overflow-visible">
           <SidebarContent
             isCollapsed={isCollapsed}
@@ -385,7 +346,7 @@ function SidebarContent({
   }, [featureFlags, sidebarData.isOrganisationHidden, sidebarData.modulePermissions]);
 
   return (
-    <div className="h-full w-full flex flex-col relative pl-4 pr-4 md:pr-0 overflow-visible">
+    <div className="h-full w-full flex flex-col relative m-0 p-2.5 overflow-visible border-2 border-red-500">
       {/* Header / Brand Logo */}
       <SidebarHeader
         isCollapsed={isCollapsed}
@@ -394,8 +355,11 @@ function SidebarContent({
         setIsOpen={setIsOpen}
       />
 
-      <div className="flex-1 overflow-y-auto min-h-0 py-2 custom-scrollbar">
-        <nav className="grid gap-1">
+      <div className={cn(
+        "flex-1 overflow-y-auto min-h-0 p-1.5 custom-scrollbar border-2 border-cyan-500",
+        isCollapsed && !isMobile ? "flex flex-col items-center" : ""
+      )}>
+        <nav className="grid gap-1.5 w-full">
           <TooltipProvider delayDuration={100} skipDelayDuration={300}>
             {visibleNavItems.map((item) => (
               <SidebarNavLink
@@ -421,7 +385,10 @@ function SidebarContent({
       />
       
       {/* User profile / settings */}
-      <div className="pt-2 pb-4 md:pb-0 flex flex-col gap-2 border-t border-border shrink-0 overflow-visible">
+      <div className={cn(
+        "pt-2.5 pb-2.5 flex flex-col gap-2 border-t border-border shrink-0 overflow-visible border-2 border-orange-500 p-0.5",
+        isCollapsed && !isMobile ? "items-center justify-center" : ""
+      )}>
         <UserSettings collapsed={isCollapsed && !isMobile} initialData={sidebarData} />
       </div>
     </div>
@@ -441,11 +408,21 @@ function SidebarHeader({
   setIsOpen: (open: boolean) => void
 }) {
   return (
-    <div className="flex items-center h-14 justify-between w-full pb-4 relative overflow-hidden shrink-0">
-      <div className="flex items-center overflow-hidden flex-1 min-w-0">
-        <MotionLink 
-          variants={logoVariants}
-          animate={isCollapsed && !isMobile ? "collapsed" : "expanded"}
+    <div className={cn(
+      "flex items-center justify-between gap-2 w-full mb-2.5 p-1.5 shrink-0 border-2 border-blue-500",
+      isCollapsed && !isMobile ? "justify-center" : ""
+    )}>
+      {/* Workspace / Brand Pill Container (Pink Border) */}
+      <m.div 
+        variants={logoVariants}
+        animate={isCollapsed && !isMobile ? "collapsed" : "expanded"}
+        className={cn(
+          "flex items-center justify-between gap-2 p-1 rounded-xl hover:bg-zinc-100 dark:hover:bg-zinc-800/60 transition-colors duration-150 group/logo select-none border-2 border-pink-500 min-h-[40px]",
+          isCollapsed && !isMobile ? "justify-center p-1 w-10 h-10 mx-auto" : "w-full pl-1 pr-0.5"
+        )}
+      >
+        {/* Brand Link (Logo + Name + Subtitle) */}
+        <Link
           href="/"
           onClick={(e) => {
             if (isCollapsed && !isMobile) {
@@ -453,89 +430,100 @@ function SidebarHeader({
               toggleCollapse?.();
             }
           }}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              if (isCollapsed && !isMobile) {
-                e.preventDefault();
-                toggleCollapse?.();
-              }
-            }
-          }}
-          role={isCollapsed && !isMobile ? "button" : undefined}
-          tabIndex={isCollapsed && !isMobile ? 0 : undefined}
-          className="flex items-center font-semibold overflow-hidden group/logo relative select-none shrink-0 cursor-pointer pl-1 transition-colors duration-200 gap-3 rounded-xl"
+          className={cn(
+            "flex items-center gap-2.5 min-w-0 cursor-pointer overflow-hidden",
+            isCollapsed && !isMobile ? "justify-center p-0" : "flex-1"
+          )}
           title={isCollapsed && !isMobile ? "Menü ausklappen" : undefined}
         >
           <m.div 
-            layout
-            transition={layoutTransition}
-            className="relative size-8 min-w-8 rounded-full overflow-hidden shadow-xs shrink-0 flex items-center justify-center"
+            layout={false}
+            className="relative size-8 min-w-8 min-h-8 rounded-lg overflow-hidden shadow-2xs shrink-0 flex items-center justify-center"
           >
             {/* Logo Image */}
             <div className={cn(
-              "absolute inset-0 transition-[opacity,transform] duration-300",
-              isCollapsed && !isMobile ? "group-hover/logo:opacity-0 group-hover/logo:scale-90" : ""
+              "absolute inset-0 transition-opacity duration-200",
+              isCollapsed && !isMobile ? "group-hover/logo:opacity-0" : ""
             )}>
               <Image
                 src={LOGO_URL}
-                alt="IV Logo"
+                alt="Mietevo Logo"
                 fill
-                className="object-cover rounded-full"
+                className="object-cover rounded-lg"
                 sizes="32px"
                 unoptimized
               />
             </div>
             {/* Hover Collapse Icon (only when collapsed) */}
             {isCollapsed && !isMobile && (
-              <div className="absolute inset-0 flex items-center justify-center opacity-0 scale-75 group-hover/logo:scale-100 group-hover/logo:opacity-100 transition-[opacity,transform] duration-300 pointer-events-none">
-                <PanelLeft className="size-5 text-zinc-900 dark:text-zinc-50" />
+              <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover/logo:opacity-100 transition-opacity duration-200 pointer-events-none">
+                <PanelLeft className="size-4 text-zinc-900 dark:text-zinc-50" />
               </div>
             )}
           </m.div>
-          {!isMobile && (
-            <m.span
-              variants={textVariants}
-              animate={isCollapsed && !isMobile ? "collapsed" : "expanded"}
-              className="text-lg whitespace-nowrap overflow-hidden font-bold"
-            >
-              Mietevo
-            </m.span>
-          )}
-          {isMobile && <span className="text-lg font-bold">Mietevo</span>}
-        </MotionLink>
-      </div>
 
-      {!isMobile && (
-        <m.button
-          variants={{
-            expanded: {
-              opacity: 1,
-              scale: 1,
-              display: "flex",
-              transition: {
-                duration: 0.2,
-                ease: [0.2, 0.8, 0.2, 1]
-              }
-            },
-            collapsed: {
-              opacity: 0,
-              scale: 0.8,
-              transition: {
-                duration: 0.15,
-                ease: [0.2, 0.8, 0.2, 1]
+          {!isMobile && !isCollapsed && (
+            <div className="flex flex-col flex-1 min-w-0 text-left overflow-hidden">
+              <div className="flex items-center gap-1">
+                <span className="text-sm font-bold text-zinc-900 dark:text-zinc-100 truncate leading-tight">
+                  Mietevo
+                </span>
+                <ChevronDown className="size-3.5 text-zinc-400 shrink-0" />
+              </div>
+              <span className="text-[11px] font-medium text-zinc-500 dark:text-zinc-400 truncate leading-tight">
+                Immobilienverwaltung
+              </span>
+            </div>
+          )}
+          {isMobile && (
+            <div className="flex flex-col flex-1 min-w-0 text-left">
+              <span className="text-sm font-bold text-zinc-900 dark:text-zinc-100 truncate">
+                Mietevo
+              </span>
+              <span className="text-[11px] font-medium text-zinc-500 dark:text-zinc-400 truncate">
+                Immobilienverwaltung
+              </span>
+            </div>
+          )}
+        </Link>
+
+        {/* Collapse Button inside the container (Purple Border) */}
+        {!isMobile && (
+          <m.button
+            variants={{
+              expanded: {
+                opacity: 1,
+                scale: 1,
+                display: "flex",
+                transition: {
+                  duration: 0.2,
+                  ease: [0.2, 0.8, 0.2, 1]
+                }
               },
-              transitionEnd: { display: "none" }
-            }
-          }}
-          animate={isCollapsed ? "collapsed" : "expanded"}
-          onClick={toggleCollapse}
-          type="button"
-          className="flex items-center justify-center rounded-xl size-10 text-zinc-500 hover:bg-zinc-200/80 dark:hover:bg-zinc-700/80 hover:text-zinc-950 dark:hover:text-zinc-50 transition-colors duration-200 shrink-0 z-50 focus:outline-none cursor-pointer hover:scale-105 active:scale-95"
-          title="Menü einklappen"
-        >
-          <PanelLeft className="size-5" />
-        </m.button>
-      )}
+              collapsed: {
+                opacity: 0,
+                scale: 0.8,
+                transition: {
+                  duration: 0.15,
+                  ease: [0.2, 0.8, 0.2, 1]
+                },
+                transitionEnd: { display: "none" }
+              }
+            }}
+            animate={isCollapsed ? "collapsed" : "expanded"}
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              toggleCollapse?.();
+            }}
+            type="button"
+            className="size-8 min-w-[32px] mr-0 rounded-lg border border-zinc-200/80 dark:border-zinc-800/80 bg-white dark:bg-zinc-900 shadow-2xs hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100 flex items-center justify-center transition-colors shrink-0 cursor-pointer border-2 border-purple-500"
+            title="Menü einklappen"
+          >
+            <PanelLeft className="size-4" />
+          </m.button>
+        )}
+      </m.div>
     </div>
   )
 }
@@ -609,7 +597,8 @@ function SidebarNavLink({
         }
       }}
       className={cn(
-        "group flex items-center h-10 text-sm font-medium transition-colors duration-200 relative cursor-pointer active:scale-98 hover:z-10 px-3 justify-start rounded-xl isolate",
+        "group flex items-center h-10 text-sm font-medium transition-colors duration-200 relative cursor-pointer active:scale-98 hover:z-10 rounded-xl isolate",
+        isCollapsed && !isMobile ? "px-0 justify-center mx-auto" : "px-3 justify-start w-full",
         !isActive && "hover:bg-accent/10 dark:hover:bg-accent/15",
         getActiveStateClasses(item.href),
       )}
@@ -689,7 +678,7 @@ function SidebarActions({
       transition={layoutTransition}
       className={cn(
         "flex gap-3 w-full pb-4 shrink-0 transition-colors duration-200",
-        isCollapsed ? "flex-col items-start" : "flex-row justify-start"
+        isCollapsed ? "flex-col items-center justify-center" : "flex-row justify-start"
       )}
     >
       {/* Support Popover */}

--- a/components/settings/user-settings-permissions.test.tsx
+++ b/components/settings/user-settings-permissions.test.tsx
@@ -1,0 +1,214 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { UserSettings, OrganisationItem } from '@/components/common/user-settings'
+import { useApartmentUsage } from '@/hooks/use-apartment-usage'
+import { User } from '@supabase/supabase-js'
+import { SidebarUserData } from '@/lib/server/user-data'
+
+// Mock dependencies
+jest.mock('@/hooks/use-apartment-usage')
+jest.mock('@/hooks/use-user-profile', () => ({
+  useUserProfile: jest.fn(() => ({
+    user: null,
+    userName: 'Test User',
+    userEmail: 'test@example.com',
+    userInitials: 'TU',
+    isLoading: false,
+    error: null,
+  })),
+}))
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+  usePathname: () => '/dashboard',
+}))
+jest.mock('@/hooks/use-modal-store', () => ({
+  useModalStore: jest.fn(() => ({
+    openTemplatesModal: jest.fn(),
+    openTrashBinModal: jest.fn(),
+  })),
+}))
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: jest.fn(),
+  }),
+}))
+jest.mock('posthog-js/react', () => ({
+  useFeatureFlagEnabled: () => false,
+}))
+jest.mock('@/utils/supabase/client', () => ({
+  createClient: jest.fn(() => ({
+    auth: {
+      signOut: jest.fn(() => Promise.resolve({ error: null })),
+    },
+  })),
+}))
+jest.mock('@/components/ui/custom-dropdown', () => ({
+  CustomDropdown: ({ children, trigger }: { children: React.ReactNode; trigger: React.ReactNode }) => (
+    <div>
+      {trigger}
+      <div data-testid="dropdown-content">{children}</div>
+    </div>
+  ),
+  CustomDropdownItem: ({ children, onClick, ...props }: { children: React.ReactNode; onClick?: () => void }) => (
+    <div onClick={onClick} {...props}>{children}</div>
+  ),
+  CustomDropdownLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CustomDropdownSeparator: () => <hr />,
+}))
+
+describe('UserSettings Organisation Permissions (isOrgAdminOrOwner)', () => {
+  const mockUseApartmentUsage = useApartmentUsage as jest.MockedFunction<typeof useApartmentUsage>
+  
+  const mockUser = {
+    id: 'test-user-id',
+    email: 'test@example.com',
+  } as unknown as User
+
+  const mockSidebarData: SidebarUserData = {
+    user: mockUser,
+    userName: 'Test User',
+    userEmail: 'test@example.com',
+    userInitials: 'TU',
+    apartmentCount: 0,
+    apartmentLimit: null,
+    hasOrganisationPermission: true,
+    isOrganisationHidden: false,
+    modulePermissions: null,
+  }
+
+  const sampleOrgs: OrganisationItem[] = [
+    {
+      organisation_id: 'org-owner',
+      owner_id: 'user-1',
+      rolle: 'owner',
+      name: 'Owner Org',
+    },
+    {
+      organisation_id: 'org-admin',
+      owner_id: 'user-2',
+      rolle: 'admin',
+      name: 'Admin Org',
+    },
+    {
+      organisation_id: 'org-employee',
+      owner_id: 'user-3',
+      rolle: 'mitarbeiter',
+      name: 'Employee Org',
+    },
+  ]
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseApartmentUsage.mockReturnValue({
+      count: 0,
+      limit: null,
+      isLoading: false,
+      error: null,
+      progressPercentage: 0,
+    })
+  })
+
+  it('allows admin actions in personal context (currentOrgId === null)', async () => {
+    render(
+      <UserSettings 
+        initialData={mockSidebarData}
+        organisations={sampleOrgs}
+        currentOrgId={null}
+      />
+    )
+
+    // Open user settings dropdown
+    const trigger = screen.getByLabelText('User menu')
+    fireEvent.click(trigger)
+
+    await waitFor(() => {
+      expect(screen.getByText('Papierkorb')).toBeInTheDocument()
+    })
+  })
+
+  it('allows admin actions in owner organisation context', async () => {
+    render(
+      <UserSettings 
+        initialData={mockSidebarData}
+        organisations={sampleOrgs}
+        currentOrgId="org-owner"
+      />
+    )
+
+    const trigger = screen.getByLabelText('User menu')
+    fireEvent.click(trigger)
+
+    await waitFor(() => {
+      expect(screen.getByText('Papierkorb')).toBeInTheDocument()
+    })
+  })
+
+  it('allows admin actions in admin organisation context', async () => {
+    render(
+      <UserSettings 
+        initialData={mockSidebarData}
+        organisations={sampleOrgs}
+        currentOrgId="org-admin"
+      />
+    )
+
+    const trigger = screen.getByLabelText('User menu')
+    fireEvent.click(trigger)
+
+    await waitFor(() => {
+      expect(screen.getByText('Papierkorb')).toBeInTheDocument()
+    })
+  })
+
+  it('hides admin actions in employee organisation context (rolle === mitarbeiter)', async () => {
+    render(
+      <UserSettings 
+        initialData={mockSidebarData}
+        organisations={sampleOrgs}
+        currentOrgId="org-employee"
+      />
+    )
+
+    const trigger = screen.getByLabelText('User menu')
+    fireEvent.click(trigger)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Papierkorb')).not.toBeInTheDocument()
+    })
+  })
+
+  it('fails closed (hides admin actions) when organisation data is loaded but currentOrgId is unknown', async () => {
+    render(
+      <UserSettings 
+        initialData={mockSidebarData}
+        organisations={sampleOrgs}
+        currentOrgId="org-unknown"
+      />
+    )
+
+    const trigger = screen.getByLabelText('User menu')
+    fireEvent.click(trigger)
+
+    await waitFor(() => {
+      expect(screen.queryByText('Papierkorb')).not.toBeInTheDocument()
+    })
+  })
+
+  it('falls back to initialData.hasOrganisationPermission while organisations array is empty/loading', async () => {
+    render(
+      <UserSettings 
+        initialData={{ ...mockSidebarData, hasOrganisationPermission: true }}
+        organisations={[]}
+        currentOrgId="org-loading"
+      />
+    )
+
+    const trigger = screen.getByLabelText('User menu')
+    fireEvent.click(trigger)
+
+    await waitFor(() => {
+      expect(screen.getByText('Papierkorb')).toBeInTheDocument()
+    })
+  })
+})

--- a/e2e/organisation-switch.spec.ts
+++ b/e2e/organisation-switch.spec.ts
@@ -40,8 +40,10 @@ test.describe('Organisation Switcher E2E', () => {
 
     console.log(`Clicking target item: "${targetName}"...`);
 
-    await targetItem.click();
-    await page.waitForLoadState('load');
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'load' }),
+      targetItem.click(),
+    ]);
 
     console.log("Page reloaded. Verifying new context...");
 

--- a/e2e/organisation-switch.spec.ts
+++ b/e2e/organisation-switch.spec.ts
@@ -7,8 +7,8 @@ test.describe('Organisation Switcher E2E', () => {
     await login(page);
     await acceptCookieConsent(page);
 
-    console.log("Locating user menu trigger...");
-    const userMenuTrigger = page.locator('[aria-label="User menu"], [data-dropdown-trigger]').first();
+    console.log("Locating organisation menu trigger...");
+    const userMenuTrigger = page.locator('[aria-label="Organisation menu"], [data-org-switcher-trigger], [aria-label="User menu"]').first();
     await expect(userMenuTrigger).toBeVisible({ timeout: 15000 });
 
     console.log("Opening user menu...");

--- a/e2e/organisation-switch.spec.ts
+++ b/e2e/organisation-switch.spec.ts
@@ -40,10 +40,8 @@ test.describe('Organisation Switcher E2E', () => {
 
     console.log(`Clicking target item: "${targetName}"...`);
 
-    await Promise.all([
-      page.waitForNavigation({ waitUntil: 'load' }),
-      targetItem.click(),
-    ]);
+    await targetItem.click();
+    await page.waitForLoadState('load');
 
     console.log("Page reloaded. Verifying new context...");
 

--- a/hooks/use-media-query.ts
+++ b/hooks/use-media-query.ts
@@ -1,0 +1,21 @@
+"use client"
+
+import { useState, useEffect } from "react"
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false)
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(query)
+    setMatches(mediaQuery.matches)
+
+    const handleMediaChange = (e: MediaQueryListEvent) => {
+      setMatches(e.matches)
+    }
+
+    mediaQuery.addEventListener("change", handleMediaChange)
+    return () => mediaQuery.removeEventListener("change", handleMediaChange)
+  }, [query])
+
+  return matches
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -30,6 +30,9 @@ export const INFO_EMAIL = "info@mietevo.de";
 // For backward compatibility, CONTACT_EMAIL now aliases INFO_EMAIL (it was previously SUPPORT_EMAIL).
 export const CONTACT_EMAIL = INFO_EMAIL;
 
+// Centralized media query breakpoints
+export const TABLET_BREAKPOINT = '(max-width: 1023px)';
+
 // Base URL - centralized to ensure consistency across all environments
 export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'https://mietevo.de';
 


### PR DESCRIPTION
## Summary
Redesigns the dashboard sidebar header by turning the static brand logo into an organisation switcher dropdown and moving organisation selection out of the user settings menu. Also unifies spacing and hover styling across the sidebar, replaces all spring-based layout animations with instant transitions, and makes the sidebar collapse dynamically on tablet viewports.

## Changes

- **`components/dashboard/dashboard-sidebar.tsx`**
  - `SidebarHeader` rebuilt: the logo/brand pill now opens a `CustomDropdown` for organisation switching instead of linking to `/`; the separate `PanelLeft` collapse toggle button and the hover-expand overlay on the collapsed logo are removed (`toggleCollapse` prop dropped)
  - Organisation switching logic moved here from `UserSettings`: loads orgs via `getMyOrganisationsAction` (with `sessionStorage` cache `cached_organisations:v1`), switches via `switchOrganisationAction`, and reloads on success
  - Header now displays the active organisation name with a subtitle — role label localised to German (`Eigentümer` / `Admin` / `Mitarbeiter`), or `Immobilienverwaltung` for the personal space; dropdown items show name and role on separate lines
  - All framer-motion spring transitions (`layoutTransition`, `textVariants`, `iconVariants`, `linkVariants`, `logoVariants`) replaced with `duration: 0` for instant state changes
  - Collapsed nav links and logo are now full-width `rounded-xl` (20px) instead of 40px `rounded-full` circles
  - Spacing unified: `aside` vertical padding removed, content container uses `p-2.5`, nav gap increased to `gap-1.5`; `TooltipProvider` hoisted to wrap the entire sidebar content

- **`components/common/user-settings.tsx`**
  - Organisation switcher section removed from the user dropdown (now lives in the sidebar header)
  - Trigger restyled to match the org switcher: `hover:bg-hover-bg` / `data-[state=open]:bg-hover-bg`, `rounded-xl`, border/shadow/background styling removed
  - `whileHover`/`whileTap` scale animations and spring transitions removed; collapsed trigger corner radius changed from `rounded-full` to `rounded-2xl` (24px)

- **`components/dashboard/dashboard-layout.tsx`**
  - New tablet breakpoint: sidebar auto-collapses at `max-width: 1023px` via `matchMedia`, combined with the user's collapse preference (`isCollapsed = isTabletCollapsed || preference === 'collapsed'`)
  - Collapsed sidebar width reduced from `5rem` to `4.25rem`; `transition-all` on the sidebar container removed (width now switches instantly)
  - Main content padding unified to `p-3` (12px) to match the sidebar; redundant flex wrapper removed and scroll container / content card flattened by one nesting level
  - Removed leftover debug borders

## Breaking Changes
None