### PR TITLE
feat(pricing): remove mock fallback plans and add connection failed UI with OTel logging

### DIFF
--- a/app/api/stripe/plans/route.ts
+++ b/app/api/stripe/plans/route.ts
@@ -13,12 +13,11 @@ export async function GET() {
     // Only log in non-CI environments to avoid cluttering test output
     if (process.env.CI !== 'true' && !process.env.STRIPE_SECRET_KEY?.startsWith('mock-')) {
       console.error('Stripe secret key not configured or is a mock key');
+      posthogLogger.error('Failed to load pricing plans from Stripe: Stripe secret key not configured or is a mock key', {
+        endpoint: '/api/stripe/plans',
+        isStripeMocked: true,
+      });
     }
-
-    posthogLogger.error('Failed to load pricing plans from Stripe: Stripe secret key not configured or is a mock key', {
-      endpoint: '/api/stripe/plans',
-      isStripeMocked: true,
-    });
 
     return NextResponse.json({ error: 'Stripe secret key not configured.' }, {
       status: 500,

--- a/app/api/stripe/plans/route.ts
+++ b/app/api/stripe/plans/route.ts
@@ -5,7 +5,8 @@ import { StripePlan } from '@/types/stripe';
 import { parseStorageString } from '@/lib/stripe-server';
 import { NO_CACHE_HEADERS } from '@/lib/constants/http';
 
-import { isTestEnv, isStripeMocked } from '@/lib/test-utils';
+import { isStripeMocked } from '@/lib/test-utils';
+import { posthogLogger } from '@/lib/posthog-logger';
 
 export async function GET() {
   if (isStripeMocked()) {
@@ -14,39 +15,10 @@ export async function GET() {
       console.error('Stripe secret key not configured or is a mock key');
     }
 
-    if (isTestEnv()) {
-      return NextResponse.json([{
-        id: 'price_mock_starter',
-        priceId: 'price_mock_starter',
-        name: 'Starter Plan (Mock)',
-        productName: 'Starter',
-        price: 990,
-        currency: 'eur',
-        interval: 'month',
-        interval_count: 1,
-        features: ['Up to 5 units', 'Basic support'],
-        limit_wohnungen: 5,
-        storage_limit: 1024 * 1024 * 1024,
-        position: 1,
-        description: 'Mock starter plan for testing',
-        metadata: { feat_units: '5', feat_storage: '1 GB' }
-      }, {
-        id: 'price_mock_pro',
-        priceId: 'price_mock_pro',
-        name: 'Pro Plan (Mock)',
-        productName: 'Pro',
-        price: 2990,
-        currency: 'eur',
-        interval: 'month',
-        interval_count: 1,
-        features: ['Up to 50 units', 'Priority support'],
-        limit_wohnungen: 50,
-        storage_limit: 10 * 1024 * 1024 * 1024,
-        position: 2,
-        description: 'Mock pro plan for testing',
-        metadata: { feat_units: '50', feat_storage: '10 GB' }
-      }]);
-    }
+    posthogLogger.error('Failed to load pricing plans from Stripe: Stripe secret key not configured or is a mock key', {
+      endpoint: '/api/stripe/plans',
+      isStripeMocked: true,
+    });
 
     return NextResponse.json({ error: 'Stripe secret key not configured.' }, {
       status: 500,
@@ -155,6 +127,11 @@ export async function GET() {
     } else {
       console.error('Unknown error object when fetching plans:', error);
     }
+    posthogLogger.error('Failed to load pricing plans from Stripe', {
+      endpoint: '/api/stripe/plans',
+      error: errorMessage,
+    });
+
     return NextResponse.json({ error: 'Failed to fetch plans from Stripe.', details: errorMessage }, {
       status: 500,
       headers: NO_CACHE_HEADERS

--- a/app/modern/components/pricing.test.tsx
+++ b/app/modern/components/pricing.test.tsx
@@ -27,6 +27,14 @@ jest.mock('./preview-limit-notice-banner', () => ({
   PreviewLimitNoticeBanner: () => <div>PreviewLimitNoticeBanner</div>,
 }));
 
+jest.mock('@/lib/posthog-logger', () => ({
+  posthogLogger: {
+    error: jest.fn(),
+  },
+}));
+
+import { posthogLogger } from '@/lib/posthog-logger';
+
 const mockPlans = [
   {
     id: 'price_1',
@@ -81,6 +89,30 @@ describe('Pricing Component', () => {
       // Find all elements with text 'Basis'. In the new layout, it appears in the card and the comparison table.
       const basisElements = screen.getAllByText('Basis');
       expect(basisElements.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('renders connection failed container and logs error when fetch fails', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ error: 'Stripe secret key not configured.' }),
+      })
+    ) as jest.Mock;
+
+    render(<Pricing onSelectPlan={jest.fn()} userProfile={null} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Verbindung fehlgeschlagen')).toBeInTheDocument();
+      expect(screen.getByText('Erneut versuchen')).toBeInTheDocument();
+      expect(posthogLogger.error).toHaveBeenCalledWith(
+        'Pricing plans could not be loaded on frontend',
+        expect.objectContaining({
+          component: 'Pricing',
+          error: 'Stripe secret key not configured.',
+        })
+      );
     });
   });
 });

--- a/app/modern/components/pricing.test.tsx
+++ b/app/modern/components/pricing.test.tsx
@@ -115,4 +115,20 @@ describe('Pricing Component', () => {
       );
     });
   });
+
+  it('renders empty plans state when no plans are available', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      })
+    ) as jest.Mock;
+
+    render(<Pricing onSelectPlan={jest.fn()} userProfile={null} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Keine Tarife verfügbar')).toBeInTheDocument();
+      expect(screen.getByText('Aktualisieren')).toBeInTheDocument();
+    });
+  });
 });

--- a/app/modern/components/pricing.tsx
+++ b/app/modern/components/pricing.tsx
@@ -553,67 +553,6 @@ export default function Pricing({
     );
   }
 
-  if (error) {
-    return (
-      <section className="py-24 px-4 relative overflow-hidden">
-        <div className="max-w-md mx-auto text-center">
-          <Card className="border-destructive/20 bg-card/50 backdrop-blur-xs shadow-xl rounded-[2.5rem] p-8 sm:p-10">
-            <CardContent className="flex flex-col items-center text-center space-y-6 p-0">
-              <div className="rounded-full bg-destructive/10 p-4 ring-1 ring-destructive/20 text-destructive">
-                <WifiOff className="w-10 h-10" />
-              </div>
-
-              <div className="space-y-2 max-w-sm">
-                <h3 className="text-2xl font-bold tracking-tight">Verbindung fehlgeschlagen</h3>
-                <p className="text-muted-foreground text-sm leading-relaxed">
-                  Die Preisinformationen konnten derzeit nicht geladen werden. Bitte überprüfen Sie Ihre Netzwerkverbindung oder versuchen Sie es später erneut.
-                </p>
-              </div>
-
-              <Button
-                onClick={fetchPlans}
-                variant="outline"
-                className="rounded-xl gap-2 mt-2"
-              >
-                <RotateCw className="w-4 h-4" />
-                Erneut versuchen
-              </Button>
-            </CardContent>
-          </Card>
-        </div>
-      </section>
-    );
-  }
-
-  if (groupedPlans.length === 0 && !isLoadingPlans) {
-    return (
-      <section className="py-24 px-4 relative overflow-hidden">
-        <div className="max-w-md mx-auto text-center">
-          <Card className="border-border/60 bg-card/50 backdrop-blur-xs shadow-xl rounded-[2.5rem] p-8 sm:p-10">
-            <CardContent className="flex flex-col items-center text-center space-y-6 p-0">
-              <div className="space-y-2 max-w-sm">
-                <h3 className="text-2xl font-bold tracking-tight">Keine Tarife verfügbar</h3>
-                <p className="text-muted-foreground text-sm leading-relaxed">
-                  Derzeit sind keine Abonnement-Pläne verfügbar. Bitte schauen Sie zu einem späteren Zeitpunkt wieder vorbei.
-                </p>
-              </div>
-
-              <Button
-                onClick={fetchPlans}
-                variant="outline"
-                className="rounded-xl gap-2 mt-2"
-              >
-                <RotateCw className="w-4 h-4" />
-                Aktualisieren
-              </Button>
-            </CardContent>
-          </Card>
-        </div>
-      </section>
-    );
-  }
-
-
   return (
     <>
       <section className="py-16 px-4">
@@ -625,163 +564,215 @@ export default function Pricing({
             </p>
           </div>
 
-          <PreviewLimitNoticeBanner
-            onGetStarted={handleFreePlanGetStarted}
-            isSignedIn={!!userProfile}
-          />
+          {error ? (
+            <div className="max-w-md mx-auto text-center py-8">
+              <Card className="border-destructive/20 bg-card/50 backdrop-blur-xs shadow-xl rounded-[2.5rem] p-8 sm:p-10">
+                <CardContent className="flex flex-col items-center text-center space-y-6 p-0">
+                  <div className="rounded-full bg-destructive/10 p-4 ring-1 ring-destructive/20 text-destructive">
+                    <WifiOff className="w-10 h-10" />
+                  </div>
 
-          <div className="flex justify-center mb-12">
-            <div className="flex items-center gap-1 bg-zinc-100/80 dark:bg-zinc-900/80 border border-zinc-200/30 dark:border-zinc-800/30 p-1 rounded-full relative w-full sm:w-fit max-w-[400px] select-none z-0">
-              <motion.button
-                type="button"
-                layout
-                onClick={() => {
-                  if (billingCycle !== "monthly") {
-                    trackBillingCycleChanged(billingCycle, "monthly")
-                    setBillingCycle("monthly")
-                  }
-                }}
-                className={cn(
-                  "flex-1 sm:flex-initial flex items-center justify-center gap-2 rounded-full h-9 px-6 relative outline-none cursor-pointer text-sm font-medium transition-colors duration-300",
-                  billingCycle === "monthly" ? "text-gray-900 dark:text-gray-100 font-semibold" : "text-muted-foreground hover:text-foreground",
-                )}
-              >
-                {billingCycle === "monthly" && (
-                  <motion.div
-                    layoutId="active-billing-tab-pill"
-                    className="absolute inset-0 bg-white dark:bg-zinc-800 shadow-sm border border-zinc-200/10 dark:border-zinc-700/30 rounded-full -z-10"
-                    transition={{ type: "spring", stiffness: 380, damping: 30 }}
-                  />
-                )}
-                <span>Monatlich</span>
-              </motion.button>
-              <motion.button
-                type="button"
-                layout
-                onClick={() => {
-                  if (billingCycle !== "yearly") {
-                    trackBillingCycleChanged(billingCycle, "yearly")
-                    setBillingCycle("yearly")
-                  }
-                }}
-                className={cn(
-                  "flex-1 sm:flex-initial flex items-center justify-center gap-2 rounded-full h-9 px-6 relative outline-none cursor-pointer text-sm font-medium transition-colors duration-300",
-                  billingCycle === "yearly" ? "text-gray-900 dark:text-gray-100 font-semibold" : "text-muted-foreground hover:text-foreground",
-                )}
-              >
-                {billingCycle === "yearly" && (
-                  <motion.div
-                    layoutId="active-billing-tab-pill"
-                    className="absolute inset-0 bg-white dark:bg-zinc-800 shadow-sm border border-zinc-200/10 dark:border-zinc-700/30 rounded-full -z-10"
-                    transition={{ type: "spring", stiffness: 380, damping: 30 }}
-                  />
-                )}
-                <span>Jährlich (20% Rabatt)</span>
-              </motion.button>
+                  <div className="space-y-2 max-w-sm">
+                    <h3 className="text-2xl font-bold tracking-tight">Verbindung fehlgeschlagen</h3>
+                    <p className="text-muted-foreground text-sm leading-relaxed">
+                      Die Preisinformationen konnten derzeit nicht geladen werden. Bitte überprüfen Sie Ihre Netzwerkverbindung oder versuchen Sie es später erneut.
+                    </p>
+                  </div>
+
+                  <Button
+                    onClick={fetchPlans}
+                    variant="outline"
+                    className="rounded-xl gap-2 mt-2"
+                  >
+                    <RotateCw className="w-4 h-4" />
+                    Erneut versuchen
+                  </Button>
+                </CardContent>
+              </Card>
             </div>
-          </div>
+          ) : groupedPlans.length === 0 && !isLoadingPlans ? (
+            <div className="max-w-md mx-auto text-center py-8">
+              <Card className="border-border/60 bg-card/50 backdrop-blur-xs shadow-xl rounded-[2.5rem] p-8 sm:p-10">
+                <CardContent className="flex flex-col items-center text-center space-y-6 p-0">
+                  <div className="space-y-2 max-w-sm">
+                    <h3 className="text-2xl font-bold tracking-tight">Keine Tarife verfügbar</h3>
+                    <p className="text-muted-foreground text-sm leading-relaxed">
+                      Derzeit sind keine Abonnement-Pläne verfügbar. Bitte schauen Sie zu einem späteren Zeitpunkt wieder vorbei.
+                    </p>
+                  </div>
 
-          <div className="grid md:grid-cols-3 gap-8 max-w-5xl mx-auto items-stretch">
-            {groupedPlans.filter(group => group.position !== 0).map((group) => {
-              const planToDisplay = billingCycle === 'monthly' ? group.monthly : group.annually;
-              if (!planToDisplay) return null;
+                  <Button
+                    onClick={fetchPlans}
+                    variant="outline"
+                    className="rounded-xl gap-2 mt-2"
+                  >
+                    <RotateCw className="w-4 h-4" />
+                    Aktualisieren
+                  </Button>
+                </CardContent>
+              </Card>
+            </div>
+          ) : (
+            <>
+              <PreviewLimitNoticeBanner
+                onGetStarted={handleFreePlanGetStarted}
+                isSignedIn={!!userProfile}
+              />
 
-              const { text, disabled } = getButtonTextAndState(planToDisplay.priceId);
+              <div className="flex justify-center mb-12">
+                <div className="flex items-center gap-1 bg-zinc-100/80 dark:bg-zinc-900/80 border border-zinc-200/30 dark:border-zinc-800/30 p-1 rounded-full relative w-full sm:w-fit max-w-[400px] select-none z-0">
+                  <motion.button
+                    type="button"
+                    layout
+                    onClick={() => {
+                      if (billingCycle !== "monthly") {
+                        trackBillingCycleChanged(billingCycle, "monthly")
+                        setBillingCycle("monthly")
+                      }
+                    }}
+                    className={cn(
+                      "flex-1 sm:flex-initial flex items-center justify-center gap-2 rounded-full h-9 px-6 relative outline-none cursor-pointer text-sm font-medium transition-colors duration-300",
+                      billingCycle === "monthly" ? "text-gray-900 dark:text-gray-100 font-semibold" : "text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    {billingCycle === "monthly" && (
+                      <motion.div
+                        layoutId="active-billing-tab-pill"
+                        className="absolute inset-0 bg-white dark:bg-zinc-800 shadow-sm border border-zinc-200/10 dark:border-zinc-700/30 rounded-full -z-10"
+                        transition={{ type: "spring", stiffness: 380, damping: 30 }}
+                      />
+                    )}
+                    <span>Monatlich</span>
+                  </motion.button>
+                  <motion.button
+                    type="button"
+                    layout
+                    onClick={() => {
+                      if (billingCycle !== "yearly") {
+                        trackBillingCycleChanged(billingCycle, "yearly")
+                        setBillingCycle("yearly")
+                      }
+                    }}
+                    className={cn(
+                      "flex-1 sm:flex-initial flex items-center justify-center gap-2 rounded-full h-9 px-6 relative outline-none cursor-pointer text-sm font-medium transition-colors duration-300",
+                      billingCycle === "yearly" ? "text-gray-900 dark:text-gray-100 font-semibold" : "text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    {billingCycle === "yearly" && (
+                      <motion.div
+                        layoutId="active-billing-tab-pill"
+                        className="absolute inset-0 bg-white dark:bg-zinc-800 shadow-sm border border-zinc-200/10 dark:border-zinc-700/30 rounded-full -z-10"
+                        transition={{ type: "spring", stiffness: 380, damping: 30 }}
+                      />
+                    )}
+                    <span>Jährlich (20% Rabatt)</span>
+                  </motion.button>
+                </div>
+              </div>
 
-              return (
-                <Card
-                  key={group.productName}
-                  className={`relative flex flex-col rounded-[2.5rem] ${group.popular ? "border-primary shadow-lg scale-105" : "border-border"}`}
-                >
-                  {group.popular && (
-                    <Badge className="absolute -top-3 left-1/2 transform -translate-x-1/2">Am beliebtesten</Badge>
-                  )}
+              <div className="grid md:grid-cols-3 gap-8 max-w-5xl mx-auto items-stretch">
+                {groupedPlans.filter(group => group.position !== 0).map((group) => {
+                  const planToDisplay = billingCycle === 'monthly' ? group.monthly : group.annually;
+                  if (!planToDisplay) return null;
 
-                  <CardHeader className="text-center pb-8">
-                    <CardTitle className="text-xl font-semibold">{group.productName}</CardTitle>
-                    <div className="mt-4 flex flex-col items-center">
-                      <div className="flex items-end justify-center gap-1">
-                        <AnimatedPrice
-                          key={billingCycle}
-                          value={`${formatDisplayPrice(planToDisplay.price, planToDisplay.currency, planToDisplay.interval)} €`}
-                          className="text-4xl font-bold"
-                        />
-                        <span className="mb-1 text-sm text-muted-foreground">
-                          /{billingCycle === "monthly" ? "Monat" : "Jahr"}
-                        </span>
-                      </div>
-                    </div>
-                    <CardDescription className="mt-4 text-center text-sm leading-relaxed text-muted-foreground">
-                      {group.description || `Unser ${group.productName} Plan.`}
-                    </CardDescription>
-                  </CardHeader>
+                  const { text, disabled } = getButtonTextAndState(planToDisplay.priceId);
 
-                  <CardContent className="grow flex flex-col gap-6">
-                    <Button
-                      onClick={() => {
-                        trackPricingPlanSelected(
-                          group.productName,
-                          planToDisplay.priceId,
-                          billingCycle,
-                          planToDisplay.price / 100,
-                          planToDisplay.currency
-                        )
-                        onSelectPlan(planToDisplay.priceId)
-                      }}
-                      className="w-full rounded-xl"
-                      variant={group.popular ? "default" : "outline"}
-                      size="lg"
-                      disabled={disabled}
+                  return (
+                    <Card
+                      key={group.productName}
+                      className={`relative flex flex-col rounded-[2.5rem] ${group.popular ? "border-primary shadow-lg scale-105" : "border-border"}`}
                     >
-                      {text}
-                    </Button>
+                      {group.popular && (
+                        <Badge className="absolute -top-3 left-1/2 transform -translate-x-1/2">Am beliebtesten</Badge>
+                      )}
 
-                    <ul className="space-y-3">
-                      {group.features.map((feature, featureIndex) => (
-                        <li key={featureIndex} className="flex items-start gap-3 text-sm">
-                          <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-accent/10 text-accent">
-                            <Check className="h-3.5 w-3.5" />
-                          </span>
-                          <span>{feature}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  </CardContent>
-                </Card>
-              );
-            })}
-          </div>
+                      <CardHeader className="text-center pb-8">
+                        <CardTitle className="text-xl font-semibold">{group.productName}</CardTitle>
+                        <div className="mt-4 flex flex-col items-center">
+                          <div className="flex items-end justify-center gap-1">
+                            <AnimatedPrice
+                              key={billingCycle}
+                              value={`${formatDisplayPrice(planToDisplay.price, planToDisplay.currency, planToDisplay.interval)} €`}
+                              className="text-4xl font-bold"
+                            />
+                            <span className="mb-1 text-sm text-muted-foreground">
+                              /{billingCycle === "monthly" ? "Monat" : "Jahr"}
+                            </span>
+                          </div>
+                        </div>
+                        <CardDescription className="mt-4 text-center text-sm leading-relaxed text-muted-foreground">
+                          {group.description || `Unser ${group.productName} Plan.`}
+                        </CardDescription>
+                      </CardHeader>
 
-          {isTrialEligible && (
-            <div className="text-center mt-12">
-              <p className="text-muted-foreground">Alle Pläne beinhalten eine 14-tägige kostenlose Testversion. Keine Kreditkarte erforderlich.</p>
-            </div>
-          )}
+                      <CardContent className="grow flex flex-col gap-6">
+                        <Button
+                          onClick={() => {
+                            trackPricingPlanSelected(
+                              group.productName,
+                              planToDisplay.priceId,
+                              billingCycle,
+                              planToDisplay.price / 100,
+                              planToDisplay.currency
+                            )
+                            onSelectPlan(planToDisplay.priceId)
+                          }}
+                          className="w-full rounded-xl"
+                          variant={group.popular ? "default" : "outline"}
+                          size="lg"
+                          disabled={disabled}
+                        >
+                          {text}
+                        </Button>
 
-          {showComparison && <ComparisonTable
-            plans={groupedPlans}
-            billingCycle={billingCycle}
-            onSelectPlan={onSelectPlan}
-            getButtonTextAndState={getButtonTextAndState}
-          />}
+                        <ul className="space-y-3">
+                          {group.features.map((feature, featureIndex) => (
+                            <li key={featureIndex} className="flex items-start gap-3 text-sm">
+                              <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-accent/10 text-accent">
+                                <Check className="h-3.5 w-3.5" />
+                              </span>
+                              <span>{feature}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      </CardContent>
+                    </Card>
+                  );
+                })}
+              </div>
 
-          {showViewAllButton && (
-            <div className="text-center mt-16">
-              <Button
-                size="lg"
-                variant="outline"
-                className="px-12 py-6 text-xl font-semibold group text-foreground hover:bg-muted hover:text-foreground transition-all duration-300 ease-in-out transform hover:scale-105 hover:shadow-lg rounded-full"
-                onClick={() => {
-                  trackPricingViewAllClicked()
-                  router.push('/preise')
-                }}
-              >
-                <span className="flex items-center gap-2">
-                  Alle Preise und Pläne ansehen
-                  <SquareArrowOutUpRight className="w-5 h-5 group-hover:scale-110 transition-transform duration-300" />
-                </span>
-              </Button>
-            </div>
+              {isTrialEligible && (
+                <div className="text-center mt-12">
+                  <p className="text-muted-foreground">Alle Pläne beinhalten eine 14-tägige kostenlose Testversion. Keine Kreditkarte erforderlich.</p>
+                </div>
+              )}
+
+              {showComparison && <ComparisonTable
+                plans={groupedPlans}
+                billingCycle={billingCycle}
+                onSelectPlan={onSelectPlan}
+                getButtonTextAndState={getButtonTextAndState}
+              />}
+
+              {showViewAllButton && (
+                <div className="text-center mt-16">
+                  <Button
+                    size="lg"
+                    variant="outline"
+                    className="px-12 py-6 text-xl font-semibold group text-foreground hover:bg-muted hover:text-foreground transition-all duration-300 ease-in-out transform hover:scale-105 hover:shadow-lg rounded-full"
+                    onClick={() => {
+                      trackPricingViewAllClicked()
+                      router.push('/preise')
+                    }}
+                  >
+                    <span className="flex items-center gap-2">
+                      Alle Preise und Pläne ansehen
+                      <SquareArrowOutUpRight className="w-5 h-5 group-hover:scale-110 transition-transform duration-300" />
+                    </span>
+                  </Button>
+                </div>
+              )}
+            </>
           )}
         </div>
       </section>

--- a/app/modern/components/pricing.tsx
+++ b/app/modern/components/pricing.tsx
@@ -14,8 +14,9 @@ import {
 } from '@/components/ui/card';
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Check, Minus, HelpCircle, SquareArrowOutUpRight, Sparkles } from "lucide-react";
-import { useEffect, useState, useMemo, Fragment } from 'react';
+import { Check, Minus, HelpCircle, SquareArrowOutUpRight, Sparkles, WifiOff, RotateCw } from "lucide-react";
+import { useEffect, useState, useMemo, useCallback, Fragment } from 'react';
+import { posthogLogger } from "@/lib/posthog-logger";
 import { motion } from "framer-motion";
 import { WaitlistButton } from './waitlist-button';
 import { FAQ } from './faq';
@@ -332,29 +333,34 @@ export default function Pricing({
     setIsMounted(true);
   }, []);
 
-  useEffect(() => {
-    const fetchPlans = async () => {
-      setIsLoadingPlans(true);
-      setError(null);
-      try {
-        const response = await fetch('/api/stripe/plans');
-        if (!response.ok) {
-          const errorData = await response.json();
-          throw new Error(errorData.error || `Failed to fetch plans: ${response.status}`);
-        }
-        // productName now comes directly from the API
-        const data: Plan[] = await response.json();
-        setAllPlans(data);
-      } catch (err) {
-        console.error(err);
-        setError((err as Error).message || 'An unexpected error occurred');
-      } finally {
-        setIsLoadingPlans(false);
+  const fetchPlans = useCallback(async () => {
+    setIsLoadingPlans(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/stripe/plans');
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        const message = errorData.error || `Failed to fetch plans: ${response.status}`;
+        throw new Error(message);
       }
-    };
-
-    fetchPlans();
+      const data: Plan[] = await response.json();
+      setAllPlans(data);
+    } catch (err) {
+      const errorMessage = (err as Error).message || 'An unexpected error occurred';
+      console.error(err);
+      setError(errorMessage);
+      posthogLogger.error('Pricing plans could not be loaded on frontend', {
+        error: errorMessage,
+        component: 'Pricing',
+      });
+    } finally {
+      setIsLoadingPlans(false);
+    }
   }, []);
+
+  useEffect(() => {
+    fetchPlans();
+  }, [fetchPlans]);
 
   const groupedPlans = useMemo(() => {
     const groups: Record<string, GroupedPlan> = {};
@@ -547,21 +553,33 @@ export default function Pricing({
     );
   }
 
-  if (error) {
+  if (error || (groupedPlans.length === 0 && !isLoadingPlans)) {
     return (
-      <section className="py-16 px-4 text-foreground">
-        <div className="max-w-6xl mx-auto text-center text-destructive">
-          <p>Error loading plans: {error}</p>
-        </div>
-      </section>
-    );
-  }
+      <section className="py-24 px-4 relative overflow-hidden">
+        <div className="max-w-md mx-auto text-center">
+          <Card className="border-destructive/20 bg-card/50 backdrop-blur-xs shadow-xl rounded-[2.5rem] p-8 sm:p-10">
+            <CardContent className="flex flex-col items-center text-center space-y-6 p-0">
+              <div className="rounded-full bg-destructive/10 p-4 ring-1 ring-destructive/20 text-destructive">
+                <WifiOff className="w-10 h-10" />
+              </div>
 
-  if (groupedPlans.length === 0 && !isLoadingPlans) {
-    return (
-      <section className="py-16 px-4 text-foreground">
-        <div className="max-w-6xl mx-auto text-center">
-          <p>No subscription plans are currently available. Please check back later.</p>
+              <div className="space-y-2 max-w-sm">
+                <h3 className="text-2xl font-bold tracking-tight">Verbindung fehlgeschlagen</h3>
+                <p className="text-muted-foreground text-sm leading-relaxed">
+                  Die Preisinformationen konnten derzeit nicht geladen werden. Bitte überprüfen Sie Ihre Netzwerkverbindung oder versuchen Sie es später erneut.
+                </p>
+              </div>
+
+              <Button
+                onClick={() => fetchPlans()}
+                variant="outline"
+                className="rounded-xl gap-2 mt-2"
+              >
+                <RotateCw className="w-4 h-4" />
+                Erneut versuchen
+              </Button>
+            </CardContent>
+          </Card>
         </div>
       </section>
     );

--- a/app/modern/components/pricing.tsx
+++ b/app/modern/components/pricing.tsx
@@ -553,7 +553,7 @@ export default function Pricing({
     );
   }
 
-  if (error || (groupedPlans.length === 0 && !isLoadingPlans)) {
+  if (error) {
     return (
       <section className="py-24 px-4 relative overflow-hidden">
         <div className="max-w-md mx-auto text-center">
@@ -571,12 +571,40 @@ export default function Pricing({
               </div>
 
               <Button
-                onClick={() => fetchPlans()}
+                onClick={fetchPlans}
                 variant="outline"
                 className="rounded-xl gap-2 mt-2"
               >
                 <RotateCw className="w-4 h-4" />
                 Erneut versuchen
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+    );
+  }
+
+  if (groupedPlans.length === 0 && !isLoadingPlans) {
+    return (
+      <section className="py-24 px-4 relative overflow-hidden">
+        <div className="max-w-md mx-auto text-center">
+          <Card className="border-border/60 bg-card/50 backdrop-blur-xs shadow-xl rounded-[2.5rem] p-8 sm:p-10">
+            <CardContent className="flex flex-col items-center text-center space-y-6 p-0">
+              <div className="space-y-2 max-w-sm">
+                <h3 className="text-2xl font-bold tracking-tight">Keine Tarife verfügbar</h3>
+                <p className="text-muted-foreground text-sm leading-relaxed">
+                  Derzeit sind keine Abonnement-Pläne verfügbar. Bitte schauen Sie zu einem späteren Zeitpunkt wieder vorbei.
+                </p>
+              </div>
+
+              <Button
+                onClick={fetchPlans}
+                variant="outline"
+                className="rounded-xl gap-2 mt-2"
+              >
+                <RotateCw className="w-4 h-4" />
+                Aktualisieren
               </Button>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary

- Removed hardcoded mock fallback pricing plans (`price_mock_starter`, `price_mock_pro`) from `/api/stripe/plans`.
- Emitted OpenTelemetry error logs to PostHog via `posthogLogger.error` whenever loading pricing plans fails on backend or frontend.
- Added a clean "Verbindung fehlgeschlagen" container with a `WifiOff` icon and an "Erneut versuchen" (retry) button in `Pricing` component.
- Added comprehensive unit tests in `pricing.test.tsx` verifying the connection error state and OTel logger invocation.