### PR TITLE
feat(settings): Phase 4 – API-Keys Management UI & Lifecycle Routes

### DIFF
--- a/app/(dashboard)/einstellungen/api-keys/page.tsx
+++ b/app/(dashboard)/einstellungen/api-keys/page.tsx
@@ -1,0 +1,25 @@
+import { Suspense } from "react";
+import { redirect } from "next/navigation";
+import { createClient } from "@/utils/supabase/server";
+import ApiKeysSection from "@/components/settings/api-keys-section";
+import { SettingsSectionSkeleton } from "@/components/settings/section-skeletons";
+
+export const instant = false;
+
+export default async function ApiKeysPage() {
+  const supabase = await createClient();
+  const { data: orgData } = await supabase
+    .from("Organisation")
+    .select("api_zugriff_aktiviert")
+    .single();
+
+  if (!orgData?.api_zugriff_aktiviert) {
+    redirect("/einstellungen/profil");
+  }
+
+  return (
+    <Suspense fallback={<SettingsSectionSkeleton />}>
+      <ApiKeysSection />
+    </Suspense>
+  );
+}

--- a/app/(dashboard)/einstellungen/layout.tsx
+++ b/app/(dashboard)/einstellungen/layout.tsx
@@ -1,5 +1,6 @@
-import type { Metadata } from "next"
-import { SettingsLayoutClient } from "./settings-layout-client"
+import type { Metadata } from "next";
+import { createClient } from "@/utils/supabase/server";
+import { SettingsLayoutClient } from "./settings-layout-client";
 
 // TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
 // See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
@@ -10,8 +11,20 @@ export const metadata: Metadata = {
     index: false,
     follow: false,
   },
-}
+};
 
-export default function EinstellungenLayout({ children }: { children: React.ReactNode }) {
-  return <SettingsLayoutClient>{children}</SettingsLayoutClient>
+export default async function EinstellungenLayout({ children }: { children: React.ReactNode }) {
+  const supabase = await createClient();
+  const { data: orgData } = await supabase
+    .from("Organisation")
+    .select("api_zugriff_aktiviert")
+    .single();
+
+  const apiZugriffAktiviert = orgData?.api_zugriff_aktiviert ?? false;
+
+  return (
+    <SettingsLayoutClient apiZugriffAktiviert={apiZugriffAktiviert}>
+      {children}
+    </SettingsLayoutClient>
+  );
 }

--- a/app/(dashboard)/einstellungen/settings-layout-client.tsx
+++ b/app/(dashboard)/einstellungen/settings-layout-client.tsx
@@ -13,11 +13,17 @@ import {
   FlaskConical,
   Mail,
   Brain,
+  Key,
 } from "lucide-react"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { POSTHOG_FEATURE_FLAGS } from "@/lib/constants"
 
-export function SettingsLayoutClient({ children }: { children: React.ReactNode }) {
+interface SettingsLayoutClientProps {
+  children: React.ReactNode
+  apiZugriffAktiviert?: boolean
+}
+
+export function SettingsLayoutClient({ children, apiZugriffAktiviert = false }: SettingsLayoutClientProps) {
   const mailsEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.MAILS_TAB)
   const aiAgentEnabled = useFeatureFlagEnabled(POSTHOG_FEATURE_FLAGS.MIETEVO_AI_AGENT)
 
@@ -28,12 +34,13 @@ export function SettingsLayoutClient({ children }: { children: React.ReactNode }
       { value: "abo", label: "Abo", icon: CreditCard },
       ...(mailsEnabled ? [{ value: "mail", label: "E-Mail", icon: Mail }] : []),
       { value: "darstellung", label: "Darstellung", icon: Monitor },
+      ...(apiZugriffAktiviert ? [{ value: "api-keys", label: "API-Keys", icon: Key }] : []),
       { value: "datenexport", label: "Datenexport", icon: DownloadCloud },
       { value: "vorschau", label: "Vorschau", icon: FlaskConical },
       ...(aiAgentEnabled ? [{ value: "ki", label: "KI", icon: Brain }] : []),
       { value: "mietevo", label: "Mietevo", icon: Info },
     ],
-    [mailsEnabled, aiAgentEnabled],
+    [mailsEnabled, aiAgentEnabled, apiZugriffAktiviert],
   )
 
   return (

--- a/app/api/einstellungen/api-keys/[id]/ablehnen/route.ts
+++ b/app/api/einstellungen/api-keys/[id]/ablehnen/route.ts
@@ -25,8 +25,8 @@ export async function POST(
     }
 
     return NextResponse.json({ success: true }, { headers: NO_CACHE_HEADERS });
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error("Exception in POST api-keys/ablehnen:", err);
-    return NextResponse.json({ error: err.message || "Interner Serverfehler" }, { status: 500, headers: NO_CACHE_HEADERS });
+    return NextResponse.json({ error: "Ein interner Serverfehler ist aufgetreten." }, { status: 500, headers: NO_CACHE_HEADERS });
   }
 }

--- a/app/api/einstellungen/api-keys/[id]/ablehnen/route.ts
+++ b/app/api/einstellungen/api-keys/[id]/ablehnen/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/utils/supabase/server";
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    if (!id) {
+      return NextResponse.json({ error: "Key ID fehlt." }, { status: 400, headers: NO_CACHE_HEADERS });
+    }
+
+    const supabase = await createClient();
+    const { data: userData, error: userError } = await supabase.auth.getUser();
+    if (userError || !userData?.user) {
+      return NextResponse.json({ error: "Nicht authentifiziert" }, { status: 401, headers: NO_CACHE_HEADERS });
+    }
+
+    const { error } = await supabase.rpc("api_key_ablehnen", { p_key_id: id });
+    if (error) {
+      console.error("Error in api_key_ablehnen RPC:", error);
+      return NextResponse.json({ error: error.message }, { status: 400, headers: NO_CACHE_HEADERS });
+    }
+
+    return NextResponse.json({ success: true }, { headers: NO_CACHE_HEADERS });
+  } catch (err: any) {
+    console.error("Exception in POST api-keys/ablehnen:", err);
+    return NextResponse.json({ error: err.message || "Interner Serverfehler" }, { status: 500, headers: NO_CACHE_HEADERS });
+  }
+}

--- a/app/api/einstellungen/api-keys/[id]/fortsetzen/route.ts
+++ b/app/api/einstellungen/api-keys/[id]/fortsetzen/route.ts
@@ -25,8 +25,8 @@ export async function POST(
     }
 
     return NextResponse.json({ success: true }, { headers: NO_CACHE_HEADERS });
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error("Exception in POST api-keys/fortsetzen:", err);
-    return NextResponse.json({ error: err.message || "Interner Serverfehler" }, { status: 500, headers: NO_CACHE_HEADERS });
+    return NextResponse.json({ error: "Ein interner Serverfehler ist aufgetreten." }, { status: 500, headers: NO_CACHE_HEADERS });
   }
 }

--- a/app/api/einstellungen/api-keys/[id]/fortsetzen/route.ts
+++ b/app/api/einstellungen/api-keys/[id]/fortsetzen/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/utils/supabase/server";
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    if (!id) {
+      return NextResponse.json({ error: "Key ID fehlt." }, { status: 400, headers: NO_CACHE_HEADERS });
+    }
+
+    const supabase = await createClient();
+    const { data: userData, error: userError } = await supabase.auth.getUser();
+    if (userError || !userData?.user) {
+      return NextResponse.json({ error: "Nicht authentifiziert" }, { status: 401, headers: NO_CACHE_HEADERS });
+    }
+
+    const { error } = await supabase.rpc("api_key_fortsetzen", { p_key_id: id });
+    if (error) {
+      console.error("Error in api_key_fortsetzen RPC:", error);
+      return NextResponse.json({ error: error.message }, { status: 400, headers: NO_CACHE_HEADERS });
+    }
+
+    return NextResponse.json({ success: true }, { headers: NO_CACHE_HEADERS });
+  } catch (err: any) {
+    console.error("Exception in POST api-keys/fortsetzen:", err);
+    return NextResponse.json({ error: err.message || "Interner Serverfehler" }, { status: 500, headers: NO_CACHE_HEADERS });
+  }
+}

--- a/app/api/einstellungen/api-keys/[id]/genehmigen/route.ts
+++ b/app/api/einstellungen/api-keys/[id]/genehmigen/route.ts
@@ -46,8 +46,8 @@ export async function POST(
       },
       { headers: NO_CACHE_HEADERS }
     );
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error("Exception in POST api-keys/genehmigen:", err);
-    return NextResponse.json({ error: err.message || "Interner Serverfehler" }, { status: 500, headers: NO_CACHE_HEADERS });
+    return NextResponse.json({ error: "Ein interner Serverfehler ist aufgetreten." }, { status: 500, headers: NO_CACHE_HEADERS });
   }
 }

--- a/app/api/einstellungen/api-keys/[id]/genehmigen/route.ts
+++ b/app/api/einstellungen/api-keys/[id]/genehmigen/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/utils/supabase/server";
+import { generateApiKeySecret } from "@/lib/api-keys";
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    if (!id) {
+      return NextResponse.json({ error: "Key ID fehlt." }, { status: 400, headers: NO_CACHE_HEADERS });
+    }
+
+    const supabase = await createClient();
+    const { data: userData, error: userError } = await supabase.auth.getUser();
+    if (userError || !userData?.user) {
+      return NextResponse.json({ error: "Nicht authentifiziert" }, { status: 401, headers: NO_CACHE_HEADERS });
+    }
+
+    const body = await request.json();
+    const { berechtigungen, environment } = body;
+
+    // Generate plain secret, hash, and prefix securely on the server
+    const { plaintext, key_hash, key_prefix } = generateApiKeySecret(environment === "test" ? "test" : "live");
+
+    const { data, error } = await supabase.rpc("api_key_genehmigen", {
+      p_key_id: id,
+      p_berechtigungen: berechtigungen || {},
+      p_key_hash: key_hash,
+      p_key_prefix: key_prefix,
+    });
+
+    if (error) {
+      console.error("Error in api_key_genehmigen RPC:", error);
+      return NextResponse.json({ error: error.message }, { status: 400, headers: NO_CACHE_HEADERS });
+    }
+
+    // Return the plaintext secret ONCE to the approving admin
+    return NextResponse.json(
+      {
+        ...data,
+        plaintext,
+        key_prefix,
+      },
+      { headers: NO_CACHE_HEADERS }
+    );
+  } catch (err: any) {
+    console.error("Exception in POST api-keys/genehmigen:", err);
+    return NextResponse.json({ error: err.message || "Interner Serverfehler" }, { status: 500, headers: NO_CACHE_HEADERS });
+  }
+}

--- a/app/api/einstellungen/api-keys/[id]/pausieren/route.ts
+++ b/app/api/einstellungen/api-keys/[id]/pausieren/route.ts
@@ -25,8 +25,8 @@ export async function POST(
     }
 
     return NextResponse.json({ success: true }, { headers: NO_CACHE_HEADERS });
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error("Exception in POST api-keys/pausieren:", err);
-    return NextResponse.json({ error: err.message || "Interner Serverfehler" }, { status: 500, headers: NO_CACHE_HEADERS });
+    return NextResponse.json({ error: "Ein interner Serverfehler ist aufgetreten." }, { status: 500, headers: NO_CACHE_HEADERS });
   }
 }

--- a/app/api/einstellungen/api-keys/[id]/pausieren/route.ts
+++ b/app/api/einstellungen/api-keys/[id]/pausieren/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/utils/supabase/server";
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    if (!id) {
+      return NextResponse.json({ error: "Key ID fehlt." }, { status: 400, headers: NO_CACHE_HEADERS });
+    }
+
+    const supabase = await createClient();
+    const { data: userData, error: userError } = await supabase.auth.getUser();
+    if (userError || !userData?.user) {
+      return NextResponse.json({ error: "Nicht authentifiziert" }, { status: 401, headers: NO_CACHE_HEADERS });
+    }
+
+    const { error } = await supabase.rpc("api_key_pausieren", { p_key_id: id });
+    if (error) {
+      console.error("Error in api_key_pausieren RPC:", error);
+      return NextResponse.json({ error: error.message }, { status: 400, headers: NO_CACHE_HEADERS });
+    }
+
+    return NextResponse.json({ success: true }, { headers: NO_CACHE_HEADERS });
+  } catch (err: any) {
+    console.error("Exception in POST api-keys/pausieren:", err);
+    return NextResponse.json({ error: err.message || "Interner Serverfehler" }, { status: 500, headers: NO_CACHE_HEADERS });
+  }
+}

--- a/app/api/einstellungen/api-keys/[id]/route.ts
+++ b/app/api/einstellungen/api-keys/[id]/route.ts
@@ -25,8 +25,8 @@ export async function DELETE(
     }
 
     return NextResponse.json({ success: true }, { headers: NO_CACHE_HEADERS });
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error("Exception in DELETE api-keys/[id]:", err);
-    return NextResponse.json({ error: err.message || "Interner Serverfehler" }, { status: 500, headers: NO_CACHE_HEADERS });
+    return NextResponse.json({ error: "Ein interner Serverfehler ist aufgetreten." }, { status: 500, headers: NO_CACHE_HEADERS });
   }
 }

--- a/app/api/einstellungen/api-keys/[id]/route.ts
+++ b/app/api/einstellungen/api-keys/[id]/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/utils/supabase/server";
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    if (!id) {
+      return NextResponse.json({ error: "Key ID fehlt." }, { status: 400, headers: NO_CACHE_HEADERS });
+    }
+
+    const supabase = await createClient();
+    const { data: userData, error: userError } = await supabase.auth.getUser();
+    if (userError || !userData?.user) {
+      return NextResponse.json({ error: "Nicht authentifiziert" }, { status: 401, headers: NO_CACHE_HEADERS });
+    }
+
+    const { error } = await supabase.rpc("api_key_loeschen", { p_key_id: id });
+    if (error) {
+      console.error("Error in api_key_loeschen RPC:", error);
+      return NextResponse.json({ error: error.message }, { status: 400, headers: NO_CACHE_HEADERS });
+    }
+
+    return NextResponse.json({ success: true }, { headers: NO_CACHE_HEADERS });
+  } catch (err: any) {
+    console.error("Exception in DELETE api-keys/[id]:", err);
+    return NextResponse.json({ error: err.message || "Interner Serverfehler" }, { status: 500, headers: NO_CACHE_HEADERS });
+  }
+}

--- a/app/api/einstellungen/api-keys/[id]/widerrufen/route.ts
+++ b/app/api/einstellungen/api-keys/[id]/widerrufen/route.ts
@@ -25,8 +25,8 @@ export async function POST(
     }
 
     return NextResponse.json({ success: true }, { headers: NO_CACHE_HEADERS });
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error("Exception in POST api-keys/widerrufen:", err);
-    return NextResponse.json({ error: err.message || "Interner Serverfehler" }, { status: 500, headers: NO_CACHE_HEADERS });
+    return NextResponse.json({ error: "Ein interner Serverfehler ist aufgetreten." }, { status: 500, headers: NO_CACHE_HEADERS });
   }
 }

--- a/app/api/einstellungen/api-keys/[id]/widerrufen/route.ts
+++ b/app/api/einstellungen/api-keys/[id]/widerrufen/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/utils/supabase/server";
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    if (!id) {
+      return NextResponse.json({ error: "Key ID fehlt." }, { status: 400, headers: NO_CACHE_HEADERS });
+    }
+
+    const supabase = await createClient();
+    const { data: userData, error: userError } = await supabase.auth.getUser();
+    if (userError || !userData?.user) {
+      return NextResponse.json({ error: "Nicht authentifiziert" }, { status: 401, headers: NO_CACHE_HEADERS });
+    }
+
+    const { error } = await supabase.rpc("api_key_widerrufen", { p_key_id: id });
+    if (error) {
+      console.error("Error in api_key_widerrufen RPC:", error);
+      return NextResponse.json({ error: error.message }, { status: 400, headers: NO_CACHE_HEADERS });
+    }
+
+    return NextResponse.json({ success: true }, { headers: NO_CACHE_HEADERS });
+  } catch (err: any) {
+    console.error("Exception in POST api-keys/widerrufen:", err);
+    return NextResponse.json({ error: err.message || "Interner Serverfehler" }, { status: 500, headers: NO_CACHE_HEADERS });
+  }
+}

--- a/app/api/einstellungen/api-keys/route.ts
+++ b/app/api/einstellungen/api-keys/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/utils/supabase/server";
+import { NO_CACHE_HEADERS } from "@/lib/constants/http";
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    const { data: userData, error: userError } = await supabase.auth.getUser();
+    if (userError || !userData?.user) {
+      return NextResponse.json({ error: "Nicht authentifiziert" }, { status: 401, headers: NO_CACHE_HEADERS });
+    }
+
+    const { data, error } = await supabase.rpc("api_keys_liste");
+    if (error) {
+      console.error("Error in api_keys_liste RPC:", error);
+      return NextResponse.json({ error: error.message }, { status: 500, headers: NO_CACHE_HEADERS });
+    }
+
+    return NextResponse.json(data || [], { headers: NO_CACHE_HEADERS });
+  } catch (err: any) {
+    console.error("Exception in GET /api/einstellungen/api-keys:", err);
+    return NextResponse.json({ error: err.message || "Interner Serverfehler" }, { status: 500, headers: NO_CACHE_HEADERS });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const { data: userData, error: userError } = await supabase.auth.getUser();
+    if (userError || !userData?.user) {
+      return NextResponse.json({ error: "Nicht authentifiziert" }, { status: 401, headers: NO_CACHE_HEADERS });
+    }
+
+    const body = await request.json();
+    const { name, angefragte_berechtigungen, environment, expires_at } = body;
+
+    if (!name || typeof name !== "string" || name.trim().length === 0) {
+      return NextResponse.json({ error: "Ein Name für den API-Key ist erforderlich." }, { status: 400, headers: NO_CACHE_HEADERS });
+    }
+
+    const { data: keyId, error } = await supabase.rpc("api_key_anfragen", {
+      p_name: name.trim(),
+      p_angefragte_berechtigungen: angefragte_berechtigungen || null,
+      p_environment: environment || "live",
+      p_expires_at: expires_at || null,
+    });
+
+    if (error) {
+      console.error("Error in api_key_anfragen RPC:", error);
+      return NextResponse.json({ error: error.message }, { status: 400, headers: NO_CACHE_HEADERS });
+    }
+
+    return NextResponse.json({ id: keyId, success: true }, { status: 201, headers: NO_CACHE_HEADERS });
+  } catch (err: any) {
+    console.error("Exception in POST /api/einstellungen/api-keys:", err);
+    return NextResponse.json({ error: err.message || "Interner Serverfehler" }, { status: 500, headers: NO_CACHE_HEADERS });
+  }
+}

--- a/app/api/einstellungen/api-keys/route.ts
+++ b/app/api/einstellungen/api-keys/route.ts
@@ -17,9 +17,9 @@ export async function GET() {
     }
 
     return NextResponse.json(data || [], { headers: NO_CACHE_HEADERS });
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error("Exception in GET /api/einstellungen/api-keys:", err);
-    return NextResponse.json({ error: err.message || "Interner Serverfehler" }, { status: 500, headers: NO_CACHE_HEADERS });
+    return NextResponse.json({ error: "Ein interner Serverfehler ist aufgetreten." }, { status: 500, headers: NO_CACHE_HEADERS });
   }
 }
 
@@ -62,8 +62,8 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.json({ id: keyId, success: true }, { status: 201, headers: NO_CACHE_HEADERS });
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error("Exception in POST /api/einstellungen/api-keys:", err);
-    return NextResponse.json({ error: err.message || "Interner Serverfehler" }, { status: 500, headers: NO_CACHE_HEADERS });
+    return NextResponse.json({ error: "Ein interner Serverfehler ist aufgetreten." }, { status: 500, headers: NO_CACHE_HEADERS });
   }
 }

--- a/app/api/einstellungen/api-keys/route.ts
+++ b/app/api/einstellungen/api-keys/route.ts
@@ -38,6 +38,17 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Ein Name für den API-Key ist erforderlich." }, { status: 400, headers: NO_CACHE_HEADERS });
     }
 
+    if (name.trim().length > 100) {
+      return NextResponse.json({ error: "Der Name des API-Keys darf maximal 100 Zeichen lang sein." }, { status: 400, headers: NO_CACHE_HEADERS });
+    }
+
+    if (expires_at) {
+      const expDate = new Date(expires_at);
+      if (isNaN(expDate.getTime()) || expDate.getTime() <= Date.now()) {
+        return NextResponse.json({ error: "Das Ablaufdatum muss in der Zukunft liegen." }, { status: 400, headers: NO_CACHE_HEADERS });
+      }
+    }
+
     const { data: keyId, error } = await supabase.rpc("api_key_anfragen", {
       p_name: name.trim(),
       p_angefragte_berechtigungen: angefragte_berechtigungen || null,

--- a/components/settings/api-keys-section.tsx
+++ b/components/settings/api-keys-section.tsx
@@ -1,0 +1,814 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  Key,
+  Plus,
+  Copy,
+  Check,
+  AlertTriangle,
+  RefreshCw,
+  Trash2,
+  XCircle,
+  Play,
+  Pause,
+  Clock,
+  CheckCircle2,
+  Info,
+  Calendar,
+  User,
+  Shield,
+  Activity,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useToast } from "@/hooks/use-toast";
+import { SettingsCard, SettingsSection } from "@/components/settings/shared";
+
+interface ApiKeyItem {
+  id: string;
+  organisation_id: string;
+  mitglied_id: string;
+  name: string;
+  key_prefix: string | null;
+  environment: "live" | "test";
+  status: "ausstehend" | "aktiv" | "abgelehnt" | "widerrufen" | "pausiert";
+  erstellt_von: string | null;
+  ersteller_email?: string | null;
+  ersteller_first_name?: string | null;
+  ersteller_last_name?: string | null;
+  angefragte_berechtigungen: any;
+  berechtigungen: any;
+  genehmigt_von: string | null;
+  genehmigt_von_email?: string | null;
+  genehmigt_von_first_name?: string | null;
+  genehmigt_von_last_name?: string | null;
+  genehmigt_am: string | null;
+  expires_at: string | null;
+  last_used_at: string | null;
+  pausiert_grund: string | null;
+  erstellt_am: string;
+  geaendert_am: string;
+  ersteller_status?: string;
+}
+
+const AVAILABLE_MODULES = [
+  { id: "haeuser", label: "Häuser" },
+  { id: "wohnungen", label: "Wohnungen" },
+  { id: "mieter", label: "Mieter" },
+  { id: "finanzen", label: "Finanzen" },
+  { id: "aufgaben", label: "Aufgaben" },
+  { id: "zaehler", label: "Zähler" },
+  { id: "zaehler_ablesungen", label: "Zählerablesungen" },
+];
+
+const AVAILABLE_ACTIONS = [
+  { id: "ansehen", label: "Lesen" },
+  { id: "erstellen", label: "Erstellen" },
+  { id: "bearbeiten", label: "Bearbeiten" },
+  { id: "loeschen", label: "Löschen" },
+];
+
+export default function ApiKeysSection() {
+  const { toast } = useToast();
+  const [keys, setKeys] = useState<ApiKeyItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Modals state
+  const [requestModalOpen, setRequestModalOpen] = useState(false);
+  const [approveModalOpen, setApproveModalOpen] = useState(false);
+  const [secretModalOpen, setSecretModalOpen] = useState(false);
+
+  // Form states
+  const [keyName, setKeyName] = useState("");
+  const [environment, setEnvironment] = useState<"live" | "test">("live");
+  const [expiresAt, setExpiresAt] = useState("");
+  const [selectedModules, setSelectedModules] = useState<Record<string, Record<string, boolean>>>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  // Approval state
+  const [selectedKeyForApproval, setSelectedKeyForApproval] = useState<ApiKeyItem | null>(null);
+  const [approvalPermissions, setApprovalPermissions] = useState<Record<string, Record<string, boolean>>>({});
+
+  // Secret display state
+  const [revealedSecret, setRevealedSecret] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const fetchKeys = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await fetch("/api/einstellungen/api-keys");
+      if (res.ok) {
+        const data = await res.json();
+        setKeys(Array.isArray(data) ? data : []);
+      }
+    } catch (err) {
+      console.error("Failed to fetch API keys:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchKeys();
+  }, [fetchKeys]);
+
+  const handleRequestKey = async () => {
+    if (!keyName.trim()) {
+      toast({
+        title: "Fehler",
+        description: "Bitte geben Sie einen Namen für den API-Key ein.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      const payload = {
+        name: keyName.trim(),
+        environment,
+        expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
+        angefragte_berechtigungen: {
+          module: selectedModules,
+        },
+      };
+
+      const res = await fetch("/api/einstellungen/api-keys", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      const json = await res.json();
+      if (!res.ok) {
+        throw new Error(json.error || "Fehler beim Beantragen des API-Keys.");
+      }
+
+      toast({
+        title: "Erfolg",
+        description: "API-Key wurde erfolgreich beantragt und wartet auf Genehmigung.",
+        variant: "success",
+      });
+
+      setRequestModalOpen(false);
+      setKeyName("");
+      setExpiresAt("");
+      setSelectedModules({});
+      fetchKeys();
+    } catch (err: any) {
+      toast({
+        title: "Fehler",
+        description: err.message || "Fehler beim Beantragen.",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleApproveKey = async () => {
+    if (!selectedKeyForApproval) return;
+
+    try {
+      setSubmitting(true);
+      const res = await fetch(`/api/einstellungen/api-keys/${selectedKeyForApproval.id}/genehmigen`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          berechtigungen: { module: approvalPermissions },
+          environment: selectedKeyForApproval.environment,
+        }),
+      });
+
+      const json = await res.json();
+      if (!res.ok) {
+        throw new Error(json.error || "Fehler bei der Genehmigung.");
+      }
+
+      setApproveModalOpen(false);
+      setRevealedSecret(json.plaintext);
+      setSecretModalOpen(true);
+      fetchKeys();
+    } catch (err: any) {
+      toast({
+        title: "Fehler",
+        description: err.message || "Fehler bei der Genehmigung.",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleRejectKey = async (id: string) => {
+    try {
+      const res = await fetch(`/api/einstellungen/api-keys/${id}/ablehnen`, { method: "POST" });
+      if (!res.ok) {
+        const json = await res.json();
+        throw new Error(json.error || "Fehler beim Ablehnen.");
+      }
+      toast({ title: "Abgelehnt", description: "API-Key wurde abgelehnt." });
+      fetchKeys();
+    } catch (err: any) {
+      toast({ title: "Fehler", description: err.message, variant: "destructive" });
+    }
+  };
+
+  const handleRevokeKey = async (id: string) => {
+    try {
+      const res = await fetch(`/api/einstellungen/api-keys/${id}/widerrufen`, { method: "POST" });
+      if (!res.ok) {
+        const json = await res.json();
+        throw new Error(json.error || "Fehler beim Widerrufen.");
+      }
+      toast({ title: "Widerrufen", description: "API-Key wurde widerrufen." });
+      fetchKeys();
+    } catch (err: any) {
+      toast({ title: "Fehler", description: err.message, variant: "destructive" });
+    }
+  };
+
+  const handlePauseKey = async (id: string) => {
+    try {
+      const res = await fetch(`/api/einstellungen/api-keys/${id}/pausieren`, { method: "POST" });
+      if (!res.ok) {
+        const json = await res.json();
+        throw new Error(json.error || "Fehler beim Deaktivieren des API-Keys.");
+      }
+      toast({ title: "Deaktiviert", description: "API-Key wurde erfolgreich pausiert/deaktiviert." });
+      fetchKeys();
+    } catch (err: any) {
+      toast({ title: "Fehler", description: err.message, variant: "destructive" });
+    }
+  };
+
+  const handleResumeKey = async (id: string) => {
+    try {
+      const res = await fetch(`/api/einstellungen/api-keys/${id}/fortsetzen`, { method: "POST" });
+      if (!res.ok) {
+        const json = await res.json();
+        throw new Error(json.error || "Fehler beim Fortsetzen.");
+      }
+      toast({ title: "Aktiviert", description: "API-Key wurde erfolgreich fortgesetzt." });
+      fetchKeys();
+    } catch (err: any) {
+      toast({ title: "Fehler", description: err.message, variant: "destructive" });
+    }
+  };
+
+  const handleDeleteKey = async (id: string) => {
+    try {
+      const res = await fetch(`/api/einstellungen/api-keys/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        const json = await res.json();
+        throw new Error(json.error || "Fehler beim Löschen.");
+      }
+      toast({ title: "Gelöscht", description: "API-Key wurde gelöscht." });
+      fetchKeys();
+    } catch (err: any) {
+      toast({ title: "Fehler", description: err.message, variant: "destructive" });
+    }
+  };
+
+  const openApprovalModal = (keyItem: ApiKeyItem) => {
+    setSelectedKeyForApproval(keyItem);
+    const requested = keyItem.angefragte_berechtigungen?.module || {};
+    setApprovalPermissions(JSON.parse(JSON.stringify(requested)));
+    setApproveModalOpen(true);
+  };
+
+  const copyToClipboard = () => {
+    if (revealedSecret) {
+      navigator.clipboard.writeText(revealedSecret);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 3000);
+      toast({ title: "Kopiert", description: "API-Key in die Zwischenablage kopiert." });
+    }
+  };
+
+  const renderStatusBadge = (status: ApiKeyItem["status"], pausiertGrund?: string | null) => {
+    switch (status) {
+      case "aktiv":
+        return <Badge className="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20">Aktiv</Badge>;
+      case "ausstehend":
+        return <Badge className="bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20">Ausstehend</Badge>;
+      case "pausiert":
+        return (
+          <Badge
+            className="bg-orange-500/10 text-orange-600 dark:text-orange-400 border-orange-500/20"
+            title={pausiertGrund === "ersteller_deaktiviert" ? "Ersteller deaktiviert — Prüfung nötig" : "Manuell deaktiviert"}
+          >
+            {pausiertGrund === "ersteller_deaktiviert" ? "Pausiert (Ersteller inaktiv)" : "Deaktiviert"}
+          </Badge>
+        );
+      case "widerrufen":
+        return <Badge variant="secondary">Widerrufen</Badge>;
+      case "abgelehnt":
+        return <Badge variant="destructive">Abgelehnt</Badge>;
+      default:
+        return <Badge variant="outline">{status}</Badge>;
+    }
+  };
+
+  const formatUserName = (firstName?: string | null, lastName?: string | null, email?: string | null) => {
+    const fullName = `${firstName || ""} ${lastName || ""}`.trim();
+    if (fullName) {
+      return email ? `${fullName} (${email})` : fullName;
+    }
+    return email || "Unbekannter Nutzer";
+  };
+
+  const renderPermissionsSummary = (permsObj: any) => {
+    if (!permsObj || !permsObj.module) return <span className="text-muted-foreground">Keine Module zugewiesen</span>;
+    const entries = Object.entries(permsObj.module).filter(([_, actions]: [string, any]) => {
+      if (Array.isArray(actions)) return actions.length > 0;
+      if (typeof actions === "object" && actions !== null) return Object.values(actions).some(Boolean);
+      return false;
+    });
+
+    if (entries.length === 0) return <span className="text-muted-foreground">Keine Berechtigungen</span>;
+
+    return (
+      <div className="flex flex-wrap gap-1 mt-1">
+        {entries.map(([modName, acts]: [string, any]) => {
+          const modDef = AVAILABLE_MODULES.find((m) => m.id === modName);
+          const label = modDef ? modDef.label : modName;
+          let actList = "";
+          if (Array.isArray(acts)) {
+            actList = acts.join(", ");
+          } else if (typeof acts === "object" && acts !== null) {
+            actList = Object.entries(acts)
+              .filter(([_, v]) => Boolean(v))
+              .map(([k]) => AVAILABLE_ACTIONS.find((a) => a.id === k)?.label || k)
+              .join(", ");
+          }
+          return (
+            <Badge key={modName} variant="secondary" className="text-[11px] font-normal py-0.5 px-2 bg-muted/60">
+              {label}: {actList || "Aktiv"}
+            </Badge>
+          );
+        })}
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      <SettingsSection
+        title="API-Schlüssel"
+        description="Verwalten Sie API-Schlüssel für den automatisierten und programmatischen Zugriff auf die Mietevo API."
+      >
+        <SettingsCard>
+          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 pb-4 border-b border-border/50">
+            <div>
+              <h4 className="font-semibold text-base">Aktive & Beantragte Schlüssel</h4>
+              <p className="text-xs text-muted-foreground">
+                Schlüssel werden kryptografisch abgesichert und Klartext-Secrets nur bei Genehmigung einmalig angezeigt.
+              </p>
+            </div>
+            <Button
+              onClick={() => {
+                setKeyName("");
+                setSelectedModules({
+                  haeuser: { ansehen: true },
+                  wohnungen: { ansehen: true },
+                });
+                setRequestModalOpen(true);
+              }}
+              className="gap-2 shrink-0"
+            >
+              <Plus className="h-4 w-4" />
+              API-Key beantragen
+            </Button>
+          </div>
+
+          {loading ? (
+            <div className="py-12 flex items-center justify-center text-muted-foreground gap-2">
+              <RefreshCw className="h-4 w-4 animate-spin" />
+              Lade API-Schlüssel...
+            </div>
+          ) : keys.length === 0 ? (
+            <div className="py-12 text-center text-muted-foreground space-y-3">
+              <Key className="h-10 w-10 mx-auto text-muted-foreground/40" />
+              <p className="text-sm font-medium">Bislang keine API-Keys vorhanden.</p>
+              <p className="text-xs">Beantragen Sie einen neuen Schlüssel, um den programmatischen Zugriff zu nutzen.</p>
+            </div>
+          ) : (
+            <div className="divide-y divide-border/40 mt-2">
+              {keys.map((k) => {
+                const creatorDisplayName = formatUserName(k.ersteller_first_name, k.ersteller_last_name, k.ersteller_email);
+                const approverDisplayName = formatUserName(k.genehmigt_von_first_name, k.genehmigt_von_last_name, k.genehmigt_von_email);
+
+                return (
+                  <div key={k.id} className="py-5 space-y-3">
+                    {/* Header line: Name, Badges & Action Buttons */}
+                    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+                      <div className="flex items-center gap-2.5 flex-wrap min-w-0">
+                        <div className="h-7 w-7 rounded-md bg-muted/80 flex items-center justify-center text-muted-foreground">
+                          <Key className="h-3.5 w-3.5" />
+                        </div>
+                        <span className="font-semibold text-sm truncate">{k.name}</span>
+                        {renderStatusBadge(k.status, k.pausiert_grund)}
+                        <Badge variant="outline" className="text-[10px] uppercase font-mono tracking-wider">
+                          {k.environment}
+                        </Badge>
+                        <span className="font-mono text-[11px] bg-muted/60 text-muted-foreground px-2 py-0.5 rounded border border-border/40">
+                          {k.key_prefix || "mie_••••••••••••"}
+                        </span>
+                      </div>
+
+                      <div className="flex items-center gap-2 self-end sm:self-center">
+                        {k.status === "ausstehend" && (
+                          <>
+                            <Button
+                              size="sm"
+                              variant="default"
+                              onClick={() => openApprovalModal(k)}
+                              className="h-8 text-xs font-medium"
+                            >
+                              Genehmigen
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => handleRejectKey(k.id)}
+                              className="h-8 text-xs text-destructive hover:bg-destructive/10"
+                            >
+                              Ablehnen
+                            </Button>
+                          </>
+                        )}
+
+                        {k.status === "aktiv" && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => handlePauseKey(k.id)}
+                            className="h-8 text-xs gap-1.5 text-orange-600 dark:text-orange-400 hover:bg-orange-500/10 border-orange-500/30"
+                          >
+                            <Pause className="h-3.5 w-3.5" />
+                            Deaktivieren
+                          </Button>
+                        )}
+
+                        {k.status === "pausiert" && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => handleResumeKey(k.id)}
+                            className="h-8 text-xs gap-1.5 text-emerald-600 dark:text-emerald-400 hover:bg-emerald-500/10 border-emerald-500/30"
+                          >
+                            <Play className="h-3.5 w-3.5" />
+                            Aktivieren
+                          </Button>
+                        )}
+
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+                              •••
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            {(k.status === "aktiv" || k.status === "pausiert") && (
+                              <DropdownMenuItem
+                                onClick={() => handleRevokeKey(k.id)}
+                                className="text-destructive gap-2 cursor-pointer"
+                              >
+                                <XCircle className="h-4 w-4" />
+                                Endgültig widerrufen
+                              </DropdownMenuItem>
+                            )}
+                            {(k.status === "abgelehnt" || k.status === "widerrufen") && (
+                              <DropdownMenuItem
+                                onClick={() => handleDeleteKey(k.id)}
+                                className="text-destructive gap-2 cursor-pointer"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                                Löschen
+                              </DropdownMenuItem>
+                            )}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </div>
+                    </div>
+
+                    {/* Paused alert info if applicable */}
+                    {k.status === "pausiert" && (
+                      <div className="p-2.5 rounded-md bg-orange-500/10 border border-orange-500/20 text-xs text-orange-800 dark:text-orange-300 flex items-start gap-2">
+                        <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5 text-orange-600 dark:text-orange-400" />
+                        <div>
+                          {k.pausiert_grund === "ersteller_deaktiviert" ? (
+                            <span>
+                              <strong>Automatisch pausiert:</strong> Das Mitgliedskonto des Antragstellers ist inaktiv/deaktiviert. Der Schlüssel kann erst nach Reaktivierung des Erstellers fortgesetzt werden.
+                            </span>
+                          ) : (
+                            <span>
+                              <strong>Schlüssel ist deaktiviert:</strong> Eingehende API-Anfragen mit diesem Schlüssel werden abgewiesen. Klicken Sie auf „Aktivieren“, um den Zugriff wieder freizuschalten.
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    )}
+
+                    {/* Metadata Grid: Creator, Approver, Usage & Permissions */}
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs bg-muted/20 border border-border/40 rounded-lg p-3">
+                      {/* Left: Antragsteller & Genehmigung */}
+                      <div className="space-y-1.5">
+                        <div className="flex items-center gap-1.5 text-foreground">
+                          <User className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                          <span className="font-medium">Beantragt von:</span>
+                          <span className="text-muted-foreground truncate">{creatorDisplayName}</span>
+                          {k.ersteller_status && k.ersteller_status !== "aktiv" && (
+                            <Badge variant="outline" className="text-[10px] text-destructive border-destructive/30 h-4 px-1.5">
+                              {k.ersteller_status}
+                            </Badge>
+                          )}
+                        </div>
+                        <div className="text-muted-foreground pl-5 text-[11px]">
+                          Beantragt am: {new Date(k.erstellt_am).toLocaleDateString("de-DE")}
+                        </div>
+
+                        {k.genehmigt_am && (
+                          <div className="flex items-center gap-1.5 text-foreground pt-1">
+                            <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
+                            <span className="font-medium">Genehmigt von:</span>
+                            <span className="text-muted-foreground truncate">{approverDisplayName}</span>
+                          </div>
+                        )}
+                      </div>
+
+                      {/* Right: Verwendung & Gültigkeit */}
+                      <div className="space-y-1.5">
+                        <div className="flex items-center gap-1.5 text-foreground">
+                          <Activity className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                          <span className="font-medium">Zuletzt aktiv:</span>
+                          <span className="text-muted-foreground">
+                            {k.last_used_at
+                              ? new Date(k.last_used_at).toLocaleDateString("de-DE", {
+                                  hour: "2-digit",
+                                  minute: "2-digit",
+                                  day: "2-digit",
+                                  month: "2-digit",
+                                  year: "numeric",
+                                })
+                              : "Noch nie verwendet"}
+                          </span>
+                        </div>
+
+                        <div className="flex items-center gap-1.5 text-foreground">
+                          <Calendar className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                          <span className="font-medium">Gültig bis:</span>
+                          <span className="text-muted-foreground">
+                            {k.expires_at ? new Date(k.expires_at).toLocaleDateString("de-DE") : "Unbegrenzt gültig"}
+                          </span>
+                        </div>
+                      </div>
+
+                      {/* Full width: Permissions Summary */}
+                      <div className="md:col-span-2 pt-2 border-t border-border/40">
+                        <div className="flex items-center gap-1.5 text-foreground mb-1">
+                          <Shield className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                          <span className="font-medium">
+                            {k.status === "ausstehend" ? "Angefragte Berechtigungen:" : "Aktive Berechtigungen:"}
+                          </span>
+                        </div>
+                        {renderPermissionsSummary(k.status === "ausstehend" ? k.angefragte_berechtigungen : k.berechtigungen)}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </SettingsCard>
+      </SettingsSection>
+
+      {/* REQUEST MODAL */}
+      <Dialog open={requestModalOpen} onOpenChange={setRequestModalOpen}>
+        <DialogContent className="sm:max-w-[550px]">
+          <DialogHeader>
+            <DialogTitle>API-Schlüssel beantragen</DialogTitle>
+            <DialogDescription>
+              Wählen Sie den gewünschten Namen und die benötigten Berechtigungen.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div className="space-y-1.5">
+              <label className="text-xs font-semibold">Name des Schlüssels</label>
+              <Input
+                placeholder="z. B. Buchhaltungs-Integration"
+                value={keyName}
+                onChange={(e) => setKeyName(e.target.value)}
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1.5">
+                <label className="text-xs font-semibold">Umgebung</label>
+                <select
+                  value={environment}
+                  onChange={(e) => setEnvironment(e.target.value as "live" | "test")}
+                  className="w-full h-9 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-xs"
+                >
+                  <option value="live">Live</option>
+                  <option value="test">Test</option>
+                </select>
+              </div>
+
+              <div className="space-y-1.5">
+                <label className="text-xs font-semibold">Ablaufdatum (optional)</label>
+                <Input
+                  type="date"
+                  value={expiresAt}
+                  onChange={(e) => setExpiresAt(e.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2 pt-2">
+              <label className="text-xs font-semibold">Angefragte Berechtigungen</label>
+              <div className="border border-border/60 rounded-lg p-3 space-y-3 bg-muted/20">
+                {AVAILABLE_MODULES.map((mod) => (
+                  <div key={mod.id} className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 text-xs">
+                    <span className="font-medium w-32">{mod.label}</span>
+                    <div className="flex items-center gap-4 flex-wrap">
+                      {AVAILABLE_ACTIONS.map((act) => {
+                        const isChecked = !!selectedModules[mod.id]?.[act.id];
+                        return (
+                          <label key={act.id} className="flex items-center gap-1.5 cursor-pointer">
+                            <Checkbox
+                              checked={isChecked}
+                              onCheckedChange={(val) => {
+                                setSelectedModules((prev) => ({
+                                  ...prev,
+                                  [mod.id]: {
+                                    ...(prev[mod.id] || {}),
+                                    [act.id]: !!val,
+                                  },
+                                }));
+                              }}
+                            />
+                            <span>{act.label}</span>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRequestModalOpen(false)}>
+              Abbrechen
+            </Button>
+            <Button onClick={handleRequestKey} disabled={submitting}>
+              {submitting ? "Beantrage..." : "Antrag absenden"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* APPROVE MODAL */}
+      <Dialog open={approveModalOpen} onOpenChange={setApproveModalOpen}>
+        <DialogContent className="sm:max-w-[600px]">
+          <DialogHeader>
+            <DialogTitle>API-Schlüssel genehmigen</DialogTitle>
+            <DialogDescription>
+              Prüfen und passen Sie den finalen Berechtigungsumfang für „{selectedKeyForApproval?.name}“ an.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div className="p-3 bg-blue-500/10 border border-blue-500/20 rounded-lg text-xs flex items-start gap-2.5 text-blue-700 dark:text-blue-300">
+              <Info className="h-4 w-4 shrink-0 mt-0.5" />
+              <span>
+                <strong>Hinweis zur Sicherheitsbegrenzung:</strong> Die gespeicherten Rechte werden serverseitig automatisch auf die effektiven Berechtigungen des Antragstellers begrenzt.
+              </span>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-xs font-semibold">Finaler Berechtigungsumfang</label>
+              <div className="border border-border/60 rounded-lg p-3 space-y-3 bg-muted/20">
+                {AVAILABLE_MODULES.map((mod) => (
+                  <div key={mod.id} className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 text-xs">
+                    <span className="font-medium w-32">{mod.label}</span>
+                    <div className="flex items-center gap-4 flex-wrap">
+                      {AVAILABLE_ACTIONS.map((act) => {
+                        const isChecked = !!approvalPermissions[mod.id]?.[act.id];
+                        return (
+                          <label key={act.id} className="flex items-center gap-1.5 cursor-pointer">
+                            <Checkbox
+                              checked={isChecked}
+                              onCheckedChange={(val) => {
+                                setApprovalPermissions((prev) => ({
+                                  ...prev,
+                                  [mod.id]: {
+                                    ...(prev[mod.id] || {}),
+                                    [act.id]: !!val,
+                                  },
+                                }));
+                              }}
+                            />
+                            <span>{act.label}</span>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setApproveModalOpen(false)}>
+              Abbrechen
+            </Button>
+            <Button onClick={handleApproveKey} disabled={submitting}>
+              {submitting ? "Genehmige..." : "Genehmigen & Secret generieren"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* ONE-TIME SECRET MODAL */}
+      <Dialog open={secretModalOpen} onOpenChange={setSecretModalOpen}>
+        <DialogContent className="sm:max-w-[500px]">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 text-emerald-600 dark:text-emerald-400">
+              <CheckCircle2 className="h-5 w-5" />
+              API-Key erfolgreich genehmigt!
+            </DialogTitle>
+            <DialogDescription>
+              Der Schlüssel wurde erstellt. Bitte kopieren Sie den Secret-Key jetzt.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <div className="p-3.5 bg-amber-500/10 border border-amber-500/20 rounded-lg text-xs flex items-start gap-2.5 text-amber-800 dark:text-amber-300">
+              <AlertTriangle className="h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400 mt-0.5" />
+              <div>
+                <p className="font-semibold">Wichtig: Einmalige Anzeige!</p>
+                <p className="mt-0.5">
+                  Dieser Schlüssel wird aus Sicherheitsgründen <strong>nur dieses eine Mal</strong> im Klartext angezeigt und nirgends in der Datenbank gespeichert.
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="text-xs font-semibold">Ihr API-Secret:</label>
+              <div className="flex items-center gap-2">
+                <Input
+                  readOnly
+                  value={revealedSecret || ""}
+                  className="font-mono text-xs bg-muted/60 select-all"
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={copyToClipboard}
+                  className="shrink-0 gap-1.5"
+                >
+                  {copied ? <Check className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
+                  {copied ? "Kopiert" : "Kopieren"}
+                </Button>
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              onClick={() => {
+                setSecretModalOpen(false);
+                setRevealedSecret(null);
+              }}
+            >
+              Ich habe den Schlüssel gespeichert
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/components/settings/api-keys-section.tsx
+++ b/components/settings/api-keys-section.tsx
@@ -63,14 +63,14 @@ export default function ApiKeysSection() {
     fetchKeys();
   };
 
-  const handleRejectKey = async (id: string) => {
+  const runAction = async (url: string, method: "POST" | "DELETE", title: string, description: string) => {
     try {
-      const res = await fetch(`/api/einstellungen/api-keys/${id}/ablehnen`, { method: "POST" });
+      const res = await fetch(url, { method });
       if (!res.ok) {
-        const json = await res.json();
-        throw new Error(json.error || "Fehler beim Ablehnen.");
+        const json = await res.json().catch(() => ({}));
+        throw new Error(json.error || "Fehler bei der Aktion.");
       }
-      toast({ title: "Abgelehnt", description: "API-Key wurde abgelehnt." });
+      toast({ title, description });
       fetchKeys();
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Fehler beim Ausführen.";
@@ -78,65 +78,25 @@ export default function ApiKeysSection() {
     }
   };
 
-  const handleRevokeKey = async (id: string) => {
-    try {
-      const res = await fetch(`/api/einstellungen/api-keys/${id}/widerrufen`, { method: "POST" });
-      if (!res.ok) {
-        const json = await res.json();
-        throw new Error(json.error || "Fehler beim Widerrufen.");
-      }
-      toast({ title: "Widerrufen", description: "API-Key wurde widerrufen." });
-      fetchKeys();
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : "Fehler beim Ausführen.";
-      toast({ title: "Fehler", description: msg, variant: "destructive" });
-    }
-  };
+  const handleRejectKey = (id: string) =>
+    runAction(`/api/einstellungen/api-keys/${id}/ablehnen`, "POST", "Abgelehnt", "API-Key wurde abgelehnt.");
 
-  const handlePauseKey = async (id: string) => {
-    try {
-      const res = await fetch(`/api/einstellungen/api-keys/${id}/pausieren`, { method: "POST" });
-      if (!res.ok) {
-        const json = await res.json();
-        throw new Error(json.error || "Fehler beim Deaktivieren des API-Keys.");
-      }
-      toast({ title: "Deaktiviert", description: "API-Key wurde erfolgreich pausiert/deaktiviert." });
-      fetchKeys();
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : "Fehler beim Ausführen.";
-      toast({ title: "Fehler", description: msg, variant: "destructive" });
-    }
-  };
+  const handleRevokeKey = (id: string) =>
+    runAction(`/api/einstellungen/api-keys/${id}/widerrufen`, "POST", "Widerrufen", "API-Key wurde widerrufen.");
 
-  const handleResumeKey = async (id: string) => {
-    try {
-      const res = await fetch(`/api/einstellungen/api-keys/${id}/fortsetzen`, { method: "POST" });
-      if (!res.ok) {
-        const json = await res.json();
-        throw new Error(json.error || "Fehler beim Fortsetzen.");
-      }
-      toast({ title: "Aktiviert", description: "API-Key wurde erfolgreich fortgesetzt." });
-      fetchKeys();
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : "Fehler beim Ausführen.";
-      toast({ title: "Fehler", description: msg, variant: "destructive" });
-    }
-  };
+  const handlePauseKey = (id: string) =>
+    runAction(
+      `/api/einstellungen/api-keys/${id}/pausieren`,
+      "POST",
+      "Deaktiviert",
+      "API-Key wurde erfolgreich pausiert/deaktiviert."
+    );
 
-  const handleDeleteKey = async (id: string) => {
-    try {
-      const res = await fetch(`/api/einstellungen/api-keys/${id}`, { method: "DELETE" });
-      if (!res.ok) {
-        const json = await res.json();
-        throw new Error(json.error || "Fehler beim Löschen.");
-      }
-      toast({ title: "Gelöscht", description: "API-Key wurde gelöscht." });
-      fetchKeys();
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : "Fehler beim Ausführen.";
-      toast({ title: "Fehler", description: msg, variant: "destructive" });
-    }
-  };
+  const handleResumeKey = (id: string) =>
+    runAction(`/api/einstellungen/api-keys/${id}/fortsetzen`, "POST", "Aktiviert", "API-Key wurde erfolgreich fortgesetzt.");
+
+  const handleDeleteKey = (id: string) =>
+    runAction(`/api/einstellungen/api-keys/${id}`, "DELETE", "Gelöscht", "API-Key wurde gelöscht.");
 
   return (
     <div className="space-y-6">

--- a/components/settings/api-keys-section.tsx
+++ b/components/settings/api-keys-section.tsx
@@ -1,114 +1,29 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import {
-  Key,
-  Plus,
-  Copy,
-  Check,
-  AlertTriangle,
-  RefreshCw,
-  Trash2,
-  XCircle,
-  Play,
-  Pause,
-  Clock,
-  CheckCircle2,
-  Info,
-  Calendar,
-  User,
-  Shield,
-  Activity,
-} from "lucide-react";
+import { Key, Plus, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
-import { Checkbox } from "@/components/ui/checkbox";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-} from "@/components/ui/dialog";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { useToast } from "@/hooks/use-toast";
 import { SettingsCard, SettingsSection } from "@/components/settings/shared";
-
-interface ApiKeyItem {
-  id: string;
-  organisation_id: string;
-  mitglied_id: string;
-  name: string;
-  key_prefix: string | null;
-  environment: "live" | "test";
-  status: "ausstehend" | "aktiv" | "abgelehnt" | "widerrufen" | "pausiert";
-  erstellt_von: string | null;
-  ersteller_email?: string | null;
-  ersteller_first_name?: string | null;
-  ersteller_last_name?: string | null;
-  angefragte_berechtigungen: any;
-  berechtigungen: any;
-  genehmigt_von: string | null;
-  genehmigt_von_email?: string | null;
-  genehmigt_von_first_name?: string | null;
-  genehmigt_von_last_name?: string | null;
-  genehmigt_am: string | null;
-  expires_at: string | null;
-  last_used_at: string | null;
-  pausiert_grund: string | null;
-  erstellt_am: string;
-  geaendert_am: string;
-  ersteller_status?: string;
-}
-
-const AVAILABLE_MODULES = [
-  { id: "haeuser", label: "Häuser" },
-  { id: "wohnungen", label: "Wohnungen" },
-  { id: "mieter", label: "Mieter" },
-  { id: "finanzen", label: "Finanzen" },
-  { id: "aufgaben", label: "Aufgaben" },
-  { id: "zaehler", label: "Zähler" },
-  { id: "zaehler_ablesungen", label: "Zählerablesungen" },
-];
-
-const AVAILABLE_ACTIONS = [
-  { id: "ansehen", label: "Lesen" },
-  { id: "erstellen", label: "Erstellen" },
-  { id: "bearbeiten", label: "Bearbeiten" },
-  { id: "loeschen", label: "Löschen" },
-];
+import { ApiKeyItem } from "./api-keys/types";
+import { ApiKeyCard } from "./api-keys/api-key-card";
+import { ApiKeyRequestDialog } from "./api-keys/api-key-request-dialog";
+import { ApiKeyApproveDialog } from "./api-keys/api-key-approve-dialog";
+import { ApiKeySecretDialog } from "./api-keys/api-key-secret-dialog";
 
 export default function ApiKeysSection() {
   const { toast } = useToast();
   const [keys, setKeys] = useState<ApiKeyItem[]>([]);
   const [loading, setLoading] = useState(true);
 
-  // Modals state
+  // Dialog state
   const [requestModalOpen, setRequestModalOpen] = useState(false);
   const [approveModalOpen, setApproveModalOpen] = useState(false);
   const [secretModalOpen, setSecretModalOpen] = useState(false);
 
-  // Form states
-  const [keyName, setKeyName] = useState("");
-  const [environment, setEnvironment] = useState<"live" | "test">("live");
-  const [expiresAt, setExpiresAt] = useState("");
-  const [selectedModules, setSelectedModules] = useState<Record<string, Record<string, boolean>>>({});
-  const [submitting, setSubmitting] = useState(false);
-
-  // Approval state
+  // Approval & secret payload state
   const [selectedKeyForApproval, setSelectedKeyForApproval] = useState<ApiKeyItem | null>(null);
-  const [approvalPermissions, setApprovalPermissions] = useState<Record<string, Record<string, boolean>>>({});
-
-  // Secret display state
   const [revealedSecret, setRevealedSecret] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
 
   const fetchKeys = useCallback(async () => {
     try {
@@ -129,92 +44,15 @@ export default function ApiKeysSection() {
     fetchKeys();
   }, [fetchKeys]);
 
-  const handleRequestKey = async () => {
-    if (!keyName.trim()) {
-      toast({
-        title: "Fehler",
-        description: "Bitte geben Sie einen Namen für den API-Key ein.",
-        variant: "destructive",
-      });
-      return;
-    }
-
-    try {
-      setSubmitting(true);
-      const payload = {
-        name: keyName.trim(),
-        environment,
-        expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
-        angefragte_berechtigungen: {
-          module: selectedModules,
-        },
-      };
-
-      const res = await fetch("/api/einstellungen/api-keys", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-
-      const json = await res.json();
-      if (!res.ok) {
-        throw new Error(json.error || "Fehler beim Beantragen des API-Keys.");
-      }
-
-      toast({
-        title: "Erfolg",
-        description: "API-Key wurde erfolgreich beantragt und wartet auf Genehmigung.",
-        variant: "success",
-      });
-
-      setRequestModalOpen(false);
-      setKeyName("");
-      setExpiresAt("");
-      setSelectedModules({});
-      fetchKeys();
-    } catch (err: any) {
-      toast({
-        title: "Fehler",
-        description: err.message || "Fehler beim Beantragen.",
-        variant: "destructive",
-      });
-    } finally {
-      setSubmitting(false);
-    }
+  const handleApproveClick = (keyItem: ApiKeyItem) => {
+    setSelectedKeyForApproval(keyItem);
+    setApproveModalOpen(true);
   };
 
-  const handleApproveKey = async () => {
-    if (!selectedKeyForApproval) return;
-
-    try {
-      setSubmitting(true);
-      const res = await fetch(`/api/einstellungen/api-keys/${selectedKeyForApproval.id}/genehmigen`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          berechtigungen: { module: approvalPermissions },
-          environment: selectedKeyForApproval.environment,
-        }),
-      });
-
-      const json = await res.json();
-      if (!res.ok) {
-        throw new Error(json.error || "Fehler bei der Genehmigung.");
-      }
-
-      setApproveModalOpen(false);
-      setRevealedSecret(json.plaintext);
-      setSecretModalOpen(true);
-      fetchKeys();
-    } catch (err: any) {
-      toast({
-        title: "Fehler",
-        description: err.message || "Fehler bei der Genehmigung.",
-        variant: "destructive",
-      });
-    } finally {
-      setSubmitting(false);
-    }
+  const handleApproveSuccess = (plaintextSecret: string) => {
+    setRevealedSecret(plaintextSecret);
+    setSecretModalOpen(true);
+    fetchKeys();
   };
 
   const handleRejectKey = async (id: string) => {
@@ -226,8 +64,9 @@ export default function ApiKeysSection() {
       }
       toast({ title: "Abgelehnt", description: "API-Key wurde abgelehnt." });
       fetchKeys();
-    } catch (err: any) {
-      toast({ title: "Fehler", description: err.message, variant: "destructive" });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Fehler beim Ausführen.";
+      toast({ title: "Fehler", description: msg, variant: "destructive" });
     }
   };
 
@@ -240,8 +79,9 @@ export default function ApiKeysSection() {
       }
       toast({ title: "Widerrufen", description: "API-Key wurde widerrufen." });
       fetchKeys();
-    } catch (err: any) {
-      toast({ title: "Fehler", description: err.message, variant: "destructive" });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Fehler beim Ausführen.";
+      toast({ title: "Fehler", description: msg, variant: "destructive" });
     }
   };
 
@@ -254,8 +94,9 @@ export default function ApiKeysSection() {
       }
       toast({ title: "Deaktiviert", description: "API-Key wurde erfolgreich pausiert/deaktiviert." });
       fetchKeys();
-    } catch (err: any) {
-      toast({ title: "Fehler", description: err.message, variant: "destructive" });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Fehler beim Ausführen.";
+      toast({ title: "Fehler", description: msg, variant: "destructive" });
     }
   };
 
@@ -268,8 +109,9 @@ export default function ApiKeysSection() {
       }
       toast({ title: "Aktiviert", description: "API-Key wurde erfolgreich fortgesetzt." });
       fetchKeys();
-    } catch (err: any) {
-      toast({ title: "Fehler", description: err.message, variant: "destructive" });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Fehler beim Ausführen.";
+      toast({ title: "Fehler", description: msg, variant: "destructive" });
     }
   };
 
@@ -282,91 +124,10 @@ export default function ApiKeysSection() {
       }
       toast({ title: "Gelöscht", description: "API-Key wurde gelöscht." });
       fetchKeys();
-    } catch (err: any) {
-      toast({ title: "Fehler", description: err.message, variant: "destructive" });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Fehler beim Ausführen.";
+      toast({ title: "Fehler", description: msg, variant: "destructive" });
     }
-  };
-
-  const openApprovalModal = (keyItem: ApiKeyItem) => {
-    setSelectedKeyForApproval(keyItem);
-    const requested = keyItem.angefragte_berechtigungen?.module || {};
-    setApprovalPermissions(JSON.parse(JSON.stringify(requested)));
-    setApproveModalOpen(true);
-  };
-
-  const copyToClipboard = () => {
-    if (revealedSecret) {
-      navigator.clipboard.writeText(revealedSecret);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 3000);
-      toast({ title: "Kopiert", description: "API-Key in die Zwischenablage kopiert." });
-    }
-  };
-
-  const renderStatusBadge = (status: ApiKeyItem["status"], pausiertGrund?: string | null) => {
-    switch (status) {
-      case "aktiv":
-        return <Badge className="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20">Aktiv</Badge>;
-      case "ausstehend":
-        return <Badge className="bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20">Ausstehend</Badge>;
-      case "pausiert":
-        return (
-          <Badge
-            className="bg-orange-500/10 text-orange-600 dark:text-orange-400 border-orange-500/20"
-            title={pausiertGrund === "ersteller_deaktiviert" ? "Ersteller deaktiviert — Prüfung nötig" : "Manuell deaktiviert"}
-          >
-            {pausiertGrund === "ersteller_deaktiviert" ? "Pausiert (Ersteller inaktiv)" : "Deaktiviert"}
-          </Badge>
-        );
-      case "widerrufen":
-        return <Badge variant="secondary">Widerrufen</Badge>;
-      case "abgelehnt":
-        return <Badge variant="destructive">Abgelehnt</Badge>;
-      default:
-        return <Badge variant="outline">{status}</Badge>;
-    }
-  };
-
-  const formatUserName = (firstName?: string | null, lastName?: string | null, email?: string | null) => {
-    const fullName = `${firstName || ""} ${lastName || ""}`.trim();
-    if (fullName) {
-      return email ? `${fullName} (${email})` : fullName;
-    }
-    return email || "Unbekannter Nutzer";
-  };
-
-  const renderPermissionsSummary = (permsObj: any) => {
-    if (!permsObj || !permsObj.module) return <span className="text-muted-foreground">Keine Module zugewiesen</span>;
-    const entries = Object.entries(permsObj.module).filter(([_, actions]: [string, any]) => {
-      if (Array.isArray(actions)) return actions.length > 0;
-      if (typeof actions === "object" && actions !== null) return Object.values(actions).some(Boolean);
-      return false;
-    });
-
-    if (entries.length === 0) return <span className="text-muted-foreground">Keine Berechtigungen</span>;
-
-    return (
-      <div className="flex flex-wrap gap-1 mt-1">
-        {entries.map(([modName, acts]: [string, any]) => {
-          const modDef = AVAILABLE_MODULES.find((m) => m.id === modName);
-          const label = modDef ? modDef.label : modName;
-          let actList = "";
-          if (Array.isArray(acts)) {
-            actList = acts.join(", ");
-          } else if (typeof acts === "object" && acts !== null) {
-            actList = Object.entries(acts)
-              .filter(([_, v]) => Boolean(v))
-              .map(([k]) => AVAILABLE_ACTIONS.find((a) => a.id === k)?.label || k)
-              .join(", ");
-          }
-          return (
-            <Badge key={modName} variant="secondary" className="text-[11px] font-normal py-0.5 px-2 bg-muted/60">
-              {label}: {actList || "Aktiv"}
-            </Badge>
-          );
-        })}
-      </div>
-    );
   };
 
   return (
@@ -383,17 +144,7 @@ export default function ApiKeysSection() {
                 Schlüssel werden kryptografisch abgesichert und Klartext-Secrets nur bei Genehmigung einmalig angezeigt.
               </p>
             </div>
-            <Button
-              onClick={() => {
-                setKeyName("");
-                setSelectedModules({
-                  haeuser: { ansehen: true },
-                  wohnungen: { ansehen: true },
-                });
-                setRequestModalOpen(true);
-              }}
-              className="gap-2 shrink-0"
-            >
+            <Button onClick={() => setRequestModalOpen(true)} className="gap-2 shrink-0">
               <Plus className="h-4 w-4" />
               API-Key beantragen
             </Button>
@@ -412,403 +163,41 @@ export default function ApiKeysSection() {
             </div>
           ) : (
             <div className="divide-y divide-border/40 mt-2">
-              {keys.map((k) => {
-                const creatorDisplayName = formatUserName(k.ersteller_first_name, k.ersteller_last_name, k.ersteller_email);
-                const approverDisplayName = formatUserName(k.genehmigt_von_first_name, k.genehmigt_von_last_name, k.genehmigt_von_email);
-
-                return (
-                  <div key={k.id} className="py-5 space-y-3">
-                    {/* Header line: Name, Badges & Action Buttons */}
-                    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-                      <div className="flex items-center gap-2.5 flex-wrap min-w-0">
-                        <div className="h-7 w-7 rounded-md bg-muted/80 flex items-center justify-center text-muted-foreground">
-                          <Key className="h-3.5 w-3.5" />
-                        </div>
-                        <span className="font-semibold text-sm truncate">{k.name}</span>
-                        {renderStatusBadge(k.status, k.pausiert_grund)}
-                        <Badge variant="outline" className="text-[10px] uppercase font-mono tracking-wider">
-                          {k.environment}
-                        </Badge>
-                        <span className="font-mono text-[11px] bg-muted/60 text-muted-foreground px-2 py-0.5 rounded border border-border/40">
-                          {k.key_prefix || "mie_••••••••••••"}
-                        </span>
-                      </div>
-
-                      <div className="flex items-center gap-2 self-end sm:self-center">
-                        {k.status === "ausstehend" && (
-                          <>
-                            <Button
-                              size="sm"
-                              variant="default"
-                              onClick={() => openApprovalModal(k)}
-                              className="h-8 text-xs font-medium"
-                            >
-                              Genehmigen
-                            </Button>
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={() => handleRejectKey(k.id)}
-                              className="h-8 text-xs text-destructive hover:bg-destructive/10"
-                            >
-                              Ablehnen
-                            </Button>
-                          </>
-                        )}
-
-                        {k.status === "aktiv" && (
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => handlePauseKey(k.id)}
-                            className="h-8 text-xs gap-1.5 text-orange-600 dark:text-orange-400 hover:bg-orange-500/10 border-orange-500/30"
-                          >
-                            <Pause className="h-3.5 w-3.5" />
-                            Deaktivieren
-                          </Button>
-                        )}
-
-                        {k.status === "pausiert" && (
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => handleResumeKey(k.id)}
-                            className="h-8 text-xs gap-1.5 text-emerald-600 dark:text-emerald-400 hover:bg-emerald-500/10 border-emerald-500/30"
-                          >
-                            <Play className="h-3.5 w-3.5" />
-                            Aktivieren
-                          </Button>
-                        )}
-
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
-                              •••
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end">
-                            {(k.status === "aktiv" || k.status === "pausiert") && (
-                              <DropdownMenuItem
-                                onClick={() => handleRevokeKey(k.id)}
-                                className="text-destructive gap-2 cursor-pointer"
-                              >
-                                <XCircle className="h-4 w-4" />
-                                Endgültig widerrufen
-                              </DropdownMenuItem>
-                            )}
-                            {(k.status === "abgelehnt" || k.status === "widerrufen") && (
-                              <DropdownMenuItem
-                                onClick={() => handleDeleteKey(k.id)}
-                                className="text-destructive gap-2 cursor-pointer"
-                              >
-                                <Trash2 className="h-4 w-4" />
-                                Löschen
-                              </DropdownMenuItem>
-                            )}
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      </div>
-                    </div>
-
-                    {/* Paused alert info if applicable */}
-                    {k.status === "pausiert" && (
-                      <div className="p-2.5 rounded-md bg-orange-500/10 border border-orange-500/20 text-xs text-orange-800 dark:text-orange-300 flex items-start gap-2">
-                        <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5 text-orange-600 dark:text-orange-400" />
-                        <div>
-                          {k.pausiert_grund === "ersteller_deaktiviert" ? (
-                            <span>
-                              <strong>Automatisch pausiert:</strong> Das Mitgliedskonto des Antragstellers ist inaktiv/deaktiviert. Der Schlüssel kann erst nach Reaktivierung des Erstellers fortgesetzt werden.
-                            </span>
-                          ) : (
-                            <span>
-                              <strong>Schlüssel ist deaktiviert:</strong> Eingehende API-Anfragen mit diesem Schlüssel werden abgewiesen. Klicken Sie auf „Aktivieren“, um den Zugriff wieder freizuschalten.
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                    )}
-
-                    {/* Metadata Grid: Creator, Approver, Usage & Permissions */}
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs bg-muted/20 border border-border/40 rounded-lg p-3">
-                      {/* Left: Antragsteller & Genehmigung */}
-                      <div className="space-y-1.5">
-                        <div className="flex items-center gap-1.5 text-foreground">
-                          <User className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                          <span className="font-medium">Beantragt von:</span>
-                          <span className="text-muted-foreground truncate">{creatorDisplayName}</span>
-                          {k.ersteller_status && k.ersteller_status !== "aktiv" && (
-                            <Badge variant="outline" className="text-[10px] text-destructive border-destructive/30 h-4 px-1.5">
-                              {k.ersteller_status}
-                            </Badge>
-                          )}
-                        </div>
-                        <div className="text-muted-foreground pl-5 text-[11px]">
-                          Beantragt am: {new Date(k.erstellt_am).toLocaleDateString("de-DE")}
-                        </div>
-
-                        {k.genehmigt_am && (
-                          <div className="flex items-center gap-1.5 text-foreground pt-1">
-                            <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
-                            <span className="font-medium">Genehmigt von:</span>
-                            <span className="text-muted-foreground truncate">{approverDisplayName}</span>
-                          </div>
-                        )}
-                      </div>
-
-                      {/* Right: Verwendung & Gültigkeit */}
-                      <div className="space-y-1.5">
-                        <div className="flex items-center gap-1.5 text-foreground">
-                          <Activity className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                          <span className="font-medium">Zuletzt aktiv:</span>
-                          <span className="text-muted-foreground">
-                            {k.last_used_at
-                              ? new Date(k.last_used_at).toLocaleDateString("de-DE", {
-                                  hour: "2-digit",
-                                  minute: "2-digit",
-                                  day: "2-digit",
-                                  month: "2-digit",
-                                  year: "numeric",
-                                })
-                              : "Noch nie verwendet"}
-                          </span>
-                        </div>
-
-                        <div className="flex items-center gap-1.5 text-foreground">
-                          <Calendar className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                          <span className="font-medium">Gültig bis:</span>
-                          <span className="text-muted-foreground">
-                            {k.expires_at ? new Date(k.expires_at).toLocaleDateString("de-DE") : "Unbegrenzt gültig"}
-                          </span>
-                        </div>
-                      </div>
-
-                      {/* Full width: Permissions Summary */}
-                      <div className="md:col-span-2 pt-2 border-t border-border/40">
-                        <div className="flex items-center gap-1.5 text-foreground mb-1">
-                          <Shield className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                          <span className="font-medium">
-                            {k.status === "ausstehend" ? "Angefragte Berechtigungen:" : "Aktive Berechtigungen:"}
-                          </span>
-                        </div>
-                        {renderPermissionsSummary(k.status === "ausstehend" ? k.angefragte_berechtigungen : k.berechtigungen)}
-                      </div>
-                    </div>
-                  </div>
-                );
-              })}
+              {keys.map((k) => (
+                <ApiKeyCard
+                  key={k.id}
+                  apiKey={k}
+                  onApprove={handleApproveClick}
+                  onReject={handleRejectKey}
+                  onPause={handlePauseKey}
+                  onResume={handleResumeKey}
+                  onRevoke={handleRevokeKey}
+                  onDelete={handleDeleteKey}
+                />
+              ))}
             </div>
           )}
         </SettingsCard>
       </SettingsSection>
 
-      {/* REQUEST MODAL */}
-      <Dialog open={requestModalOpen} onOpenChange={setRequestModalOpen}>
-        <DialogContent className="sm:max-w-[550px]">
-          <DialogHeader>
-            <DialogTitle>API-Schlüssel beantragen</DialogTitle>
-            <DialogDescription>
-              Wählen Sie den gewünschten Namen und die benötigten Berechtigungen.
-            </DialogDescription>
-          </DialogHeader>
+      <ApiKeyRequestDialog
+        open={requestModalOpen}
+        onOpenChange={setRequestModalOpen}
+        onSuccess={fetchKeys}
+      />
 
-          <div className="space-y-4 py-2">
-            <div className="space-y-1.5">
-              <label className="text-xs font-semibold">Name des Schlüssels</label>
-              <Input
-                placeholder="z. B. Buchhaltungs-Integration"
-                value={keyName}
-                onChange={(e) => setKeyName(e.target.value)}
-              />
-            </div>
+      <ApiKeyApproveDialog
+        open={approveModalOpen}
+        onOpenChange={setApproveModalOpen}
+        keyItem={selectedKeyForApproval}
+        onSuccess={handleApproveSuccess}
+      />
 
-            <div className="grid grid-cols-2 gap-3">
-              <div className="space-y-1.5">
-                <label className="text-xs font-semibold">Umgebung</label>
-                <select
-                  value={environment}
-                  onChange={(e) => setEnvironment(e.target.value as "live" | "test")}
-                  className="w-full h-9 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-xs"
-                >
-                  <option value="live">Live</option>
-                  <option value="test">Test</option>
-                </select>
-              </div>
-
-              <div className="space-y-1.5">
-                <label className="text-xs font-semibold">Ablaufdatum (optional)</label>
-                <Input
-                  type="date"
-                  value={expiresAt}
-                  onChange={(e) => setExpiresAt(e.target.value)}
-                />
-              </div>
-            </div>
-
-            <div className="space-y-2 pt-2">
-              <label className="text-xs font-semibold">Angefragte Berechtigungen</label>
-              <div className="border border-border/60 rounded-lg p-3 space-y-3 bg-muted/20">
-                {AVAILABLE_MODULES.map((mod) => (
-                  <div key={mod.id} className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 text-xs">
-                    <span className="font-medium w-32">{mod.label}</span>
-                    <div className="flex items-center gap-4 flex-wrap">
-                      {AVAILABLE_ACTIONS.map((act) => {
-                        const isChecked = !!selectedModules[mod.id]?.[act.id];
-                        return (
-                          <label key={act.id} className="flex items-center gap-1.5 cursor-pointer">
-                            <Checkbox
-                              checked={isChecked}
-                              onCheckedChange={(val) => {
-                                setSelectedModules((prev) => ({
-                                  ...prev,
-                                  [mod.id]: {
-                                    ...(prev[mod.id] || {}),
-                                    [act.id]: !!val,
-                                  },
-                                }));
-                              }}
-                            />
-                            <span>{act.label}</span>
-                          </label>
-                        );
-                      })}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setRequestModalOpen(false)}>
-              Abbrechen
-            </Button>
-            <Button onClick={handleRequestKey} disabled={submitting}>
-              {submitting ? "Beantrage..." : "Antrag absenden"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* APPROVE MODAL */}
-      <Dialog open={approveModalOpen} onOpenChange={setApproveModalOpen}>
-        <DialogContent className="sm:max-w-[600px]">
-          <DialogHeader>
-            <DialogTitle>API-Schlüssel genehmigen</DialogTitle>
-            <DialogDescription>
-              Prüfen und passen Sie den finalen Berechtigungsumfang für „{selectedKeyForApproval?.name}“ an.
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="space-y-4 py-2">
-            <div className="p-3 bg-blue-500/10 border border-blue-500/20 rounded-lg text-xs flex items-start gap-2.5 text-blue-700 dark:text-blue-300">
-              <Info className="h-4 w-4 shrink-0 mt-0.5" />
-              <span>
-                <strong>Hinweis zur Sicherheitsbegrenzung:</strong> Die gespeicherten Rechte werden serverseitig automatisch auf die effektiven Berechtigungen des Antragstellers begrenzt.
-              </span>
-            </div>
-
-            <div className="space-y-2">
-              <label className="text-xs font-semibold">Finaler Berechtigungsumfang</label>
-              <div className="border border-border/60 rounded-lg p-3 space-y-3 bg-muted/20">
-                {AVAILABLE_MODULES.map((mod) => (
-                  <div key={mod.id} className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 text-xs">
-                    <span className="font-medium w-32">{mod.label}</span>
-                    <div className="flex items-center gap-4 flex-wrap">
-                      {AVAILABLE_ACTIONS.map((act) => {
-                        const isChecked = !!approvalPermissions[mod.id]?.[act.id];
-                        return (
-                          <label key={act.id} className="flex items-center gap-1.5 cursor-pointer">
-                            <Checkbox
-                              checked={isChecked}
-                              onCheckedChange={(val) => {
-                                setApprovalPermissions((prev) => ({
-                                  ...prev,
-                                  [mod.id]: {
-                                    ...(prev[mod.id] || {}),
-                                    [act.id]: !!val,
-                                  },
-                                }));
-                              }}
-                            />
-                            <span>{act.label}</span>
-                          </label>
-                        );
-                      })}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setApproveModalOpen(false)}>
-              Abbrechen
-            </Button>
-            <Button onClick={handleApproveKey} disabled={submitting}>
-              {submitting ? "Genehmige..." : "Genehmigen & Secret generieren"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* ONE-TIME SECRET MODAL */}
-      <Dialog open={secretModalOpen} onOpenChange={setSecretModalOpen}>
-        <DialogContent className="sm:max-w-[500px]">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2 text-emerald-600 dark:text-emerald-400">
-              <CheckCircle2 className="h-5 w-5" />
-              API-Key erfolgreich genehmigt!
-            </DialogTitle>
-            <DialogDescription>
-              Der Schlüssel wurde erstellt. Bitte kopieren Sie den Secret-Key jetzt.
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="space-y-4 py-2">
-            <div className="p-3.5 bg-amber-500/10 border border-amber-500/20 rounded-lg text-xs flex items-start gap-2.5 text-amber-800 dark:text-amber-300">
-              <AlertTriangle className="h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400 mt-0.5" />
-              <div>
-                <p className="font-semibold">Wichtig: Einmalige Anzeige!</p>
-                <p className="mt-0.5">
-                  Dieser Schlüssel wird aus Sicherheitsgründen <strong>nur dieses eine Mal</strong> im Klartext angezeigt und nirgends in der Datenbank gespeichert.
-                </p>
-              </div>
-            </div>
-
-            <div className="space-y-1.5">
-              <label className="text-xs font-semibold">Ihr API-Secret:</label>
-              <div className="flex items-center gap-2">
-                <Input
-                  readOnly
-                  value={revealedSecret || ""}
-                  className="font-mono text-xs bg-muted/60 select-all"
-                />
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={copyToClipboard}
-                  className="shrink-0 gap-1.5"
-                >
-                  {copied ? <Check className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
-                  {copied ? "Kopiert" : "Kopieren"}
-                </Button>
-              </div>
-            </div>
-          </div>
-
-          <DialogFooter>
-            <Button
-              onClick={() => {
-                setSecretModalOpen(false);
-                setRevealedSecret(null);
-              }}
-            >
-              Ich habe den Schlüssel gespeichert
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ApiKeySecretDialog
+        open={secretModalOpen}
+        onOpenChange={setSecretModalOpen}
+        secret={revealedSecret}
+      />
     </div>
   );
 }

--- a/components/settings/api-keys-section.tsx
+++ b/components/settings/api-keys-section.tsx
@@ -32,13 +32,21 @@ export default function ApiKeysSection() {
       if (res.ok) {
         const data = await res.json();
         setKeys(Array.isArray(data) ? data : []);
+      } else {
+        const json = await res.json().catch(() => ({}));
+        throw new Error(json.error || "Fehler beim Laden der API-Keys.");
       }
-    } catch (err) {
-      console.error("Failed to fetch API keys:", err);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Fehler beim Laden der API-Keys.";
+      toast({
+        title: "Fehler beim Laden",
+        description: msg,
+        variant: "destructive",
+      });
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [toast]);
 
   useEffect(() => {
     fetchKeys();

--- a/components/settings/api-keys/api-key-approve-dialog.tsx
+++ b/components/settings/api-keys/api-key-approve-dialog.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Info } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { useToast } from "@/hooks/use-toast";
+import { ApiKeyItem, AVAILABLE_MODULES, AVAILABLE_ACTIONS } from "./types";
+
+interface ApiKeyApproveDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  keyItem: ApiKeyItem | null;
+  onSuccess: (plaintextSecret: string) => void;
+}
+
+export function ApiKeyApproveDialog({ open, onOpenChange, keyItem, onSuccess }: ApiKeyApproveDialogProps) {
+  const { toast } = useToast();
+  const [permissions, setPermissions] = useState<Record<string, Record<string, boolean>>>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (keyItem) {
+      const requested = (keyItem.angefragte_berechtigungen?.module as Record<string, Record<string, boolean>>) || {};
+      setPermissions(structuredClone(requested));
+    }
+  }, [keyItem]);
+
+  const handleApprove = async () => {
+    if (!keyItem) return;
+
+    try {
+      setSubmitting(true);
+      const res = await fetch(`/api/einstellungen/api-keys/${keyItem.id}/genehmigen`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          berechtigungen: { module: permissions },
+          environment: keyItem.environment,
+        }),
+      });
+
+      const json = await res.json();
+      if (!res.ok) {
+        throw new Error(json.error || "Fehler bei der Genehmigung.");
+      }
+
+      onOpenChange(false);
+      onSuccess(json.plaintext);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Fehler bei der Genehmigung.";
+      toast({
+        title: "Fehler",
+        description: msg,
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>API-Schlüssel genehmigen</DialogTitle>
+          <DialogDescription>
+            Prüfen und passen Sie den finalen Berechtigungsumfang für „{keyItem?.name}“ an.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="p-3 bg-blue-500/10 border border-blue-500/20 rounded-lg text-xs flex items-start gap-2.5 text-blue-700 dark:text-blue-300">
+            <Info className="h-4 w-4 shrink-0 mt-0.5" />
+            <span>
+              <strong>Hinweis zur Sicherheitsbegrenzung:</strong> Die gespeicherten Rechte werden serverseitig automatisch auf die effektiven Berechtigungen des Antragstellers begrenzt.
+            </span>
+          </div>
+
+          <div className="space-y-2">
+            <span className="text-xs font-semibold block">Finaler Berechtigungsumfang</span>
+            <div className="border border-border/60 rounded-lg p-3 space-y-3 bg-muted/20">
+              {AVAILABLE_MODULES.map((mod) => (
+                <div key={mod.id} className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 text-xs">
+                  <span className="font-medium w-32">{mod.label}</span>
+                  <div className="flex items-center gap-4 flex-wrap">
+                    {AVAILABLE_ACTIONS.map((act) => {
+                      const isChecked = !!permissions[mod.id]?.[act.id];
+                      const checkboxId = `appr-mod-${mod.id}-act-${act.id}`;
+                      return (
+                        <div key={act.id} className="flex items-center gap-1.5">
+                          <Checkbox
+                            id={checkboxId}
+                            checked={isChecked}
+                            onCheckedChange={(val) => {
+                              setPermissions((prev) => ({
+                                ...prev,
+                                [mod.id]: {
+                                  ...(prev[mod.id] || {}),
+                                  [act.id]: !!val,
+                                },
+                              }));
+                            }}
+                          />
+                          <label htmlFor={checkboxId} className="cursor-pointer">
+                            {act.label}
+                          </label>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Abbrechen
+          </Button>
+          <Button onClick={handleApprove} disabled={submitting}>
+            {submitting ? "Genehmige..." : "Genehmigen & Secret generieren"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/settings/api-keys/api-key-approve-dialog.tsx
+++ b/components/settings/api-keys/api-key-approve-dialog.tsx
@@ -29,8 +29,25 @@ export function ApiKeyApproveDialog({ open, onOpenChange, keyItem, onSuccess }: 
 
   useEffect(() => {
     if (keyItem) {
-      const requested = (keyItem.angefragte_berechtigungen?.module as Record<string, Record<string, boolean>>) || {};
-      setPermissions(structuredClone(requested));
+      const rawModule = (keyItem.angefragte_berechtigungen?.module as Record<string, unknown>) || {};
+      const normalized: Record<string, Record<string, boolean>> = {};
+
+      Object.entries(rawModule).forEach(([modul, actions]) => {
+        normalized[modul] = {};
+        if (Array.isArray(actions)) {
+          actions.forEach((act: string) => {
+            normalized[modul][act] = true;
+          });
+        } else if (actions && typeof actions === "object") {
+          Object.entries(actions).forEach(([act, val]) => {
+            if (val === true || val === "true") {
+              normalized[modul][act] = true;
+            }
+          });
+        }
+      });
+
+      setPermissions(normalized);
     }
   }, [keyItem]);
 

--- a/components/settings/api-keys/api-key-approve-dialog.tsx
+++ b/components/settings/api-keys/api-key-approve-dialog.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dialog";
 import { useToast } from "@/hooks/use-toast";
 import { ApiKeyItem, AVAILABLE_MODULES, AVAILABLE_ACTIONS } from "./types";
+import { HouseScopeSection, HouseItem } from "./house-scope-section";
 
 interface ApiKeyApproveDialogProps {
   open: boolean;
@@ -45,14 +46,39 @@ function getNormalizedPermissions(keyItem: ApiKeyItem | null): Record<string, Re
   return normalized;
 }
 
+function getInitialHouseScope(keyItem: ApiKeyItem | null): { scope: "all" | "selected"; ids: string[] } {
+  if (!keyItem) return { scope: "all", ids: [] };
+  const rawHaeuser = keyItem.angefragte_berechtigungen?.haeuser;
+  if (Array.isArray(rawHaeuser) && rawHaeuser.length > 0) {
+    return { scope: "selected", ids: rawHaeuser.filter((h): h is string => typeof h === "string") };
+  }
+  return { scope: "all", ids: [] };
+}
+
 export function ApiKeyApproveDialog({ open, onOpenChange, keyItem, onSuccess }: ApiKeyApproveDialogProps) {
   const { toast } = useToast();
   const [permissions, setPermissions] = useState<Record<string, Record<string, boolean>>>(() => getNormalizedPermissions(keyItem));
+  const [houseScope, setHouseScope] = useState<"all" | "selected">(() => getInitialHouseScope(keyItem).scope);
+  const [selectedHouseIds, setSelectedHouseIds] = useState<string[]>(() => getInitialHouseScope(keyItem).ids);
+  const [availableHouses, setAvailableHouses] = useState<HouseItem[]>([]);
   const [submitting, setSubmitting] = useState(false);
 
   const handleOpenChange = (newOpen: boolean) => {
     if (newOpen && keyItem) {
       setPermissions(getNormalizedPermissions(keyItem));
+      const initHouses = getInitialHouseScope(keyItem);
+      setHouseScope(initHouses.scope);
+      setSelectedHouseIds(initHouses.ids);
+      fetch("/api/haeuser")
+        .then((res) => (res.ok ? res.json() : []))
+        .then((data) => {
+          if (Array.isArray(data)) {
+            setAvailableHouses(data);
+          }
+        })
+        .catch((err) => {
+          console.error("Fehler beim Laden der Häuser:", err);
+        });
     }
     onOpenChange(newOpen);
   };
@@ -60,13 +86,25 @@ export function ApiKeyApproveDialog({ open, onOpenChange, keyItem, onSuccess }: 
   const handleApprove = async () => {
     if (!keyItem) return;
 
+    if (houseScope === "selected" && selectedHouseIds.length === 0) {
+      toast({
+        title: "Fehler",
+        description: "Bitte wählen Sie mindestens ein Haus aus oder wählen Sie 'Alle Häuser'.",
+        variant: "destructive",
+      });
+      return;
+    }
+
     try {
       setSubmitting(true);
       const res = await fetch(`/api/einstellungen/api-keys/${keyItem.id}/genehmigen`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          berechtigungen: { module: permissions },
+          berechtigungen: {
+            module: permissions,
+            haeuser: houseScope === "selected" ? selectedHouseIds : null,
+          },
           environment: keyItem.environment,
         }),
       });
@@ -102,7 +140,7 @@ export function ApiKeyApproveDialog({ open, onOpenChange, keyItem, onSuccess }: 
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-[600px]">
+      <DialogContent className="sm:max-w-[600px] max-h-[85vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>API-Schlüssel genehmigen</DialogTitle>
           <DialogDescription>
@@ -110,7 +148,7 @@ export function ApiKeyApproveDialog({ open, onOpenChange, keyItem, onSuccess }: 
           </DialogDescription>
         </DialogHeader>
 
-        <div className="py-4 space-y-4 max-h-[60vh] overflow-y-auto">
+        <div className="py-2 space-y-4">
           <div className="rounded-lg border bg-muted/40 p-3 text-xs text-muted-foreground flex gap-2 items-start">
             <Info className="h-4 w-4 shrink-0 mt-0.5" />
             <p>
@@ -119,7 +157,9 @@ export function ApiKeyApproveDialog({ open, onOpenChange, keyItem, onSuccess }: 
             </p>
           </div>
 
-          <div className="space-y-4">
+          {/* Module Permissions */}
+          <div className="space-y-3">
+            <span className="text-xs font-semibold block">Modul-Berechtigungen</span>
             {AVAILABLE_MODULES.map((modul) => (
               <div key={modul.id} className="rounded-lg border p-3 bg-card">
                 <div className="font-medium text-sm mb-2">{modul.label}</div>
@@ -143,6 +183,16 @@ export function ApiKeyApproveDialog({ open, onOpenChange, keyItem, onSuccess }: 
               </div>
             ))}
           </div>
+
+          {/* House Object Scoping */}
+          <HouseScopeSection
+            idPrefix="appr"
+            houseScope={houseScope}
+            onScopeChange={setHouseScope}
+            selectedHouseIds={selectedHouseIds}
+            onSelectedHouseIdsChange={setSelectedHouseIds}
+            availableHouses={availableHouses}
+          />
         </div>
 
         <DialogFooter>

--- a/components/settings/api-keys/api-key-approve-dialog.tsx
+++ b/components/settings/api-keys/api-key-approve-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Info } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -22,34 +22,40 @@ interface ApiKeyApproveDialogProps {
   onSuccess: (plaintextSecret: string) => void;
 }
 
-export function ApiKeyApproveDialog({ open, onOpenChange, keyItem, onSuccess }: ApiKeyApproveDialogProps) {
-  const { toast } = useToast();
-  const [permissions, setPermissions] = useState<Record<string, Record<string, boolean>>>({});
-  const [submitting, setSubmitting] = useState(false);
+function getNormalizedPermissions(keyItem: ApiKeyItem | null): Record<string, Record<string, boolean>> {
+  if (!keyItem) return {};
+  const rawModule = (keyItem.angefragte_berechtigungen?.module as Record<string, unknown>) || {};
+  const normalized: Record<string, Record<string, boolean>> = {};
 
-  useEffect(() => {
-    if (keyItem) {
-      const rawModule = (keyItem.angefragte_berechtigungen?.module as Record<string, unknown>) || {};
-      const normalized: Record<string, Record<string, boolean>> = {};
-
-      Object.entries(rawModule).forEach(([modul, actions]) => {
-        normalized[modul] = {};
-        if (Array.isArray(actions)) {
-          actions.forEach((act: string) => {
-            normalized[modul][act] = true;
-          });
-        } else if (actions && typeof actions === "object") {
-          Object.entries(actions).forEach(([act, val]) => {
-            if (val === true || val === "true") {
-              normalized[modul][act] = true;
-            }
-          });
+  Object.entries(rawModule).forEach(([modul, actions]) => {
+    normalized[modul] = {};
+    if (Array.isArray(actions)) {
+      actions.forEach((act: string) => {
+        normalized[modul][act] = true;
+      });
+    } else if (actions && typeof actions === "object") {
+      Object.entries(actions).forEach(([act, val]) => {
+        if (val === true || val === "true") {
+          normalized[modul][act] = true;
         }
       });
-
-      setPermissions(normalized);
     }
-  }, [keyItem]);
+  });
+
+  return normalized;
+}
+
+export function ApiKeyApproveDialog({ open, onOpenChange, keyItem, onSuccess }: ApiKeyApproveDialogProps) {
+  const { toast } = useToast();
+  const [permissions, setPermissions] = useState<Record<string, Record<string, boolean>>>(() => getNormalizedPermissions(keyItem));
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleOpenChange = (newOpen: boolean) => {
+    if (newOpen && keyItem) {
+      setPermissions(getNormalizedPermissions(keyItem));
+    }
+    onOpenChange(newOpen);
+  };
 
   const handleApprove = async () => {
     if (!keyItem) return;
@@ -84,68 +90,67 @@ export function ApiKeyApproveDialog({ open, onOpenChange, keyItem, onSuccess }: 
     }
   };
 
+  const togglePermission = (modul: string, aktion: string, checked: boolean) => {
+    setPermissions((prev) => ({
+      ...prev,
+      [modul]: {
+        ...(prev[modul] || {}),
+        [aktion]: checked,
+      },
+    }));
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-[600px]">
         <DialogHeader>
           <DialogTitle>API-Schlüssel genehmigen</DialogTitle>
           <DialogDescription>
-            Prüfen und passen Sie den finalen Berechtigungsumfang für „{keyItem?.name}“ an.
+            Prüfen und passen Sie die Berechtigungen für <strong>{keyItem?.name}</strong> an.
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 py-2">
-          <div className="p-3 bg-blue-500/10 border border-blue-500/20 rounded-lg text-xs flex items-start gap-2.5 text-blue-700 dark:text-blue-300">
+        <div className="py-4 space-y-4 max-h-[60vh] overflow-y-auto">
+          <div className="rounded-lg border bg-muted/40 p-3 text-xs text-muted-foreground flex gap-2 items-start">
             <Info className="h-4 w-4 shrink-0 mt-0.5" />
-            <span>
-              <strong>Hinweis zur Sicherheitsbegrenzung:</strong> Die gespeicherten Rechte werden serverseitig automatisch auf die effektiven Berechtigungen des Antragstellers begrenzt.
-            </span>
+            <p>
+              Hinweis: Die finalen Rechte werden serverseitig automatisch auf die maximalen Rechte des Antragstellers
+              begrenzt.
+            </p>
           </div>
 
-          <div className="space-y-2">
-            <span className="text-xs font-semibold block">Finaler Berechtigungsumfang</span>
-            <div className="border border-border/60 rounded-lg p-3 space-y-3 bg-muted/20">
-              {AVAILABLE_MODULES.map((mod) => (
-                <div key={mod.id} className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 text-xs">
-                  <span className="font-medium w-32">{mod.label}</span>
-                  <div className="flex items-center gap-4 flex-wrap">
-                    {AVAILABLE_ACTIONS.map((act) => {
-                      const isChecked = !!permissions[mod.id]?.[act.id];
-                      const checkboxId = `appr-mod-${mod.id}-act-${act.id}`;
-                      return (
-                        <div key={act.id} className="flex items-center gap-1.5">
-                          <Checkbox
-                            id={checkboxId}
-                            checked={isChecked}
-                            onCheckedChange={(val) => {
-                              setPermissions((prev) => ({
-                                ...prev,
-                                [mod.id]: {
-                                  ...(prev[mod.id] || {}),
-                                  [act.id]: !!val,
-                                },
-                              }));
-                            }}
-                          />
-                          <label htmlFor={checkboxId} className="cursor-pointer">
-                            {act.label}
-                          </label>
-                        </div>
-                      );
-                    })}
-                  </div>
+          <div className="space-y-4">
+            {AVAILABLE_MODULES.map((modul) => (
+              <div key={modul.id} className="rounded-lg border p-3 bg-card">
+                <div className="font-medium text-sm mb-2">{modul.label}</div>
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                  {AVAILABLE_ACTIONS.map((aktion) => {
+                    const isChecked = !!permissions[modul.id]?.[aktion.id];
+                    return (
+                      <label
+                        key={aktion.id}
+                        className="flex items-center space-x-2 text-xs cursor-pointer hover:text-foreground"
+                      >
+                        <Checkbox
+                          checked={isChecked}
+                          onCheckedChange={(c) => togglePermission(modul.id, aktion.id, !!c)}
+                        />
+                        <span>{aktion.label}</span>
+                      </label>
+                    );
+                  })}
                 </div>
-              ))}
-            </div>
+              </div>
+            ))}
           </div>
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
             Abbrechen
           </Button>
           <Button onClick={handleApprove} disabled={submitting}>
-            {submitting ? "Genehmige..." : "Genehmigen & Secret generieren"}
+            {submitting ? "Genehmige..." : "Genehmigen & Schlüssel anzeigen"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/components/settings/api-keys/api-key-card.tsx
+++ b/components/settings/api-keys/api-key-card.tsx
@@ -24,6 +24,8 @@ import {
 import {
   ApiKeyItem,
   formatUserName,
+  formatDateDeterministic,
+  formatDateTimeDeterministic,
 } from "./types";
 import {
   renderStatusBadge,
@@ -184,7 +186,7 @@ export function ApiKeyCard({
             )}
           </div>
           <div className="text-muted-foreground pl-5 text-[11px]">
-            Beantragt am: {new Date(k.erstellt_am).toLocaleDateString("de-DE")}
+            Beantragt am: {formatDateDeterministic(k.erstellt_am)}
           </div>
 
           {k.genehmigt_am && (
@@ -203,13 +205,7 @@ export function ApiKeyCard({
             <span className="font-medium">Zuletzt aktiv:</span>
             <span className="text-muted-foreground">
               {k.last_used_at
-                ? new Date(k.last_used_at).toLocaleDateString("de-DE", {
-                    hour: "2-digit",
-                    minute: "2-digit",
-                    day: "2-digit",
-                    month: "2-digit",
-                    year: "numeric",
-                  })
+                ? formatDateTimeDeterministic(k.last_used_at)
                 : "Noch nie verwendet"}
             </span>
           </div>
@@ -218,7 +214,7 @@ export function ApiKeyCard({
             <Calendar className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
             <span className="font-medium">Gültig bis:</span>
             <span className="text-muted-foreground">
-              {k.expires_at ? new Date(k.expires_at).toLocaleDateString("de-DE") : "Unbegrenzt gültig"}
+              {k.expires_at ? formatDateDeterministic(k.expires_at) : "Unbegrenzt gültig"}
             </span>
           </div>
         </div>

--- a/components/settings/api-keys/api-key-card.tsx
+++ b/components/settings/api-keys/api-key-card.tsx
@@ -132,7 +132,11 @@ export function ApiKeyCard({
             <DropdownMenuContent align="end">
               {(k.status === "aktiv" || k.status === "pausiert") && (
                 <DropdownMenuItem
-                  onClick={() => onRevoke(k.id)}
+                  onClick={() => {
+                    if (window.confirm(`Möchten Sie den API-Schlüssel "${k.name}" wirklich endgültig widerrufen? Dieser Vorgang kann nicht rückgängig gemacht werden.`)) {
+                      onRevoke(k.id);
+                    }
+                  }}
                   className="text-destructive gap-2 cursor-pointer"
                 >
                   <XCircle className="h-4 w-4" />
@@ -141,7 +145,11 @@ export function ApiKeyCard({
               )}
               {(k.status === "abgelehnt" || k.status === "widerrufen") && (
                 <DropdownMenuItem
-                  onClick={() => onDelete(k.id)}
+                  onClick={() => {
+                    if (window.confirm(`Möchten Sie den API-Schlüssel "${k.name}" wirklich löschen?`)) {
+                      onDelete(k.id);
+                    }
+                  }}
                   className="text-destructive gap-2 cursor-pointer"
                 >
                   <Trash2 className="h-4 w-4" />

--- a/components/settings/api-keys/api-key-card.tsx
+++ b/components/settings/api-keys/api-key-card.tsx
@@ -28,8 +28,8 @@ import {
   formatDateTimeDeterministic,
 } from "./types";
 import {
-  renderStatusBadge,
-  renderPermissionsSummary,
+  StatusBadge,
+  PermissionsSummary,
 } from "./helpers";
 
 interface ApiKeyCardProps {
@@ -63,7 +63,7 @@ export function ApiKeyCard({
             <Key className="h-3.5 w-3.5" />
           </div>
           <span className="font-semibold text-sm truncate">{k.name}</span>
-          {renderStatusBadge(k.status, k.pausiert_grund)}
+          <StatusBadge status={k.status} pausiertGrund={k.pausiert_grund} />
           <Badge variant="outline" className="text-[10px] uppercase font-mono tracking-wider">
             {k.environment}
           </Badge>
@@ -235,7 +235,7 @@ export function ApiKeyCard({
               {k.status === "ausstehend" ? "Angefragte Berechtigungen:" : "Aktive Berechtigungen:"}
             </span>
           </div>
-          {renderPermissionsSummary(k.status === "ausstehend" ? k.angefragte_berechtigungen : k.berechtigungen)}
+          <PermissionsSummary berechtigungen={k.status === "ausstehend" ? k.angefragte_berechtigungen : k.berechtigungen} />
         </div>
       </div>
     </div>

--- a/components/settings/api-keys/api-key-card.tsx
+++ b/components/settings/api-keys/api-key-card.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import {
+  Key,
+  Trash2,
+  XCircle,
+  Play,
+  Pause,
+  AlertTriangle,
+  Calendar,
+  User,
+  Shield,
+  Activity,
+  CheckCircle2,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  ApiKeyItem,
+  formatUserName,
+} from "./types";
+import {
+  renderStatusBadge,
+  renderPermissionsSummary,
+} from "./helpers";
+
+interface ApiKeyCardProps {
+  apiKey: ApiKeyItem;
+  onApprove: (key: ApiKeyItem) => void;
+  onReject: (id: string) => void;
+  onPause: (id: string) => void;
+  onResume: (id: string) => void;
+  onRevoke: (id: string) => void;
+  onDelete: (id: string) => void;
+}
+
+export function ApiKeyCard({
+  apiKey: k,
+  onApprove,
+  onReject,
+  onPause,
+  onResume,
+  onRevoke,
+  onDelete,
+}: ApiKeyCardProps) {
+  const creatorDisplayName = formatUserName(k.ersteller_first_name, k.ersteller_last_name, k.ersteller_email);
+  const approverDisplayName = formatUserName(k.genehmigt_von_first_name, k.genehmigt_von_last_name, k.genehmigt_von_email);
+
+  return (
+    <div className="py-5 space-y-3">
+      {/* Header line: Name, Badges & Action Buttons */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <div className="flex items-center gap-2.5 flex-wrap min-w-0">
+          <div className="h-7 w-7 rounded-md bg-muted/80 flex items-center justify-center text-muted-foreground">
+            <Key className="h-3.5 w-3.5" />
+          </div>
+          <span className="font-semibold text-sm truncate">{k.name}</span>
+          {renderStatusBadge(k.status, k.pausiert_grund)}
+          <Badge variant="outline" className="text-[10px] uppercase font-mono tracking-wider">
+            {k.environment}
+          </Badge>
+          <span className="font-mono text-[11px] bg-muted/60 text-muted-foreground px-2 py-0.5 rounded border border-border/40">
+            {k.key_prefix || "mie_••••••••••••"}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2 self-end sm:self-center">
+          {k.status === "ausstehend" && (
+            <>
+              <Button
+                size="sm"
+                variant="default"
+                onClick={() => onApprove(k)}
+                className="h-8 text-xs font-medium"
+              >
+                Genehmigen
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => onReject(k.id)}
+                className="h-8 text-xs text-destructive hover:bg-destructive/10"
+              >
+                Ablehnen
+              </Button>
+            </>
+          )}
+
+          {k.status === "aktiv" && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => onPause(k.id)}
+              className="h-8 text-xs gap-1.5 text-orange-600 dark:text-orange-400 hover:bg-orange-500/10 border-orange-500/30"
+            >
+              <Pause className="h-3.5 w-3.5" />
+              Deaktivieren
+            </Button>
+          )}
+
+          {k.status === "pausiert" && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => onResume(k.id)}
+              className="h-8 text-xs gap-1.5 text-emerald-600 dark:text-emerald-400 hover:bg-emerald-500/10 border-emerald-500/30"
+            >
+              <Play className="h-3.5 w-3.5" />
+              Aktivieren
+            </Button>
+          )}
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 w-8 p-0"
+                aria-label={`Aktionen für API-Schlüssel ${k.name}`}
+              >
+                •••
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {(k.status === "aktiv" || k.status === "pausiert") && (
+                <DropdownMenuItem
+                  onClick={() => onRevoke(k.id)}
+                  className="text-destructive gap-2 cursor-pointer"
+                >
+                  <XCircle className="h-4 w-4" />
+                  Endgültig widerrufen
+                </DropdownMenuItem>
+              )}
+              {(k.status === "abgelehnt" || k.status === "widerrufen") && (
+                <DropdownMenuItem
+                  onClick={() => onDelete(k.id)}
+                  className="text-destructive gap-2 cursor-pointer"
+                >
+                  <Trash2 className="h-4 w-4" />
+                  Löschen
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {/* Paused alert info if applicable */}
+      {k.status === "pausiert" && (
+        <div className="p-2.5 rounded-md bg-orange-500/10 border border-orange-500/20 text-xs text-orange-800 dark:text-orange-300 flex items-start gap-2">
+          <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5 text-orange-600 dark:text-orange-400" />
+          <div>
+            {k.pausiert_grund === "ersteller_deaktiviert" ? (
+              <span>
+                <strong>Automatisch pausiert:</strong> Das Mitgliedskonto des Antragstellers ist inaktiv/deaktiviert. Der Schlüssel kann erst nach Reaktivierung des Erstellers fortgesetzt werden.
+              </span>
+            ) : (
+              <span>
+                <strong>Schlüssel ist deaktiviert:</strong> Eingehende API-Anfragen mit diesem Schlüssel werden abgewiesen. Klicken Sie auf „Aktivieren“, um den Zugriff wieder freizuschalten.
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Metadata Grid: Creator, Approver, Usage & Permissions */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs bg-muted/20 border border-border/40 rounded-lg p-3">
+        {/* Left: Antragsteller & Genehmigung */}
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-1.5 text-foreground">
+            <User className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <span className="font-medium">Beantragt von:</span>
+            <span className="text-muted-foreground truncate">{creatorDisplayName}</span>
+            {k.ersteller_status && k.ersteller_status !== "aktiv" && (
+              <Badge variant="outline" className="text-[10px] text-destructive border-destructive/30 h-4 px-1.5">
+                {k.ersteller_status}
+              </Badge>
+            )}
+          </div>
+          <div className="text-muted-foreground pl-5 text-[11px]">
+            Beantragt am: {new Date(k.erstellt_am).toLocaleDateString("de-DE")}
+          </div>
+
+          {k.genehmigt_am && (
+            <div className="flex items-center gap-1.5 text-foreground pt-1">
+              <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
+              <span className="font-medium">Genehmigt von:</span>
+              <span className="text-muted-foreground truncate">{approverDisplayName}</span>
+            </div>
+          )}
+        </div>
+
+        {/* Right: Verwendung & Gültigkeit */}
+        <div className="space-y-1.5">
+          <div className="flex items-center gap-1.5 text-foreground">
+            <Activity className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <span className="font-medium">Zuletzt aktiv:</span>
+            <span className="text-muted-foreground">
+              {k.last_used_at
+                ? new Date(k.last_used_at).toLocaleDateString("de-DE", {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                    day: "2-digit",
+                    month: "2-digit",
+                    year: "numeric",
+                  })
+                : "Noch nie verwendet"}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-1.5 text-foreground">
+            <Calendar className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <span className="font-medium">Gültig bis:</span>
+            <span className="text-muted-foreground">
+              {k.expires_at ? new Date(k.expires_at).toLocaleDateString("de-DE") : "Unbegrenzt gültig"}
+            </span>
+          </div>
+        </div>
+
+        {/* Full width: Permissions Summary */}
+        <div className="md:col-span-2 pt-2 border-t border-border/40">
+          <div className="flex items-center gap-1.5 text-foreground mb-1">
+            <Shield className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <span className="font-medium">
+              {k.status === "ausstehend" ? "Angefragte Berechtigungen:" : "Aktive Berechtigungen:"}
+            </span>
+          </div>
+          {renderPermissionsSummary(k.status === "ausstehend" ? k.angefragte_berechtigungen : k.berechtigungen)}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/settings/api-keys/api-key-request-dialog.tsx
+++ b/components/settings/api-keys/api-key-request-dialog.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { useToast } from "@/hooks/use-toast";
+import { AVAILABLE_MODULES, AVAILABLE_ACTIONS } from "./types";
+
+interface ApiKeyRequestDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+}
+
+export function ApiKeyRequestDialog({ open, onOpenChange, onSuccess }: ApiKeyRequestDialogProps) {
+  const { toast } = useToast();
+  const [keyName, setKeyName] = useState("");
+  const [environment, setEnvironment] = useState<"live" | "test">("live");
+  const [expiresAt, setExpiresAt] = useState("");
+  const [selectedModules, setSelectedModules] = useState<Record<string, Record<string, boolean>>>({
+    haeuser: { ansehen: true },
+    wohnungen: { ansehen: true },
+  });
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!keyName.trim()) {
+      toast({
+        title: "Fehler",
+        description: "Bitte geben Sie einen Namen für den API-Key ein.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      const payload = {
+        name: keyName.trim(),
+        environment,
+        expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
+        angefragte_berechtigungen: {
+          module: selectedModules,
+        },
+      };
+
+      const res = await fetch("/api/einstellungen/api-keys", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      const json = await res.json();
+      if (!res.ok) {
+        throw new Error(json.error || "Fehler beim Beantragen des API-Keys.");
+      }
+
+      toast({
+        title: "Erfolg",
+        description: "API-Key wurde erfolgreich beantragt und wartet auf Genehmigung.",
+        variant: "success",
+      });
+
+      onOpenChange(false);
+      setKeyName("");
+      setExpiresAt("");
+      setSelectedModules({
+        haeuser: { ansehen: true },
+        wohnungen: { ansehen: true },
+      });
+      onSuccess();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Fehler beim Beantragen.";
+      toast({
+        title: "Fehler",
+        description: msg,
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[550px]">
+        <DialogHeader>
+          <DialogTitle>API-Schlüssel beantragen</DialogTitle>
+          <DialogDescription>
+            Wählen Sie den gewünschten Namen und die benötigten Berechtigungen.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-1.5">
+            <label htmlFor="api-key-name-input" className="text-xs font-semibold">
+              Name des Schlüssels
+            </label>
+            <Input
+              id="api-key-name-input"
+              placeholder="z. B. Buchhaltungs-Integration"
+              value={keyName}
+              onChange={(e) => setKeyName(e.target.value)}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <label htmlFor="api-key-env-select" className="text-xs font-semibold">
+                Umgebung
+              </label>
+              <select
+                id="api-key-env-select"
+                aria-label="Umgebung"
+                value={environment}
+                onChange={(e) => setEnvironment(e.target.value as "live" | "test")}
+                className="w-full h-9 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-xs"
+              >
+                <option value="live">Live</option>
+                <option value="test">Test</option>
+              </select>
+            </div>
+
+            <div className="space-y-1.5">
+              <label htmlFor="api-key-expires-input" className="text-xs font-semibold">
+                Ablaufdatum (optional)
+              </label>
+              <Input
+                id="api-key-expires-input"
+                type="date"
+                value={expiresAt}
+                onChange={(e) => setExpiresAt(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2 pt-2">
+            <span className="text-xs font-semibold block">Angefragte Berechtigungen</span>
+            <div className="border border-border/60 rounded-lg p-3 space-y-3 bg-muted/20">
+              {AVAILABLE_MODULES.map((mod) => (
+                <div key={mod.id} className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 text-xs">
+                  <span className="font-medium w-32">{mod.label}</span>
+                  <div className="flex items-center gap-4 flex-wrap">
+                    {AVAILABLE_ACTIONS.map((act) => {
+                      const isChecked = !!selectedModules[mod.id]?.[act.id];
+                      const checkboxId = `req-mod-${mod.id}-act-${act.id}`;
+                      return (
+                        <div key={act.id} className="flex items-center gap-1.5">
+                          <Checkbox
+                            id={checkboxId}
+                            checked={isChecked}
+                            onCheckedChange={(val) => {
+                              setSelectedModules((prev) => ({
+                                ...prev,
+                                [mod.id]: {
+                                  ...(prev[mod.id] || {}),
+                                  [act.id]: !!val,
+                                },
+                              }));
+                            }}
+                          />
+                          <label htmlFor={checkboxId} className="cursor-pointer">
+                            {act.label}
+                          </label>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Abbrechen
+          </Button>
+          <Button onClick={handleSubmit} disabled={submitting}>
+            {submitting ? "Beantrage..." : "Antrag absenden"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/settings/api-keys/api-key-request-dialog.tsx
+++ b/components/settings/api-keys/api-key-request-dialog.tsx
@@ -14,6 +14,28 @@ import {
 } from "@/components/ui/dialog";
 import { useToast } from "@/hooks/use-toast";
 import { AVAILABLE_MODULES, AVAILABLE_ACTIONS } from "./types";
+import { HouseScopeSection, HouseItem } from "./house-scope-section";
+
+interface FormState {
+  keyName: string;
+  environment: "live" | "test";
+  expiresAt: string;
+  selectedModules: Record<string, Record<string, boolean>>;
+  houseScope: "all" | "selected";
+  selectedHouseIds: string[];
+}
+
+const initialFormState: FormState = {
+  keyName: "",
+  environment: "live",
+  expiresAt: "",
+  selectedModules: {
+    haeuser: { ansehen: true },
+    wohnungen: { ansehen: true },
+  },
+  houseScope: "all",
+  selectedHouseIds: [],
+};
 
 interface ApiKeyRequestDialogProps {
   open: boolean;
@@ -23,17 +45,28 @@ interface ApiKeyRequestDialogProps {
 
 export function ApiKeyRequestDialog({ open, onOpenChange, onSuccess }: ApiKeyRequestDialogProps) {
   const { toast } = useToast();
-  const [keyName, setKeyName] = useState("");
-  const [environment, setEnvironment] = useState<"live" | "test">("live");
-  const [expiresAt, setExpiresAt] = useState("");
-  const [selectedModules, setSelectedModules] = useState<Record<string, Record<string, boolean>>>({
-    haeuser: { ansehen: true },
-    wohnungen: { ansehen: true },
-  });
+  const [form, setForm] = useState<FormState>(initialFormState);
+  const [availableHouses, setAvailableHouses] = useState<HouseItem[]>([]);
   const [submitting, setSubmitting] = useState(false);
 
+  const handleOpenChange = (newOpen: boolean) => {
+    if (newOpen) {
+      fetch("/api/haeuser")
+        .then((res) => (res.ok ? res.json() : []))
+        .then((data) => {
+          if (Array.isArray(data)) {
+            setAvailableHouses(data);
+          }
+        })
+        .catch((err) => {
+          console.error("Fehler beim Laden der Häuser:", err);
+        });
+    }
+    onOpenChange(newOpen);
+  };
+
   const handleSubmit = async () => {
-    if (!keyName.trim()) {
+    if (!form.keyName.trim()) {
       toast({
         title: "Fehler",
         description: "Bitte geben Sie einen Namen für den API-Key ein.",
@@ -42,14 +75,24 @@ export function ApiKeyRequestDialog({ open, onOpenChange, onSuccess }: ApiKeyReq
       return;
     }
 
+    if (form.houseScope === "selected" && form.selectedHouseIds.length === 0) {
+      toast({
+        title: "Fehler",
+        description: "Bitte wählen Sie mindestens ein Haus aus oder wählen Sie 'Alle Häuser'.",
+        variant: "destructive",
+      });
+      return;
+    }
+
     try {
       setSubmitting(true);
       const payload = {
-        name: keyName.trim(),
-        environment,
-        expires_at: expiresAt ? new Date(expiresAt).toISOString() : null,
+        name: form.keyName.trim(),
+        environment: form.environment,
+        expires_at: form.expiresAt ? new Date(form.expiresAt).toISOString() : null,
         angefragte_berechtigungen: {
-          module: selectedModules,
+          module: form.selectedModules,
+          haeuser: form.houseScope === "selected" ? form.selectedHouseIds : null,
         },
       };
 
@@ -71,12 +114,7 @@ export function ApiKeyRequestDialog({ open, onOpenChange, onSuccess }: ApiKeyReq
       });
 
       onOpenChange(false);
-      setKeyName("");
-      setExpiresAt("");
-      setSelectedModules({
-        haeuser: { ansehen: true },
-        wohnungen: { ansehen: true },
-      });
+      setForm(initialFormState);
       onSuccess();
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Fehler beim Beantragen.";
@@ -91,12 +129,12 @@ export function ApiKeyRequestDialog({ open, onOpenChange, onSuccess }: ApiKeyReq
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[550px]">
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-[550px] max-h-[85vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>API-Schlüssel beantragen</DialogTitle>
           <DialogDescription>
-            Wählen Sie den gewünschten Namen und die benötigten Berechtigungen.
+            Wählen Sie den Namen, Modulberechtigungen und den Objekt-Zugriff.
           </DialogDescription>
         </DialogHeader>
 
@@ -108,8 +146,8 @@ export function ApiKeyRequestDialog({ open, onOpenChange, onSuccess }: ApiKeyReq
             <Input
               id="api-key-name-input"
               placeholder="z. B. Buchhaltungs-Integration"
-              value={keyName}
-              onChange={(e) => setKeyName(e.target.value)}
+              value={form.keyName}
+              onChange={(e) => setForm((prev) => ({ ...prev, keyName: e.target.value }))}
             />
           </div>
 
@@ -121,8 +159,10 @@ export function ApiKeyRequestDialog({ open, onOpenChange, onSuccess }: ApiKeyReq
               <select
                 id="api-key-env-select"
                 aria-label="Umgebung"
-                value={environment}
-                onChange={(e) => setEnvironment(e.target.value as "live" | "test")}
+                value={form.environment}
+                onChange={(e) =>
+                  setForm((prev) => ({ ...prev, environment: e.target.value as "live" | "test" }))
+                }
                 className="w-full h-9 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-xs"
               >
                 <option value="live">Live</option>
@@ -137,21 +177,22 @@ export function ApiKeyRequestDialog({ open, onOpenChange, onSuccess }: ApiKeyReq
               <Input
                 id="api-key-expires-input"
                 type="date"
-                value={expiresAt}
-                onChange={(e) => setExpiresAt(e.target.value)}
+                value={form.expiresAt}
+                onChange={(e) => setForm((prev) => ({ ...prev, expiresAt: e.target.value }))}
               />
             </div>
           </div>
 
+          {/* Module Permissions */}
           <div className="space-y-2 pt-2">
-            <span className="text-xs font-semibold block">Angefragte Berechtigungen</span>
+            <span className="text-xs font-semibold block">Angefragte Modul-Berechtigungen</span>
             <div className="border border-border/60 rounded-lg p-3 space-y-3 bg-muted/20">
               {AVAILABLE_MODULES.map((mod) => (
                 <div key={mod.id} className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 text-xs">
                   <span className="font-medium w-32">{mod.label}</span>
                   <div className="flex items-center gap-4 flex-wrap">
                     {AVAILABLE_ACTIONS.map((act) => {
-                      const isChecked = !!selectedModules[mod.id]?.[act.id];
+                      const isChecked = !!form.selectedModules[mod.id]?.[act.id];
                       const checkboxId = `req-mod-${mod.id}-act-${act.id}`;
                       return (
                         <div key={act.id} className="flex items-center gap-1.5">
@@ -159,11 +200,14 @@ export function ApiKeyRequestDialog({ open, onOpenChange, onSuccess }: ApiKeyReq
                             id={checkboxId}
                             checked={isChecked}
                             onCheckedChange={(val) => {
-                              setSelectedModules((prev) => ({
+                              setForm((prev) => ({
                                 ...prev,
-                                [mod.id]: {
-                                  ...(prev[mod.id] || {}),
-                                  [act.id]: !!val,
+                                selectedModules: {
+                                  ...prev.selectedModules,
+                                  [mod.id]: {
+                                    ...(prev.selectedModules[mod.id] || {}),
+                                    [act.id]: !!val,
+                                  },
                                 },
                               }));
                             }}
@@ -179,6 +223,16 @@ export function ApiKeyRequestDialog({ open, onOpenChange, onSuccess }: ApiKeyReq
               ))}
             </div>
           </div>
+
+          {/* House Object Scoping */}
+          <HouseScopeSection
+            idPrefix="req"
+            houseScope={form.houseScope}
+            onScopeChange={(scope) => setForm((prev) => ({ ...prev, houseScope: scope }))}
+            selectedHouseIds={form.selectedHouseIds}
+            onSelectedHouseIdsChange={(ids) => setForm((prev) => ({ ...prev, selectedHouseIds: ids }))}
+            availableHouses={availableHouses}
+          />
         </div>
 
         <DialogFooter>

--- a/components/settings/api-keys/api-key-secret-dialog.tsx
+++ b/components/settings/api-keys/api-key-secret-dialog.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { CheckCircle2, AlertTriangle, Check, Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { useToast } from "@/hooks/use-toast";
+
+interface ApiKeySecretDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  secret: string | null;
+}
+
+export function ApiKeySecretDialog({ open, onOpenChange, secret }: ApiKeySecretDialogProps) {
+  const { toast } = useToast();
+  const [copied, setCopied] = useState(false);
+
+  const copyToClipboard = () => {
+    if (secret) {
+      navigator.clipboard.writeText(secret);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 3000);
+      toast({ title: "Kopiert", description: "API-Key in die Zwischenablage kopiert." });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-emerald-600 dark:text-emerald-400">
+            <CheckCircle2 className="h-5 w-5" />
+            API-Key erfolgreich genehmigt!
+          </DialogTitle>
+          <DialogDescription>
+            Der Schlüssel wurde erstellt. Bitte kopieren Sie den Secret-Key jetzt.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="p-3.5 bg-amber-500/10 border border-amber-500/20 rounded-lg text-xs flex items-start gap-2.5 text-amber-800 dark:text-amber-300">
+            <AlertTriangle className="h-5 w-5 shrink-0 text-amber-600 dark:text-amber-400 mt-0.5" />
+            <div>
+              <p className="font-semibold">Wichtig: Einmalige Anzeige!</p>
+              <p className="mt-0.5">
+                Dieser Schlüssel wird aus Sicherheitsgründen <strong>nur dieses eine Mal</strong> im Klartext angezeigt und nirgends in der Datenbank gespeichert.
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="revealed-api-secret" className="text-xs font-semibold">
+              Ihr API-Secret:
+            </label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="revealed-api-secret"
+                readOnly
+                value={secret || ""}
+                className="font-mono text-xs bg-muted/60 select-all"
+              />
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={copyToClipboard}
+                className="shrink-0 gap-1.5"
+              >
+                {copied ? <Check className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
+                {copied ? "Kopiert" : "Kopieren"}
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button onClick={() => onOpenChange(false)}>
+            Ich habe den Schlüssel gespeichert
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/settings/api-keys/helpers.tsx
+++ b/components/settings/api-keys/helpers.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { Badge } from "@/components/ui/badge";
+import { ApiKeyItem, AVAILABLE_MODULES, AVAILABLE_ACTIONS } from "./types";
+
+export function renderStatusBadge(status: ApiKeyItem["status"], pausiertGrund?: string | null): React.ReactElement {
+  switch (status) {
+    case "aktiv":
+      return <Badge className="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20">Aktiv</Badge>;
+    case "ausstehend":
+      return <Badge className="bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20">Ausstehend</Badge>;
+    case "pausiert":
+      return (
+        <Badge
+          className="bg-orange-500/10 text-orange-600 dark:text-orange-400 border-orange-500/20"
+          title={pausiertGrund === "ersteller_deaktiviert" ? "Ersteller deaktiviert — Prüfung nötig" : "Manuell deaktiviert"}
+        >
+          {pausiertGrund === "ersteller_deaktiviert" ? "Pausiert (Ersteller inaktiv)" : "Deaktiviert"}
+        </Badge>
+      );
+    case "widerrufen":
+      return <Badge variant="secondary">Widerrufen</Badge>;
+    case "abgelehnt":
+      return <Badge variant="destructive">Abgelehnt</Badge>;
+    default:
+      return <Badge variant="outline">{status}</Badge>;
+  }
+}
+
+export function renderPermissionsSummary(permsObj: Record<string, unknown> | null): React.ReactElement {
+  if (!permsObj || !permsObj.module || typeof permsObj.module !== "object") {
+    return <span className="text-muted-foreground">Keine Module zugewiesen</span>;
+  }
+
+  const moduleObj = permsObj.module as Record<string, unknown>;
+  const badges: React.ReactElement[] = [];
+
+  for (const [modName, acts] of Object.entries(moduleObj)) {
+    let actList = "";
+    if (Array.isArray(acts) && acts.length > 0) {
+      actList = acts.join(", ");
+    } else if (typeof acts === "object" && acts !== null) {
+      const activeActs: string[] = [];
+      for (const [actionKey, isEnabled] of Object.entries(acts as Record<string, unknown>)) {
+        if (isEnabled) {
+          const actionDef = AVAILABLE_ACTIONS.find((a) => a.id === actionKey);
+          activeActs.push(actionDef ? actionDef.label : actionKey);
+        }
+      }
+      if (activeActs.length > 0) {
+        actList = activeActs.join(", ");
+      }
+    }
+
+    if (actList) {
+      const modDef = AVAILABLE_MODULES.find((m) => m.id === modName);
+      const label = modDef ? modDef.label : modName;
+      badges.push(
+        <Badge key={modName} variant="secondary" className="text-[11px] font-normal py-0.5 px-2 bg-muted/60">
+          {label}: {actList}
+        </Badge>
+      );
+    }
+  }
+
+  if (badges.length === 0) {
+    return <span className="text-muted-foreground">Keine Berechtigungen</span>;
+  }
+
+  return <div className="flex flex-wrap gap-1 mt-1">{badges}</div>;
+}

--- a/components/settings/api-keys/helpers.tsx
+++ b/components/settings/api-keys/helpers.tsx
@@ -71,6 +71,21 @@ export function PermissionsSummary({ berechtigungen }: PermissionsSummaryProps):
     }
   }
 
+  // House scope badge
+  if (Array.isArray(berechtigungen.haeuser) && berechtigungen.haeuser.length > 0) {
+    badges.push(
+      <Badge key="haeuser-scope" variant="outline" className="text-[11px] font-normal py-0.5 px-2 border-primary/40 text-primary bg-primary/5">
+        Objekte: {berechtigungen.haeuser.length} {berechtigungen.haeuser.length === 1 ? "Haus" : "Häuser"}
+      </Badge>
+    );
+  } else if (berechtigungen.haeuser === null || berechtigungen.haeuser === undefined) {
+    badges.push(
+      <Badge key="haeuser-scope" variant="outline" className="text-[11px] font-normal py-0.5 px-2 border-border/60 text-muted-foreground">
+        Objekte: Alle
+      </Badge>
+    );
+  }
+
   if (badges.length === 0) {
     return <span className="text-muted-foreground">Keine aktiven Rechte</span>;
   }

--- a/components/settings/api-keys/helpers.tsx
+++ b/components/settings/api-keys/helpers.tsx
@@ -2,7 +2,12 @@ import React from "react";
 import { Badge } from "@/components/ui/badge";
 import { ApiKeyItem, AVAILABLE_MODULES, AVAILABLE_ACTIONS } from "./types";
 
-export function renderStatusBadge(status: ApiKeyItem["status"], pausiertGrund?: string | null): React.ReactElement {
+interface StatusBadgeProps {
+  status: ApiKeyItem["status"];
+  pausiertGrund?: string | null;
+}
+
+export function StatusBadge({ status, pausiertGrund }: StatusBadgeProps): React.ReactElement {
   switch (status) {
     case "aktiv":
       return <Badge className="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20">Aktiv</Badge>;
@@ -26,12 +31,16 @@ export function renderStatusBadge(status: ApiKeyItem["status"], pausiertGrund?: 
   }
 }
 
-export function renderPermissionsSummary(permsObj: Record<string, unknown> | null): React.ReactElement {
-  if (!permsObj || !permsObj.module || typeof permsObj.module !== "object") {
+interface PermissionsSummaryProps {
+  berechtigungen: Record<string, unknown> | null;
+}
+
+export function PermissionsSummary({ berechtigungen }: PermissionsSummaryProps): React.ReactElement {
+  if (!berechtigungen || !berechtigungen.module || typeof berechtigungen.module !== "object") {
     return <span className="text-muted-foreground">Keine Module zugewiesen</span>;
   }
 
-  const moduleObj = permsObj.module as Record<string, unknown>;
+  const moduleObj = berechtigungen.module as Record<string, unknown>;
   const badges: React.ReactElement[] = [];
 
   for (const [modName, acts] of Object.entries(moduleObj)) {
@@ -63,8 +72,8 @@ export function renderPermissionsSummary(permsObj: Record<string, unknown> | nul
   }
 
   if (badges.length === 0) {
-    return <span className="text-muted-foreground">Keine Berechtigungen</span>;
+    return <span className="text-muted-foreground">Keine aktiven Rechte</span>;
   }
 
-  return <div className="flex flex-wrap gap-1 mt-1">{badges}</div>;
+  return <div className="flex flex-wrap gap-1.5">{badges}</div>;
 }

--- a/components/settings/api-keys/house-scope-section.tsx
+++ b/components/settings/api-keys/house-scope-section.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useMemo } from "react";
+import { Building2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+
+export interface HouseItem {
+  id: string;
+  name: string;
+  strasse?: string;
+  ort?: string;
+}
+
+interface HouseScopeSectionProps {
+  idPrefix: string;
+  houseScope: "all" | "selected";
+  onScopeChange: (scope: "all" | "selected") => void;
+  selectedHouseIds: string[];
+  onSelectedHouseIdsChange: (ids: string[]) => void;
+  availableHouses: HouseItem[];
+}
+
+export function HouseScopeSection({
+  idPrefix,
+  houseScope,
+  onScopeChange,
+  selectedHouseIds,
+  onSelectedHouseIdsChange,
+  availableHouses,
+}: HouseScopeSectionProps) {
+  const selectedSet = useMemo(() => new Set(selectedHouseIds), [selectedHouseIds]);
+
+  const toggleHouse = (houseId: string) => {
+    if (selectedSet.has(houseId)) {
+      onSelectedHouseIdsChange(selectedHouseIds.filter((id) => id !== houseId));
+    } else {
+      onSelectedHouseIdsChange([...selectedHouseIds, houseId]);
+    }
+  };
+
+  const handleSelectAllToggle = () => {
+    if (selectedHouseIds.length === availableHouses.length) {
+      onSelectedHouseIdsChange([]);
+    } else {
+      onSelectedHouseIdsChange(availableHouses.map((h) => h.id));
+    }
+  };
+
+  return (
+    <div className="space-y-2 pt-2">
+      <span className="text-xs font-semibold block">Objekt-Zugriff (Häuser)</span>
+      <div className="border border-border/60 rounded-lg p-3 space-y-3 bg-muted/20">
+        <div className="flex flex-col gap-2 text-xs">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name={`${idPrefix}-house-scope`}
+              value="all"
+              checked={houseScope === "all"}
+              onChange={() => onScopeChange("all")}
+              className="accent-primary"
+            />
+            <span>Alle Häuser (Zugriff auf alle freigegebenen Objekte)</span>
+          </label>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name={`${idPrefix}-house-scope`}
+              value="selected"
+              checked={houseScope === "selected"}
+              onChange={() => onScopeChange("selected")}
+              className="accent-primary"
+            />
+            <span>Auf bestimmte Häuser einschränken</span>
+          </label>
+        </div>
+
+        {houseScope === "selected" && (
+          <div className="pt-2 border-t border-border/40 space-y-2">
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>Verfügbare Häuser:</span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-[11px]"
+                onClick={handleSelectAllToggle}
+              >
+                {selectedHouseIds.length === availableHouses.length
+                  ? "Keine auswählen"
+                  : "Alle auswählen"}
+              </Button>
+            </div>
+            <div className="max-h-36 overflow-y-auto space-y-1.5 pr-1">
+              {availableHouses.length === 0 ? (
+                <p className="text-xs text-muted-foreground italic py-1">
+                  Keine Häuser gefunden.
+                </p>
+              ) : (
+                availableHouses.map((h) => {
+                  const isChecked = selectedSet.has(h.id);
+                  const houseCheckboxId = `${idPrefix}-house-${h.id}`;
+                  return (
+                    <div
+                      key={h.id}
+                      className="flex items-center gap-2 p-1.5 rounded hover:bg-muted/40 text-xs"
+                    >
+                      <Checkbox
+                        id={houseCheckboxId}
+                        checked={isChecked}
+                        onCheckedChange={() => toggleHouse(h.id)}
+                      />
+                      <label
+                        htmlFor={houseCheckboxId}
+                        className="flex items-center gap-1.5 cursor-pointer flex-1 min-w-0"
+                      >
+                        <Building2 className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                        <span className="font-medium truncate">{h.name}</span>
+                        {h.ort && (
+                          <span className="text-muted-foreground truncate">
+                            ({h.ort})
+                          </span>
+                        )}
+                      </label>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/settings/api-keys/types.ts
+++ b/components/settings/api-keys/types.ts
@@ -1,0 +1,51 @@
+export interface ApiKeyItem {
+  id: string;
+  organisation_id: string;
+  mitglied_id: string;
+  name: string;
+  key_prefix: string | null;
+  environment: "live" | "test";
+  status: "ausstehend" | "aktiv" | "abgelehnt" | "widerrufen" | "pausiert";
+  erstellt_von: string | null;
+  ersteller_email?: string | null;
+  ersteller_first_name?: string | null;
+  ersteller_last_name?: string | null;
+  angefragte_berechtigungen: Record<string, unknown> | null;
+  berechtigungen: Record<string, unknown> | null;
+  genehmigt_von: string | null;
+  genehmigt_von_email?: string | null;
+  genehmigt_von_first_name?: string | null;
+  genehmigt_von_last_name?: string | null;
+  genehmigt_am: string | null;
+  expires_at: string | null;
+  last_used_at: string | null;
+  pausiert_grund: string | null;
+  erstellt_am: string;
+  geaendert_am: string;
+  ersteller_status?: string;
+}
+
+export const AVAILABLE_MODULES = [
+  { id: "haeuser", label: "Häuser" },
+  { id: "wohnungen", label: "Wohnungen" },
+  { id: "mieter", label: "Mieter" },
+  { id: "finanzen", label: "Finanzen" },
+  { id: "aufgaben", label: "Aufgaben" },
+  { id: "zaehler", label: "Zähler" },
+  { id: "zaehler_ablesungen", label: "Zählerablesungen" },
+] as const;
+
+export const AVAILABLE_ACTIONS = [
+  { id: "ansehen", label: "Lesen" },
+  { id: "erstellen", label: "Erstellen" },
+  { id: "bearbeiten", label: "Bearbeiten" },
+  { id: "loeschen", label: "Löschen" },
+] as const;
+
+export function formatUserName(firstName?: string | null, lastName?: string | null, email?: string | null): string {
+  const fullName = `${firstName || ""} ${lastName || ""}`.trim();
+  if (fullName) {
+    return email ? `${fullName} (${email})` : fullName;
+  }
+  return email || "Unbekannter Nutzer";
+}

--- a/components/settings/api-keys/types.ts
+++ b/components/settings/api-keys/types.ts
@@ -49,3 +49,33 @@ export function formatUserName(firstName?: string | null, lastName?: string | nu
   }
   return email || "Unbekannter Nutzer";
 }
+
+export function formatDateDeterministic(isoDateStr?: string | null): string {
+  if (!isoDateStr) return "";
+  try {
+    const d = new Date(isoDateStr);
+    if (isNaN(d.getTime())) return isoDateStr;
+    const day = String(d.getDate()).padStart(2, "0");
+    const month = String(d.getMonth() + 1).padStart(2, "0");
+    const year = d.getFullYear();
+    return `${day}.${month}.${year}`;
+  } catch {
+    return isoDateStr;
+  }
+}
+
+export function formatDateTimeDeterministic(isoDateStr?: string | null): string {
+  if (!isoDateStr) return "";
+  try {
+    const d = new Date(isoDateStr);
+    if (isNaN(d.getTime())) return isoDateStr;
+    const day = String(d.getDate()).padStart(2, "0");
+    const month = String(d.getMonth() + 1).padStart(2, "0");
+    const year = d.getFullYear();
+    const hours = String(d.getHours()).padStart(2, "0");
+    const minutes = String(d.getMinutes()).padStart(2, "0");
+    return `${day}.${month}.${year}, ${hours}:${minutes} Uhr`;
+  } catch {
+    return isoDateStr;
+  }
+}

--- a/lib/api-keys.ts
+++ b/lib/api-keys.ts
@@ -1,0 +1,21 @@
+import crypto from "crypto";
+
+export interface GeneratedApiKey {
+  plaintext: string;
+  key_hash: string;
+  key_prefix: string;
+}
+
+/**
+ * Generates a cryptographically secure random API key secret,
+ * calculates its SHA-256 hash for database storage, and derives the prefix.
+ *
+ * Format: mie_<environment>_<32 bytes base64url>
+ */
+export function generateApiKeySecret(environment: "live" | "test" = "live"): GeneratedApiKey {
+  const secret = crypto.randomBytes(32).toString("base64url");
+  const plaintext = `mie_${environment}_${secret}`;
+  const key_hash = crypto.createHash("sha256").update(plaintext).digest("hex");
+  const key_prefix = plaintext.slice(0, 16); // e.g. mie_live_a1b2c3d4
+  return { plaintext, key_hash, key_prefix };
+}

--- a/lib/permissions-core.ts
+++ b/lib/permissions-core.ts
@@ -8,7 +8,8 @@ export type Modul =
   | 'dokumente'
   | 'aufgaben'
   | 'vorlagen'
-  | 'organisation';
+  | 'organisation'
+  | 'api_keys';
 
 export type Aktion = 'ansehen' | 'erstellen' | 'bearbeiten' | 'loeschen' | 'verwalten';
 


### PR DESCRIPTION
## Summary

This PR implements Phase 4 of the Mietevo API project in `RMS`:
- **API Routes (`app/api/einstellungen/api-keys/`):**
  - `POST /api/einstellungen/api-keys`: Request a new API key.
  - `POST /api/einstellungen/api-keys/[id]/genehmigen`: Approve API key and generate plaintext secret (`mie_live_...` / `mie_test_...`).
  - `POST /api/einstellungen/api-keys/[id]/pausieren`: Manually pause / deactivate API key.
  - `POST /api/einstellungen/api-keys/[id]/fortsetzen`: Reactivate / resume paused key.
  - `POST /api/einstellungen/api-keys/[id]/ablehnen`: Reject key request.
  - `POST /api/einstellungen/api-keys/[id]/widerrufen`: Revoke key.
  - `DELETE /api/einstellungen/api-keys/[id]`: Soft delete key.
- **UI Components (`components/settings/api-keys-section.tsx`):**
  - Detailed card view with requester ("Beantragt von"), approver ("Genehmigt von"), last active timestamp, environment, and permissions summary.
  - One-time secret display modal with copy button.
  - Pause / Deactivate and Resume buttons.
- **Organization & Gating:**
  - Conditionally renders API-Keys tab and guards `/einstellungen/api-keys` route based on `Organisation.api_zugriff_aktiviert`.