### PR TITLE
fix(test): mock useToast in dashboard-sidebar-navigation tests

### DIFF
--- a/components/dashboard/dashboard-sidebar-navigation.test.tsx
+++ b/components/dashboard/dashboard-sidebar-navigation.test.tsx
@@ -27,6 +27,13 @@ jest.mock('@/utils/supabase/client', () => ({
   })),
 }))
 
+// Mock useToast hook
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: jest.fn(),
+  }),
+}))
+
 const mockUsePathname = usePathname as jest.MockedFunction<typeof usePathname>
 
 const mockSidebarData: SidebarUserData = {

--- a/components/dashboard/dashboard-sidebar-navigation.test.tsx
+++ b/components/dashboard/dashboard-sidebar-navigation.test.tsx
@@ -27,10 +27,10 @@ jest.mock('@/utils/supabase/client', () => ({
   })),
 }))
 
-// Mock useToast hook
+const mockToast = jest.fn()
 jest.mock('@/hooks/use-toast', () => ({
   useToast: () => ({
-    toast: jest.fn(),
+    toast: mockToast,
   }),
 }))
 


### PR DESCRIPTION
## Summary
- Adds missing `@/hooks/use-toast` mock in `dashboard-sidebar-navigation.test.tsx`
- Fixes Jest component test failures caused by the recent sidebar header redesign where `useToast` was added to `SidebarHeader`

## Testing
- Ran `npx jest components/dashboard/dashboard-sidebar-navigation.test.tsx` (5/5 tests passing)