### PR TITLE
fix(oauth): resolve Minified React error #441 on OAuth consent page

### DIFF
--- a/app/api/oauth/approve/route.ts
+++ b/app/api/oauth/approve/route.ts
@@ -1,8 +1,6 @@
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import { NO_CACHE_HEADERS } from '@/lib/constants/http';
-
+import { submitDecisionAction } from '@/app/oauth/consent/actions';
 
 export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
@@ -13,102 +11,25 @@ export async function GET(request: NextRequest) {
         return NextResponse.json({ error: 'Missing authorization_id' }, { status: 400, headers: NO_CACHE_HEADERS });
     }
 
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-    if (!supabaseUrl || !anonKey) {
-        console.error('Missing Supabase environment variables');
-        return NextResponse.json({ error: 'Configuration error' }, { status: 500, headers: NO_CACHE_HEADERS });
-    }
-
     try {
-        const cookieStore = await cookies();
+        const { success, redirect_to, error } = await submitDecisionAction(authorizationId, 'allow');
 
-        // Create Supabase server client with cookie handling
-        const supabase = createServerClient(
-            supabaseUrl,
-            anonKey,
-            {
-                cookies: {
-                    getAll: async () => cookieStore.getAll(),
-                    setAll: async (cookiesToSet) => {
-                        cookiesToSet.forEach(({ name, value, options }) => cookieStore.set(name, value, options));
-                    },
-                },
-            }
+        if (!success || error || !redirect_to) {
+            console.error('[OAuth Approve] Approval failed:', error);
+            return NextResponse.redirect(
+                new URL(
+                    `/oauth/consent?error=approval_failed&message=${encodeURIComponent(error || 'Unknown error')}`,
+                    baseUrl
+                )
+            );
+        }
+
+        return NextResponse.redirect(redirect_to);
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Unknown server error';
+        console.error('[OAuth Approve] Approval error:', err);
+        return NextResponse.redirect(
+            new URL(`/oauth/consent?error=server_error&message=${encodeURIComponent(message)}`, baseUrl)
         );
-
-        // Check if user is authenticated and get the session
-        const { data: { session }, error: sessionError } = await supabase.auth.getSession();
-
-        if (sessionError || !session) {
-            console.error('No session found:', sessionError);
-            return NextResponse.redirect(new URL(`/oauth/consent?error=no_session&message=Not authenticated. Please login first.`, baseUrl));
-        }
-
-        console.log('User authenticated:', session.user.id);
-        console.log('Approving authorization:', authorizationId);
-
-        // Try calling the approval endpoint directly with the access token
-        // Use the standard Supabase OAuth authorize endpoint
-        const approveUrl = `${supabaseUrl}/auth/v1/oauth/authorize`;
-
-        console.log('Calling approve URL:', approveUrl);
-
-        const response = await fetch(approveUrl, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'apikey': anonKey,
-                'Authorization': `Bearer ${session.access_token}`,
-            },
-            body: JSON.stringify({
-                authorization_id: authorizationId,
-                consent: 'approve',
-            }),
-        });
-
-        const responseText = await response.text();
-        console.log('Approve response status:', response.status);
-
-        if (!response.ok) {
-            console.error('Approve failed:', responseText);
-
-            // If the first attempt fails, we can try the SDK method as a robust fallback
-            // This handles potential differences in internal vs public endpoints
-            console.log('API call failed, trying SDK method as fallback...');
-            try {
-                const { data: sdkData, error: sdkError } = await (supabase.auth as unknown as import('@/types/supabase').SupabaseAuthWithOAuth).oauth.approveAuthorization(authorizationId);
-
-                if (sdkError) {
-                    throw sdkError;
-                }
-
-                if (sdkData?.redirect_to) {
-                    return NextResponse.redirect(sdkData.redirect_to);
-                }
-                // If success but no redirect, we might be done or need to guess
-                console.log('SDK success but no explicit redirect_to returned immediately');
-            } catch (sdkErr: any) {
-                console.error('SDK fallback also failed:', sdkErr);
-                return NextResponse.redirect(new URL(`/oauth/consent?error=approval_failed&message=${encodeURIComponent(sdkErr.message || 'Unknown error')}`, baseUrl));
-            }
-        }
-
-        // Parse successful API response
-        try {
-            const data = JSON.parse(responseText);
-            if (data.redirect_to) {
-                console.log('Redirecting to:', data.redirect_to);
-                return NextResponse.redirect(data.redirect_to);
-            }
-        } catch (e) {
-            console.error('Failed to parse approval response JSON:', e);
-        }
-
-        return NextResponse.redirect(new URL(`/oauth/consent?error=no_redirect&message=No redirect URL received`, baseUrl));
-    } catch (err: any) {
-        console.error('Approval error:', err);
-        return NextResponse.redirect(new URL(`/oauth/consent?error=server_error&message=${encodeURIComponent(err.message)}`, baseUrl));
     }
 }

--- a/app/api/oauth/approve/route.ts
+++ b/app/api/oauth/approve/route.ts
@@ -20,16 +20,18 @@ export async function GET(request: NextRequest) {
                 new URL(
                     `/oauth/consent?error=approval_failed&message=${encodeURIComponent(error || 'Unknown error')}`,
                     baseUrl
-                )
+                ),
+                { headers: NO_CACHE_HEADERS }
             );
         }
 
-        return NextResponse.redirect(redirect_to);
+        return NextResponse.redirect(redirect_to, { headers: NO_CACHE_HEADERS });
     } catch (err: unknown) {
         const message = err instanceof Error ? err.message : 'Unknown server error';
         console.error('[OAuth Approve] Approval error:', err);
         return NextResponse.redirect(
-            new URL(`/oauth/consent?error=server_error&message=${encodeURIComponent(message)}`, baseUrl)
+            new URL(`/oauth/consent?error=server_error&message=${encodeURIComponent(message)}`, baseUrl),
+            { headers: NO_CACHE_HEADERS }
         );
     }
 }

--- a/app/api/oauth/decision/route.ts
+++ b/app/api/oauth/decision/route.ts
@@ -1,8 +1,6 @@
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 import { NO_CACHE_HEADERS } from '@/lib/constants/http';
-
+import { submitDecisionAction } from '@/app/oauth/consent/actions';
 
 export async function POST(request: Request) {
     const formData = await request.formData();
@@ -13,43 +11,14 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: 'Missing authorization_id' }, { status: 400, headers: NO_CACHE_HEADERS });
     }
 
-    if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
-        throw new Error('Missing Supabase environment variables');
-    }
-
-    const supabase = createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-        {
-            cookies: {
-                getAll: async () => (await cookies()).getAll(),
-                setAll: async (cookiesToSet) => {
-                    const cookieStore = await cookies();
-                    cookiesToSet.forEach(({ name, value, options }) => cookieStore.set(name, value, options));
-                },
-            },
-        }
+    const { success, redirect_to, error } = await submitDecisionAction(
+        authorizationId,
+        decision === 'approve' ? 'allow' : 'deny'
     );
 
-    if (decision === 'approve') {
-        const { data, error } = await (supabase.auth as unknown as import('@/types/supabase').SupabaseAuthWithOAuth).oauth.approveAuthorization(authorizationId);
-
-        if (error) {
-            console.error('Approval error:', error);
-            return NextResponse.json({ error: error.message }, { status: 400, headers: NO_CACHE_HEADERS });
-        }
-
-        // Redirect back to the client with authorization code
-        return NextResponse.redirect(data.redirect_to);
-    } else {
-        const { data, error } = await (supabase.auth as unknown as import('@/types/supabase').SupabaseAuthWithOAuth).oauth.denyAuthorization(authorizationId);
-
-        if (error) {
-            console.error('Denial error:', error);
-            return NextResponse.json({ error: error.message }, { status: 400, headers: NO_CACHE_HEADERS });
-        }
-
-        // Redirect back to the client with error
-        return NextResponse.redirect(data.redirect_to);
+    if (!success || error || !redirect_to) {
+        return NextResponse.json({ error: error || 'Decision failed' }, { status: 400, headers: NO_CACHE_HEADERS });
     }
+
+    return NextResponse.redirect(redirect_to);
 }

--- a/app/api/oauth/decision/route.ts
+++ b/app/api/oauth/decision/route.ts
@@ -20,5 +20,5 @@ export async function POST(request: Request) {
         return NextResponse.json({ error: error || 'Decision failed' }, { status: 400, headers: NO_CACHE_HEADERS });
     }
 
-    return NextResponse.redirect(redirect_to);
+    return NextResponse.redirect(redirect_to, { headers: NO_CACHE_HEADERS });
 }

--- a/app/oauth/consent/actions.test.ts
+++ b/app/oauth/consent/actions.test.ts
@@ -86,9 +86,33 @@ describe('OAuth Consent actions', () => {
             expect(result.success).toBe(false);
             expect(result.error).toContain('bereits verwendet oder ist abgelaufen');
         });
+        it('handles 401/403 unauthorized responses gracefully', async () => {
+            (global.fetch as jest.Mock).mockResolvedValueOnce({
+                ok: false,
+                status: 401,
+            });
+
+            const result = await getAuthorizationDetailsAction('auth_123456789012');
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('Sitzung ist abgelaufen');
+        });
+
+        it('handles network failure rejection in catch block', async () => {
+            (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network failure'));
+
+            const result = await getAuthorizationDetailsAction('auth_123456789012');
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('Network failure');
+        });
     });
 
     describe('submitDecisionAction', () => {
+        it('rejects invalid decision parameter values', async () => {
+            const result = await submitDecisionAction('auth_123456789012', 'invalid_decision' as any);
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('Invalid decision value');
+        });
+
         it('submits allow decision to /consent endpoint', async () => {
             (global.fetch as jest.Mock).mockResolvedValueOnce({
                 ok: true,
@@ -143,6 +167,44 @@ describe('OAuth Consent actions', () => {
             expect(result.success).toBe(true);
             expect(result.redirect_to).toBe('https://mcp.mietevo.de/oauth/callback?code=fallback_code');
             expect(global.fetch).toHaveBeenCalledTimes(2);
+        });
+
+        it('falls back to /authorizations/{id} when /consent returns 405', async () => {
+            (global.fetch as jest.Mock).mockResolvedValueOnce({
+                ok: false,
+                status: 405,
+            });
+            (global.fetch as jest.Mock).mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => ({
+                    redirect_to: 'https://mcp.mietevo.de/oauth/callback?code=fallback_code_405',
+                }),
+            });
+
+            const result = await submitDecisionAction('auth_123456789012', 'allow');
+            expect(result.success).toBe(true);
+            expect(result.redirect_to).toBe('https://mcp.mietevo.de/oauth/callback?code=fallback_code_405');
+            expect(global.fetch).toHaveBeenCalledTimes(2);
+        });
+
+        it('handles 401 unauthorized responses on decision submit', async () => {
+            (global.fetch as jest.Mock).mockResolvedValueOnce({
+                ok: false,
+                status: 401,
+            });
+
+            const result = await submitDecisionAction('auth_123456789012', 'allow');
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('Sitzung ist abgelaufen');
+        });
+
+        it('handles network failure rejection in submit decision', async () => {
+            (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('Network down'));
+
+            const result = await submitDecisionAction('auth_123456789012', 'allow');
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('Network down');
         });
     });
 });

--- a/app/oauth/consent/actions.test.ts
+++ b/app/oauth/consent/actions.test.ts
@@ -1,0 +1,148 @@
+import { getAuthorizationDetailsAction, submitDecisionAction } from './actions';
+
+// Mock ensureAuth
+jest.mock('@/lib/auth-utils', () => ({
+    ensureAuth: jest.fn().mockResolvedValue({
+        supabase: {
+            auth: {
+                getSession: jest.fn().mockResolvedValue({
+                    data: { session: { access_token: 'mock-access-token' } },
+                    error: null,
+                }),
+                getUser: jest.fn().mockResolvedValue({
+                    data: { user: { id: 'user-123' } },
+                    error: null,
+                }),
+            },
+        },
+    }),
+}));
+
+// Mock fetch
+const originalFetch = global.fetch;
+
+describe('OAuth Consent actions', () => {
+    beforeEach(() => {
+        global.fetch = jest.fn();
+    });
+
+    afterAll(() => {
+        global.fetch = originalFetch;
+    });
+
+    describe('getAuthorizationDetailsAction', () => {
+        it('rejects invalid authorization_id format', async () => {
+            const result = await getAuthorizationDetailsAction('short');
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('Invalid authorization identifier');
+        });
+
+        it('fetches authorization details successfully from GoTrue REST endpoint', async () => {
+            (global.fetch as jest.Mock).mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => ({
+                    id: 'auth_123456789012',
+                    client: { name: 'Notion MCP', logo_uri: 'https://notion.so/logo.png' },
+                    scopes: 'openid email',
+                }),
+            });
+
+            const result = await getAuthorizationDetailsAction('auth_123456789012');
+            expect(result.success).toBe(true);
+            expect(result.data?.client?.name).toBe('Notion MCP');
+            expect(global.fetch).toHaveBeenCalledWith(
+                expect.stringContaining('/auth/v1/oauth/authorizations/auth_123456789012'),
+                expect.objectContaining({
+                    method: 'GET',
+                    headers: expect.objectContaining({
+                        Authorization: 'Bearer mock-access-token',
+                    }),
+                })
+            );
+        });
+
+        it('handles 400 already processed authorization gracefully', async () => {
+            (global.fetch as jest.Mock).mockResolvedValueOnce({
+                ok: false,
+                status: 400,
+                text: async () => 'Authorization has already been processed',
+            });
+
+            const result = await getAuthorizationDetailsAction('auth_123456789012');
+            expect(result.success).toBe(true);
+            expect(result.alreadyProcessed).toBe(true);
+            expect(result.data).toBeNull();
+        });
+
+        it('handles 404 expired authorization gracefully', async () => {
+            (global.fetch as jest.Mock).mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+                text: async () => 'Not found',
+            });
+
+            const result = await getAuthorizationDetailsAction('auth_123456789012');
+            expect(result.success).toBe(false);
+            expect(result.error).toContain('bereits verwendet oder ist abgelaufen');
+        });
+    });
+
+    describe('submitDecisionAction', () => {
+        it('submits allow decision to /consent endpoint', async () => {
+            (global.fetch as jest.Mock).mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => ({
+                    redirect_to: 'https://mcp.mietevo.de/oauth/callback?code=code123',
+                }),
+            });
+
+            const result = await submitDecisionAction('auth_123456789012', 'allow');
+            expect(result.success).toBe(true);
+            expect(result.redirect_to).toBe('https://mcp.mietevo.de/oauth/callback?code=code123');
+            expect(global.fetch).toHaveBeenCalledWith(
+                expect.stringContaining('/auth/v1/oauth/authorizations/auth_123456789012/consent'),
+                expect.objectContaining({
+                    method: 'POST',
+                    body: JSON.stringify({ consent: 'approve', decision: 'allow' }),
+                })
+            );
+        });
+
+        it('submits deny decision to /consent endpoint', async () => {
+            (global.fetch as jest.Mock).mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => ({
+                    redirect_to: 'https://mcp.mietevo.de/oauth/callback?error=access_denied',
+                }),
+            });
+
+            const result = await submitDecisionAction('auth_123456789012', 'deny');
+            expect(result.success).toBe(true);
+            expect(result.redirect_to).toBe('https://mcp.mietevo.de/oauth/callback?error=access_denied');
+        });
+
+        it('falls back to /authorizations/{id} when /consent returns 404', async () => {
+            // First call returns 404
+            (global.fetch as jest.Mock).mockResolvedValueOnce({
+                ok: false,
+                status: 404,
+            });
+            // Fallback call returns 200
+            (global.fetch as jest.Mock).mockResolvedValueOnce({
+                ok: true,
+                status: 200,
+                json: async () => ({
+                    redirect_to: 'https://mcp.mietevo.de/oauth/callback?code=fallback_code',
+                }),
+            });
+
+            const result = await submitDecisionAction('auth_123456789012', 'allow');
+            expect(result.success).toBe(true);
+            expect(result.redirect_to).toBe('https://mcp.mietevo.de/oauth/callback?code=fallback_code');
+            expect(global.fetch).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/app/oauth/consent/actions.test.ts
+++ b/app/oauth/consent/actions.test.ts
@@ -86,10 +86,10 @@ describe('OAuth Consent actions', () => {
             expect(result.success).toBe(false);
             expect(result.error).toContain('bereits verwendet oder ist abgelaufen');
         });
-        it('handles 401/403 unauthorized responses gracefully', async () => {
+        it.each([401, 403])('handles %i unauthorized responses gracefully', async (status) => {
             (global.fetch as jest.Mock).mockResolvedValueOnce({
                 ok: false,
-                status: 401,
+                status,
             });
 
             const result = await getAuthorizationDetailsAction('auth_123456789012');
@@ -188,10 +188,10 @@ describe('OAuth Consent actions', () => {
             expect(global.fetch).toHaveBeenCalledTimes(2);
         });
 
-        it('handles 401 unauthorized responses on decision submit', async () => {
+        it.each([401, 403])('handles %i unauthorized responses on decision submit', async (status) => {
             (global.fetch as jest.Mock).mockResolvedValueOnce({
                 ok: false,
-                status: 401,
+                status,
             });
 
             const result = await submitDecisionAction('auth_123456789012', 'allow');

--- a/app/oauth/consent/actions.ts
+++ b/app/oauth/consent/actions.ts
@@ -35,28 +35,10 @@ function parseSupabaseAuthError(responseText: string, fallbackMessage: string): 
     try {
         errorData = JSON.parse(responseText);
     } catch {
-        // Not a JSON response, use the raw text if available.
-        return responseText || fallbackMessage;
+        // Not a JSON response — avoid leaking raw HTML/gateway errors to UI
+        return fallbackMessage;
     }
     return errorData.error_description || errorData.message || errorData.error || fallbackMessage;
-}
-
-/**
- * Retrieves the current user's access token from their Supabase session.
- * The /auth/v1/oauth/authorizations/{id} endpoint requires a Bearer token,
- * NOT cookies — unlike most other Supabase Auth endpoints.
- */
-async function getAccessToken(): Promise<string> {
-    const { supabase } = await ensureAuth();
-
-    const { data: { session }, error: sessionError } = await supabase.auth.getSession();
-    if (sessionError) {
-        throw new Error(`Session error: ${sessionError.message}`);
-    }
-    if (!session?.access_token) {
-        throw new Error('Not authenticated: no valid session found');
-    }
-    return session.access_token;
 }
 
 /**
@@ -171,26 +153,25 @@ export async function submitDecisionAction(authorizationId: string, decision: 'a
 
         const consentUrl = `${SUPABASE_URL}/auth/v1/oauth/authorizations/${encodeURIComponent(authorizationId)}/consent`;
         const consentValue = decision === 'allow' ? 'approve' : 'deny';
+        // Dual payload (consent + decision) provides compatibility across different Supabase GoTrue versions.
+        const consentPayload = JSON.stringify({
+            consent: consentValue,
+            decision: decision,
+        });
 
         let response = await fetchAuthEndpoint(consentUrl, accessToken, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                consent: consentValue,
-                decision: decision,
-            }),
+            body: consentPayload,
         });
 
-        // Fallback to /auth/v1/oauth/authorizations/{id} if /consent returns 404
-        if (response.status === 404) {
+        // Fallback to /auth/v1/oauth/authorizations/{id} if /consent returns 404 or 405 (endpoint not supported)
+        if (response.status === 404 || response.status === 405) {
             const fallbackUrl = buildAuthUrl(authorizationId);
             response = await fetchAuthEndpoint(fallbackUrl, accessToken, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    consent: consentValue,
-                    decision: decision,
-                }),
+                body: consentPayload,
             });
         }
 

--- a/app/oauth/consent/actions.ts
+++ b/app/oauth/consent/actions.ts
@@ -112,11 +112,16 @@ export interface AuthorizationDetailsResult {
  * Must run server-side — Supabase CORS policy blocks client-side requests.
  */
 export async function getAuthorizationDetailsAction(authorizationId: string): Promise<AuthorizationDetailsResult> {
+    const { supabase } = await ensureAuth();
     try {
         validateId(authorizationId);
-        const accessToken = await getAccessToken();
-        const url = buildAuthUrl(authorizationId);
+        const { data: { session } } = await supabase.auth.getSession();
+        const accessToken = session?.access_token;
+        if (!accessToken) {
+            return { success: false, error: ERR_AUTH_UNAUTHORIZED, data: null };
+        }
 
+        const url = buildAuthUrl(authorizationId);
         const response = await fetchAuthEndpoint(url, accessToken, { method: 'GET' });
 
         if (!response.ok) {
@@ -151,13 +156,19 @@ export async function getAuthorizationDetailsAction(authorizationId: string): Pr
  * POST /auth/v1/oauth/authorizations/{id}/consent
  */
 export async function submitDecisionAction(authorizationId: string, decision: 'allow' | 'deny') {
+    const { supabase } = await ensureAuth();
     try {
         validateId(authorizationId);
         if (decision !== 'allow' && decision !== 'deny') {
             throw new Error('Invalid decision value');
         }
 
-        const accessToken = await getAccessToken();
+        const { data: { session } } = await supabase.auth.getSession();
+        const accessToken = session?.access_token;
+        if (!accessToken) {
+            return { success: false, redirect_to: null, error: ERR_AUTH_UNAUTHORIZED };
+        }
+
         const consentUrl = `${SUPABASE_URL}/auth/v1/oauth/authorizations/${encodeURIComponent(authorizationId)}/consent`;
         const consentValue = decision === 'allow' ? 'approve' : 'deny';
 
@@ -204,16 +215,4 @@ export async function submitDecisionAction(authorizationId: string, decision: 'a
         console.error('Server Action: submitDecision failed:', message);
         return { success: false, redirect_to: null, error: message };
     }
-}
-
-/**
- * @deprecated Use submitDecisionAction('allow') instead.
- */
-export async function approveAuthorizationAction(authorizationId: string) {
-    const result = await submitDecisionAction(authorizationId, 'allow');
-    return {
-        success: result.success,
-        redirect_to: result.redirect_to,
-        error: result.error,
-    };
 }

--- a/app/oauth/consent/actions.ts
+++ b/app/oauth/consent/actions.ts
@@ -107,33 +107,38 @@ export interface AuthorizationDetailsResult {
 }
 
 /**
- * Fetches the authorization request details from Supabase.
- * Uses the Supabase JS client SDK's getAuthorizationDetails method.
+ * Fetches the authorization request details from Supabase GoTrue Auth REST endpoint.
+ * GET /auth/v1/oauth/authorizations/{id}
  * Must run server-side — Supabase CORS policy blocks client-side requests.
  */
 export async function getAuthorizationDetailsAction(authorizationId: string): Promise<AuthorizationDetailsResult> {
     try {
         validateId(authorizationId);
-        const { supabase } = await ensureAuth();
+        const accessToken = await getAccessToken();
+        const url = buildAuthUrl(authorizationId);
 
-        const { data, error } = await (supabase.auth as any).oauth.getAuthorizationDetails(authorizationId);
+        const response = await fetchAuthEndpoint(url, accessToken, { method: 'GET' });
 
-        if (error) {
-            const msg = error.message || 'Failed to load authorization details';
-            console.error('[OAuth] getAuthorizationDetails error:', msg, error);
-            // Check if this is a "already processed" 400 error
-            if (msg.toLowerCase().includes('cannot be processed') ||
-                msg.toLowerCase().includes('validation_failed') ||
-                error.status === 400) {
-                return { success: true, alreadyProcessed: true, error: null, data: null };
-            }
-            if (error.status === 404) {
+        if (!response.ok) {
+            if (response.status === 404) {
                 return { success: false, error: ERR_AUTH_EXPIRED, data: null };
             }
+            if (response.status === 400) {
+                // Any 400 from GET /oauth/authorizations/{id} means the authorization
+                // is in a terminal state — already consumed by a prior auto_approved redirect.
+                return { success: true, alreadyProcessed: true, error: null, data: null };
+            }
+            if (response.status === 401 || response.status === 403) {
+                return { success: false, error: ERR_AUTH_UNAUTHORIZED, data: null };
+            }
+            const responseText = await response.text();
+            const msg = parseSupabaseAuthError(responseText, `Failed to load authorization details (${response.status})`);
+            console.error('[OAuth] getAuthorizationDetails failed:', response.status, msg);
             return { success: false, error: msg, data: null };
         }
 
-        return { success: true, data: data as AuthorizationDetails, error: null };
+        const data = (await response.json()) as AuthorizationDetails;
+        return { success: true, data, error: null };
     } catch (err: unknown) {
         const message = err instanceof Error ? err.message : "Failed to load authorization details";
         console.error('Server Action: getAuthorizationDetails failed:', message);
@@ -142,9 +147,8 @@ export async function getAuthorizationDetailsAction(authorizationId: string): Pr
 }
 
 /**
- * Submits the user's consent decision (allow or deny) to Supabase.
- * Uses the Supabase JS client SDK which knows the correct endpoint
- * (POST /authorizations/{id}/consent) and request body format.
+ * Submits the user's consent decision (allow or deny) to Supabase GoTrue Auth REST endpoint.
+ * POST /auth/v1/oauth/authorizations/{id}/consent
  */
 export async function submitDecisionAction(authorizationId: string, decision: 'allow' | 'deny') {
     try {
@@ -153,25 +157,48 @@ export async function submitDecisionAction(authorizationId: string, decision: 'a
             throw new Error('Invalid decision value');
         }
 
-        const { supabase } = await ensureAuth();
+        const accessToken = await getAccessToken();
+        const consentUrl = `${SUPABASE_URL}/auth/v1/oauth/authorizations/${encodeURIComponent(authorizationId)}/consent`;
+        const consentValue = decision === 'allow' ? 'approve' : 'deny';
 
-        if (decision === 'allow') {
-            // supabase.auth.oauth.approveAuthorization() POSTs to
-            // /auth/v1/oauth/authorizations/{id}/consent with the correct body format
-            const { data, error } = await (supabase.auth as any).oauth.approveAuthorization(authorizationId);
-            if (error) {
-                console.error('[OAuth] approveAuthorization failed:', error.message);
-                return { success: false, redirect_to: null, error: error.message };
-            }
-            return { success: true, redirect_to: data?.redirect_url || data?.redirect_to || null, error: null };
-        } else {
-            const { data, error } = await (supabase.auth as any).oauth.denyAuthorization(authorizationId);
-            if (error) {
-                console.error('[OAuth] denyAuthorization failed:', error.message);
-                return { success: false, redirect_to: null, error: error.message };
-            }
-            return { success: true, redirect_to: data?.redirect_url || data?.redirect_to || null, error: null };
+        let response = await fetchAuthEndpoint(consentUrl, accessToken, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                consent: consentValue,
+                decision: decision,
+            }),
+        });
+
+        // Fallback to /auth/v1/oauth/authorizations/{id} if /consent returns 404
+        if (response.status === 404) {
+            const fallbackUrl = buildAuthUrl(authorizationId);
+            response = await fetchAuthEndpoint(fallbackUrl, accessToken, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    consent: consentValue,
+                    decision: decision,
+                }),
+            });
         }
+
+        if (!response.ok) {
+            if (response.status === 404 || response.status === 405) {
+                return { success: false, redirect_to: null, error: ERR_AUTH_EXPIRED };
+            }
+            if (response.status === 401 || response.status === 403) {
+                return { success: false, redirect_to: null, error: ERR_AUTH_UNAUTHORIZED };
+            }
+            const responseText = await response.text();
+            const msg = parseSupabaseAuthError(responseText, `Decision failed (${response.status})`);
+            console.error('[OAuth] submitDecision failed:', response.status, msg);
+            return { success: false, redirect_to: null, error: msg };
+        }
+
+        const data = (await response.json()) as { redirect_to?: string; redirect_url?: string };
+        const redirectTo = data.redirect_to || data.redirect_url || null;
+        return { success: true, redirect_to: redirectTo, error: null };
     } catch (err: unknown) {
         const message = err instanceof Error ? err.message : "Authorization decision failed";
         console.error('Server Action: submitDecision failed:', message);

--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -75,8 +75,7 @@ export default async function ConsentPage({ searchParams }: PageProps) {
     }
 
     // Detect auto-approval: Supabase successfully returned a payload without client details.
-    // Instead of auto-redirecting (which silently completes the flow without user awareness),
-    // show a manage screen where the user can review the app, manage it, or continue.
+    // The user has already approved this app previously. Redirect immediately to complete the flow.
     const autoRedirectUrl = (data?.redirect_url || data?.redirect_to) as string | undefined;
     const isAutoApproved = success && !data?.client;
 
@@ -89,14 +88,8 @@ export default async function ConsentPage({ searchParams }: PageProps) {
                 />
             );
         }
-        return (
-            <ConsentUI
-                type="manage"
-                authorizationId={authorizationId}
-                initialData={data as AuthorizationDetails}
-                autoRedirectUrl={autoRedirectUrl}
-            />
-        );
+        // Seamless auto-redirect for pre-approved sessions (no manual reconfirmation needed)
+        redirect(autoRedirectUrl);
     }
 
     return (

--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -75,7 +75,8 @@ export default async function ConsentPage({ searchParams }: PageProps) {
     }
 
     // Detect auto-approval: Supabase successfully returned a payload without client details.
-    // The user has already approved this app previously. Redirect immediately to complete the flow.
+    // Instead of auto-redirecting (which silently completes the flow without user awareness),
+    // show a manage screen where the user can review the app, manage it, or continue.
     const autoRedirectUrl = (data?.redirect_url || data?.redirect_to) as string | undefined;
     const isAutoApproved = success && !data?.client;
 
@@ -88,8 +89,14 @@ export default async function ConsentPage({ searchParams }: PageProps) {
                 />
             );
         }
-        // Seamless auto-redirect for pre-approved sessions (no manual reconfirmation needed)
-        redirect(autoRedirectUrl);
+        return (
+            <ConsentUI
+                type="manage"
+                authorizationId={authorizationId}
+                initialData={data as AuthorizationDetails}
+                autoRedirectUrl={autoRedirectUrl}
+            />
+        );
     }
 
     return (

--- a/app/oauth/consent/page.tsx
+++ b/app/oauth/consent/page.tsx
@@ -1,6 +1,6 @@
-import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
+import { createClient } from '@/utils/supabase/server';
 import ConsentUI from './ConsentUI';
 import { getAuthorizationDetailsAction, type AuthorizationDetails } from './actions';
 
@@ -42,22 +42,8 @@ export default async function ConsentPage({ searchParams }: PageProps) {
         />;
     }
 
-    // Create Supabase server client
-    const cookieStore = await cookies();
-    const supabase = createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL!,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-        {
-            cookies: {
-                getAll: () => cookieStore.getAll(),
-                setAll: (cookiesToSet) => {
-                    cookiesToSet.forEach(({ name, value, options }) =>
-                        cookieStore.set(name, value, options)
-                    );
-                },
-            },
-        }
-    );
+    // Create Supabase server client safely
+    const supabase = await createClient();
 
     // Check if user is authenticated
     const { data: { user } } = await supabase.auth.getUser();

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -11,11 +11,3 @@ export interface Profile {
   onboarding_completed?: boolean;
   setup_completed?: boolean;
 }
-
-export interface SupabaseAuthWithOAuth {
-  oauth: {
-    approveAuthorization(authorizationId: string): Promise<{ data: any; error: any }>;
-    denyAuthorization(authorizationId: string): Promise<{ data: any; error: any }>;
-    getAuthorizationDetails(authorizationId: string): Promise<{ data: any; error: any }>;
-  };
-}


### PR DESCRIPTION
## Summary

Fixes the production crash (`Minified React error #441`) encountered when opening `/oauth/consent?authorization_id=...`.

### Root Cause
1. **Unsafe cookie mutations during RSC render**: `app/oauth/consent/page.tsx` created an ad-hoc `createServerClient` with `cookies.setAll` calling `cookieStore.set()`, which throws in Next.js Server Components.
2. **Missing SDK method**: `actions.ts` called `(supabase.auth as any).oauth.getAuthorizationDetails` and `approveAuthorization`, which are undefined on the runtime Supabase JS client.

### Changes
- Switch `app/oauth/consent/page.tsx` to use the centralized `createClient()` from `@/utils/supabase/server`.
- Replace non-existent SDK calls in `app/oauth/consent/actions.ts` with direct fetch calls to Supabase GoTrue Auth REST endpoints (`GET /auth/v1/oauth/authorizations/{id}` and `POST /auth/v1/oauth/authorizations/{id}/consent`).
- Add `NO_CACHE_HEADERS` across auth redirect routes (`approve` & `decision`).
- Unify `app/api/oauth/decision/route.ts` and `app/api/oauth/approve/route.ts` to use `submitDecisionAction`.
- Add comprehensive parameterized unit tests in `app/oauth/consent/actions.test.ts`.

### Verification
- `npx tsc --noEmit`: Passed (0 errors)
- `npx jest app/oauth/consent/actions.test.ts`: Passed (15/15 tests)
- `npx react-doctor@latest`: Passed (Score: 100/100, 0 issues)
- `npm run lint`: Passed (0 errors)